### PR TITLE
[FLINK-18117][e2e] Add debugging information for hadoop startup

### DIFF
--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 # install dev tools
 RUN set -x \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    curl tar sudo openssh-server openssh-client rsync unzip krb5-user
+    curl tar sudo openssh-server openssh-client rsync unzip krb5-user net-tools
 
 # Kerberos client
 RUN set -x \

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/bootstrap.sh
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/bootstrap.sh
@@ -92,11 +92,11 @@ if [ "$1" == "--help" -o "$1" == "-h" ]; then
     exit 0
 elif [ "$1" == "master" ]; then
     yes| sudo -E -u hdfs $HADOOP_PREFIX/bin/hdfs namenode -format
-    sudo -E sudo netstat -tulpn >> /var/log/hadoop/debugging.out
+    sudo -E netstat -tulpn >> /var/log/hadoop/debugging.out
     echo "--------------------" >> /var/log/hadoop/debugging.out
-    sudo -E sudo ps -aux >> /var/log/hadoop/debugging.out
+    sudo -E ps -aux >> /var/log/hadoop/debugging.out
     echo "--------------------" >> /var/log/hadoop/debugging.out
-    sudo -E sudo jps -v >> /var/log/hadoop/debugging.out
+    sudo -E jps -v >> /var/log/hadoop/debugging.out
     echo "--------------------" >> /var/log/hadoop/debugging.out
     nohup sudo -E -u hdfs $HADOOP_PREFIX/bin/hdfs namenode 2>> /var/log/hadoop/namenode.err >> /var/log/hadoop/namenode.out &
     nohup sudo -E -u yarn $HADOOP_PREFIX/bin/yarn resourcemanager 2>> /var/log/hadoop/resourcemanager.err >> /var/log/hadoop/resourcemanager.out &

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/bootstrap.sh
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/bootstrap.sh
@@ -92,7 +92,12 @@ if [ "$1" == "--help" -o "$1" == "-h" ]; then
     exit 0
 elif [ "$1" == "master" ]; then
     yes| sudo -E -u hdfs $HADOOP_PREFIX/bin/hdfs namenode -format
-
+    sudo -E sudo netstat -tulpn >> /var/log/hadoop/debugging.out
+    echo "--------------------" >> /var/log/hadoop/debugging.out
+    sudo -E sudo ps -aux >> /var/log/hadoop/debugging.out
+    echo "--------------------" >> /var/log/hadoop/debugging.out
+    sudo -E sudo jps -v >> /var/log/hadoop/debugging.out
+    echo "--------------------" >> /var/log/hadoop/debugging.out
     nohup sudo -E -u hdfs $HADOOP_PREFIX/bin/hdfs namenode 2>> /var/log/hadoop/namenode.err >> /var/log/hadoop/namenode.out &
     nohup sudo -E -u yarn $HADOOP_PREFIX/bin/yarn resourcemanager 2>> /var/log/hadoop/resourcemanager.err >> /var/log/hadoop/resourcemanager.out &
     nohup sudo -E -u yarn $HADOOP_PREFIX/bin/yarn timelineserver 2>> /var/log/hadoop/timelineserver.err >> /var/log/hadoop/timelineserver.out &

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -111,10 +111,19 @@ function post_test_validation {
 }
 
 function log_environment_info {
+    echo "##[group]Environment Information"
     echo "Jps"
     jps
+
     echo "Disk information"
     df -hH
+
+    echo "Allocated ports"
+    sudo netstat -tulpn
+
+    echo "Running docker containers"
+    docker ps -a
+    echo "##[endgroup]"
 }
 
 # Shuts down cluster and reverts changes to cluster configs


### PR DESCRIPTION

## What is the purpose of the change

This adds some non-invasive environment debugging to understand why the namenode can not allocate the http port inside a docker container.
I was not able to reproduce the failing e2e test.


