### PR TITLE
[FLINK-19703][runtime] Untrack a result partition if its producer task failed in TaskManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1462,6 +1462,12 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	//  Callbacks and Callback Utilities
 	// --------------------------------------------------------------------------------------------
 
+	@Deprecated
+	@VisibleForTesting
+	public boolean updateState(TaskExecutionState state) {
+		return updateState(new TaskExecutionStateTransition(state));
+	}
+
 	/**
 	 * Updates the state of one of the ExecutionVertex's Execution attempts.
 	 * If the new status if "FINISHED", this also updates the accumulators.
@@ -1469,7 +1475,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	 * @param state The state update.
 	 * @return True, if the task update was properly applied, false, if the execution attempt was not found.
 	 */
-	public boolean updateState(TaskExecutionState state) {
+	public boolean updateState(TaskExecutionStateTransition state) {
 		assertRunningInJobMasterMainThread();
 		final Execution attempt = currentExecutions.get(state.getID());
 
@@ -1492,7 +1498,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		}
 	}
 
-	private boolean updateStateInternal(final TaskExecutionState state, final Execution attempt) {
+	private boolean updateStateInternal(final TaskExecutionStateTransition state, final Execution attempt) {
 		Map<String, Accumulator<?, ?>> accumulators;
 
 		switch (state.getExecutionState()) {
@@ -1514,7 +1520,13 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			case FAILED:
 				// this deserialization is exception-free
 				accumulators = deserializeAccumulators(state);
-				attempt.markFailed(state.getError(userClassLoader), accumulators, state.getIOMetrics(), !isLegacyScheduling());
+				attempt.markFailed(
+					state.getError(userClassLoader),
+					state.getCancelTask(),
+					accumulators,
+					state.getIOMetrics(),
+					state.getReleasePartitions(),
+					!isLegacyScheduling());
 				return true;
 
 			default:
@@ -1572,7 +1584,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	 * @param state The task execution state from which to deserialize the accumulators.
 	 * @return The deserialized accumulators, of null, if there are no accumulators or an error occurred.
 	 */
-	private Map<String, Accumulator<?, ?>> deserializeAccumulators(TaskExecutionState state) {
+	private Map<String, Accumulator<?, ?>> deserializeAccumulators(TaskExecutionStateTransition state) {
 		AccumulatorSnapshot serializedAccumulators = state.getAccumulators();
 
 		if (serializedAccumulators != null) {
@@ -1721,9 +1733,13 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		}
 	}
 
-	void notifySchedulerNgAboutInternalTaskFailure(final ExecutionAttemptID attemptId, final Throwable t) {
+	void notifySchedulerNgAboutInternalTaskFailure(
+			final ExecutionAttemptID attemptId,
+			final Throwable t,
+			final boolean cancelTask,
+			final boolean releasePartitions) {
 		if (internalTaskFailuresListener != null) {
-			internalTaskFailuresListener.notifyTaskFailure(attemptId, t);
+			internalTaskFailuresListener.notifyTaskFailure(attemptId, t, cancelTask, releasePartitions);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Wraps {@link TaskExecutionState}, along with actions to take
+ * if it is FAILED state.
+ */
+public class TaskExecutionStateTransition {
+
+	private final TaskExecutionState taskExecutionState;
+
+	/**
+	 * Indicating whether to send a RPC call to remove task from TaskManager.
+	 * True if the failure is fired by JobManager and the execution is already
+	 * deployed. Otherwise it should be false.
+	 */
+	private final boolean cancelTask;
+
+	private final boolean releasePartitions;
+
+	public TaskExecutionStateTransition(final TaskExecutionState taskExecutionState) {
+		this(taskExecutionState, false, false);
+	}
+
+	public TaskExecutionStateTransition(
+			final TaskExecutionState taskExecutionState,
+			final boolean cancelTask,
+			final boolean releasePartitions) {
+
+		this.taskExecutionState = checkNotNull(taskExecutionState);
+		this.cancelTask = cancelTask;
+		this.releasePartitions = releasePartitions;
+	}
+
+	public Throwable getError(ClassLoader userCodeClassloader) {
+		return taskExecutionState.getError(userCodeClassloader);
+	}
+
+	public ExecutionAttemptID getID() {
+		return taskExecutionState.getID();
+	}
+
+	public ExecutionState getExecutionState() {
+		return taskExecutionState.getExecutionState();
+	}
+
+	public JobID getJobID() {
+		return taskExecutionState.getJobID();
+	}
+
+	public AccumulatorSnapshot getAccumulators() {
+		return taskExecutionState.getAccumulators();
+	}
+
+	public IOMetrics getIOMetrics() {
+		return taskExecutionState.getIOMetrics();
+	}
+
+	public boolean getCancelTask() {
+		return cancelTask;
+	}
+
+	public boolean getReleasePartitions() {
+		return releasePartitions;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailureHandlingResult;
@@ -54,7 +55,6 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 
@@ -200,12 +200,18 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	@Override
-	protected void updateTaskExecutionStateInternal(final ExecutionVertexID executionVertexId, final TaskExecutionState taskExecutionState) {
+	protected void updateTaskExecutionStateInternal(
+			final ExecutionVertexID executionVertexId,
+			final TaskExecutionStateTransition taskExecutionState) {
+
 		schedulingStrategy.onExecutionStateChange(executionVertexId, taskExecutionState.getExecutionState());
 		maybeHandleTaskFailure(taskExecutionState, executionVertexId);
 	}
 
-	private void maybeHandleTaskFailure(final TaskExecutionState taskExecutionState, final ExecutionVertexID executionVertexId) {
+	private void maybeHandleTaskFailure(
+			final TaskExecutionStateTransition taskExecutionState,
+			final ExecutionVertexID executionVertexId) {
+
 		if (taskExecutionState.getExecutionState() == ExecutionState.FAILED) {
 			final Throwable error = taskExecutionState.getError(userCodeLoader);
 			handleTaskFailure(executionVertexId, error);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InternalFailuresListener.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
  */
 public interface InternalFailuresListener {
 
-	void notifyTaskFailure(ExecutionAttemptID attemptId, Throwable t);
+	void notifyTaskFailure(ExecutionAttemptID attemptId, Throwable t, boolean cancelTask, boolean releasePartitions);
 
 	void notifyGlobalFailure(Throwable t);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -84,7 +85,11 @@ public interface SchedulerNG {
 
 	void handleGlobalFailure(Throwable cause);
 
-	boolean updateTaskExecutionState(TaskExecutionState taskExecutionState);
+	default boolean updateTaskExecutionState(TaskExecutionState taskExecutionState) {
+		return updateTaskExecutionState(new TaskExecutionStateTransition(taskExecutionState));
+	}
+
+	boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState);
 
 	SerializedInputSplit requestNextInputSplit(JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
@@ -22,12 +22,13 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Calls {@link SchedulerNG#updateTaskExecutionState(TaskExecutionState)} on task failure.
+ * Calls {@link SchedulerNG#updateTaskExecutionState(TaskExecutionStateTransition)} on task failure.
  * Calls {@link SchedulerNG#handleGlobalFailure(Throwable)} on global failures.
  */
 class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresListener {
@@ -45,12 +46,18 @@ class UpdateSchedulerNgOnInternalFailuresListener implements InternalFailuresLis
 	}
 
 	@Override
-	public void notifyTaskFailure(final ExecutionAttemptID attemptId, final Throwable t) {
-		schedulerNg.updateTaskExecutionState(new TaskExecutionState(
+	public void notifyTaskFailure(
+			final ExecutionAttemptID attemptId,
+			final Throwable t,
+			final boolean cancelTask,
+			final boolean releasePartitions) {
+
+		final TaskExecutionState state = new TaskExecutionState(
 			jobId,
 			attemptId,
 			ExecutionState.FAILED,
-			t));
+			t);
+		schedulerNg.updateTaskExecutionState(new TaskExecutionStateTransition(state, cancelTask, releasePartitions));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -365,7 +365,8 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 	}
 
 	/**
-	 * Verifies that {@link Execution#completeCancelling(Map, IOMetrics, boolean)} and {@link Execution#markFailed(Throwable, Map, IOMetrics)}
+	 * Verifies that {@link Execution#completeCancelling(Map, IOMetrics, boolean)}
+	 * and {@link Execution#markFailed(Throwable, boolean, Map, IOMetrics, boolean, boolean)}
 	 * store the given accumulators and metrics correctly.
 	 */
 	@Test
@@ -389,7 +390,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		assertEquals(accumulators, execution1.getUserAccumulators());
 
 		Execution execution2 = executions.values().iterator().next();
-		execution2.markFailed(new Throwable(), accumulators, ioMetrics);
+		execution2.markFailed(new Throwable(), false, accumulators, ioMetrics, false, true);
 
 		assertEquals(ioMetrics, execution2.getIOMetrics());
 		assertEquals(accumulators, execution2.getUserAccumulators());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -21,21 +21,14 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
-import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
-import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.TestingJobMasterPartitionTracker;
@@ -44,7 +37,6 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -52,6 +44,8 @@ import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
@@ -59,7 +53,6 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.TestLogger;
 
@@ -172,8 +165,11 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 		testPartitionTrackingForStateTransition(
 			execution -> execution.markFailed(
 				new Exception("Test exception"),
+				false,
 				Collections.emptyMap(),
-				new IOMetrics(0, 0, 0, 0)),
+				new IOMetrics(0, 0, 0, 0),
+				false,
+				true),
 			PartitionReleaseResult.STOP_TRACKING);
 	}
 
@@ -224,7 +220,11 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 		}
 	}
 
-	private void setupExecutionGraphAndStartRunningJob(ResultPartitionType resultPartitionType, JobMasterPartitionTracker partitionTracker, TaskManagerGateway taskManagerGateway, ShuffleMaster<?> shuffleMaster) throws JobException, JobExecutionException {
+	private void setupExecutionGraphAndStartRunningJob(
+			ResultPartitionType resultPartitionType,
+			JobMasterPartitionTracker partitionTracker,
+			TaskManagerGateway taskManagerGateway,
+			ShuffleMaster<?> shuffleMaster) throws Exception {
 		final JobVertex producerVertex = createNoOpJobVertex();
 		final JobVertex consumerVertex = createNoOpJobVertex();
 		consumerVertex.connectNewDataSetAsInput(producerVertex, DistributionPattern.ALL_TO_ALL, resultPartitionType);
@@ -247,37 +247,22 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 			}
 		};
 
-		final ExecutionGraph executionGraph = ExecutionGraphBuilder.buildGraph(
-			null,
-			new JobGraph(new JobID(), "test job", producerVertex, consumerVertex),
-			new Configuration(),
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			slotProvider,
-			ExecutionPartitionLifecycleTest.class.getClassLoader(),
-			new StandaloneCheckpointRecoveryFactory(),
-			Time.seconds(10),
-			new NoRestartStrategy(),
-			new UnregisteredMetricsGroup(),
-			VoidBlobWriter.getInstance(),
-			Time.seconds(10),
-			log,
-			shuffleMaster,
-			partitionTracker,
-			System.currentTimeMillis());
+		final JobGraph jobGraph = new JobGraph(new JobID(), "test job", producerVertex, consumerVertex);
+		final SchedulerBase scheduler = SchedulerTestingUtils
+			.newSchedulerBuilderWithDefaultSlotAllocator(jobGraph, slotProvider, Time.seconds(10))
+			.setShuffleMaster(shuffleMaster)
+			.setPartitionTracker(partitionTracker)
+			.build();
 
-		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+		final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+
+		scheduler.setMainThreadExecutor(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		final ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(producerVertex.getID());
 		final ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
 		execution = executionVertex.getCurrentExecutionAttempt();
 
-		execution.allocateResourcesForExecution(
-			executionGraph.getSlotProviderStrategy(),
-			LocationPreferenceConstraint.ALL,
-			Collections.emptySet());
-
-		execution.deploy();
+		scheduler.startScheduling();
 		execution.switchToRunning();
 
 		final IntermediateResultPartitionID expectedIntermediateResultPartitionId = executionJobVertex


### PR DESCRIPTION
## What is the purpose of the change

Execution#maybeReleasePartitionsAndSendCancelRpcCall(...) will be not invoked when a task is reported to be failed in TaskManager, which results in its partitions to still be tacked by the job manager partition tracker.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no**)**
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
