### PR TITLE
[FLINK-19779][avro] Remove the record_ field name prefix for Confluen…

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -511,7 +511,7 @@ public class HiveTableSinkITCase {
 
 		@Override
 		public DataType getProducedDataType() {
-			return TypeConversions.fromLegacyInfoToDataType(rowTypeInfo);
+			return TypeConversions.fromLegacyInfoToDataType(rowTypeInfo).notNull();
 		}
 
 		@Override

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
@@ -139,7 +139,8 @@ public class RegistryAvroRowDataSeDeSchemaTest {
 		RowType rowType = (RowType) dataType.getLogicalType();
 
 		AvroRowDataSerializationSchema serializer = getSerializationSchema(rowType, schema);
-		Schema writeSchema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
+		Schema writeSchema = AvroSchemaConverter
+			.convertToSchema(dataType.getLogicalType());
 		AvroRowDataDeserializationSchema deserializer =
 				getDeserializationSchema(rowType, writeSchema);
 

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
@@ -139,7 +139,9 @@ public class RegistryAvroRowDataSeDeSchemaTest {
 		RowType rowType = (RowType) dataType.getLogicalType();
 
 		AvroRowDataSerializationSchema serializer = getSerializationSchema(rowType, schema);
-		AvroRowDataDeserializationSchema deserializer = getDeserializationSchema(rowType, schema);
+		Schema writeSchema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
+		AvroRowDataDeserializationSchema deserializer =
+				getDeserializationSchema(rowType, writeSchema);
 
 		serializer.open(null);
 		deserializer.open(null);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -265,7 +265,7 @@ public class AvroSchemaConverter {
 			if (logicalType == LogicalTypes.date()) {
 				return DataTypes.DATE().notNull();
 			} else if (logicalType == LogicalTypes.timeMillis()) {
-				return DataTypes.TIME().notNull();
+				return DataTypes.TIME(3).notNull();
 			}
 			return DataTypes.INT().notNull();
 		case LONG:
@@ -274,6 +274,8 @@ public class AvroSchemaConverter {
 				return DataTypes.TIMESTAMP(3).notNull();
 			} else if (schema.getLogicalType() == LogicalTypes.timestampMicros()) {
 				return DataTypes.TIMESTAMP(6).notNull();
+			} else if (schema.getLogicalType() == LogicalTypes.timeMillis()) {
+				return DataTypes.TIME(3).notNull();
 			} else if (schema.getLogicalType() == LogicalTypes.timeMicros()) {
 				return DataTypes.TIME(6).notNull();
 			}
@@ -293,15 +295,22 @@ public class AvroSchemaConverter {
 	/**
 	 * Converts Flink SQL {@link LogicalType} (can be nested) into an Avro schema.
 	 *
-	 * @param logicalType logical type
+	 * <p>Use "record" as the type name.
+	 *
+	 * @param schema the schema type, usually it should be the top level record type,
+	 *               e.g. not a nested type
 	 * @return Avro's {@link Schema} matching this logical type.
 	 */
-	public static Schema convertToSchema(LogicalType logicalType) {
-		return convertToSchema(logicalType, "record");
+	public static Schema convertToSchema(LogicalType schema) {
+		return convertToSchema(schema, "record");
 	}
 
 	/**
 	 * Converts Flink SQL {@link LogicalType} (can be nested) into an Avro schema.
+	 *
+	 * <p>The "{rowName}_" is used as the nested row type name prefix in order to
+	 * generate the right schema. Nested record type that only differs with type name
+	 * is still compatible.
 	 *
 	 * @param logicalType logical type
 	 * @param rowName     the record name
@@ -349,10 +358,12 @@ public class AvroSchemaConverter {
 					throw new IllegalArgumentException("Avro does not support TIMESTAMP type " +
 						"with precision: " + precision + ", it only supports precision less than 3.");
 				}
-				return avroLogicalType.addToSchema(SchemaBuilder.builder().longType());
+				Schema timestamp = avroLogicalType.addToSchema(SchemaBuilder.builder().longType());
+				return nullable ? nullableSchema(timestamp) : timestamp;
 			case DATE:
 				// use int to represents Date
-				return LogicalTypes.date().addToSchema(SchemaBuilder.builder().intType());
+				Schema date = LogicalTypes.date().addToSchema(SchemaBuilder.builder().intType());
+				return nullable ? nullableSchema(date) : date;
 			case TIME_WITHOUT_TIME_ZONE:
 				precision = ((TimeType) logicalType).getPrecision();
 				if (precision > 3) {
@@ -361,13 +372,16 @@ public class AvroSchemaConverter {
 						", it only supports precision less than 3.");
 				}
 				// use int to represents Time, we only support millisecond when deserialization
-				return LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder().intType());
+				Schema time = LogicalTypes.timeMillis()
+						.addToSchema(SchemaBuilder.builder().intType());
+				return nullable ? nullableSchema(time) : time;
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) logicalType;
 				// store BigDecimal as byte[]
-				return LogicalTypes
-					.decimal(decimalType.getPrecision(), decimalType.getScale())
-					.addToSchema(SchemaBuilder.builder().bytesType());
+				Schema decimal = LogicalTypes
+						.decimal(decimalType.getPrecision(), decimalType.getScale())
+						.addToSchema(SchemaBuilder.builder().bytesType());
+				return nullable ? nullableSchema(decimal) : decimal;
 			case ROW:
 				RowType rowType = (RowType) logicalType;
 				List<String> fieldNames = rowType.getFieldNames();
@@ -386,18 +400,16 @@ public class AvroSchemaConverter {
 				return nullable ? nullableSchema(record) : record;
 			case MULTISET:
 			case MAP:
-				return SchemaBuilder
-					.builder()
-					.nullable()
-					.map()
-					.values(convertToSchema(extractValueTypeToAvroMap(logicalType), rowName));
+				Schema map = SchemaBuilder.builder()
+						.map()
+						.values(convertToSchema(extractValueTypeToAvroMap(logicalType), rowName));
+				return nullable ? nullableSchema(map) : map;
 			case ARRAY:
 				ArrayType arrayType = (ArrayType) logicalType;
-				return SchemaBuilder
-					.builder()
-					.nullable()
-					.array()
-					.items(convertToSchema(arrayType.getElementType(), rowName));
+				Schema array = SchemaBuilder.builder()
+						.array()
+						.items(convertToSchema(arrayType.getElementType(), rowName));
+				return nullable ? nullableSchema(array) : array;
 			case RAW:
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
 			default:

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -95,7 +95,8 @@ public class AvroRowDataDeSerializationSchemaTest {
 			FIELD("map", MAP(STRING(), BIGINT())),
 			FIELD("map2map", MAP(STRING(), MAP(STRING(), INT()))),
 			FIELD("map2array", MAP(STRING(), ARRAY(INT()))),
-			FIELD("nullEntryMap", MAP(STRING(), STRING())));
+			FIELD("nullEntryMap", MAP(STRING(), STRING())))
+			.notNull();
 		final RowType rowType = (RowType) dataType.getLogicalType();
 		final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(rowType);
 
@@ -182,9 +183,10 @@ public class AvroRowDataDeSerializationSchemaTest {
 		byte[] input = byteArrayOutputStream.toByteArray();
 
 		DataType dataType = ROW(
-				FIELD("type_timestamp_millis", TIMESTAMP(3)),
-				FIELD("type_date", DATE()),
-				FIELD("type_time_millis", TIME(3)));
+				FIELD("type_timestamp_millis", TIMESTAMP(3).notNull()),
+				FIELD("type_date", DATE().notNull()),
+				FIELD("type_time_millis", TIME(3).notNull()))
+			.notNull();
 		final RowType rowType = (RowType) dataType.getLogicalType();
 		final TypeInformation<RowData> typeInfo = InternalTypeInfo.of(rowType);
 		AvroRowDataSerializationSchema serializationSchema = new AvroRowDataSerializationSchema(rowType);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -104,80 +104,79 @@ public class AvroSchemaConverterTest {
 				DataTypes.FIELD("row3", DataTypes.ROW(DataTypes.FIELD("c", DataTypes.STRING())))))
 			.build().toRowDataType().getLogicalType();
 		Schema schema = AvroSchemaConverter.convertToSchema(rowType);
-		assertEquals("[ {\n" +
-				"  \"type\" : \"record\",\n" +
-				"  \"name\" : \"record\",\n" +
-				"  \"fields\" : [ {\n" +
-				"    \"name\" : \"row1\",\n" +
-				"    \"type\" : [ {\n" +
-				"      \"type\" : \"record\",\n" +
-				"      \"name\" : \"record_row1\",\n" +
-				"      \"fields\" : [ {\n" +
-				"        \"name\" : \"a\",\n" +
-				"        \"type\" : [ \"string\", \"null\" ]\n" +
-				"      } ]\n" +
-				"    }, \"null\" ]\n" +
-				"  }, {\n" +
-				"    \"name\" : \"row2\",\n" +
-				"    \"type\" : [ {\n" +
-				"      \"type\" : \"record\",\n" +
-				"      \"name\" : \"record_row2\",\n" +
-				"      \"fields\" : [ {\n" +
-				"        \"name\" : \"b\",\n" +
-				"        \"type\" : [ \"string\", \"null\" ]\n" +
-				"      } ]\n" +
-				"    }, \"null\" ]\n" +
-				"  }, {\n" +
-				"    \"name\" : \"row3\",\n" +
-				"    \"type\" : [ {\n" +
-				"      \"type\" : \"record\",\n" +
-				"      \"name\" : \"record_row3\",\n" +
-				"      \"fields\" : [ {\n" +
-				"        \"name\" : \"row3\",\n" +
-				"        \"type\" : [ {\n" +
-				"          \"type\" : \"record\",\n" +
-				"          \"name\" : \"record_row3_row3\",\n" +
-				"          \"fields\" : [ {\n" +
-				"            \"name\" : \"c\",\n" +
-				"            \"type\" : [ \"string\", \"null\" ]\n" +
-				"          } ]\n" +
-				"        }, \"null\" ]\n" +
-				"      } ]\n" +
-				"    }, \"null\" ]\n" +
-				"  } ]\n" +
-				"}, \"null\" ]", schema.toString(true));
+		assertEquals("{\n" +
+			"  \"type\" : \"record\",\n" +
+			"  \"name\" : \"record\",\n" +
+			"  \"fields\" : [ {\n" +
+			"    \"name\" : \"row1\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"record\",\n" +
+			"      \"name\" : \"record_row1\",\n" +
+			"      \"fields\" : [ {\n" +
+			"        \"name\" : \"a\",\n" +
+			"        \"type\" : [ \"string\", \"null\" ]\n" +
+			"      } ]\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"row2\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"record\",\n" +
+			"      \"name\" : \"record_row2\",\n" +
+			"      \"fields\" : [ {\n" +
+			"        \"name\" : \"b\",\n" +
+			"        \"type\" : [ \"string\", \"null\" ]\n" +
+			"      } ]\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"row3\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"record\",\n" +
+			"      \"name\" : \"record_row3\",\n" +
+			"      \"fields\" : [ {\n" +
+			"        \"name\" : \"row3\",\n" +
+			"        \"type\" : [ {\n" +
+			"          \"type\" : \"record\",\n" +
+			"          \"name\" : \"record_row3_row3\",\n" +
+			"          \"fields\" : [ {\n" +
+			"            \"name\" : \"c\",\n" +
+			"            \"type\" : [ \"string\", \"null\" ]\n" +
+			"          } ]\n" +
+			"        }, \"null\" ]\n" +
+			"      } ]\n" +
+			"    }, \"null\" ]\n" +
+			"  } ]\n" +
+			"}", schema.toString(true));
 	}
 
 	/**
 	 * Test convert nullable data type to Avro schema then converts back.
 	 */
 	@Test
-	public void testConversionIntegralityNullable() {
+	public void testDataTypeToSchemaToDataTypeNullable() {
 		DataType dataType = DataTypes.ROW(
-				DataTypes.FIELD("f_null", DataTypes.NULL()),
-				DataTypes.FIELD("f_boolean", DataTypes.BOOLEAN()),
-				// tinyint and smallint all convert to int
-				DataTypes.FIELD("f_int", DataTypes.INT()),
-				DataTypes.FIELD("f_bigint", DataTypes.BIGINT()),
-				DataTypes.FIELD("f_float", DataTypes.FLOAT()),
-				DataTypes.FIELD("f_double", DataTypes.DOUBLE()),
-				// char converts to string
-				DataTypes.FIELD("f_string", DataTypes.STRING()),
-				// binary converts to bytes
-				DataTypes.FIELD("f_varbinary", DataTypes.BYTES()),
-				DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
-				DataTypes.FIELD("f_date", DataTypes.DATE()),
-				DataTypes.FIELD("f_time", DataTypes.TIME(3)),
-				DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(10, 0)),
-				DataTypes.FIELD("f_row", DataTypes.ROW(
-					DataTypes.FIELD("f0", DataTypes.INT()),
-					DataTypes.FIELD("f1", DataTypes.TIMESTAMP(3)))),
-				// multiset converts to map
-				// map key is always not null
-				DataTypes.FIELD("f_map",
-						DataTypes.MAP(DataTypes.STRING().notNull(), DataTypes.INT())),
-				DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.INT())))
-				.notNull();
+			DataTypes.FIELD("f_null", DataTypes.NULL()),
+			DataTypes.FIELD("f_boolean", DataTypes.BOOLEAN()),
+			// tinyint and smallint all convert to int
+			DataTypes.FIELD("f_int", DataTypes.INT()),
+			DataTypes.FIELD("f_bigint", DataTypes.BIGINT()),
+			DataTypes.FIELD("f_float", DataTypes.FLOAT()),
+			DataTypes.FIELD("f_double", DataTypes.DOUBLE()),
+			// char converts to string
+			DataTypes.FIELD("f_string", DataTypes.STRING()),
+			// binary converts to bytes
+			DataTypes.FIELD("f_varbinary", DataTypes.BYTES()),
+			DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3)),
+			DataTypes.FIELD("f_date", DataTypes.DATE()),
+			DataTypes.FIELD("f_time", DataTypes.TIME(3)),
+			DataTypes.FIELD("f_decimal", DataTypes.DECIMAL(10, 0)),
+			DataTypes.FIELD("f_row", DataTypes.ROW(
+				DataTypes.FIELD("f0", DataTypes.INT()),
+				DataTypes.FIELD("f1", DataTypes.TIMESTAMP(3)))),
+			// multiset converts to map
+			// map key is always not null
+			DataTypes.FIELD("f_map",
+				DataTypes.MAP(DataTypes.STRING().notNull(), DataTypes.INT())),
+			DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.INT())));
 		Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
 		DataType converted = AvroSchemaConverter.convertToDataType(schema.toString());
 		assertEquals(dataType, converted);
