### PR TITLE
[FLINK-19770][python][test] Changed the PythonProgramOptionTest to be an ITCase.

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
@@ -23,9 +23,6 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -37,84 +34,20 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link PythonProgramOptions}.
+ * ITCases for {@link PythonProgramOptions}.
  */
 public class PythonProgramOptionsITCase {
 
-	private Options options;
-
-	@Before
-	public void setUp() {
-		options = new Options();
-		options.addOption(PY_OPTION);
-		options.addOption(PYFILES_OPTION);
-		options.addOption(PYMODULE_OPTION);
-		options.addOption(PYREQUIREMENTS_OPTION);
-		options.addOption(PYARCHIVE_OPTION);
-		options.addOption(PYEXEC_OPTION);
-	}
-
-	@Test
-	public void testCreateProgramOptionsWithPythonCommandLine() throws CliArgsException {
-		String[] parameters = {
-			"-py", "test.py",
-			"-pym", "test",
-			"-pyfs", "test1.py,test2.zip,test3.egg,test4_dir",
-			"-pyreq", "a.txt#b_dir",
-			"-pyarch", "c.zip#venv,d.zip",
-			"-pyexec", "bin/python",
-			"userarg1", "userarg2"
-		};
-
-		CommandLine line = CliFrontendParser.parse(options, parameters, false);
-		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
-		Configuration config = new Configuration();
-		programOptions.applyToConfiguration(config);
-		assertEquals("test1.py,test2.zip,test3.egg,test4_dir", config.get(PythonOptions.PYTHON_FILES));
-		assertEquals("a.txt#b_dir", config.get(PYTHON_REQUIREMENTS));
-		assertEquals("c.zip#venv,d.zip", config.get(PythonOptions.PYTHON_ARCHIVES));
-		assertEquals("bin/python", config.get(PYTHON_EXECUTABLE));
-		assertArrayEquals(
-			new String[] {"--python", "test.py", "--pyModule", "test", "userarg1", "userarg2"},
-			programOptions.getProgramArgs());
-	}
-
-	@Test
-	public void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
-		String[] args = {
-			"--python", "xxx.py",
-			"--pyModule", "xxx",
-			"--pyFiles", "/absolute/a.py,relative/b.py,relative/c.py",
-			"--pyRequirements", "d.txt#e_dir",
-			"--pyExecutable", "/usr/bin/python",
-			"--pyArchives", "g.zip,h.zip#data,h.zip#data2",
-			"userarg1", "userarg2"
-		};
-		CommandLine line = CliFrontendParser.parse(options, args, false);
-		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
-		Configuration config = new Configuration();
-		programOptions.applyToConfiguration(config);
-		assertEquals("/absolute/a.py,relative/b.py,relative/c.py", config.get(PythonOptions.PYTHON_FILES));
-		assertEquals("d.txt#e_dir", config.get(PYTHON_REQUIREMENTS));
-		assertEquals("g.zip,h.zip#data,h.zip#data2", config.get(PythonOptions.PYTHON_ARCHIVES));
-		assertEquals("/usr/bin/python", config.get(PYTHON_EXECUTABLE));
-		assertArrayEquals(
-			new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
-			programOptions.getProgramArgs());
-	}
-
+	/**
+	 * It requires setting a job jar to build a PackagedProgram, and the dummy job jar used in this
+	 * test case is available only after the packaging phase completed, so we make it as an ITCase.
+	 * */
 	@Test
 	public void testConfigurePythonExecution() throws IllegalAccessException, NoSuchFieldException, CliArgsException, ProgramInvocationException, IOException {
 		final String[] args = {
@@ -154,5 +87,4 @@ public class PythonProgramOptionsITCase {
 			new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
 			packagedProgram.getArguments());
 	}
-
 }

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
@@ -45,9 +45,10 @@ import static org.junit.Assert.assertEquals;
 public class PythonProgramOptionsITCase {
 
 	/**
-	 * It requires setting a job jar to build a PackagedProgram, and the dummy job jar used in this
-	 * test case is available only after the packaging phase completed, so we make it as an ITCase.
-	 * */
+	 * It requires setting a job jar to build a {@link PackagedProgram}, and the dummy job jar used
+	 * in this test case is available only after the packaging phase completed, so we make it as an
+	 * ITCase.
+	 **/
 	@Test
 	public void testConfigurePythonExecution() throws IllegalAccessException, NoSuchFieldException, CliArgsException, ProgramInvocationException, IOException {
 		final String[] args = {

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link PythonProgramOptions}.
  */
-public class PythonProgramOptionsTest {
+public class PythonProgramOptionsITCase {
 
 	private Options options;
 
@@ -128,7 +128,7 @@ public class PythonProgramOptionsTest {
 		};
 
 		final File[] dummyJobJar = {null};
-		Files.walkFileTree(FileSystems.getDefault().getPath("target/dummy-job-jar"), new SimpleFileVisitor<Path>() {
+		Files.walkFileTree(FileSystems.getDefault().getPath(System.getProperty("user.dir") + "/dummy-job-jar"), new SimpleFileVisitor<Path>() {
 			@Override
 			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
 				FileVisitResult result = super.visitFile(file, attrs);

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
@@ -1,0 +1,87 @@
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.PythonOptions;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
+import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
+import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link PythonProgramOptions}.
+ */
+public class PythonProgramOptionsTest {
+	private Options options;
+
+	@Before
+	public void setUp() {
+		options = new Options();
+		options.addOption(PY_OPTION);
+		options.addOption(PYFILES_OPTION);
+		options.addOption(PYMODULE_OPTION);
+		options.addOption(PYREQUIREMENTS_OPTION);
+		options.addOption(PYARCHIVE_OPTION);
+		options.addOption(PYEXEC_OPTION);
+	}
+
+	@Test
+	public void testCreateProgramOptionsWithPythonCommandLine() throws CliArgsException {
+		String[] parameters = {
+			"-py", "test.py",
+			"-pym", "test",
+			"-pyfs", "test1.py,test2.zip,test3.egg,test4_dir",
+			"-pyreq", "a.txt#b_dir",
+			"-pyarch", "c.zip#venv,d.zip",
+			"-pyexec", "bin/python",
+			"userarg1", "userarg2"
+		};
+
+		CommandLine line = CliFrontendParser.parse(options, parameters, false);
+		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
+		Configuration config = new Configuration();
+		programOptions.applyToConfiguration(config);
+		assertEquals("test1.py,test2.zip,test3.egg,test4_dir", config.get(PythonOptions.PYTHON_FILES));
+		assertEquals("a.txt#b_dir", config.get(PYTHON_REQUIREMENTS));
+		assertEquals("c.zip#venv,d.zip", config.get(PythonOptions.PYTHON_ARCHIVES));
+		assertEquals("bin/python", config.get(PYTHON_EXECUTABLE));
+		assertArrayEquals(
+			new String[] {"--python", "test.py", "--pyModule", "test", "userarg1", "userarg2"},
+			programOptions.getProgramArgs());
+	}
+
+	@Test
+	public void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
+		String[] args = {
+			"--python", "xxx.py",
+			"--pyModule", "xxx",
+			"--pyFiles", "/absolute/a.py,relative/b.py,relative/c.py",
+			"--pyRequirements", "d.txt#e_dir",
+			"--pyExecutable", "/usr/bin/python",
+			"--pyArchives", "g.zip,h.zip#data,h.zip#data2",
+			"userarg1", "userarg2"
+		};
+		CommandLine line = CliFrontendParser.parse(options, args, false);
+		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
+		Configuration config = new Configuration();
+		programOptions.applyToConfiguration(config);
+		assertEquals("/absolute/a.py,relative/b.py,relative/c.py", config.get(PythonOptions.PYTHON_FILES));
+		assertEquals("d.txt#e_dir", config.get(PYTHON_REQUIREMENTS));
+		assertEquals("g.zip,h.zip#data,h.zip#data2", config.get(PythonOptions.PYTHON_ARCHIVES));
+		assertEquals("/usr/bin/python", config.get(PYTHON_EXECUTABLE));
+		assertArrayEquals(
+			new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
+			programOptions.getProgramArgs());
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixed the error that PythonProgramOptionsTest requires package phase before execution. 

## Brief change log

Changed the PythonProgramOptionsTest to be an ITCase and the path of dummy job jar from a relative path to absolute path.

## Verifying this change

This change has test case covered by PythonProgramOptionTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
