### PR TITLE
[FLINK-19278] Bump Scala Macros to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ under the License.
 			 and thus is changing back to java 1.6 on each maven re-import -->
 		<maven.compiler.source>${target.java.version}</maven.compiler.source>
 		<maven.compiler.target>${target.java.version}</maven.compiler.target>
-		<scala.macros.version>2.1.0</scala.macros.version>
+		<scala.macros.version>2.1.1</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
 		<scala.version>2.11.12</scala.version>


### PR DESCRIPTION
## What is the purpose of the change

This will add support for newer scala versions, in particlar 2.12.12.


## Verifying this change

Tested also against Scala 2.12: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8515&view=results

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)

## Documentation

There are no other mentions of 2.1.0 in the docs or anywhere else.