@@ -187,39 +186,223 @@ public class AvroSchemaConverterTest {
 	 * Test convert non-nullable data type to Avro schema then converts back.
 	 */
 	@Test
-	public void testConversionIntegralityNonNullable() {
+	public void testDataTypeToSchemaToDataTypeNonNullable() {
 		DataType dataType = DataTypes.ROW(
-				DataTypes.FIELD("f_boolean", DataTypes.BOOLEAN().notNull()),
-				// tinyint and smallint all convert to int
-				DataTypes.FIELD("f_int", DataTypes.INT().notNull()),
-				DataTypes.FIELD("f_bigint", DataTypes.BIGINT().notNull()),
-				DataTypes.FIELD("f_float", DataTypes.FLOAT().notNull()),
-				DataTypes.FIELD("f_double", DataTypes.DOUBLE().notNull()),
-				// char converts to string
-				DataTypes.FIELD("f_string", DataTypes.STRING().notNull()),
-				// binary converts to bytes
-				DataTypes.FIELD("f_varbinary", DataTypes.BYTES().notNull()),
-				DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3).notNull()),
-				DataTypes.FIELD("f_date", DataTypes.DATE().notNull()),
-				DataTypes.FIELD("f_time", DataTypes.TIME(3).notNull()),
-				DataTypes.FIELD("f_decimal",
-						DataTypes.DECIMAL(10, 0).notNull()),
-				DataTypes.FIELD("f_row", DataTypes.ROW(
-						DataTypes.FIELD("f0", DataTypes.INT().notNull()),
-						DataTypes.FIELD("f1", DataTypes.TIMESTAMP(3).notNull()))
-						.notNull()),
-				// multiset converts to map
-				// map key is always not null
-				DataTypes.FIELD("f_map",
-						DataTypes.MAP(
-								DataTypes.STRING().notNull(),
-								DataTypes.INT().notNull())
-								.notNull()),
-				DataTypes.FIELD("f_array",
-						DataTypes.ARRAY(DataTypes.INT().notNull()).notNull()));
+			DataTypes.FIELD("f_boolean", DataTypes.BOOLEAN().notNull()),
+			// tinyint and smallint all convert to int
+			DataTypes.FIELD("f_int", DataTypes.INT().notNull()),
+			DataTypes.FIELD("f_bigint", DataTypes.BIGINT().notNull()),
+			DataTypes.FIELD("f_float", DataTypes.FLOAT().notNull()),
+			DataTypes.FIELD("f_double", DataTypes.DOUBLE().notNull()),
+			// char converts to string
+			DataTypes.FIELD("f_string", DataTypes.STRING().notNull()),
+			// binary converts to bytes
+			DataTypes.FIELD("f_varbinary", DataTypes.BYTES().notNull()),
+			DataTypes.FIELD("f_timestamp", DataTypes.TIMESTAMP(3).notNull()),
+			DataTypes.FIELD("f_date", DataTypes.DATE().notNull()),
+			DataTypes.FIELD("f_time", DataTypes.TIME(3).notNull()),
+			DataTypes.FIELD("f_decimal",
+				DataTypes.DECIMAL(10, 0).notNull()),
+			DataTypes.FIELD("f_row", DataTypes.ROW(
+				DataTypes.FIELD("f0", DataTypes.INT().notNull()),
+				DataTypes.FIELD("f1", DataTypes.TIMESTAMP(3).notNull()))
+				.notNull()),
+			// multiset converts to map
+			// map key is always not null
+			DataTypes.FIELD("f_map",
+				DataTypes.MAP(
+					DataTypes.STRING().notNull(),
+					DataTypes.INT().notNull())
+					.notNull()),
+			DataTypes.FIELD("f_array",
+				DataTypes.ARRAY(DataTypes.INT().notNull()).notNull()))
+			.notNull();
 		Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
 		DataType converted = AvroSchemaConverter.convertToDataType(schema.toString());
 		assertEquals(dataType, converted);
