### PR TITLE
[FLINK-19700][k8s] Make Kubernetes Client in KubernetesResourceManagerDriver use io executor

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
+import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.AbstractID;
@@ -41,6 +42,8 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 
 	private static final String CLUSTER_ID_PREFIX = "flink-cluster-";
 
+	private static final KubeClientFactory kubeClientFactory = DefaultKubeClientFactory.getInstance();
+
 	@Override
 	public boolean isCompatibleWith(Configuration configuration) {
 		checkNotNull(configuration);
@@ -55,7 +58,7 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 			final String clusterId = generateClusterId();
 			configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
 		}
-		return new KubernetesClusterDescriptor(configuration, KubeClientFactory.fromConfiguration(configuration));
+		return new KubernetesClusterDescriptor(configuration, kubeClientFactory.fromConfiguration(configuration));
 	}
 
 	@Nullable

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
-import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.AbstractID;
 
@@ -42,8 +41,6 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 
 	private static final String CLUSTER_ID_PREFIX = "flink-cluster-";
 
-	private static final KubeClientFactory kubeClientFactory = DefaultKubeClientFactory.getInstance();
-
 	@Override
 	public boolean isCompatibleWith(Configuration configuration) {
 		checkNotNull(configuration);
@@ -58,7 +55,8 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 			final String clusterId = generateClusterId();
 			configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
 		}
