### PR TITLE
[FLINK-19780][table-planner-blink] Introduce FlinkRelMdUtil#numDistinctVals to work around precision problem in Calcite's implementation

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
@@ -98,7 +98,7 @@ class FlinkRelMdDistinctRowCount private extends MetadataHandler[BuiltInMetadata
     val selectivity = RelMdUtil.guessSelectivity(predicate)
     val rowCount = mq.getRowCount(rel)
     val nRows = rowCount / 2
-    RelMdUtil.numDistinctVals(nRows, nRows * selectivity)
+    FlinkRelMdUtil.numDistinctVals(nRows, nRows * selectivity)
   }
 
   def getDistinctRowCount(
@@ -191,7 +191,7 @@ class FlinkRelMdDistinctRowCount private extends MetadataHandler[BuiltInMetadata
       distinctRowCount *= subRowCount
     }
     val rowCount = mq.getRowCount(rel)
-    RelMdUtil.numDistinctVals(distinctRowCount, rowCount)
+    FlinkRelMdUtil.numDistinctVals(distinctRowCount, rowCount)
   }
 
   def getDistinctRowCount(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSize.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSize.scala
@@ -94,7 +94,7 @@ class FlinkRelMdPopulationSize private extends MetadataHandler[BuiltInMetadata.P
     // numDistinctVals.  This is needed; otherwise, population can be
     // larger than the number of rows in the RelNode.
     val rowCount = mq.getRowCount(rel)
-    RelMdUtil.numDistinctVals(population, rowCount)
+    FlinkRelMdUtil.numDistinctVals(population, rowCount)
   }
 
   def getPopulationSize(
@@ -136,7 +136,7 @@ class FlinkRelMdPopulationSize private extends MetadataHandler[BuiltInMetadata.P
     // numDistinctVals.  This is needed; otherwise, population can be
     // larger than the number of rows in the RelNode.
     val rowCount = mq.getRowCount(rel)
-    RelMdUtil.numDistinctVals(population, rowCount)
+    FlinkRelMdUtil.numDistinctVals(population, rowCount)
   }
 
   def getPopulationSize(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
@@ -660,4 +660,19 @@ class FlinkRelMdDistinctRowCountTest extends FlinkRelMdHandlerTestBase {
     assertEquals(null, mq.getDistinctRowCount(testRel, ImmutableBitSet.of(0), null))
   }
 
+  @Test
+  def testGetDistinctRowCountOnLargeDomainSize(): Unit = {
+    relBuilder.clear()
+    val rel = relBuilder
+      .scan("MyTable1")
+      .project(
+        relBuilder.field(0),
+        relBuilder.field(1),
+        relBuilder.call(SUBSTRING, relBuilder.field(3), relBuilder.literal(10)))
+      .build()
+    assertEquals(
+      7.999999964933156E8,
+      mq.getDistinctRowCount(rel, ImmutableBitSet.of(0, 1, 2), null),
+      1e-2)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
@@ -75,10 +75,10 @@ class FlinkRelMdDistinctRowCountTest extends FlinkRelMdHandlerTestBase {
   def testGetDistinctRowCountOnValues(): Unit = {
     assertEquals(1.0, mq.getDistinctRowCount(logicalValues, ImmutableBitSet.of(), null))
     (0 until logicalValues.getRowType.getFieldCount).foreach { idx =>
-      assertEquals(RelMdUtil.numDistinctVals(2.0, 2.0),
+      assertEquals(FlinkRelMdUtil.numDistinctVals(2.0, 2.0),
         mq.getDistinctRowCount(logicalValues, ImmutableBitSet.of(idx), null))
     }
-    assertEquals(RelMdUtil.numDistinctVals(2.0, 2.0),
+    assertEquals(FlinkRelMdUtil.numDistinctVals(2.0, 2.0),
       mq.getDistinctRowCount(logicalValues, ImmutableBitSet.of(0, 1), null))
 
     (0 until logicalValues.getRowType.getFieldCount).foreach { idx =>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSizeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSizeTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
 
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.ImmutableBitSet
 import org.junit.Assert._
 import org.junit.Test
@@ -362,6 +363,21 @@ class FlinkRelMdPopulationSizeTest extends FlinkRelMdHandlerTestBase {
   def testGetPopulationSizeOnDefault(): Unit = {
     assertNull(mq.getPopulationSize(testRel, ImmutableBitSet.of()))
     assertNull(mq.getPopulationSize(testRel, ImmutableBitSet.of(1)))
+  }
 
+  @Test
+  def testGetPopulationSizeOnLargeDomainSize(): Unit = {
+    relBuilder.clear()
+    val rel = relBuilder
+      .scan("MyTable1")
+      .project(
+        relBuilder.field(0),
+        relBuilder.field(1),
+        relBuilder.call(SqlStdOperatorTable.SUBSTRING, relBuilder.field(3), relBuilder.literal(10)))
+      .build()
+    assertEquals(
+      7.999999964933156E8,
+      mq.getPopulationSize(rel, ImmutableBitSet.of(0, 1, 2)),
+      1e-2)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils
+
+import org.apache.calcite.rel.metadata.RelMdUtil
+import org.junit.{Assert, Test}
+
+class FlinkRelMdUtilTest {
+
+  @Test
+  def testNumDistinctValsWithSmallInputs(): Unit = {
+    Assert.assertEquals(
+      RelMdUtil.numDistinctVals(1e5, 1e4),
+      FlinkRelMdUtil.numDistinctVals(1e5, 1e4))
+  }
+
+  @Test
+  def testNumDistinctValsWithLargeInputs(): Unit = {
+    Assert.assertNotEquals(0.0, FlinkRelMdUtil.numDistinctVals(1e18, 1e10))
+    // this test will fail once CALCITE-4351 is fixed
+    // in that case FlinkRelMdUtil#numDistinctVals should be removed
+    // see FLINK-19780
+    Assert.assertEquals(0.0, RelMdUtil.numDistinctVals(1e18, 1e10))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Due to [CALCITE-4351](https://issues.apache.org/jira/browse/CALCITE-4351) `FlinkRelMdDistinctRowCount#getDistinctRowCount(Calc)` will always return 0 when number of rows are large.

This PR introduces our own `FlinkRelMdUtil#numDistinctVals` to treat small and large inputs in different ways. For small inputs we use the more precise `RelMdUtil#numDistinctVals` and for large inputs we copy the old, approximated implementation of `RelMdUtil#numDistinctVals`.

This is a temporary solution. When [CALCITE-4351](https://issues.apache.org/jira/browse/CALCITE-4351) is fixed we should revert this commit.

## Brief change log

 - Introduce `FlinkRelMdUtil#numDistinctVals`

## Verifying this change

This change is already covered by existing tests, also this change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