+	}
+
+	/**
+	 * Test convert nullable Avro schema to data type then converts back.
+	 */
+	@Test
+	public void testSchemaToDataTypeToSchemaNullable() {
+		String schemaStr = "{\n" +
+			"  \"type\" : \"record\",\n" +
+			"  \"name\" : \"record\",\n" +
+			"  \"fields\" : [ {\n" +
+			"    \"name\" : \"f_null\",\n" +
+			"    \"type\" : \"null\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_boolean\",\n" +
+			"    \"type\" : [ \"boolean\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_int\",\n" +
+			"    \"type\" : [ \"int\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_bigint\",\n" +
+			"    \"type\" : [ \"long\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_float\",\n" +
+			"    \"type\" : [ \"float\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_double\",\n" +
+			"    \"type\" : [ \"double\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_string\",\n" +
+			"    \"type\" : [ \"string\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_varbinary\",\n" +
+			"    \"type\" : [ \"bytes\", \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_timestamp\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"long\",\n" +
+			"      \"logicalType\" : \"timestamp-millis\"\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_date\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"int\",\n" +
+			"      \"logicalType\" : \"date\"\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_time\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"int\",\n" +
+			"      \"logicalType\" : \"time-millis\"\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_decimal\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"bytes\",\n" +
+			"      \"logicalType\" : \"decimal\",\n" +
+			"      \"precision\" : 10,\n" +
+			"      \"scale\" : 0\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_row\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"record\",\n" +
+			"      \"name\" : \"record_f_row\",\n" +
+			"      \"fields\" : [ {\n" +
+			"        \"name\" : \"f0\",\n" +
+			"        \"type\" : [ \"int\", \"null\" ]\n" +
+			"      }, {\n" +
+			"        \"name\" : \"f1\",\n" +
+			"        \"type\" : [ {\n" +
+			"          \"type\" : \"long\",\n" +
+			"          \"logicalType\" : \"timestamp-millis\"\n" +
+			"        }, \"null\" ]\n" +
+			"      } ]\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_map\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"map\",\n" +
+			"      \"values\" : [ \"int\", \"null\" ]\n" +
+			"    }, \"null\" ]\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_array\",\n" +
+			"    \"type\" : [ {\n" +
+			"      \"type\" : \"array\",\n" +
+			"      \"items\" : [ \"int\", \"null\" ]\n" +
+			"    }, \"null\" ]\n" +
+			"  } ]\n" +
+			"}";
+		DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr);
+		Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
+		assertEquals(new Schema.Parser().parse(schemaStr), schema);
+	}
+
+	/**
+	 * Test convert non-nullable Avro schema to data type then converts back.
+	 */
+	@Test
+	public void testSchemaToDataTypeToSchemaNonNullable() {
+		String schemaStr = "{\n" +
+			"  \"type\" : \"record\",\n" +
+			"  \"name\" : \"record\",\n" +
+			"  \"fields\" : [ {\n" +
+			"    \"name\" : \"f_boolean\",\n" +
+			"    \"type\" : \"boolean\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_int\",\n" +
+			"    \"type\" : \"int\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_bigint\",\n" +
+			"    \"type\" : \"long\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_float\",\n" +
+			"    \"type\" : \"float\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_double\",\n" +
+			"    \"type\" : \"double\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_string\",\n" +
+			"    \"type\" : \"string\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_varbinary\",\n" +
+			"    \"type\" : \"bytes\"\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_timestamp\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"long\",\n" +
+			"      \"logicalType\" : \"timestamp-millis\"\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_date\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"int\",\n" +
+			"      \"logicalType\" : \"date\"\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_time\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"int\",\n" +
+			"      \"logicalType\" : \"time-millis\"\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_decimal\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"bytes\",\n" +
+			"      \"logicalType\" : \"decimal\",\n" +
+			"      \"precision\" : 10,\n" +
+			"      \"scale\" : 0\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_row\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"record\",\n" +
+			"      \"name\" : \"record_f_row\",\n" +
+			"      \"fields\" : [ {\n" +
+			"        \"name\" : \"f0\",\n" +
+			"        \"type\" : \"int\"\n" +
+			"      }, {\n" +
+			"        \"name\" : \"f1\",\n" +
+			"        \"type\" : {\n" +
+			"          \"type\" : \"long\",\n" +
+			"          \"logicalType\" : \"timestamp-millis\"\n" +
+			"        }\n" +
+			"      } ]\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_map\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"map\",\n" +
+			"      \"values\" : \"int\"\n" +
+			"    }\n" +
+			"  }, {\n" +
+			"    \"name\" : \"f_array\",\n" +
+			"    \"type\" : {\n" +
+			"      \"type\" : \"array\",\n" +
+			"      \"items\" : \"int\"\n" +
+			"    }\n" +
+			"  } ]\n" +
+			"}";
+		DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr);
+		Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
+		assertEquals(new Schema.Parser().parse(schemaStr), schema);
 	}
 
 	private void validateUserSchema(TypeInformation<?> actual) {
@@ -320,7 +503,7 @@ public class AvroSchemaConverterTest {
 				DataTypes.FIELD("type_nested", address),
 				DataTypes.FIELD("type_bytes", DataTypes.BYTES().notNull()),
 				DataTypes.FIELD("type_date", DataTypes.DATE().notNull()),
-				DataTypes.FIELD("type_time_millis", DataTypes.TIME().notNull()),
+				DataTypes.FIELD("type_time_millis", DataTypes.TIME(3).notNull()),
 				DataTypes.FIELD("type_time_micros", DataTypes.TIME(6).notNull()),
 				DataTypes.FIELD("type_timestamp_millis",
 						DataTypes.TIMESTAMP(3).notNull()),

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1534,7 +1534,7 @@ class TableEnvironment(object):
             jvm = get_gateway().jvm
 
             data_type = jvm.org.apache.flink.table.types.utils.TypeConversions\
-                .fromLegacyInfoToDataType(_to_java_type(result_type))
+                .fromLegacyInfoToDataType(_to_java_type(result_type)).notNull()
             if self._is_blink_planner:
                 data_type = data_type.bridgedTo(
                     load_java_class('org.apache.flink.table.data.RowData'))

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -63,7 +63,7 @@ class PandasConversionTestBase(object):
                  [DataTypes.FIELD("a", DataTypes.INT()),
                   DataTypes.FIELD("b", DataTypes.STRING()),
                   DataTypes.FIELD("c", DataTypes.TIMESTAMP(3)),
-                  DataTypes.FIELD("d", DataTypes.ARRAY(DataTypes.INT()))]))])
+                  DataTypes.FIELD("d", DataTypes.ARRAY(DataTypes.INT()))]))], False)
         cls.pdf = cls.create_pandas_data_frame()
 
     @classmethod