-		return new KubernetesClusterDescriptor(configuration, kubeClientFactory.fromConfiguration(configuration));
+		return new KubernetesClusterDescriptor(
+			configuration, DefaultKubeClientFactory.getInstance().fromConfiguration(configuration));
 	}
 
 	@Nullable

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -34,6 +34,7 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
+import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.runtime.security.SecurityUtils;
@@ -63,6 +64,8 @@ public class KubernetesSessionCli {
 		"help - show these commands\n" +
 		"stop - stop the kubernetes cluster\n" +
 		"quit - quit attach mode";
+
+	private final KubeClientFactory kubeClientFactory = DefaultKubeClientFactory.getInstance();
 
 	private final Configuration baseConfiguration;
 
@@ -99,7 +102,7 @@ public class KubernetesSessionCli {
 			final ClusterClient<String> clusterClient;
 			String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
 			final boolean detached = !configuration.get(DeploymentOptions.ATTACHED);
-			final FlinkKubeClient kubeClient = KubeClientFactory.fromConfiguration(configuration);
+			final FlinkKubeClient kubeClient = kubeClientFactory.fromConfiguration(configuration);
 
 			// Retrieve or create a session cluster.
 			if (clusterId != null && kubeClient.getRestService(clusterId).isPresent()) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -36,7 +36,6 @@ import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
 import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
-import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -64,8 +63,6 @@ public class KubernetesSessionCli {
 		"help - show these commands\n" +
 		"stop - stop the kubernetes cluster\n" +
 		"quit - quit attach mode";
-
-	private final KubeClientFactory kubeClientFactory = DefaultKubeClientFactory.getInstance();
 
 	private final Configuration baseConfiguration;
 
@@ -102,7 +99,7 @@ public class KubernetesSessionCli {
 			final ClusterClient<String> clusterClient;
 			String clusterId = kubernetesClusterClientFactory.getClusterId(configuration);
 			final boolean detached = !configuration.get(DeploymentOptions.ATTACHED);
-			final FlinkKubeClient kubeClient = kubeClientFactory.fromConfiguration(configuration);
+			final FlinkKubeClient kubeClient = DefaultKubeClientFactory.getInstance().fromConfiguration(configuration);
 
 			// Retrieve or create a session cluster.
 			if (clusterId != null && kubeClient.getRestService(clusterId).isPresent()) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -24,7 +24,7 @@ import org.apache.flink.kubernetes.KubernetesResourceManagerDriver;
 import org.apache.flink.kubernetes.KubernetesWorkerNode;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerDriverConfiguration;
-import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
+import org.apache.flink.kubernetes.kubeclient.DefaultKubeClientFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
 import org.apache.flink.runtime.resourcemanager.active.ActiveResourceManager;
 import org.apache.flink.runtime.resourcemanager.active.ActiveResourceManagerFactory;
@@ -58,7 +58,7 @@ public class KubernetesResourceManagerFactory extends ActiveResourceManagerFacto
 
 		return new KubernetesResourceManagerDriver(
 				configuration,
-				KubeClientFactory.fromConfiguration(configuration),
+				DefaultKubeClientFactory.getInstance(),
 				kubernetesResourceManagerDriverConfiguration);
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/DefaultKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/DefaultKubeClientFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.util.FileUtils;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Default implementation of the {@link KubeClientFactory}.
+ */
+public class DefaultKubeClientFactory implements KubeClientFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultKubeClientFactory.class);
+
+	private static final DefaultKubeClientFactory INSTANCE = new DefaultKubeClientFactory();
+
+	public static DefaultKubeClientFactory getInstance() {
+		return INSTANCE;
+	}
+
+	public FlinkKubeClient fromConfiguration(Configuration flinkConfig) {
+		return fromConfiguration(flinkConfig, createThreadPoolForAsyncIO());
+	}
+
+	public FlinkKubeClient fromConfiguration(Configuration flinkConfig, Executor ioExecutor) {
+		final Config config;
+
+		final String kubeContext = flinkConfig.getString(KubernetesConfigOptions.CONTEXT);
+		if (kubeContext != null) {
+			LOG.info("Configuring kubernetes client to use context {}.", kubeContext);
+		}
+
+		final String kubeConfigFile = flinkConfig.getString(KubernetesConfigOptions.KUBE_CONFIG_FILE);
+		if (kubeConfigFile != null) {
+			LOG.debug("Trying to load kubernetes config from file: {}.", kubeConfigFile);
+			try {
+				// If kubeContext is null, the default context in the kubeConfigFile will be used.
+				// Note: the third parameter kubeconfigPath is optional and is set to null. It is only used to rewrite
+				// relative tls asset paths inside kubeconfig when a file is passed, and in the case that the kubeconfig
+				// references some assets via relative paths.
+				config = Config.fromKubeconfig(
+						kubeContext,
+						FileUtils.readFileUtf8(new File(kubeConfigFile)),
+						null);
+			} catch (IOException e) {
+				throw new KubernetesClientException("Load kubernetes config failed.", e);
+			}
+		} else {
+			LOG.debug("Trying to load default kubernetes config.");
+
+			config = Config.autoConfigure(kubeContext);
+		}
+
+		final KubernetesClient client = new DefaultKubernetesClient(config);
+
+		return new Fabric8FlinkKubeClient(flinkConfig, client, () -> ioExecutor);
+	}
+
+	private static Executor createThreadPoolForAsyncIO() {
+		return Executors.newFixedThreadPool(2, new ExecutorThreadFactory("FlinkKubeClient-IO"));
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -27,7 +27,6 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
-import org.apache.flink.util.ExecutorUtils;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
@@ -47,8 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -65,12 +63,12 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 	private final String clusterId;
 	private final String namespace;
 
-	private final ExecutorService kubeClientExecutorService;
+	private final Executor kubeClientExecutorService;
 
 	public Fabric8FlinkKubeClient(
 			Configuration flinkConfig,
 			KubernetesClient client,
-			Supplier<ExecutorService> asyncExecutorFactory) {
+			Supplier<Executor> asyncExecutorFactory) {
 		this.internalClient = checkNotNull(client);
 		this.clusterId = checkNotNull(flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID));
 
@@ -220,7 +218,6 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 	@Override
 	public void close() {
 		this.internalClient.close();
-		ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, this.kubeClientExecutorService);
 	}
 
 	private void setOwnerReference(Deployment deployment, List<HasMetadata> resources) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerDriverConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient.PodCallbackHandler;
 import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.TestingKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.TestingKubernetesPod;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -217,7 +218,7 @@ public class KubernetesResourceManagerDriverTest extends ResourceManagerDriverTe
 					return FutureUtils.completedVoidFuture();
 				});
 
-		private TestingFlinkKubeClient flinkKubeClient;
+		private TestingKubeClientFactory kubeClientFactory;
 
 		PodCallbackHandler getPodCallbackHandler() {
 			try {
@@ -233,7 +234,7 @@ public class KubernetesResourceManagerDriverTest extends ResourceManagerDriverTe
 			flinkConfig.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
 			flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
-			flinkKubeClient = flinkKubeClientBuilder.build();
+			kubeClientFactory = new TestingKubeClientFactory(flinkKubeClientBuilder);
 		}
 
 		@Override
@@ -243,7 +244,7 @@ public class KubernetesResourceManagerDriverTest extends ResourceManagerDriverTe
 
 		@Override
 		protected ResourceManagerDriver<KubernetesWorkerNode> createResourceManagerDriver() {
-			return new KubernetesResourceManagerDriver(flinkConfig, flinkKubeClient, KUBERNETES_RESOURCE_MANAGER_CONFIGURATION);
+			return new KubernetesResourceManagerDriver(flinkConfig, kubeClientFactory, KUBERNETES_RESOURCE_MANAGER_CONFIGURATION);
 		}
 
 		@Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingKubeClientFactory.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingKubeClientFactory.java
@@ -19,28 +19,32 @@
 package org.apache.flink.kubernetes.kubeclient;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
 
 /**
- * Factory to create {@link FlinkKubeClient}.
+ * Testing implementation of {@link KubeClientFactory}.
  */
-public interface KubeClientFactory {
+public class TestingKubeClientFactory implements KubeClientFactory {
 
-	/**
-	 * Get the kubernetes client with the given configuration.
-	 *
-	 * @param configuration flink configuration
-	 * @return Return the kubernetes client with the specified configuration.
-	 */
-	FlinkKubeClient fromConfiguration(Configuration configuration);
+	private TestingFlinkKubeClient.Builder flinkKubeClientBuilder;
 
-	/**
-	 * Get the kubernetes client with the given configuration and io executor.
-	 *
-	 * @param configuration flink configuration
-	 * @param ioExecutor IO executor
-	 * @return Return the kubernetes client with the specified flink configuration and IO executor.
-	 */
-	FlinkKubeClient fromConfiguration(Configuration configuration, Executor ioExecutor);
+	public TestingKubeClientFactory(TestingFlinkKubeClient.Builder flinkKubeClientBuilder) {
+		this.flinkKubeClientBuilder = flinkKubeClientBuilder;
+	}
+
+	@Override
+	public FlinkKubeClient fromConfiguration(Configuration flinkConfig) {
+		return fromConfiguration(
+				flinkConfig,
+				Executors.newFixedThreadPool(2, new ExecutorThreadFactory("FlinkKubeClient-IO")));
+	}
+
+	@Override
+	public FlinkKubeClient fromConfiguration(Configuration flinkConfig, Executor ioExecutor) {
+		return flinkKubeClientBuilder.build();
+	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingKubeClientFactory.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingKubeClientFactory.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executors;
  */
 public class TestingKubeClientFactory implements KubeClientFactory {
 
-	private TestingFlinkKubeClient.Builder flinkKubeClientBuilder;
+	private final TestingFlinkKubeClient.Builder flinkKubeClientBuilder;
 
 	public TestingKubeClientFactory(TestingFlinkKubeClient.Builder flinkKubeClientBuilder) {
 		this.flinkKubeClientBuilder = flinkKubeClientBuilder;


### PR DESCRIPTION
## What is the purpose of the change

*Currently, the Kubernetes Client in `KubernetesResourceManagerDriver` is using a dedicated thread pool through calling `KubeClientFactory::createThreadPoolForAsyncIO` to create fixed thread pool. `KubernetesResourceManagerDriver` could get the io executor and eliminate the redundant thread pool. `KubeClientFactory` uses `KubeClientFactory::createThreadPoolForAsyncIO` by default.*

## Brief change log

  - *`KubernetesResourceManagerDriver` adds constructor with creating `FlinkKubeClient ` through `KubeClientFactory#fromConfiguration(flinkConfig, ioExecutor)` to reuse the io executor of `AbstractResourceManagerDriver`.*

## Verifying this change

  - *`TestingResourceManagerDriver` updates `initialize()` with `ExecutorService` type parameter to verify the `AbstractResourceManagerDriver` whether to work.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)