### PR TITLE
[FLINK-19627][table-runtime] Introduce multiple input operator for batch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInputNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInputNode.scala
@@ -97,7 +97,7 @@ class BatchExecMultipleInputNode(
     // set resources
     multipleInputTransform.setResources(generator.getMinResources, generator.getPreferredResources)
     val memoryKB = generator.getManagedMemoryWeight
-    ExecNode.setManagedMemoryWeight(multipleInputTransform, memoryKB * 1024)
+    ExecNode.setManagedMemoryWeight(multipleInputTransform, memoryKB * 1024L)
 
     multipleInputTransform
   }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSelectionHandler;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link MultipleInputStreamOperatorBase} to handle batch operators.
+ */
+public class BatchMultipleInputStreamOperator
+		extends MultipleInputStreamOperatorBase
+		implements BoundedMultiInput, InputSelectable {
+	private static final long serialVersionUID = 1L;
+
+	private final InputSelectionHandler inputSelectionHandler;
+
+	public BatchMultipleInputStreamOperator(
+			StreamOperatorParameters<RowData> parameters,
+			List<InputSpec> inputSpecs,
+			List<TableOperatorWrapper<?>> headWrapper,
+			TableOperatorWrapper<?> tailWrapper) {
+		super(parameters, inputSpecs, headWrapper, tailWrapper);
+		inputSelectionHandler = new InputSelectionHandler(inputSpecs);
+	}
+
+	@Override
+	public void endInput(int inputId) throws Exception {
+		inputSelectionHandler.endInput(inputId);
+		InputSpec inputSpec = inputSpecMap.get(inputId);
+		inputSpec.getOutput().endOperatorInput(inputSpec.getOutputOpInputId());
+	}
+
+	@Override
+	public InputSelection nextSelection() {
+		return inputSelectionHandler.getInputSelection();
+	}
+
+	protected StreamConfig createStreamConfig(
+			StreamOperatorParameters<RowData> multipleInputOperatorParameters,
+			TableOperatorWrapper<?> wrapper) {
+		StreamConfig streamConfig = super.createStreamConfig(multipleInputOperatorParameters, wrapper);
+		checkState(wrapper.getManagedMemoryFraction() >= 0);
+		Configuration taskManagerConfig = getRuntimeContext().getTaskManagerRuntimeInfo().getConfiguration();
+		double managedMemoryFraction = multipleInputOperatorParameters.getStreamConfig()
+				.getManagedMemoryFractionOperatorUseCaseOfSlot(
+						ManagedMemoryUseCase.BATCH_OP,
+						taskManagerConfig,
+						getRuntimeContext().getUserCodeClassLoader()) *
+				wrapper.getManagedMemoryFraction();
+		streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, managedMemoryFraction);
+		return streamConfig;
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.multipleinput;
 
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.table.data.RowData;
@@ -28,7 +27,7 @@ import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
 import java.util.List;
 
 /**
- * The factory to create batch {@link MultipleInputStreamOperator}.
+ * The factory to create {@link BatchMultipleInputStreamOperator}.
  */
 public class BatchMultipleInputStreamOperatorFactory extends AbstractStreamOperatorFactory<RowData> {
 	private static final long serialVersionUID = 1L;
@@ -46,14 +45,18 @@ public class BatchMultipleInputStreamOperatorFactory extends AbstractStreamOpera
 		this.tailWrapper = tailWrapper;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends StreamOperator<RowData>> T createStreamOperator(
-			StreamOperatorParameters<RowData> parameters) {
-		throw new UnsupportedOperationException("Unsupported now.");
+	public <T extends StreamOperator<RowData>> T createStreamOperator(StreamOperatorParameters<RowData> parameters) {
+		return (T) new BatchMultipleInputStreamOperator(
+				parameters,
+				inputSpecs,
+				headWrappers,
+				tailWrapper);
 	}
 
 	@Override
 	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
-		throw new UnsupportedOperationException("Unsupported now.");
+		return BatchMultipleInputStreamOperator.class;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.multipleinput.input.FirstInputOfTwoInput;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+import org.apache.flink.table.runtime.operators.multipleinput.input.OneInput;
+import org.apache.flink.table.runtime.operators.multipleinput.input.SecondInputOfTwoInput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.BroadcastingOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.CopyingBroadcastingOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.CopyingFirstInputOfTwoInputStreamOperatorOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.CopyingOneInputStreamOperatorOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.CopyingSecondInputOfTwoInputStreamOperatorOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.FirstInputOfTwoInputStreamOperatorOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.OneInputStreamOperatorOutput;
+import org.apache.flink.table.runtime.operators.multipleinput.output.SecondInputOfTwoInputStreamOperatorOutput;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Base {@link MultipleInputStreamOperator} to handle multiple inputs in table module.
+ */
+public abstract class MultipleInputStreamOperatorBase
+		extends AbstractStreamOperatorV2<RowData>
+		implements MultipleInputStreamOperator<RowData> {
+
+	private final List<InputSpec> inputSpecs;
+
+	protected final Map<Integer, InputSpec> inputSpecMap;
+
+	/**
+	 * The head operators of this multiple input operator.
+	 */
+	private final List<TableOperatorWrapper<?>> headWrappers;
+
+	/**
+	 * The tail operator of this multiple input operator.
+	 */
+	private final TableOperatorWrapper<?> tailWrapper;
+
+	/**
+	 * all operator as topological ordering in this multiple input operator.
+	 */
+	protected final Deque<TableOperatorWrapper<?>> topologicalOrderingOperators;
+
+	public MultipleInputStreamOperatorBase(
+			StreamOperatorParameters<RowData> parameters,
+			List<InputSpec> inputSpecs,
+			List<TableOperatorWrapper<?>> headWrappers,
+			TableOperatorWrapper<?> tailWrapper) {
+		super(parameters, inputSpecs.size());
+		this.inputSpecs = inputSpecs;
+		this.headWrappers = headWrappers;
+		this.tailWrapper = tailWrapper;
+		// get all operator list as topological ordering
+		this.topologicalOrderingOperators = getAllOperatorsAsTopologicalOrdering();
+		// create all operators by corresponding operator factory
+		createAllOperators(parameters);
+		this.inputSpecMap = inputSpecs.stream().collect(Collectors.toMap(InputSpec::getMultipleInputId, s -> s));
+		checkArgument(inputSpecMap.size() == inputSpecs.size());
+	}
+
+	@Override
+	public List<Input> getInputs() {
+		return inputSpecs.stream().map(this::createInput).collect(Collectors.toList());
+	}
+
+	private Input createInput(InputSpec inputSpec) {
+		StreamOperator<RowData> operator = inputSpec.getOutput().getStreamOperator();
+		if (operator instanceof OneInputStreamOperator) {
+			return new OneInput((OneInputStreamOperator<RowData, RowData>) operator);
+		} else if (operator instanceof TwoInputStreamOperator) {
+			TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
+					(TwoInputStreamOperator<RowData, RowData, RowData>) operator;
+			if (inputSpec.getOutputOpInputId() == 1) {
+				return new FirstInputOfTwoInput(twoInputOp);
+			} else {
+				return new SecondInputOfTwoInput(twoInputOp);
+			}
+		} else {
+			throw new RuntimeException("Unsupported StreamOperator: " + operator);
+		}
+	}
+
+	/**
+	 * Open all sub-operators in a multiple input operator from <b>tail to head</b>,
+	 * contrary to {@link StreamOperator#close()} which happens <b>head to tail</b>
+	 * (see {@link #close()}).
+	 */
+	@Override
+	public void open() throws Exception {
+		super.open();
+		final Iterator<TableOperatorWrapper<?>> it = topologicalOrderingOperators.descendingIterator();
+		while (it.hasNext()) {
+			StreamOperator<?> operator = it.next().getStreamOperator();
+			operator.open();
+		}
+	}
+
+	/**
+	 * Closes all sub-operators in a multiple input operator effect way. Closing happens from <b>head to tail</b>
+	 * sub-operator in a multiple input operator, contrary to {@link StreamOperator#open()}
+	 * which happens <b>tail to head</b>.
+	 */
+	@Override
+	public void close() throws Exception {
+		super.close();
+		for (TableOperatorWrapper<?> wrapper : topologicalOrderingOperators) {
+			wrapper.close();
+		}
+	}
+
+	/**
+	 * Dispose all sub-operators in a multiple input operator effect way. Disposing happens from <b>head to tail</b>
+	 * sub-operator in a multiple input operator, contrary to {@link StreamOperator#open()}
+	 * which happens <b>tail to head</b>.
+	 */
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		for (TableOperatorWrapper<?> wrapper : topologicalOrderingOperators) {
+			StreamOperator<?> operator = wrapper.getStreamOperator();
+			operator.dispose();
+		}
+	}
+
+	private Deque<TableOperatorWrapper<?>> getAllOperatorsAsTopologicalOrdering() {
+		final Deque<TableOperatorWrapper<?>> allOperators = new ArrayDeque<>();
+		final Queue<TableOperatorWrapper<?>> toVisitOperators = new LinkedList<>();
+
+		// mapping an operator to its input count
+		final Map<TableOperatorWrapper<?>, Integer> operatorToInputCount = buildOperatorToInputCountMap();
+
+		// find the operators which all inputs are not in this multiple input operator to traverse first
+		for (TableOperatorWrapper<?> wrapper : headWrappers) {
+			if (operatorToInputCount.get(wrapper) == 0) {
+				toVisitOperators.add(wrapper);
+			}
+		}
+		checkArgument(!toVisitOperators.isEmpty(), "This should not happen.");
+
+		while (!toVisitOperators.isEmpty()) {
+			TableOperatorWrapper<?> wrapper = toVisitOperators.poll();
+			allOperators.add(wrapper);
+
+			for (TableOperatorWrapper<?> output : wrapper.getOutputWrappers()) {
+				int inputCountRemaining = operatorToInputCount.get(output) - 1;
+				operatorToInputCount.put(output, inputCountRemaining);
+				if (inputCountRemaining == 0) {
+					toVisitOperators.add(output);
+				}
+			}
+		}
+
+		return allOperators;
+	}
+
+	private Map<TableOperatorWrapper<?>, Integer> buildOperatorToInputCountMap() {
+		final Map<TableOperatorWrapper<?>, Integer> operatorToInputCount = new IdentityHashMap<>();
+		final Queue<TableOperatorWrapper<?>> toVisitOperators = new LinkedList<>();
+		toVisitOperators.add(tailWrapper);
+
+		while (!toVisitOperators.isEmpty()) {
+			TableOperatorWrapper<?> wrapper = toVisitOperators.poll();
+			List<TableOperatorWrapper<?>> inputs = wrapper.getInputWrappers();
+			operatorToInputCount.put(wrapper, inputs.size());
+			toVisitOperators.addAll(inputs);
+		}
+
+		return operatorToInputCount;
+	}
+
+	/**
+	 * Create all sub-operators by corresponding operator factory in a multiple input operator from <b>tail to head</b>.
+	 */
+	@SuppressWarnings("unchecked")
+	private void createAllOperators(StreamOperatorParameters<RowData> parameters) {
+		final boolean isObjectReuseEnabled = parameters.getContainingTask().getExecutionConfig().isObjectReuseEnabled();
+		final ExecutionConfig executionConfig = parameters.getContainingTask().getExecutionConfig();
+		final Iterator<TableOperatorWrapper<?>> it = topologicalOrderingOperators.descendingIterator();
+
+		while (it.hasNext()) {
+			final TableOperatorWrapper<?> wrapper = it.next();
+			final Output<StreamRecord<RowData>> output;
+			if (wrapper == this.tailWrapper) {
+				output = this.output;
+			} else {
+				final int numberOfOutputs = wrapper.getOutputEdges().size();
+				final Output<StreamRecord<RowData>>[] outputs = new Output[numberOfOutputs];
+				for (int i = 0; i < numberOfOutputs; ++i) {
+					TableOperatorWrapper.Edge edge = wrapper.getOutputEdges().get(i);
+					int inputId = edge.getInputId();
+					StreamOperator<RowData> outputOperator = edge.getTarget().getStreamOperator();
+					if (isObjectReuseEnabled) {
+						outputs[i] = createOutput(outputOperator, inputId);
+					} else {
+						// the source's output type info is equal to the target's type info for the corresponding index
+						TypeSerializer<RowData> serializer =
+								(TypeSerializer<RowData>) edge.getSource().getOutputType().createSerializer(executionConfig);
+						outputs[i] = createCopyingOutput(serializer, outputOperator, inputId);
+					}
+				}
+				if (outputs.length == 1) {
+					output = outputs[0];
+				} else {
+					if (isObjectReuseEnabled) {
+						output = new BroadcastingOutput(outputs);
+					} else {
+						output = new CopyingBroadcastingOutput(outputs);
+					}
+				}
+			}
+			final StreamOperatorParameters<RowData> newParameters =
+					createSubOperatorParameters(parameters, output, wrapper);
+			wrapper.createOperator(newParameters);
+		}
+	}
+
+	private StreamOperatorParameters<RowData> createSubOperatorParameters(
+			StreamOperatorParameters<RowData> multipleInputOperatorParameters,
+			Output<StreamRecord<RowData>> output,
+			TableOperatorWrapper<?> wrapper) {
+		final StreamConfig streamConfig = createStreamConfig(multipleInputOperatorParameters, wrapper);
+		return new StreamOperatorParameters<>(
+				multipleInputOperatorParameters.getContainingTask(),
+				streamConfig,
+				output,
+				multipleInputOperatorParameters::getProcessingTimeService,
+				multipleInputOperatorParameters.getOperatorEventDispatcher()
+		);
+	}
+
+	protected StreamConfig createStreamConfig(
+			StreamOperatorParameters<RowData> multipleInputOperatorParameters,
+			TableOperatorWrapper<?> wrapper) {
+		final ExecutionConfig executionConfig = getExecutionConfig();
+
+		final StreamConfig streamConfig = new StreamConfig(
+				multipleInputOperatorParameters.getStreamConfig().getConfiguration().clone());
+		streamConfig.setOperatorName(wrapper.getOperatorName());
+		streamConfig.setNumberOfNetworkInputs(wrapper.getAllInputTypes().size());
+		streamConfig.setNumberOfOutputs(wrapper.getOutputEdges().size());
+		streamConfig.setTypeSerializersIn(
+				wrapper.getAllInputTypes().stream().map(
+						t -> t.createSerializer(executionConfig)).toArray(TypeSerializer[]::new));
+		streamConfig.setTypeSerializerOut(wrapper.getOutputType().createSerializer(executionConfig));
+		return streamConfig;
+	}
+
+	private Output<StreamRecord<RowData>> createOutput(
+			StreamOperator<RowData> outputOperator,
+			int inputId) {
+		if (outputOperator instanceof OneInputStreamOperator) {
+			OneInputStreamOperator<RowData, RowData> oneInputOp =
+					(OneInputStreamOperator<RowData, RowData>) outputOperator;
+			return new OneInputStreamOperatorOutput(oneInputOp);
+		} else if (outputOperator instanceof TwoInputStreamOperator) {
+			TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
+					(TwoInputStreamOperator<RowData, RowData, RowData>) outputOperator;
+			if (inputId == 1) {
+				return new FirstInputOfTwoInputStreamOperatorOutput(twoInputOp);
+			} else {
+				return new SecondInputOfTwoInputStreamOperatorOutput(twoInputOp);
+			}
+		} else {
+			throw new RuntimeException("Unsupported StreamOperator: " + outputOperator);
+		}
+	}
+
+	private Output<StreamRecord<RowData>> createCopyingOutput(
+			TypeSerializer<RowData> serializer,
+			StreamOperator<RowData> outputOperator,
+			int inputId) {
+		if (outputOperator instanceof OneInputStreamOperator) {
+			final OneInputStreamOperator<RowData, RowData> oneInputOp =
+					(OneInputStreamOperator<RowData, RowData>) outputOperator;
+			return new CopyingOneInputStreamOperatorOutput(oneInputOp, serializer);
+		} else if (outputOperator instanceof TwoInputStreamOperator) {
+			final TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
+					(TwoInputStreamOperator<RowData, RowData, RowData>) outputOperator;
+			if (inputId == 1) {
+				return new CopyingFirstInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer);
+			} else {
+				return new CopyingSecondInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer);
+			}
+		} else {
+			throw new RuntimeException("Unsupported StreamOperator: " + outputOperator);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.operators.multipleinput;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
@@ -47,12 +46,12 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class TableOperatorWrapperGenerator {
 
 	/**
-	 * Original input transformations for {@link MultipleInputStreamOperator}.
+	 * Original input transformations for {@link MultipleInputStreamOperatorBase}.
 	 */
 	private final List<Transformation<?>> inputTransforms;
 
 	/**
-	 * The tail (root) transformation of the transformation-graph in {@link MultipleInputStreamOperator}.
+	 * The tail (root) transformation of the transformation-graph in {@link MultipleInputStreamOperatorBase}.
 	 */
 	private final Transformation<?> tailTransform;
 
@@ -67,12 +66,12 @@ public class TableOperatorWrapperGenerator {
 	private final List<Pair<Transformation<?>, InputSpec>> inputTransformAndInputSpecPairs;
 
 	/**
-	 * The head (leaf) operator wrappers of the operator-graph in {@link MultipleInputStreamOperator}.
+	 * The head (leaf) operator wrappers of the operator-graph in {@link MultipleInputStreamOperatorBase}.
 	 */
 	private final List<TableOperatorWrapper<?>> headWrappers;
 
 	/**
-	 * The tail (root) operator wrapper of the operator-graph in {@link MultipleInputStreamOperator}.
+	 * The tail (root) operator wrapper of the operator-graph in {@link MultipleInputStreamOperatorBase}.
 	 */
 	private TableOperatorWrapper<?> tailWrapper;
 
@@ -81,7 +80,7 @@ public class TableOperatorWrapperGenerator {
 	 */
 	private final Map<Transformation<?>, TableOperatorWrapper<?>> visitedTransforms;
 	/**
-	 * The identifier for each sub operator in {@link MultipleInputStreamOperator}.
+	 * The identifier for each sub operator in {@link MultipleInputStreamOperatorBase}.
 	 */
 	private int identifierOfSubOp = 0;
 
@@ -92,7 +91,7 @@ public class TableOperatorWrapperGenerator {
 	/**
 	 * managed memory weight for batch operator.
 	 */
-	private int managedMemoryWeight;
+	private long managedMemoryWeight;
 
 	public TableOperatorWrapperGenerator(
 			List<Transformation<?>> inputTransforms,
@@ -149,7 +148,7 @@ public class TableOperatorWrapperGenerator {
 		return preferredResources;
 	}
 
-	public int getManagedMemoryWeight() {
+	public long getManagedMemoryWeight() {
 		return managedMemoryWeight;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/UnionStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/UnionStreamOperator.java
@@ -20,13 +20,12 @@ package org.apache.flink.table.runtime.operators.multipleinput;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.table.data.RowData;
 
 /**
  * A special operator which collects all inputs' records and forwards them
- * in {@link MultipleInputStreamOperator}.
+ * in {@link MultipleInputStreamOperatorBase}.
  */
 public class UnionStreamOperator extends StreamMap<RowData, RowData> implements BoundedMultiInput {
 	private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * {@link Input} for the first input of {@link TwoInputStreamOperator}.
+ */
+public class FirstInputOfTwoInput extends InputBase {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+
+	public FirstInputOfTwoInput(TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		this.operator = operator;
+	}
+
+	@Override
+	public void processElement(StreamRecord<RowData> element) throws Exception {
+		operator.processElement1(element);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		operator.processWatermark1(mark);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		operator.processLatencyMarker1(latencyMarker);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputBase.java
@@ -19,12 +19,12 @@
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
 import org.apache.flink.streaming.api.operators.Input;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputStreamOperatorBase;
 
 /**
- * Base {@link Input} used in {@link MultipleInputStreamOperator}.
+ * Base {@link Input} used in {@link MultipleInputStreamOperatorBase}.
  */
 public abstract class InputBase implements Input<RowData> {
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputBase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Base {@link Input} used in {@link MultipleInputStreamOperator}.
+ */
+public abstract class InputBase implements Input<RowData> {
+
+	@Override
+	public void setKeyContextElement(StreamRecord<RowData> record) throws Exception {
+		// do nothing
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandler.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * This handler is mainly used for selecting the next available input index
+ * according to read priority in {@link MultipleInputStreamOperator}.
+ *
+ * <p>Input read order: the input with high priority (the value of read order is lower)
+ * will be read first, the inputs with same priorities will be read fairly.
+ */
+public class InputSelectionHandler {
+	private final List<InputSpec> inputSpecs;
+	private final int numberOfInput;
+	/** All inputs ids sorted by priority. */
+	private final List<List<Integer>> sortedAvailableInputs;
+	private InputSelection inputSelection;
+
+	public InputSelectionHandler(List<InputSpec> inputSpecs) {
+		this.inputSpecs = inputSpecs;
+		this.numberOfInput = inputSpecs.size();
+		this.sortedAvailableInputs = buildSortedAvailableInputs();
+		// read the highest priority inputs first
+		this.inputSelection = buildInputSelection(sortedAvailableInputs.get(0));
+	}
+
+	public InputSelection getInputSelection() {
+		return inputSelection;
+	}
+
+	public void endInput(int inputId) {
+		List<Integer> inputIds = sortedAvailableInputs.get(0);
+		checkState(inputIds.remove(Integer.valueOf(inputId)), "This should not happen.");
+		if (inputIds.isEmpty()) {
+			// remove the finished input
+			sortedAvailableInputs.remove(0);
+
+			if (sortedAvailableInputs.isEmpty()) {
+				// all inputs are finished
+				inputIds = new ArrayList<>();
+			} else {
+				// read next one
+				inputIds = sortedAvailableInputs.get(0);
+			}
+			inputSelection = buildInputSelection(inputIds);
+		}
+	}
+
+	private List<List<Integer>> buildSortedAvailableInputs() {
+		final SortedMap<Integer, List<Integer>> orderedAvailableInputIds = new TreeMap<>();
+		for (InputSpec inputSpec : inputSpecs) {
+			List<Integer> inputIds = orderedAvailableInputIds
+					.computeIfAbsent(inputSpec.getReadOrder(), k -> new LinkedList<>());
+			inputIds.add(inputSpec.getMultipleInputId());
+		}
+		return new LinkedList<>(orderedAvailableInputIds.values());
+	}
+
+	private InputSelection buildInputSelection(List<Integer> inputIds) {
+		if (inputIds.isEmpty()) {
+			// even all inputs are finished, an InputSelection instance should be returned.
+			// see StreamMultipleInputProcessor#processInput
+			return InputSelection.ALL;
+		}
+		InputSelection.Builder builder = new InputSelection.Builder();
+		inputIds.forEach(builder::select);
+		return builder.build(numberOfInput);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandler.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandler.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
 import org.apache.flink.streaming.api.operators.InputSelection;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputStreamOperatorBase;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * This handler is mainly used for selecting the next available input index
- * according to read priority in {@link MultipleInputStreamOperator}.
+ * according to read priority in {@link MultipleInputStreamOperatorBase}.
  *
  * <p>Input read order: the input with high priority (the value of read order is lower)
  * will be read first, the inputs with same priorities will be read fairly.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSpec.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSpec.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
 import org.apache.flink.streaming.api.operators.Input;
-import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputStreamOperatorBase;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper;
 
 import java.io.Serializable;
@@ -35,7 +35,7 @@ public class InputSpec implements Serializable {
 
 	/**
 	 * The input id (start from 1) used for identifying each {@link Input}
-	 * in {@link MultipleInputStreamOperator#getInputs()}.
+	 * in {@link MultipleInputStreamOperatorBase#getInputs()}.
 	 */
 	private final int multipleInputId;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * {@link Input} for {@link OneInputStreamOperator}.
+ */
+public class OneInput extends InputBase {
+
+	private final OneInputStreamOperator<RowData, RowData> operator;
+
+	public OneInput(OneInputStreamOperator<RowData, RowData> operator) {
+		this.operator = operator;
+	}
+
+	@Override
+	public void processElement(StreamRecord<RowData> element) throws Exception {
+		operator.processElement(element);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		operator.processWatermark(mark);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		operator.processLatencyMarker(latencyMarker);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * {@link Input} for the second input of {@link TwoInputStreamOperator}.
+ */
+public class SecondInputOfTwoInput extends InputBase {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+
+	public SecondInputOfTwoInput(TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		this.operator = operator;
+	}
+
+	@Override
+	public void processElement(StreamRecord<RowData> element) throws Exception {
+		operator.processElement2(element);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		operator.processWatermark2(mark);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		operator.processLatencyMarker2(latencyMarker);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/BroadcastingOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/BroadcastingOutput.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.XORShiftRandom;
+
+import java.util.Random;
+
+/**
+ * An {@link Output} that can be used to emit elements and other messages to multiple outputs.
+ *
+ * <p>The functionality of this class is similar to {@link OperatorChain#BroadcastingOutputCollector}.
+ */
+public class BroadcastingOutput implements Output<StreamRecord<RowData>> {
+	protected final Output<StreamRecord<RowData>>[] outputs;
+	private final Random random = new XORShiftRandom();
+
+	public BroadcastingOutput(Output<StreamRecord<RowData>>[] outputs) {
+		this.outputs = outputs;
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		for (Output<StreamRecord<RowData>> output : outputs) {
+			output.emitWatermark(mark);
+		}
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		for (Output<StreamRecord<RowData>> output : outputs) {
+			output.collect(outputTag, record);
+		}
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		if (outputs.length <= 0) {
+			// ignore
+		} else if (outputs.length == 1) {
+			outputs[0].emitLatencyMarker(latencyMarker);
+		} else {
+			// randomly select an output (see OperatorChain#BroadcastingOutputCollector)
+			outputs[random.nextInt(outputs.length)].emitLatencyMarker(latencyMarker);
+		}
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		for (Output<StreamRecord<RowData>> output : outputs) {
+			output.collect(record);
+		}
+	}
+
+	@Override
+	public void close() {
+		for (Output<StreamRecord<RowData>> output : outputs) {
+			output.close();
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingBroadcastingOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingBroadcastingOutput.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Special version of {@link BroadcastingOutput} that performs a shallow copy of the
+ * {@link StreamRecord} to ensure that multi-output works correctly.
+ *
+ * <p>The functionality of this class is similar to {@link OperatorChain#CopyingBroadcastingOutputCollector}.
+ */
+public class CopyingBroadcastingOutput extends BroadcastingOutput {
+
+	public CopyingBroadcastingOutput(Output<StreamRecord<RowData>>[] outputs) {
+		super(outputs);
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		for (int i = 0; i < outputs.length - 1; i++) {
+			StreamRecord<RowData> shallowCopy = record.copy(record.getValue());
+			outputs[i].collect(shallowCopy);
+		}
+
+		if (outputs.length > 0) {
+			// don't copy for the last output
+			outputs[outputs.length - 1].collect(record);
+		}
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		for (int i = 0; i < outputs.length - 1; i++) {
+			StreamRecord<X> shallowCopy = record.copy(record.getValue());
+			outputs[i].collect(outputTag, shallowCopy);
+		}
+
+		if (outputs.length > 0) {
+			// don't copy for the last output
+			outputs[outputs.length - 1].collect(outputTag, record);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingFirstInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingFirstInputOfTwoInputStreamOperatorOutput.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * An {@link Output} that can be used to emit copying elements and other messages
+ * for the first input of {@link TwoInputStreamOperator}.
+ */
+public class CopyingFirstInputOfTwoInputStreamOperatorOutput extends FirstInputOfTwoInputStreamOperatorOutput {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+	private final TypeSerializer<RowData> serializer;
+
+	public CopyingFirstInputOfTwoInputStreamOperatorOutput(
+			TwoInputStreamOperator<RowData, RowData, RowData> operator,
+			TypeSerializer<RowData> serializer) {
+		super(operator);
+		this.operator = operator;
+		this.serializer = serializer;
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+			StreamRecord<RowData> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
+
+			operator.processElement1(copy);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingOneInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingOneInputStreamOperatorOutput.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * An {@link Output} that can be used to emit copying elements and other messages for {@link OneInputStreamOperator}.
+ */
+public class CopyingOneInputStreamOperatorOutput extends OneInputStreamOperatorOutput {
+
+	private final OneInputStreamOperator<RowData, RowData> operator;
+	private final TypeSerializer<RowData> serializer;
+
+	public CopyingOneInputStreamOperatorOutput(
+			OneInputStreamOperator<RowData, RowData> operator,
+			TypeSerializer<RowData> serializer) {
+		super(operator);
+		this.operator = operator;
+		this.serializer = serializer;
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+			StreamRecord<RowData> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
+
+			operator.processElement(copy);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingSecondInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingSecondInputOfTwoInputStreamOperatorOutput.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * An {@link Output} that can be used to emit copying elements and other messages
+ * for the second input of {@link TwoInputStreamOperator}.
+ */
+public class CopyingSecondInputOfTwoInputStreamOperatorOutput extends OutputBase {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+	private final TypeSerializer<RowData> serializer;
+
+	public CopyingSecondInputOfTwoInputStreamOperatorOutput(
+			TwoInputStreamOperator<RowData, RowData, RowData> operator,
+			TypeSerializer<RowData> serializer) {
+		super(operator);
+		this.operator = operator;
+		this.serializer = serializer;
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		try {
+			operator.processWatermark2(mark);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		try {
+			operator.processLatencyMarker2(latencyMarker);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		pushToOperator(record);
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		pushToOperator(record);
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+			StreamRecord<RowData> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
+
+			operator.processElement2(copy);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/ExceptionInMultipleInputOperatorException.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/ExceptionInMultipleInputOperatorException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.util.WrappingRuntimeException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A special exception that signifies that the cause exception came from a {@link MultipleInputStreamOperator}.
+ */
+@Internal
+public class ExceptionInMultipleInputOperatorException extends WrappingRuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public ExceptionInMultipleInputOperatorException(Throwable cause) {
+		this("Could not forward element to next operator", cause);
+	}
+
+	public ExceptionInMultipleInputOperatorException(String message, Throwable cause) {
+		super(message, requireNonNull(cause));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * An {@link Output} that can be used to emit elements and other messages
+ * for the first input of {@link TwoInputStreamOperator}.
+ */
+public class FirstInputOfTwoInputStreamOperatorOutput extends OutputBase {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+
+	public FirstInputOfTwoInputStreamOperatorOutput(
+			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		super(operator);
+		this.operator = operator;
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		try {
+			operator.processWatermark1(mark);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		try {
+			operator.processLatencyMarker1(latencyMarker);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		pushToOperator(record);
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		pushToOperator(record);
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+
+			operator.processElement1(castRecord);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OneInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OneInputStreamOperatorOutput.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * An {@link Output} that can be used to emit elements and other messages for {@link OneInputStreamOperator}.
+ */
+public class OneInputStreamOperatorOutput extends OutputBase {
+
+	private final OneInputStreamOperator<RowData, RowData> operator;
+
+	public OneInputStreamOperatorOutput(
+			OneInputStreamOperator<RowData, RowData> operator) {
+		super(operator);
+		this.operator = operator;
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		try {
+			operator.processWatermark(mark);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		try {
+			operator.processLatencyMarker(latencyMarker);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		pushToOperator(record);
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		pushToOperator(record);
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+
+			operator.processElement(castRecord);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputBase.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Base {@link Output} that can be used to emit elements and other messages in {@link MultipleInputStreamOperatorBase}.
+ */
+public abstract class OutputBase implements Output<StreamRecord<RowData>> {
+	private final StreamOperator<?> operator;
+
+	public OutputBase(StreamOperator<?> operator) {
+		this.operator = operator;
+	}
+
+	@Override
+	public void close() {
+		try {
+			operator.close();
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * An {@link Output} that can be used to emit elements and other messages
+ * for the second input of {@link TwoInputStreamOperator}.
+ */
+public class SecondInputOfTwoInputStreamOperatorOutput extends OutputBase {
+
+	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+
+	public SecondInputOfTwoInputStreamOperatorOutput(
+			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		super(operator);
+		this.operator = operator;
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		try {
+			operator.processWatermark2(mark);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		try {
+			operator.processLatencyMarker2(latencyMarker);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		pushToOperator(record);
+	}
+
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		pushToOperator(record);
+	}
+
+	protected <X> void pushToOperator(StreamRecord<X> record) {
+		try {
+			// we know that the given outputTag matches our OutputTag so the record
+			// must be of the type that our operator expects.
+			@SuppressWarnings("unchecked")
+			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
+
+			operator.processElement2(castRecord);
+		} catch (Exception e) {
+			throw new ExceptionInMultipleInputOperatorException(e);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.CollectorOutput;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+import org.apache.flink.table.runtime.operators.multipleinput.input.OneInput;
+import org.apache.flink.table.runtime.operators.multipleinput.input.SecondInputOfTwoInput;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link BatchMultipleInputStreamOperator}.
+ */
+public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase {
+
+	@Test
+	public void testOpen() throws Exception {
+		TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp2 =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> joinWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingTwoInputStreamOperator joinOp1 = (TestingTwoInputStreamOperator) joinWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = joinWrapper1.getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = joinWrapper1.getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertFalse(aggOp1.isOpened());
+		assertFalse(aggOp2.isOpened());
+		assertFalse(aggOp1.isOpened());
+		assertFalse(joinOp2.isOpened());
+
+		op.open();
+
+		assertTrue(aggOp1.isOpened());
+		assertTrue(aggOp2.isOpened());
+		assertTrue(joinOp1.isOpened());
+		assertTrue(joinOp2.isOpened());
+	}
+
+	@Test
+	public void testNextSelectionAndEndInput() throws Exception {
+		TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp2 =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> joinWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingTwoInputStreamOperator joinOp1 = (TestingTwoInputStreamOperator) joinWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = joinWrapper1.getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = joinWrapper1.getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertFalse(aggOp1.isEnd());
+		assertFalse(aggOp2.isEnd());
+		assertTrue(joinOp1.getEndInputs().isEmpty());
+		assertTrue(joinOp2.getEndInputs().isEmpty());
+		assertEquals(new InputSelection.Builder().select(3).build(3), op.nextSelection());
+
+		op.endInput(3);
+		assertFalse(aggOp1.isEnd());
+		assertFalse(aggOp2.isEnd());
+		assertTrue(joinOp1.getEndInputs().isEmpty());
+		assertEquals(Collections.singletonList(2), joinOp2.getEndInputs());
+		assertEquals(new InputSelection.Builder().select(1).build(3), op.nextSelection());
+
+		op.endInput(1);
+		assertTrue(aggOp1.isEnd());
+		assertFalse(aggOp2.isEnd());
+		assertEquals(Collections.singletonList(1), joinOp1.getEndInputs());
+		assertEquals(Collections.singletonList(2), joinOp2.getEndInputs());
+		assertEquals(new InputSelection.Builder().select(2).build(3), op.nextSelection());
+
+		op.endInput(2);
+		assertTrue(aggOp1.isEnd());
+		assertTrue(aggOp2.isEnd());
+		assertEquals(Arrays.asList(1, 2), joinOp1.getEndInputs());
+		assertEquals(Arrays.asList(2, 1), joinOp2.getEndInputs());
+		assertEquals(InputSelection.ALL, op.nextSelection());
+	}
+
+	@Test
+	public void testDispose() throws Exception {
+		TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp2 =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> joinWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingTwoInputStreamOperator joinOp1 = (TestingTwoInputStreamOperator) joinWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = joinWrapper1.getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = joinWrapper1.getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertFalse(aggOp1.isDisposed());
+		assertFalse(aggOp2.isDisposed());
+		assertFalse(aggOp1.isDisposed());
+		assertFalse(joinOp2.isDisposed());
+
+		op.dispose();
+
+		assertTrue(aggOp1.isDisposed());
+		assertTrue(aggOp2.isDisposed());
+		assertTrue(joinOp1.isDisposed());
+		assertTrue(joinOp2.isDisposed());
+	}
+
+	@Test
+	public void testClose() throws Exception {
+		TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp2 =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> joinWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingTwoInputStreamOperator joinOp1 = (TestingTwoInputStreamOperator) joinWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = joinWrapper1.getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = joinWrapper1.getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertFalse(aggOp1.isClosed());
+		assertFalse(aggOp2.isClosed());
+		assertFalse(aggOp1.isClosed());
+		assertFalse(joinOp2.isClosed());
+
+		op.close();
+
+		assertTrue(aggOp1.isClosed());
+		assertTrue(aggOp2.isClosed());
+		assertTrue(joinOp1.isClosed());
+		assertTrue(joinOp2.isClosed());
+	}
+
+	@Test
+	public void testProcess() throws Exception {
+		TestingBatchMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		List<StreamElement> outputData = op.getOutputData();
+
+		TestingTwoInputStreamOperator joinOp2 =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> joinWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingTwoInputStreamOperator joinOp1 = (TestingTwoInputStreamOperator) joinWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = joinWrapper1.getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = joinWrapper1.getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		List<Input> inputs = op.getInputs();
+		assertEquals(3, inputs.size());
+		Input input1 = inputs.get(0);
+		Input input2 = inputs.get(1);
+		Input input3 = inputs.get(2);
+
+		assertTrue(input1 instanceof OneInput);
+		assertTrue(input2 instanceof OneInput);
+		assertTrue(input3 instanceof SecondInputOfTwoInput);
+
+		assertNull(joinOp2.getCurrentElement1());
+		assertNull(joinOp2.getCurrentElement2());
+
+		assertNull(joinOp1.getCurrentElement1());
+		assertNull(joinOp1.getCurrentElement2());
+
+		assertNull(aggOp1.getCurrentElement());
+		assertNull(aggOp2.getCurrentElement());
+		assertTrue(outputData.isEmpty());
+
+		// process first input (input id is 3)
+		StreamRecord<RowData> element1 = new StreamRecord<>(GenericRowData.of(StringData.fromString("123")), 456);
+		input3.processElement(element1);
+
+		assertEquals(element1, joinOp2.getCurrentElement2());
+		assertNull(joinOp2.getCurrentElement1());
+		assertTrue(outputData.isEmpty());
+
+		// finish first input
+		assertTrue(joinOp2.getEndInputs().isEmpty());
+		op.endInput(3);
+		assertTrue(outputData.isEmpty());
+		assertEquals(Collections.singletonList(2), joinOp2.getEndInputs());
+
+		// process second input (input id is 1)
+		StreamRecord<RowData> element2 = new StreamRecord<>(GenericRowData.of(StringData.fromString("124")), 457);
+		input1.processElement(element2);
+
+		assertEquals(element2, aggOp1.getCurrentElement());
+		assertNull(joinOp1.getCurrentElement1());
+		assertNull(joinOp2.getCurrentElement1());
+		assertTrue(outputData.isEmpty());
+
+		// finish second input
+		assertTrue(joinOp1.getEndInputs().isEmpty());
+		op.endInput(1);
+		assertEquals(Collections.singletonList(1), joinOp1.getEndInputs());
+		assertEquals(Collections.singletonList(2), joinOp2.getEndInputs());
+		assertEquals(element2, joinOp1.getCurrentElement1());
+		assertTrue(outputData.isEmpty());
+
+		// process third input (input id is 2)
+		StreamRecord<RowData> element3 = new StreamRecord<>(GenericRowData.of(StringData.fromString("125")), 458);
+		input2.processElement(element3);
+
+		assertEquals(element3, aggOp2.getCurrentElement());
+		assertNull(joinOp1.getCurrentElement2());
+		assertNull(joinOp2.getCurrentElement1());
+		assertTrue(outputData.isEmpty());
+
+		// finish third input
+		assertEquals(Collections.singletonList(1), joinOp1.getEndInputs());
+		op.endInput(2);
+		assertEquals(Arrays.asList(1, 2), joinOp1.getEndInputs());
+		assertEquals(Arrays.asList(2, 1), joinOp2.getEndInputs());
+		assertEquals(element3, joinOp1.getCurrentElement2());
+		assertEquals(3, outputData.size());
+	}
+
+	/**
+	 * Create a BatchMultipleInputStreamOperator which contains the following sub-graph.
+	 * <pre>
+	 *
+	 * source1  source2
+	 *   |        |
+	 *  agg1     agg2
+	 * (b) \     / (p)
+	 *      join1   source3
+	 *     (p) \     / (b)
+	 *         join2
+	 * (b) is the build side of the join, (p) is the probe side of the join.
+	 * </pre>
+	 */
+	private TestingBatchMultipleInputStreamOperator createMultipleInputStreamOperator() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		Transformation<RowData> source1 = createSource(env, "source1");
+		Transformation<RowData> source2 = createSource(env, "source2");
+		Transformation<RowData> source3 = createSource(env, "source3");
+		OneInputTransformation<RowData, RowData> agg1 = createOneInputTransform(
+				source1,
+				"agg1",
+				new TestingOneInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+		OneInputTransformation<RowData, RowData> agg2 = createOneInputTransform(
+				source2,
+				"agg2",
+				new TestingOneInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+		TwoInputTransformation<RowData, RowData, RowData> join1 = createTwoInputTransform(
+				agg1,
+				agg2,
+				"join1",
+				new TestingTwoInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+
+		TwoInputTransformation<RowData, RowData, RowData> join2 = createTwoInputTransform(
+				join1,
+				source3,
+				"join2",
+				new TestingTwoInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+
+		TableOperatorWrapperGenerator generator = new TableOperatorWrapperGenerator(
+				Arrays.asList(source1, source2, source3),
+				join2,
+				new int[] { 1, 2, 0 });
+		generator.generate();
+
+		List<Pair<Transformation<?>, InputSpec>> inputTransformAndInputSpecPairs =
+				generator.getInputTransformAndInputSpecPairs();
+
+		List<StreamElement> outputData = new ArrayList<>();
+		return new TestingBatchMultipleInputStreamOperator(
+				createStreamOperatorParameters(new TestingOutput(outputData)),
+				inputTransformAndInputSpecPairs.stream().map(Pair::getValue).collect(Collectors.toList()),
+				generator.getHeadWrappers(),
+				generator.getTailWrapper(),
+				outputData);
+	}
+
+	/**
+	 * A sub class of {@link BatchMultipleInputStreamOperator} for testing.
+	 */
+	private static class TestingBatchMultipleInputStreamOperator extends BatchMultipleInputStreamOperator {
+		private final TableOperatorWrapper<?> tailWrapper;
+		private final List<StreamElement> outputData;
+
+		public TestingBatchMultipleInputStreamOperator(
+				StreamOperatorParameters<RowData> parameters,
+				List<InputSpec> inputSpecs,
+				List<TableOperatorWrapper<?>> headWrapper,
+				TableOperatorWrapper<?> tailWrapper,
+				List<StreamElement> outputData) {
+			super(parameters, inputSpecs, headWrapper, tailWrapper);
+			this.tailWrapper = tailWrapper;
+			this.outputData = outputData;
+		}
+
+		public List<StreamElement> getOutputData() {
+			return outputData;
+		}
+
+		public TableOperatorWrapper<?> getTailWrapper() {
+			return tailWrapper;
+		}
+	}
+
+	/**
+	 * A sub class of {@link CollectorOutput} for testing.
+	 * Notes: the data to collect will not be copied, object reuse should be disabled when using this class.
+	 */
+	private static class TestingOutput extends CollectorOutput<RowData> {
+		private final List<StreamElement> list;
+
+		public TestingOutput(List<StreamElement> list) {
+			super(list);
+			this.list = list;
+		}
+
+		@Override
+		public void collect(StreamRecord<RowData> record) {
+			list.add(record);
+		}
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputTestBase.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.util.CollectorOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
+import org.apache.flink.streaming.util.MockStreamTaskBuilder;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.output.BlackHoleOutput;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * A class that provides utility methods for multiple input testing.
+ */
+public class MultipleInputTestBase {
+
+	protected Transformation<RowData> createSource(StreamExecutionEnvironment env, String... data) {
+		return env.fromCollection(
+				Arrays.stream(data).map(StringData::fromString).map(GenericRowData::of).collect(Collectors.toList()),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())))
+				.getTransformation();
+	}
+
+	protected TestingOneInputStreamOperator createOneInputStreamOperator() throws Exception {
+		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+		op.setup(createStreamTask(), createStreamConfig(), new BlackHoleOutput());
+		return op;
+	}
+
+	protected TestingTwoInputStreamOperator createTwoInputStreamOperator() throws Exception {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		op.setup(createStreamTask(), createStreamConfig(), new BlackHoleOutput());
+		return op;
+	}
+
+	protected OneInputTransformation<RowData, RowData> createOneInputTransform(
+			Transformation<RowData> input,
+			String name,
+			TypeInformation<RowData> outputType) {
+		return createOneInputTransform(
+				input,
+				name,
+				new TestingOneInputStreamOperator(),
+				outputType);
+	}
+
+	protected OneInputTransformation<RowData, RowData> createOneInputTransform(
+			Transformation<RowData> input,
+			String name,
+			TestingOneInputStreamOperator operator,
+			TypeInformation<RowData> outputType) {
+		return new OneInputTransformation<>(
+				input,
+				name,
+				operator,
+				outputType,
+				10);
+	}
+
+	protected TwoInputTransformation<RowData, RowData, RowData> createTwoInputTransform(
+			Transformation<RowData> input1,
+			Transformation<RowData> input2,
+			String name,
+			TypeInformation<RowData> outputType) {
+		return createTwoInputTransform(
+				input1,
+				input2,
+				name,
+				new TestingTwoInputStreamOperator(),
+				outputType);
+	}
+
+	protected TwoInputTransformation<RowData, RowData, RowData> createTwoInputTransform(
+			Transformation<RowData> input1,
+			Transformation<RowData> input2,
+			String name,
+			TestingTwoInputStreamOperator operator,
+			TypeInformation<RowData> outputType) {
+		return new TwoInputTransformation<>(
+				input1,
+				input2,
+				name,
+				operator,
+				outputType,
+				10);
+	}
+
+	protected TableOperatorWrapper<TestingOneInputStreamOperator> createOneInputOperatorWrapper(
+			TestingOneInputStreamOperator operator, String name) {
+		return new TableOperatorWrapper<>(
+				SimpleOperatorFactory.of(operator),
+				name,
+				Collections.singletonList(new RowTypeInfo(Types.STRING)),
+				new RowTypeInfo(Types.STRING)
+		);
+	}
+
+	protected TableOperatorWrapper<TestingOneInputStreamOperator> createOneInputOperatorWrapper(String name) {
+		return createOneInputOperatorWrapper(new TestingOneInputStreamOperator(), name);
+	}
+
+	protected TableOperatorWrapper<TestingTwoInputStreamOperator> createTwoInputOperatorWrapper(
+			TestingTwoInputStreamOperator operator, String name) {
+		return new TableOperatorWrapper<>(
+				SimpleOperatorFactory.of(operator),
+				name,
+				Arrays.asList(new RowTypeInfo(Types.STRING), new RowTypeInfo(Types.STRING)),
+				new RowTypeInfo(Types.STRING, Types.STRING)
+		);
+	}
+
+	protected TableOperatorWrapper<TestingTwoInputStreamOperator> createTwoInputOperatorWrapper(String name) {
+		return createTwoInputOperatorWrapper(new TestingTwoInputStreamOperator(), name);
+	}
+
+	protected StreamOperatorParameters<RowData> createStreamOperatorParameters() throws Exception {
+		return createStreamOperatorParameters(new CollectorOutput<>(new ArrayList<>()));
+	}
+
+	protected StreamConfig createStreamConfig() {
+		return new MockStreamConfig(new Configuration(), 1);
+	}
+
+	protected StreamTask createStreamTask() throws Exception {
+		Environment env = new MockEnvironmentBuilder().build();
+		return new MockStreamTaskBuilder(env).build();
+	}
+
+	protected StreamOperatorParameters<RowData> createStreamOperatorParameters(
+			CollectorOutput<RowData> output) throws Exception {
+		return new StreamOperatorParameters<>(
+				createStreamTask(),
+				createStreamConfig(),
+				output,
+				TestProcessingTimeService::new,
+				null
+		);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.operators.multipleinput;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -29,9 +28,7 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
@@ -49,7 +46,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link TableOperatorWrapperGenerator}.
  */
-public class TableOperatorWrapperGeneratorTest {
+public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
 
 	/**
 	 * Test for simple sub-graph in a multiple input node.
@@ -399,39 +396,6 @@ public class TableOperatorWrapperGeneratorTest {
 				join,
 				new int[] { 0, 0 });
 		generator.generate();
-	}
-
-	private Transformation<RowData> createSource(StreamExecutionEnvironment env, String... data) {
-		return env.fromCollection(
-				Arrays.stream(data).map(StringData::fromString).map(GenericRowData::of).collect(Collectors.toList()),
-				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())))
-				.getTransformation();
-	}
-
-	private OneInputTransformation<RowData, RowData> createOneInputTransform(
-			Transformation<RowData> input,
-			String name,
-			TypeInformation<RowData> outputType) {
-		return new OneInputTransformation<>(
-				input,
-				name,
-				new TestingOneInputStreamOperator(),
-				outputType,
-				10);
-	}
-
-	private TwoInputTransformation<RowData, RowData, RowData> createTwoInputTransform(
-			Transformation<RowData> input1,
-			Transformation<RowData> input2,
-			String name,
-			TypeInformation<RowData> outputType) {
-		return new TwoInputTransformation<>(
-				input1,
-				input2,
-				name,
-				new TestingTwoInputStreamOperator(),
-				outputType,
-				10);
 	}
 
 	@SafeVarargs

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
@@ -18,24 +18,12 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput;
 
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
-import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
-import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
-import org.apache.flink.streaming.util.MockOutput;
-import org.apache.flink.streaming.util.MockStreamConfig;
-import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper.Edge;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -47,7 +35,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link TableOperatorWrapper}.
  */
-public class TableOperatorWrapperTest {
+public class TableOperatorWrapperTest extends MultipleInputTestBase {
 
 	@Test
 	public void testBasicInfo() {
@@ -170,38 +158,6 @@ public class TableOperatorWrapperTest {
 		wrapper.close();
 		assertTrue(wrapper.isClosed());
 		assertTrue(operator.isClosed());
-	}
-
-	private StreamOperatorParameters<RowData> createStreamOperatorParameters() throws Exception {
-		Environment env = new MockEnvironmentBuilder().build();
-		StreamTask task = new MockStreamTaskBuilder(env).build();
-		return new StreamOperatorParameters<>(
-				task,
-				new MockStreamConfig(new Configuration(), 1),
-				new MockOutput<>(new ArrayList<>()),
-				TestProcessingTimeService::new,
-				null
-		);
-	}
-
-	private TableOperatorWrapper<TestingOneInputStreamOperator> createOneInputOperatorWrapper(
-			TestingOneInputStreamOperator operator, String name) {
-		return new TableOperatorWrapper<>(
-				SimpleOperatorFactory.of(operator),
-				name,
-				Collections.singletonList(new RowTypeInfo(Types.STRING)),
-				new RowTypeInfo(Types.STRING)
-		);
-	}
-
-	private TableOperatorWrapper<TestingTwoInputStreamOperator> createTwoInputOperatorWrapper(
-			TestingTwoInputStreamOperator operator, String name) {
-		return new TableOperatorWrapper<>(
-				SimpleOperatorFactory.of(operator),
-				name,
-				Arrays.asList(new RowTypeInfo(Types.STRING), new RowTypeInfo(Types.STRING)),
-				new RowTypeInfo(Types.STRING, Types.STRING)
-		);
 	}
 
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingOneInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingOneInputStreamOperator.java
@@ -25,41 +25,85 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A {@link OneInputStreamOperator} for testing.
  */
 public class TestingOneInputStreamOperator extends AbstractStreamOperator<RowData>
 		implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput {
+
+	private final boolean emitDataInEndInput;
+
+	private boolean isOpened = false;
 	private StreamRecord<RowData> currentElement = null;
 	private Watermark currentWatermark = null;
 	private LatencyMarker currentLatencyMarker = null;
 	private boolean isEnd = false;
+	private boolean isDisposed = false;
 	private boolean isClosed = false;
+	private final List<StreamRecord<RowData>> receivedElements = new ArrayList<>();
+
+	public TestingOneInputStreamOperator() {
+		this(false);
+	}
+
+	public TestingOneInputStreamOperator(boolean emitDataInEndInput) {
+		this.emitDataInEndInput = emitDataInEndInput;
+	}
+
+	@Override
+	public void open() throws Exception {
+		isOpened = true;
+	}
 
 	@Override
 	public void processElement(StreamRecord<RowData> element) throws Exception {
 		currentElement = element;
+		if (emitDataInEndInput) {
+			receivedElements.add(element);
+		} else {
+			output.collect(element);
+		}
 	}
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
 		currentWatermark = mark;
+		output.emitWatermark(mark);
 	}
 
 	@Override
 	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
 		currentLatencyMarker = latencyMarker;
+		output.emitLatencyMarker(latencyMarker);
 	}
 
 	@Override
 	public void endInput() throws Exception {
 		isEnd = true;
+		if (emitDataInEndInput) {
+			receivedElements.forEach(output::collect);
+		} else {
+			Preconditions.checkArgument(receivedElements.isEmpty());
+		}
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		this.isDisposed = true;
 	}
 
 	@Override
 	public void close() throws Exception {
 		isClosed = true;
+	}
+
+	public boolean isOpened() {
+		return isOpened;
 	}
 
 	public StreamRecord<RowData> getCurrentElement() {
@@ -76,6 +120,10 @@ public class TestingOneInputStreamOperator extends AbstractStreamOperator<RowDat
 
 	public boolean isEnd() {
 		return isEnd;
+	}
+
+	public boolean isDisposed() {
+		return isDisposed;
 	}
 
 	public boolean isClosed() {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingOneInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingOneInputStreamOperator.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.runtime.operators.multipleinput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 
@@ -29,12 +31,25 @@ import org.apache.flink.table.data.RowData;
  */
 public class TestingOneInputStreamOperator extends AbstractStreamOperator<RowData>
 		implements OneInputStreamOperator<RowData, RowData>, BoundedOneInput {
+	private StreamRecord<RowData> currentElement = null;
+	private Watermark currentWatermark = null;
+	private LatencyMarker currentLatencyMarker = null;
 	private boolean isEnd = false;
 	private boolean isClosed = false;
 
 	@Override
 	public void processElement(StreamRecord<RowData> element) throws Exception {
+		currentElement = element;
+	}
 
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		currentWatermark = mark;
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		currentLatencyMarker = latencyMarker;
 	}
 
 	@Override
@@ -45,6 +60,18 @@ public class TestingOneInputStreamOperator extends AbstractStreamOperator<RowDat
 	@Override
 	public void close() throws Exception {
 		isClosed = true;
+	}
+
+	public StreamRecord<RowData> getCurrentElement() {
+		return currentElement;
+	}
+
+	public Watermark getCurrentWatermark() {
+		return currentWatermark;
+	}
+
+	public LatencyMarker getCurrentLatencyMarker() {
+		return currentLatencyMarker;
 	}
 
 	public boolean isEnd() {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingTwoInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingTwoInputStreamOperator.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,10 @@ import java.util.List;
 public class TestingTwoInputStreamOperator extends AbstractStreamOperator<RowData>
 		implements TwoInputStreamOperator<RowData, RowData, RowData>, BoundedMultiInput {
 
+	private final boolean emitDataInEndInput;
+	private final List<StreamRecord<RowData>> receivedElements = new ArrayList<>();
+
+	private boolean isOpened = false;
 	private StreamRecord<RowData> currentElement1 = null;
 	private StreamRecord<RowData> currentElement2 = null;
 	private Watermark currentWatermark1 = null;
@@ -42,46 +47,90 @@ public class TestingTwoInputStreamOperator extends AbstractStreamOperator<RowDat
 	private LatencyMarker currentLatencyMarker1 = null;
 	private LatencyMarker currentLatencyMarker2 = null;
 	private final List<Integer> endInputs = new ArrayList<>();
+	private boolean isDisposed = false;
 	private boolean isClosed = false;
+
+	public TestingTwoInputStreamOperator() {
+		this(false);
+	}
+
+	public TestingTwoInputStreamOperator(boolean emitDataInEndInput) {
+		this.emitDataInEndInput = emitDataInEndInput;
+	}
+
+	@Override
+	public void open() throws Exception {
+		isOpened = true;
+	}
 
 	@Override
 	public void processElement1(StreamRecord<RowData> element) throws Exception {
 		currentElement1 = element;
+		if (emitDataInEndInput) {
+			receivedElements.add(element);
+		} else {
+			output.collect(element);
+		}
 	}
 
 	@Override
 	public void processElement2(StreamRecord<RowData> element) throws Exception {
 		currentElement2 = element;
+		if (emitDataInEndInput) {
+			receivedElements.add(element);
+		} else {
+			output.collect(element);
+		}
 	}
 
 	@Override
 	public void processWatermark1(Watermark mark) throws Exception {
 		currentWatermark1 = mark;
+		output.emitWatermark(mark);
 	}
 
 	@Override
 	public void processWatermark2(Watermark mark) throws Exception {
 		currentWatermark2 = mark;
+		output.emitWatermark(mark);
 	}
 
 	@Override
 	public void processLatencyMarker1(LatencyMarker latencyMarker) throws Exception {
 		currentLatencyMarker1 = latencyMarker;
+		output.emitLatencyMarker(latencyMarker);
 	}
 
 	@Override
 	public void processLatencyMarker2(LatencyMarker latencyMarker) throws Exception {
 		currentLatencyMarker2 = latencyMarker;
+		output.emitLatencyMarker(latencyMarker);
 	}
 
 	@Override
 	public void endInput(int inputId) throws Exception {
 		endInputs.add(inputId);
+		if (emitDataInEndInput) {
+			if (endInputs.size() == 2) {
+				receivedElements.forEach(output::collect);
+			}
+		} else {
+			Preconditions.checkArgument(receivedElements.isEmpty());
+		}
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		this.isDisposed = true;
 	}
 
 	@Override
 	public void close() throws Exception {
 		isClosed = true;
+	}
+
+	public boolean isOpened() {
+		return isOpened;
 	}
 
 	public StreamRecord<RowData> getCurrentElement1() {
@@ -110,6 +159,10 @@ public class TestingTwoInputStreamOperator extends AbstractStreamOperator<RowDat
 
 	public List<Integer> getEndInputs() {
 		return endInputs;
+	}
+
+	public boolean isDisposed() {
+		return isDisposed;
 	}
 
 	public boolean isClosed() {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingTwoInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingTwoInputStreamOperator.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.runtime.operators.multipleinput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 
@@ -33,17 +35,43 @@ import java.util.List;
 public class TestingTwoInputStreamOperator extends AbstractStreamOperator<RowData>
 		implements TwoInputStreamOperator<RowData, RowData, RowData>, BoundedMultiInput {
 
+	private StreamRecord<RowData> currentElement1 = null;
+	private StreamRecord<RowData> currentElement2 = null;
+	private Watermark currentWatermark1 = null;
+	private Watermark currentWatermark2 = null;
+	private LatencyMarker currentLatencyMarker1 = null;
+	private LatencyMarker currentLatencyMarker2 = null;
 	private final List<Integer> endInputs = new ArrayList<>();
 	private boolean isClosed = false;
 
 	@Override
 	public void processElement1(StreamRecord<RowData> element) throws Exception {
-
+		currentElement1 = element;
 	}
 
 	@Override
 	public void processElement2(StreamRecord<RowData> element) throws Exception {
+		currentElement2 = element;
+	}
 
+	@Override
+	public void processWatermark1(Watermark mark) throws Exception {
+		currentWatermark1 = mark;
+	}
+
+	@Override
+	public void processWatermark2(Watermark mark) throws Exception {
+		currentWatermark2 = mark;
+	}
+
+	@Override
+	public void processLatencyMarker1(LatencyMarker latencyMarker) throws Exception {
+		currentLatencyMarker1 = latencyMarker;
+	}
+
+	@Override
+	public void processLatencyMarker2(LatencyMarker latencyMarker) throws Exception {
+		currentLatencyMarker2 = latencyMarker;
 	}
 
 	@Override
@@ -54,6 +82,30 @@ public class TestingTwoInputStreamOperator extends AbstractStreamOperator<RowDat
 	@Override
 	public void close() throws Exception {
 		isClosed = true;
+	}
+
+	public StreamRecord<RowData> getCurrentElement1() {
+		return currentElement1;
+	}
+
+	public StreamRecord<RowData> getCurrentElement2() {
+		return currentElement2;
+	}
+
+	public Watermark getCurrentWatermark1() {
+		return currentWatermark1;
+	}
+
+	public Watermark getCurrentWatermark2() {
+		return currentWatermark2;
+	}
+
+	public LatencyMarker getCurrentLatencyMarker1() {
+		return currentLatencyMarker1;
+	}
+
+	public LatencyMarker getCurrentLatencyMarker2() {
+		return currentLatencyMarker2;
 	}
 
 	public List<Integer> getEndInputs() {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link InputSelectionHandler}.
+ */
+public class InputSelectionHandlerTest {
+
+	@Test
+	public void testWithSamePriority() {
+		List<InputSpec> inputSpecs = Arrays.asList(
+				new InputSpec(1, 0, createOneInputOperatorWrapper("input1"), 1),
+				new InputSpec(2, 0, createOneInputOperatorWrapper("input2"), 2),
+				new InputSpec(3, 0, createTwoInputOperatorWrapper("input3"), 1),
+				new InputSpec(4, 0, createTwoInputOperatorWrapper("input4"), 2),
+				new InputSpec(5, 0, createOneInputOperatorWrapper("input5"), 1));
+		InputSelectionHandler handler = new InputSelectionHandler(inputSpecs);
+		assertEquals(InputSelection.ALL, handler.getInputSelection());
+
+		List<Integer> inputIds = Arrays.asList(1, 2, 3, 4, 5);
+		Collections.shuffle(inputIds);
+		for (int inputId: inputIds) {
+			handler.endInput(inputId);
+			assertEquals(InputSelection.ALL, handler.getInputSelection());
+		}
+	}
+
+	@Test
+	public void testWithDifferentPriority() {
+		List<InputSpec> inputSpecs = Arrays.asList(
+				new InputSpec(1, 1, createOneInputOperatorWrapper("input1"), 1),
+				new InputSpec(2, 1, createOneInputOperatorWrapper("input2"), 2),
+				new InputSpec(3, 0, createTwoInputOperatorWrapper("input3"), 1),
+				new InputSpec(4, 0, createTwoInputOperatorWrapper("input4"), 2),
+				new InputSpec(5, 2, createOneInputOperatorWrapper("input5"), 1));
+		InputSelectionHandler handler = new InputSelectionHandler(inputSpecs);
+		assertEquals(
+				new InputSelection.Builder().select(3).select(4).build(5),
+				handler.getInputSelection());
+
+		handler.endInput(3);
+		assertEquals(
+				new InputSelection.Builder().select(3).select(4).build(5),
+				handler.getInputSelection());
+
+		handler.endInput(4);
+		assertEquals(
+				new InputSelection.Builder().select(1).select(2).build(5),
+				handler.getInputSelection());
+
+		handler.endInput(2);
+		assertEquals(
+				new InputSelection.Builder().select(1).select(2).build(5),
+				handler.getInputSelection());
+
+		handler.endInput(1);
+		assertEquals(
+				new InputSelection.Builder().select(5).build(5),
+				handler.getInputSelection());
+
+		handler.endInput(5);
+		assertEquals(InputSelection.ALL, handler.getInputSelection());
+	}
+
+	private TableOperatorWrapper<TestingOneInputStreamOperator> createOneInputOperatorWrapper(String name) {
+		return new TableOperatorWrapper<>(
+				SimpleOperatorFactory.of(new TestingOneInputStreamOperator()),
+				name,
+				Collections.singletonList(new RowTypeInfo(Types.STRING)),
+				new RowTypeInfo(Types.STRING)
+		);
+	}
+
+	private TableOperatorWrapper<TestingTwoInputStreamOperator> createTwoInputOperatorWrapper(String name) {
+		return new TableOperatorWrapper<>(
+				SimpleOperatorFactory.of(new TestingTwoInputStreamOperator()),
+				name,
+				Arrays.asList(new RowTypeInfo(Types.STRING), new RowTypeInfo(Types.STRING)),
+				new RowTypeInfo(Types.STRING, Types.STRING)
+		);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputSelectionHandlerTest.java
@@ -18,13 +18,8 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
-import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.operators.InputSelection;
-import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper;
-import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
-import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestBase;
 
 import org.junit.Test;
 
@@ -37,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test for {@link InputSelectionHandler}.
  */
-public class InputSelectionHandlerTest {
+public class InputSelectionHandlerTest extends MultipleInputTestBase {
 
 	@Test
 	public void testWithSamePriority() {
@@ -93,23 +88,5 @@ public class InputSelectionHandlerTest {
 
 		handler.endInput(5);
 		assertEquals(InputSelection.ALL, handler.getInputSelection());
-	}
-
-	private TableOperatorWrapper<TestingOneInputStreamOperator> createOneInputOperatorWrapper(String name) {
-		return new TableOperatorWrapper<>(
-				SimpleOperatorFactory.of(new TestingOneInputStreamOperator()),
-				name,
-				Collections.singletonList(new RowTypeInfo(Types.STRING)),
-				new RowTypeInfo(Types.STRING)
-		);
-	}
-
-	private TableOperatorWrapper<TestingTwoInputStreamOperator> createTwoInputOperatorWrapper(String name) {
-		return new TableOperatorWrapper<>(
-				SimpleOperatorFactory.of(new TestingTwoInputStreamOperator()),
-				name,
-				Arrays.asList(new RowTypeInfo(Types.STRING), new RowTypeInfo(Types.STRING)),
-				new RowTypeInfo(Types.STRING, Types.STRING)
-		);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.input;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test for the sub-classes of {@link Input}.
+ */
+public class InputTest {
+
+	private StreamRecord<RowData> element;
+	private Watermark watermark;
+	private LatencyMarker latencyMarker;
+
+	@Before
+	public void setup() {
+		element = new StreamRecord<>(GenericRowData.of(StringData.fromString("123")), 456);
+		watermark = new Watermark(1223456789);
+		latencyMarker = new LatencyMarker(122345678, new OperatorID(123, 456), 1);
+	}
+
+	@Test
+	public void testOneInput() throws Exception {
+		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+		OneInput input = new OneInput(op);
+
+		input.processElement(element);
+		assertEquals(element, op.getCurrentElement());
+
+		input.processWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark());
+
+		input.processLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker());
+	}
+
+	@Test
+	public void testFirstInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		FirstInputOfTwoInput input = new FirstInputOfTwoInput(op);
+
+		input.processElement(element);
+		assertEquals(element, op.getCurrentElement1());
+		assertNull(op.getCurrentElement2());
+
+		input.processWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark1());
+		assertNull(op.getCurrentWatermark2());
+
+		input.processLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker1());
+		assertNull(op.getCurrentLatencyMarker2());
+	}
+
+	@Test
+	public void testSecondInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		SecondInputOfTwoInput input = new SecondInputOfTwoInput(op);
+
+		input.processElement(element);
+		assertEquals(element, op.getCurrentElement2());
+		assertNull(op.getCurrentElement1());
+
+		input.processWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark2());
+		assertNull(op.getCurrentWatermark1());
+
+		input.processLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker2());
+		assertNull(op.getCurrentLatencyMarker1());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/input/InputTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestBase;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
 
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertNull;
 /**
  * Test for the sub-classes of {@link Input}.
  */
-public class InputTest {
+public class InputTest extends MultipleInputTestBase {
 
 	private StreamRecord<RowData> element;
 	private Watermark watermark;
@@ -53,7 +54,7 @@ public class InputTest {
 
 	@Test
 	public void testOneInput() throws Exception {
-		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+		TestingOneInputStreamOperator op = createOneInputStreamOperator();
 		OneInput input = new OneInput(op);
 
 		input.processElement(element);
@@ -68,7 +69,7 @@ public class InputTest {
 
 	@Test
 	public void testFirstInputOfTwoInput() throws Exception {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
 		FirstInputOfTwoInput input = new FirstInputOfTwoInput(op);
 
 		input.processElement(element);
@@ -86,7 +87,7 @@ public class InputTest {
 
 	@Test
 	public void testSecondInputOfTwoInput() throws Exception {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
 		SecondInputOfTwoInput input = new SecondInputOfTwoInput(op);
 
 		input.processElement(element);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/BlackHoleOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/BlackHoleOutput.java
@@ -18,25 +18,40 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.output;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputStreamOperatorBase;
-import org.apache.flink.util.WrappingRuntimeException;
-
-import static java.util.Objects.requireNonNull;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.OutputTag;
 
 /**
- * A special exception that signifies that the cause exception came from a {@link MultipleInputStreamOperatorBase}.
+ * A {@link Output} for testing which does not output anything.
  */
-@Internal
-public class ExceptionInMultipleInputOperatorException extends WrappingRuntimeException {
+public class BlackHoleOutput implements Output<StreamRecord<RowData>> {
 
-	private static final long serialVersionUID = 1L;
-
-	public ExceptionInMultipleInputOperatorException(Throwable cause) {
-		this("Could not forward element to next operator", cause);
+	@Override
+	public void emitWatermark(Watermark mark) {
+		// do nothing
 	}
 
-	public ExceptionInMultipleInputOperatorException(String message, Throwable cause) {
-		super(message, requireNonNull(cause));
+	@Override
+	public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+		// do nothing
+	}
+
+	@Override
+	public void emitLatencyMarker(LatencyMarker latencyMarker) {
+		// do nothing
+	}
+
+	@Override
+	public void collect(StreamRecord<RowData> record) {
+		// do nothing
+	}
+
+	@Override
+	public void close() {
+		// do nothing
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput.output;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Test for the sub-classes of {@link Output}.
+ */
+public class OutputTest {
+
+	private StreamRecord<RowData> element;
+	private Watermark watermark;
+	private LatencyMarker latencyMarker;
+	private TypeSerializer<RowData> serializer;
+
+	@Before
+	public void setup() {
+		element = new StreamRecord<>(GenericRowData.of(StringData.fromString("123")), 456);
+		watermark = new Watermark(1223456789);
+		latencyMarker = new LatencyMarker(122345678, new OperatorID(123, 456), 1);
+		serializer = InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType()))
+				.createSerializer(new ExecutionConfig());
+	}
+
+	@Test
+	public void testOneInput() {
+		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+		OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op);
+
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement());
+
+		output.emitWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker());
+	}
+
+	@Test
+	public void testCopyingOneInput() {
+		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+		CopyingOneInputStreamOperatorOutput output = new CopyingOneInputStreamOperatorOutput(op, serializer);
+
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement());
+		assertEquals(element, op.getCurrentElement());
+
+		output.emitWatermark(watermark);
+		assertSame(watermark, op.getCurrentWatermark());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertSame(latencyMarker, op.getCurrentLatencyMarker());
+	}
+
+	@Test
+	public void testFirstInputOfTwoInput() {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		FirstInputOfTwoInputStreamOperatorOutput output = new FirstInputOfTwoInputStreamOperatorOutput(op);
+
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement1());
+		assertNull(op.getCurrentElement2());
+
+		output.emitWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark1());
+		assertNull(op.getCurrentWatermark2());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker1());
+		assertNull(op.getCurrentLatencyMarker2());
+	}
+
+	@Test
+	public void testCopyingFirstInputOfTwoInput() {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(op, serializer);
+
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement1());
+		assertEquals(element, op.getCurrentElement1());
+		assertNull(op.getCurrentElement2());
+
+		output.emitWatermark(watermark);
+		assertSame(watermark, op.getCurrentWatermark1());
+		assertNull(op.getCurrentWatermark2());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertSame(latencyMarker, op.getCurrentLatencyMarker1());
+		assertNull(op.getCurrentLatencyMarker2());
+	}
+
+	@Test
+	public void testSecondInputOfTwoInput() {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		SecondInputOfTwoInputStreamOperatorOutput output = new SecondInputOfTwoInputStreamOperatorOutput(op);
+
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement2());
+		assertNull(op.getCurrentElement1());
+
+		output.emitWatermark(watermark);
+		assertEquals(watermark, op.getCurrentWatermark2());
+		assertNull(op.getCurrentWatermark1());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertEquals(latencyMarker, op.getCurrentLatencyMarker2());
+		assertNull(op.getCurrentLatencyMarker1());
+	}
+
+	@Test
+	public void testCopyingSecondInputOfTwoInput() {
+		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+		CopyingSecondInputOfTwoInputStreamOperatorOutput output = new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer);
+
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement2());
+		assertEquals(element, op.getCurrentElement2());
+		assertNull(op.getCurrentElement1());
+
+		output.emitWatermark(watermark);
+		assertSame(watermark, op.getCurrentWatermark2());
+		assertNull(op.getCurrentWatermark1());
+
+		output.emitLatencyMarker(latencyMarker);
+		assertSame(latencyMarker, op.getCurrentLatencyMarker2());
+		assertNull(op.getCurrentLatencyMarker1());
+	}
+
+	@Test
+	public void testBroadcasting() {
+		TestingOneInputStreamOperator op1 = new TestingOneInputStreamOperator();
+		OneInputStreamOperatorOutput output1 = new OneInputStreamOperatorOutput(op1);
+		TestingOneInputStreamOperator op2 = new TestingOneInputStreamOperator();
+		OneInputStreamOperatorOutput output2 = new OneInputStreamOperatorOutput(op2);
+		BroadcastingOutput output = new BroadcastingOutput(new Output[] { output1, output2 });
+
+		output.collect(element);
+		assertEquals(element, op1.getCurrentElement());
+		assertEquals(element, op2.getCurrentElement());
+
+		output.emitWatermark(watermark);
+		assertEquals(watermark, op1.getCurrentWatermark());
+		assertEquals(watermark, op2.getCurrentWatermark());
+
+		// random choose one output to emit LatencyMarker
+		output.emitLatencyMarker(latencyMarker);
+		if (op1.getCurrentLatencyMarker() != null) {
+			assertEquals(latencyMarker, op1.getCurrentLatencyMarker());
+			assertNull(op2.getCurrentLatencyMarker());
+		} else {
+			assertEquals(latencyMarker, op2.getCurrentLatencyMarker());
+		}
+	}
+
+	@Test
+	public void testCopyingBroadcasting() {
+		TestingOneInputStreamOperator op1 = new TestingOneInputStreamOperator();
+		OneInputStreamOperatorOutput output1 = new OneInputStreamOperatorOutput(op1);
+		TestingOneInputStreamOperator op2 = new TestingOneInputStreamOperator();
+		OneInputStreamOperatorOutput output2 = new OneInputStreamOperatorOutput(op2);
+		CopyingBroadcastingOutput output = new CopyingBroadcastingOutput(new Output[] { output1, output2 });
+
+		output.collect(element);
+		assertNotSame(element, op1.getCurrentElement());
+		assertEquals(element, op1.getCurrentElement());
+		// the last element does not need copy
+		assertSame(element, op2.getCurrentElement());
+
+		output.emitWatermark(watermark);
+		assertSame(watermark, op1.getCurrentWatermark());
+		assertSame(watermark, op2.getCurrentWatermark());
+
+		// random choose one output to emit LatencyMarker
+		output.emitLatencyMarker(latencyMarker);
+		if (op1.getCurrentLatencyMarker() != null) {
+			assertSame(latencyMarker, op1.getCurrentLatencyMarker());
+			assertNull(op2.getCurrentLatencyMarker());
+		} else {
+			assertSame(latencyMarker, op2.getCurrentLatencyMarker());
+		}
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestBase;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -45,7 +46,7 @@ import static org.junit.Assert.assertSame;
 /**
  * Test for the sub-classes of {@link Output}.
  */
-public class OutputTest {
+public class OutputTest extends MultipleInputTestBase {
 
 	private StreamRecord<RowData> element;
 	private Watermark watermark;
@@ -62,8 +63,8 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testOneInput() {
-		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+	public void testOneInput() throws Exception {
+		TestingOneInputStreamOperator op = createOneInputStreamOperator();
 		OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op);
 
 		output.collect(element);
@@ -77,8 +78,8 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testCopyingOneInput() {
-		TestingOneInputStreamOperator op = new TestingOneInputStreamOperator();
+	public void testCopyingOneInput() throws Exception {
+		TestingOneInputStreamOperator op = createOneInputStreamOperator();
 		CopyingOneInputStreamOperatorOutput output = new CopyingOneInputStreamOperatorOutput(op, serializer);
 
 		output.collect(element);
@@ -93,8 +94,8 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testFirstInputOfTwoInput() {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+	public void testFirstInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
 		FirstInputOfTwoInputStreamOperatorOutput output = new FirstInputOfTwoInputStreamOperatorOutput(op);
 
 		output.collect(element);
@@ -111,9 +112,10 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testCopyingFirstInputOfTwoInput() {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
-		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(op, serializer);
+	public void testCopyingFirstInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(op,
+				serializer);
 
 		output.collect(element);
 		assertNotSame(element, op.getCurrentElement1());
@@ -130,8 +132,8 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testSecondInputOfTwoInput() {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
+	public void testSecondInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
 		SecondInputOfTwoInputStreamOperatorOutput output = new SecondInputOfTwoInputStreamOperatorOutput(op);
 
 		output.collect(element);
@@ -148,9 +150,10 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testCopyingSecondInputOfTwoInput() {
-		TestingTwoInputStreamOperator op = new TestingTwoInputStreamOperator();
-		CopyingSecondInputOfTwoInputStreamOperatorOutput output = new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer);
+	public void testCopyingSecondInputOfTwoInput() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		CopyingSecondInputOfTwoInputStreamOperatorOutput output =
+				new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer);
 
 		output.collect(element);
 		assertNotSame(element, op.getCurrentElement2());
@@ -167,12 +170,12 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testBroadcasting() {
-		TestingOneInputStreamOperator op1 = new TestingOneInputStreamOperator();
-		OneInputStreamOperatorOutput output1 = new OneInputStreamOperatorOutput(op1);
-		TestingOneInputStreamOperator op2 = new TestingOneInputStreamOperator();
-		OneInputStreamOperatorOutput output2 = new OneInputStreamOperatorOutput(op2);
-		BroadcastingOutput output = new BroadcastingOutput(new Output[] { output1, output2 });
+	public void testBroadcasting() throws Exception {
+		TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
+		TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
+		BroadcastingOutput output = new BroadcastingOutput(new Output[] {
+				new OneInputStreamOperatorOutput(op1),
+				new OneInputStreamOperatorOutput(op2) });
 
 		output.collect(element);
 		assertEquals(element, op1.getCurrentElement());
@@ -193,12 +196,12 @@ public class OutputTest {
 	}
 
 	@Test
-	public void testCopyingBroadcasting() {
-		TestingOneInputStreamOperator op1 = new TestingOneInputStreamOperator();
-		OneInputStreamOperatorOutput output1 = new OneInputStreamOperatorOutput(op1);
-		TestingOneInputStreamOperator op2 = new TestingOneInputStreamOperator();
-		OneInputStreamOperatorOutput output2 = new OneInputStreamOperatorOutput(op2);
-		CopyingBroadcastingOutput output = new CopyingBroadcastingOutput(new Output[] { output1, output2 });
+	public void testCopyingBroadcasting() throws Exception {
+		TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
+		TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
+		CopyingBroadcastingOutput output = new CopyingBroadcastingOutput(new Output[] {
+				new OneInputStreamOperatorOutput(op1),
+				new OneInputStreamOperatorOutput(op2) });
 
 		output.collect(element);
 		assertNotSame(element, op1.getCurrentElement());


### PR DESCRIPTION

## What is the purpose of the change

*This pr aims to introduce multiple input operator for batch. The logic in a multiple input operator is similar to OperatorChain, mainly including: initialize all sub-operators, initialize the Input list of the multiple input operator, connect each sub-operator via Output, delegate open/close/dispose action to each sub-operator, etc*



## Brief change log
  - *Introduce OneInput, FirstInputOfTwoInput, SecondInputOfTwoInput, InputSelectionHandler for multiple input operator*
  - *Introduce different Output sub-classes for multiple input operator*
  - *Introduce multiple input operator for batch*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added InputTest to verify different kinds of Input*
  - *Added OutputTest to verify different kinds of Output*
  - *Added BatchMultipleInputStreamOperatorTest to verify all actions of BatchMultipleInputStreamOperator*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