--- a/flink-python/pyflink/table/tests/test_table_schema.py
+++ b/flink-python/pyflink/table/tests/test_table_schema.py
@@ -100,7 +100,8 @@ class TableSchemaTests(PyFlinkTestCase):
 
         expected = DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
                                   DataTypes.FIELD("b", DataTypes.BIGINT()),
-                                  DataTypes.FIELD("c", DataTypes.STRING())])
+                                  DataTypes.FIELD("c", DataTypes.STRING())],
+                                 nullable=False)
         self.assertEqual(expected, row_type)
 
     def test_hash(self):

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/SimpleCatalogFactory.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/SimpleCatalogFactory.java
@@ -86,8 +86,8 @@ public class SimpleCatalogFactory implements CatalogFactory {
 			public DataType getProducedDataType() {
 				return DataTypes.ROW(
 					DataTypes.FIELD("id", DataTypes.INT()),
-					DataTypes.FIELD("string", DataTypes.STRING())
-				);
+					DataTypes.FIELD("string", DataTypes.STRING()))
+					.notNull();
 			}
 		};
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -245,7 +245,8 @@ public class TableSchema {
 		final Field[] fields = columns.stream()
 			.map(column -> FIELD(column.getName(), column.getType()))
 			.toArray(Field[]::new);
-		return ROW(fields);
+		// The row should be never null.
+		return ROW(fields).notNull();
 	}
 
 	/**
@@ -263,7 +264,8 @@ public class TableSchema {
 			.filter(TableColumn::isPhysical)
 			.map(column -> FIELD(column.getName(), column.getType()))
 			.toArray(Field[]::new);
-		return ROW(fields);
+		// The row should be never null.
+		return ROW(fields).notNull();
 	}
 
 	/**
@@ -283,7 +285,8 @@ public class TableSchema {
 			.filter(TableColumn::isPersisted)
 			.map(column -> FIELD(column.getName(), column.getType()))
 			.toArray(Field[]::new);
-		return ROW(fields);
+		// The row should be never null.
+		return ROW(fields).notNull();
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FileSystemFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FileSystemFormatFactory.java
@@ -134,6 +134,7 @@ public interface FileSystemFormatFactory extends Factory {
 		 */
 		default RowType getFormatRowType() {
 			return RowType.of(
+				false,
 				Arrays.stream(getFormatFieldTypes())
 					.map(DataType::getLogicalType)
 					.toArray(LogicalType[]::new),
@@ -198,6 +199,7 @@ public interface FileSystemFormatFactory extends Factory {
 		 */
 		default RowType getFormatRowType() {
 			return RowType.of(
+				false,
 				Arrays.stream(getFormatFieldTypes())
 					.map(DataType::getLogicalType)
 					.toArray(LogicalType[]::new),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
@@ -60,7 +60,7 @@ public interface TableSource<T> {
 		if (legacyType == null) {
 			throw new TableException("Table source does not implement a produced data type.");
 		}
-		return fromLegacyInfoToDataType(legacyType);
+		return fromLegacyInfoToDataType(legacyType).notNull();
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
@@ -292,10 +292,14 @@ public final class RowType extends LogicalType {
 	}
 
 	public static RowType of(LogicalType[] types, String[] names) {
+		return of(true, types, names);
+	}
+
+	public static RowType of(boolean nullable, LogicalType[] types, String[] names) {
 		List<RowField> fields = new ArrayList<>();
 		for (int i = 0; i < types.length; i++) {
 			fields.add(new RowField(names[i], types[i]));
 		}
-		return new RowType(fields);
+		return new RowType(nullable, fields);
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -109,10 +109,52 @@ public class TableSchemaTest {
 			DataTypes.FIELD("f0", DataTypes.BIGINT()),
 			DataTypes.FIELD("f2", DataTypes.BIGINT()),
 			DataTypes.FIELD("f3", DataTypes.STRING()),
-			DataTypes.FIELD("f5", DataTypes.BIGINT())
-		);
+			DataTypes.FIELD("f5", DataTypes.BIGINT()))
+			.notNull();
 
 		assertThat(schema.toPersistedRowDataType(), equalTo(expectedDataType));
+	}
+
+	@Test
+	public void testPhysicalRowDataType() {
+		final TableSchema schema = TableSchema.builder()
+			.add(TableColumn.physical("f0", DataTypes.BIGINT()))
+			.add(TableColumn.metadata("f1", DataTypes.BIGINT(), true))
+			.add(TableColumn.metadata("f2", DataTypes.BIGINT(), false))
+			.add(TableColumn.physical("f3", DataTypes.STRING()))
+			.add(TableColumn.computed("f4", DataTypes.BIGINT(), "f0 + 1"))
+			.add(TableColumn.metadata("f5", DataTypes.BIGINT(), false))
+			.build();
+
+		final DataType expectedDataType = DataTypes.ROW(
+			DataTypes.FIELD("f0", DataTypes.BIGINT()),
+			DataTypes.FIELD("f3", DataTypes.STRING()))
+			.notNull();
+
+		assertThat(schema.toPhysicalRowDataType(), equalTo(expectedDataType));
+	}
+
+	@Test
+	public void testRowDataType() {
+		final TableSchema schema = TableSchema.builder()
+			.add(TableColumn.physical("f0", DataTypes.BIGINT()))
+			.add(TableColumn.metadata("f1", DataTypes.BIGINT(), true))
+			.add(TableColumn.metadata("f2", DataTypes.BIGINT(), false))
+			.add(TableColumn.physical("f3", DataTypes.STRING()))
+			.add(TableColumn.computed("f4", DataTypes.BIGINT(), "f0 + 1"))
+			.add(TableColumn.metadata("f5", DataTypes.BIGINT(), false))
+			.build();
+
+		final DataType expectedDataType = DataTypes.ROW(
+			DataTypes.FIELD("f0", DataTypes.BIGINT()),
+			DataTypes.FIELD("f1", DataTypes.BIGINT()),
+			DataTypes.FIELD("f2", DataTypes.BIGINT()),
+			DataTypes.FIELD("f3", DataTypes.STRING()),
+			DataTypes.FIELD("f4", DataTypes.BIGINT()),
+			DataTypes.FIELD("f5", DataTypes.BIGINT()))
+			.notNull();
+
+		assertThat(schema.toRowDataType(), equalTo(expectedDataType));
 	}
 
 	@Test

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/BatchTableSourceScan.scala
@@ -116,7 +116,8 @@ class BatchTableSourceScan(
       case _ => throw new TableException("Only BatchTableSource and InputFormatTableSource are " +
         "supported in BatchTableEnvironment.")
     }
-    val inputDataType = fromLegacyInfoToDataType(inputDataSet.getType)
+    // Fix the nullability of row type info.
+    val inputDataType = fromLegacyInfoToDataType(inputDataSet.getType).notNull()
     val producedDataType = tableSource.getProducedDataType
 
     // check that declared and actual type of table source DataSet are identical

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
@@ -106,7 +106,8 @@ class StreamTableSourceScan(
       .asInstanceOf[DataStream[Any]]
     val outputSchema = new RowSchema(this.getRowType)
 
-    val inputDataType = fromLegacyInfoToDataType(inputDataStream.getType)
+    // Fix the nullability of row type info.
+    val inputDataType = fromLegacyInfoToDataType(inputDataStream.getType).notNull()
     val producedDataType = tableSource.getProducedDataType
 
     // check that declared and actual type of table source DataStream are identical

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -296,6 +296,7 @@ public class FileSystemTableSource extends AbstractFileSystemTable implements
 		return DataTypes.ROW(Arrays.stream(fields)
 				.mapToObj(i -> DataTypes.FIELD(schemaFieldNames[i], schemaTypes[i]))
 				.toArray(DataTypes.Field[]::new))
-				.bridgedTo(RowData.class);
+				.bridgedTo(RowData.class)
+			.notNull();
 	}
 }


### PR DESCRIPTION
…t Avro format deserialization

## What is the purpose of the change

Add prefix for the field name only when the record and field have the same name.


## Brief change log

  - Modify `AvroSchemaConverter.convertToSchema` to only append field prefix when the record and field have the same name
  - Modify the existing test


## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
