### PR TITLE
[FLINK-19741] Allow AbstractStreamOperator to skip restoring timers if subclasses are using raw keyed state

### DIFF
--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -257,6 +257,8 @@ Set the configuration option `state.backend.rocksdb.timer-service.factory` to `h
 
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state. Other state like keyed state is still snapshotted asynchronously.*
 
+<span class="label label-info">Note</span> *When using RocksDB state backend with heap-based timers, checkpointing and taking savepoints is expected to fail if there are operators in application that write to raw keyed state.*
+
 ### Enabling RocksDB Native Metrics
 
 You can optionally access RockDB's native metrics through Flink's metrics system, by enabling certain metrics selectively.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -184,7 +184,8 @@ public class KeyedStateInputFormat<K, N, OUT> extends RichInputFormat<OUT, KeyGr
 				operator.getKeyType().createSerializer(environment.getExecutionConfig()),
 				registry,
 				getRuntimeContext().getMetricGroup(),
-				1.0);
+				1.0,
+				false);
 		} catch (Exception e) {
 			throw new IOException("Failed to restore state backend", e);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
-import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
@@ -56,14 +56,24 @@ public interface InternalTimeServiceManager<K> {
 	void advanceWatermark(Watermark watermark) throws Exception;
 
 	/**
-	 * Snapshots the timers to keyed state.
+	 * Snapshots the timers to raw keyed state. This should only be called iff
+	 * {@link #isUsingLegacyRawKeyedStateSnapshots()} returns {@code true}.
 	 *
 	 * <p><b>TODO:</b> This can be removed once heap-based timers are integrated with RocksDB
 	 * incremental snapshots.
 	 */
-	void snapshotState(
-		StateSnapshotContext context,
+	void snapshotToRawKeyedState(
+		KeyedStateCheckpointOutputStream stateCheckpointOutputStream,
 		String operatorName) throws Exception;
+
+	/**
+	 * Flag indicating whether or not the internal timer services should be checkpointed
+	 * with legacy synchronous snapshots.
+	 *
+	 * <p><b>TODO:</b> This can be removed once heap-based timers are integrated with RocksDB
+	 * incremental snapshots.
+	 */
+	boolean isUsingLegacyRawKeyedStateSnapshots();
 
 	/**
 	 * A provider pattern for creating an instance of a {@link InternalTimeServiceManager}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -46,6 +46,8 @@ public interface StreamTaskStateInitializer {
 	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
 	 * @param metricGroup the parent metric group for all statebackend metrics
 	 * @param managedMemoryFraction the managed memory fraction of the operator for state backend
+	 * @param isUsingCustomRawKeyedState flag indicating whether or not the {@link AbstractStreamOperator} is writing
+	 *                                   custom raw keyed state.
 	 * @return a context from which the given operator can initialize everything related to state.
 	 * @throws Exception when something went wrong while creating the context.
 	 */
@@ -57,5 +59,6 @@ public interface StreamTaskStateInitializer {
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
 		@Nonnull MetricGroup metricGroup,
-		double managedMemoryFraction) throws Exception;
+		double managedMemoryFraction,
+		boolean isUsingCustomRawKeyedState) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.KeyContext;
@@ -79,9 +79,14 @@ public class BatchExecutionInternalTimeServiceManager<K> implements InternalTime
 	}
 
 	@Override
-	public void snapshotState(
-			StateSnapshotContext context,
+	public void snapshotToRawKeyedState(
+			KeyedStateCheckpointOutputStream context,
 			String operatorName) throws Exception {
+		throw new UnsupportedOperationException("Checkpoints are not supported in BATCH execution");
+	}
+
+	@Override
+	public boolean isUsingLegacyRawKeyedStateSnapshots() {
 		throw new UnsupportedOperationException("Checkpoints are not supported in BATCH execution");
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -202,7 +202,8 @@ public class StateInitializationContextImplTest {
 			IntSerializer.INSTANCE,
 			closableRegistry,
 			new UnregisteredMetricsGroup(),
-			1.0);
+			1.0,
+			false);
 
 		this.initializationContext =
 				new StateInitializationContextImpl(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -147,7 +147,8 @@ public class StreamOperatorStateHandlerTest {
 					CheckpointOptions.forCheckpointWithDefaultLocation(),
 					new MemCheckpointStreamFactory(1024),
 					operatorSnapshotResult,
-					context);
+					context,
+					false);
 				fail("Exception expected.");
 			} catch (CheckpointException e) {
 				// We can not check for ExpectedTestException class directly,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -105,7 +105,8 @@ public class StreamOperatorStateHandlerTest {
 				IntSerializer.INSTANCE,
 				closeableRegistry,
 				new InterceptingOperatorMetricGroup(),
-				1.0);
+				1.0,
+				false);
 			StreamOperatorStateHandler stateHandler = new StreamOperatorStateHandler(stateContext, new ExecutionConfig(), closeableRegistry);
 
 			final String keyedStateField = "keyedStateField";

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -102,7 +102,8 @@ public class StreamTaskStateInitializerImplTest {
 			typeSerializer,
 			closeableRegistry,
 			new UnregisteredMetricsGroup(),
-			1.0);
+			1.0,
+			false);
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
@@ -214,7 +215,8 @@ public class StreamTaskStateInitializerImplTest {
 			typeSerializer,
 			closeableRegistry,
 			new UnregisteredMetricsGroup(),
-			1.0);
+			1.0,
+			false);
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		CheckpointableKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1529,7 +1529,15 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 			final StreamTaskStateInitializer streamTaskStateManager = super.createStreamTaskStateInitializer();
-			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup, fraction) -> {
+			return (operatorID,
+					operatorClassName,
+					processingTimeService,
+					keyContext,
+					keySerializer,
+					closeableRegistry,
+					metricGroup,
+					fraction,
+					isUsingCustomRawKeyedState) -> {
 
 				final StreamOperatorStateContext controller = streamTaskStateManager.streamOperatorStateContext(
 					operatorID,
@@ -1539,7 +1547,8 @@ public class StreamTaskTest extends TestLogger {
 					keySerializer,
 					closeableRegistry,
 					metricGroup,
-					fraction);
+					fraction,
+					isUsingCustomRawKeyedState);
 
 				return new StreamOperatorStateContext() {
 					@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR provides a temporary solution for the following issue:
- On restore, the timer services **_always_** attempts to read timers from raw keyed state streams, regardless of whether or not timers were actually written to raw keyed state. This is done to allow users to swap from heap-based timers to RocksDB timers across savepoint restores. Since there is no information about the previous timer configuration in savepoints, the only way to support the timer swapping is to always see if something was written.
- The issue is that this implementation **assumes that there are no other writers to the raw keyed streams**.
- If a `AbstractStreamOperator` implementation uses the raw keyed streams, on restore the timer services would assume that they wrote the checkpointed data and tries to read them, and then the restore obviously fails (because of read errors).

## Solution

This PR solves this by adding a flag `isUsingCustomRawKeyedState` to the `AbstractStreamOperator`, which by default is `false` so that under normal circumstances things remain as before:
```
protected boolean isUsingCustomRawKeyedState() {
    return false;
}
```

If a `AbstractStreamOperator` implementation writes to raw keyed streams, it should also override this to return `true`.
On restore, the timer services would respect this flag and skip reading from the raw keyed streams.

Note that this works due to the fact that there could only ever be one writer to raw keyed streams.
If there are multiple writers attempting to write to the raw keyed stream (i.e. legacy heap-based timers + some custom writing in user code), checkpointing would have already failed consistently, since the raw keyed stream API (`KeyedStateCheckpointOutputStream`) only allows calling `startNewKeyGroup` once for the same stream.

## Backport

This change should be backported to `release-1.11`.
Separate PR for the backport: #13762 

## Brief change log

- 10bfda6 introduces the `isUsingCustomRawKeyedState` flag to `AbstractStreamOperator`
- 2eab38b allows passing in the flag when creating the `StreamOperatorStateContext`
- c8b5f04 wires in the flag to be respected by the `StreamOperatorStateContext` instantiation, so that timer services do no read from raw keyed state if they weren't the ones who wrote to it.
- ece424e Adds a test that uses an `AbstractStreamOperator` implementation that writes to raw keyed state and verifies that snapshotting and restoring works, and the new flag is being respected. If you alter the flag to be `false` in the test, the test would fail.
- ebaacde Add an extra notice in docs mentioning that checkpoint would fail if you're using RocksDB + heap timers + writing to custom raw keyed state in some operators.

## Verifying this change

The new test `AbstractStreamOperatorTest#testCustomRawKeyedStateSnapshotAndRestore` should cover this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **NO**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**YES** / no)
  - The serializers: (yes / **NO** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **NO** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**YES** / no / don't know)
  - The S3 file system connector: (yes / **NO** / don't know)

## Documentation

While technically this PR introduces a new feature, we deliberately do not mention it in the docs as raw keyed state is intended as an internal feature that users should not be using (unless in some very edge cases).
