### PR TITLE
[FLINK-19789][hive] Migrate Hive connector to new table source sink interface

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -21,16 +21,12 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.config.CatalogConfig;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.util.Preconditions;
-
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.mapred.JobConf;
 
 import java.util.List;
 import java.util.Map;
@@ -41,13 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A table factory implementation for Hive catalog.
  */
 public class HiveTableFactory
-		implements TableSourceFactory<RowData>, TableSinkFactory {
-
-	private final HiveConf hiveConf;
-
-	public HiveTableFactory(HiveConf hiveConf) {
-		this.hiveConf = checkNotNull(hiveConf, "hiveConf cannot be null");
-	}
+		implements TableSourceFactory, TableSinkFactory {
 
 	@Override
 	public Map<String, String> requiredContext() {
@@ -60,7 +50,7 @@ public class HiveTableFactory
 	}
 
 	@Override
-	public TableSource<RowData> createTableSource(TableSourceFactory.Context context) {
+	public TableSource createTableSource(TableSourceFactory.Context context) {
 		CatalogTable table = checkNotNull(context.getTable());
 		Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
@@ -68,11 +58,7 @@ public class HiveTableFactory
 
 		// temporary table doesn't have the IS_GENERIC flag but we still consider it generic
 		if (!isGeneric && !context.isTemporary()) {
-			return new HiveTableSource(
-					new JobConf(hiveConf),
-					context.getConfiguration(),
-					context.getObjectIdentifier().toObjectPath(),
-					table);
+			throw new UnsupportedOperationException("Hive table should be resolved by HiveDynamicTableFactory.");
 		} else {
 			return TableFactoryUtil.findAndCreateTableSource(context);
 		}
@@ -87,13 +73,7 @@ public class HiveTableFactory
 
 		// temporary table doesn't have the IS_GENERIC flag but we still consider it generic
 		if (!isGeneric && !context.isTemporary()) {
-			return new HiveTableSink(
-					context.getConfiguration().get(
-							HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_WRITER),
-					context.isBounded(),
-					new JobConf(hiveConf),
-					context.getObjectIdentifier(),
-					table);
+			throw new UnsupportedOperationException("Hive table should be resolved by HiveDynamicTableFactory.");
 		} else {
 			return TableFactoryUtil.findAndCreateTableSink(context);
 		}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -342,6 +342,9 @@ public class HiveTableSource implements
 	public void applyPartitions(List<Map<String, String>> remainingPartitions) {
 		if (catalogTable.getPartitionKeys() != null && catalogTable.getPartitionKeys().size() != 0) {
 			this.remainingPartitions = remainingPartitions;
+		} else {
+			throw new UnsupportedOperationException(
+					"Should not apply partitions to a non-partitioned table.");
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -45,23 +45,24 @@ import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.TableFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
 import org.apache.flink.table.filesystem.FileSystemOptions;
-import org.apache.flink.table.functions.AsyncTableFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
-import org.apache.flink.table.sources.LimitableTableSource;
-import org.apache.flink.table.sources.LookupableTableSource;
-import org.apache.flink.table.sources.PartitionableTableSource;
-import org.apache.flink.table.sources.ProjectableTableSource;
-import org.apache.flink.table.sources.StreamTableSource;
-import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TimeUtils;
 
@@ -85,6 +86,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -102,11 +104,11 @@ import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOUR
  * A TableSource implementation to read data from Hive tables.
  */
 public class HiveTableSource implements
-		StreamTableSource<RowData>,
-		PartitionableTableSource,
-		ProjectableTableSource<RowData>,
-		LimitableTableSource<RowData>,
-		LookupableTableSource<RowData> {
+		ScanTableSource,
+		LookupTableSource,
+		SupportsPartitionPushDown,
+		SupportsProjectionPushDown,
+		SupportsLimitPushDown {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HiveTableSource.class);
 
@@ -114,14 +116,13 @@ public class HiveTableSource implements
 	private final ReadableConfig flinkConf;
 	private final ObjectPath tablePath;
 	private final CatalogTable catalogTable;
+	private final String hiveVersion;
+	private final HiveShim hiveShim;
+
 	// Remaining partition specs after partition pruning is performed. Null if pruning is not pushed down.
 	@Nullable
 	private List<Map<String, String>> remainingPartitions = null;
-	private String hiveVersion;
-	private HiveShim hiveShim;
-	private boolean partitionPruned;
 	private int[] projectedFields;
-	private boolean isLimitPushDown = false;
 	private long limit = -1L;
 	private Duration hiveTableCacheTTL;
 
@@ -134,7 +135,6 @@ public class HiveTableSource implements
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
 		hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
-		partitionPruned = false;
 	}
 
 	// A constructor mainly used to create copies during optimizations like partition pruning and projection push down.
@@ -143,11 +143,9 @@ public class HiveTableSource implements
 			ReadableConfig flinkConf,
 			ObjectPath tablePath,
 			CatalogTable catalogTable,
-			List<Map<String, String>> remainingPartitions,
+			@Nullable List<Map<String, String>> remainingPartitions,
 			String hiveVersion,
-			boolean partitionPruned,
 			int[] projectedFields,
-			boolean isLimitPushDown,
 			long limit) {
 		this.jobConf = Preconditions.checkNotNull(jobConf);
 		this.flinkConf = Preconditions.checkNotNull(flinkConf);
@@ -156,19 +154,26 @@ public class HiveTableSource implements
 		this.remainingPartitions = remainingPartitions;
 		this.hiveVersion = hiveVersion;
 		hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
-		this.partitionPruned = partitionPruned;
 		this.projectedFields = projectedFields;
-		this.isLimitPushDown = isLimitPushDown;
 		this.limit = limit;
 	}
 
 	@Override
-	public boolean isBounded() {
-		return !isStreamingSource();
+	public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+		return new DataStreamScanProvider() {
+			@Override
+			public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
+				return getDataStream(execEnv);
+			}
+
+			@Override
+			public boolean isBounded() {
+				return !isStreamingSource();
+			}
+		};
 	}
 
-	@Override
-	public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+	private DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
 		checkAcidTable(catalogTable, tablePath);
 		List<HiveTablePartition> allHivePartitions = initAllPartitions();
 
@@ -227,7 +232,7 @@ public class HiveTableSource implements
 		parallelism = limit > 0 ? Math.min(parallelism, (int) limit / 1000) : parallelism;
 		parallelism = Math.max(1, parallelism);
 		source.setParallelism(parallelism);
-		return source.name(explainSource());
+		return source.name("HiveSource-" + tablePath.getFullName());
 	}
 
 	private DataStream<RowData> createStreamSourceForPartitionTable(
@@ -322,13 +327,11 @@ public class HiveTableSource implements
 				useMapRedReader);
 	}
 
-	@Override
-	public TableSchema getTableSchema() {
+	private TableSchema getTableSchema() {
 		return catalogTable.getSchema();
 	}
 
-	@Override
-	public DataType getProducedDataType() {
+	private DataType getProducedDataType() {
 		return getProducedTableSchema().toRowDataType().bridgedTo(RowData.class);
 	}
 
@@ -346,63 +349,30 @@ public class HiveTableSource implements
 	}
 
 	@Override
-	public boolean isLimitPushedDown() {
-		return isLimitPushDown;
+	public void applyLimit(long limit) {
+		this.limit = limit;
 	}
 
 	@Override
-	public TableSource<RowData> applyLimit(long limit) {
-		return new HiveTableSource(
-				jobConf,
-				flinkConf,
-				tablePath,
-				catalogTable,
-				remainingPartitions,
-				hiveVersion,
-				partitionPruned,
-				projectedFields,
-				true,
-				limit);
+	public Optional<List<Map<String, String>>> listPartitions() {
+		return Optional.empty();
 	}
 
 	@Override
-	public List<Map<String, String>> getPartitions() {
-		throw new UnsupportedOperationException(
-				"Please use Catalog API to retrieve all partitions of a table");
-	}
-
-	@Override
-	public TableSource<RowData> applyPartitionPruning(List<Map<String, String>> remainingPartitions) {
-		if (catalogTable.getPartitionKeys() == null || catalogTable.getPartitionKeys().size() == 0) {
-			return this;
-		} else {
-			return new HiveTableSource(
-					jobConf,
-					flinkConf,
-					tablePath,
-					catalogTable,
-					remainingPartitions,
-					hiveVersion,
-					true,
-					projectedFields,
-					isLimitPushDown,
-					limit);
+	public void applyPartitions(List<Map<String, String>> remainingPartitions) {
+		if (catalogTable.getPartitionKeys() != null && catalogTable.getPartitionKeys().size() != 0) {
+			this.remainingPartitions = remainingPartitions;
 		}
 	}
 
 	@Override
-	public TableSource<RowData> projectFields(int[] fields) {
-		return new HiveTableSource(
-				jobConf,
-				flinkConf,
-				tablePath,
-				catalogTable,
-				remainingPartitions,
-				hiveVersion,
-				partitionPruned,
-				fields,
-				isLimitPushDown,
-				limit);
+	public boolean supportsNestedProjection() {
+		return false;
+	}
+
+	@Override
+	public void applyProjection(int[][] projectedFields) {
+		this.projectedFields = Arrays.stream(projectedFields).mapToInt(value -> value[0]).toArray();
 	}
 
 	private List<HiveTablePartition> initAllPartitions() {
@@ -524,25 +494,29 @@ public class HiveTableSource implements
 	}
 
 	@Override
-	public String explainSource() {
-		String explain = String.format(" TablePath: %s, PartitionPruned: %s, PartitionNums: %d",
-				tablePath.getFullName(), partitionPruned, null == remainingPartitions ? null : remainingPartitions.size());
-		if (projectedFields != null) {
-			explain += ", ProjectedFields: " + Arrays.toString(projectedFields);
-		}
-		if (isLimitPushDown) {
-			explain += String.format(", LimitPushDown %s, Limit %d", isLimitPushDown, limit);
-		}
-		return TableConnectorUtils.generateRuntimeName(getClass(), getTableSchema().getFieldNames()) + explain;
+	public String asSummaryString() {
+		return "HiveSource";
 	}
 
 	@Override
-	public TableFunction<RowData> getLookupFunction(String[] lookupKeys) {
+	public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+		return TableFunctionProvider.of(getLookupFunction(context.getKeys()));
+	}
+
+	private TableFunction<RowData> getLookupFunction(int[][] keys) {
+		List<String> keyNames = new ArrayList<>();
+		TableSchema schema = getTableSchema();
+		for (int[] key : keys) {
+			if (key.length > 1) {
+				throw new UnsupportedOperationException("Hive lookup can not support nested key now.");
+			}
+			keyNames.add(schema.getFieldName(key[0]).get());
+		}
 		List<HiveTablePartition> allPartitions = initAllPartitions();
 		TableSchema producedSchema = getProducedTableSchema();
 		return new FileSystemLookupFunction<>(
 				getInputFormat(allPartitions, flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER)),
-				lookupKeys,
+				keyNames.toArray(new String[0]),
 				producedSchema.getFieldNames(),
 				producedSchema.getFieldDataTypes(),
 				hiveTableCacheTTL
@@ -550,12 +524,20 @@ public class HiveTableSource implements
 	}
 
 	@Override
-	public AsyncTableFunction<RowData> getAsyncLookupFunction(String[] lookupKeys) {
-		throw new UnsupportedOperationException("Hive table doesn't support async lookup");
+	public ChangelogMode getChangelogMode() {
+		return ChangelogMode.insertOnly();
 	}
 
 	@Override
-	public boolean isAsyncEnabled() {
-		return false;
+	public DynamicTableSource copy() {
+		return new HiveTableSource(
+				jobConf,
+				flinkConf,
+				tablePath,
+				catalogTable,
+				remainingPartitions,
+				hiveVersion,
+				projectedFields,
+				limit);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -173,7 +173,8 @@ public class HiveTableSource implements
 		};
 	}
 
-	private DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+	@VisibleForTesting
+	protected DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
 		checkAcidTable(catalogTable, tablePath);
 		List<HiveTablePartition> allHivePartitions = initAllPartitions();
 
@@ -512,11 +513,16 @@ public class HiveTableSource implements
 			}
 			keyNames.add(schema.getFieldName(key[0]).get());
 		}
+		return getLookupFunction(keyNames.toArray(new String[0]));
+	}
+
+	@VisibleForTesting
+	TableFunction<RowData> getLookupFunction(String[] keys) {
 		List<HiveTablePartition> allPartitions = initAllPartitions();
 		TableSchema producedSchema = getProducedTableSchema();
 		return new FileSystemLookupFunction<>(
 				getInputFormat(allPartitions, flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER)),
-				keyNames.toArray(new String[0]),
+				keys,
 				producedSchema.getFieldNames(),
 				producedSchema.getFieldDataTypes(),
 				hiveTableCacheTTL

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -134,28 +134,7 @@ public class HiveTableSource implements
 		this.catalogTable = Preconditions.checkNotNull(catalogTable);
 		this.hiveVersion = Preconditions.checkNotNull(jobConf.get(HiveCatalogValidator.CATALOG_HIVE_VERSION),
 				"Hive version is not defined");
-		hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
-	}
-
-	// A constructor mainly used to create copies during optimizations like partition pruning and projection push down.
-	private HiveTableSource(
-			JobConf jobConf,
-			ReadableConfig flinkConf,
-			ObjectPath tablePath,
-			CatalogTable catalogTable,
-			@Nullable List<Map<String, String>> remainingPartitions,
-			String hiveVersion,
-			int[] projectedFields,
-			long limit) {
-		this.jobConf = Preconditions.checkNotNull(jobConf);
-		this.flinkConf = Preconditions.checkNotNull(flinkConf);
-		this.tablePath = Preconditions.checkNotNull(tablePath);
-		this.catalogTable = Preconditions.checkNotNull(catalogTable);
-		this.remainingPartitions = remainingPartitions;
-		this.hiveVersion = hiveVersion;
-		hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
-		this.projectedFields = projectedFields;
-		this.limit = limit;
+		this.hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
 	}
 
 	@Override
@@ -536,14 +515,10 @@ public class HiveTableSource implements
 
 	@Override
 	public DynamicTableSource copy() {
-		return new HiveTableSource(
-				jobConf,
-				flinkConf,
-				tablePath,
-				catalogTable,
-				remainingPartitions,
-				hiveVersion,
-				projectedFields,
-				limit);
+		HiveTableSource source = new HiveTableSource(jobConf, flinkConf, tablePath, catalogTable);
+		source.remainingPartitions = remainingPartitions;
+		source.projectedFields = projectedFields;
+		source.limit = limit;
+		return source;
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -251,12 +251,12 @@ public class HiveCatalog extends AbstractCatalog {
 
 	@Override
 	public Optional<Factory> getFactory() {
-		return Optional.of(new HiveDynamicTableFactory());
+		return Optional.of(new HiveDynamicTableFactory(hiveConf));
 	}
 
 	@Override
 	public Optional<TableFactory> getTableFactory() {
-		return Optional.of(new HiveTableFactory(hiveConf));
+		return Optional.of(new HiveTableFactory());
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
-import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
 import org.apache.flink.table.filesystem.FileSystemOptions;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
@@ -78,8 +78,15 @@ public class HiveLookupJoinITCase {
 		// verify we properly configured the cache TTL
 		ObjectIdentifier tableIdentifier = ObjectIdentifier.of(hiveCatalog.getName(), "default", "build");
 		CatalogTable catalogTable = (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
-		HiveTableSource hiveTableSource = (HiveTableSource) ((HiveTableFactory) hiveCatalog.getTableFactory().get()).createTableSource(
-				new TableSourceFactoryContextImpl(tableIdentifier, catalogTable, tableEnv.getConfig().getConfiguration(), false));
+
+		HiveTableSource hiveTableSource = (HiveTableSource) FactoryUtil.createTableSource(
+				hiveCatalog,
+				tableIdentifier,
+				catalogTable,
+				tableEnv.getConfig().getConfiguration(),
+				Thread.currentThread().getContextClassLoader(),
+				false);
+
 		FileSystemLookupFunction lookupFunction = (FileSystemLookupFunction) hiveTableSource.getLookupFunction(new String[]{"x"});
 		assertEquals(Duration.ofMinutes(5), lookupFunction.getCacheTTL());
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -29,6 +29,9 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.table.factories.TableSinkFactoryContextImpl;
 import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
@@ -107,18 +110,24 @@ public class HiveTableFactoryTest {
 		ObjectPath path = new ObjectPath("mydb", "mytable");
 		CatalogTable table = new CatalogTableImpl(schema, properties, "hive table");
 		catalog.createTable(path, table, true);
-		Optional<TableFactory> opt = catalog.getTableFactory();
-		assertTrue(opt.isPresent());
-		HiveTableFactory tableFactory = (HiveTableFactory) opt.get();
-		TableSink tableSink = tableFactory.createTableSink(new TableSinkFactoryContextImpl(
+
+		DynamicTableSource tableSource = FactoryUtil.createTableSource(
+				catalog,
 				ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
 				table,
 				new Configuration(),
-				true, false));
-		assertTrue(tableSink instanceof HiveTableSink);
-		TableSource tableSource = tableFactory.createTableSource(new TableSourceFactoryContextImpl(
-				ObjectIdentifier.of("mycatalog", "mydb", "mytable"), table, new Configuration(), false));
+				Thread.currentThread().getContextClassLoader(),
+				false);
 		assertTrue(tableSource instanceof HiveTableSource);
+
+		DynamicTableSink tableSink = FactoryUtil.createTableSink(
+				catalog,
+				ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
+				table,
+				new Configuration(),
+				Thread.currentThread().getContextClassLoader(),
+				false);
+		assertTrue(tableSink instanceof HiveTableSink);
 	}
 
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
@@ -210,11 +211,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		String[] explain = src.explain().split("==.*==\n");
 		assertEquals(4, explain.length);
 		String optimizedLogicalPlan = explain[2];
-		String physicalExecutionPlan = explain[3];
 		assertTrue(optimizedLogicalPlan, optimizedLogicalPlan.contains(
-				"HiveTableSource(year, value, pt) TablePath: source_db.test_table_pt_1, PartitionPruned: true, PartitionNums: 1"));
-		assertTrue(physicalExecutionPlan, physicalExecutionPlan.contains(
-				"HiveTableSource(year, value, pt) TablePath: source_db.test_table_pt_1, PartitionPruned: true, PartitionNums: 1"));
+				"table=[[hive, source_db, test_table_pt_1, partitions=[{pt=0}], project=[year, value]]]"));
 		// second check execute results
 		List<Row> rows = CollectionUtil.iteratorToList(src.execute().collect());
 		assertEquals(2, rows.size());
@@ -245,7 +243,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			String[] explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			String optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 3"));
+			assertTrue(optimizedPlan, optimizedPlan.contains(
+					"table=[[test-catalog, db1, part, partitions=[{p1=2, p2=b}, {p1=3, p2=c}, {p1=4, p2=c:2}]"));
 			List<Row> results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[2, 3, 4]", results.toString());
 
@@ -253,7 +252,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 0"));
+			assertTrue(optimizedPlan, optimizedPlan.contains("table=[[test-catalog, db1, part, partitions=[], project=[x]]]"));
 			results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[]", results.toString());
 
@@ -261,7 +260,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 2"));
+			assertTrue(optimizedPlan, optimizedPlan.contains(
+					"table=[[test-catalog, db1, part, partitions=[{p1=1, p2=a}, {p1=3, p2=c}], project=[x]]]"));
 			results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[1, 3]", results.toString());
 
@@ -269,7 +269,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 2"));
+			assertTrue(optimizedPlan, optimizedPlan.contains(
+					"table=[[test-catalog, db1, part, partitions=[{p1=1, p2=a}, {p1=2, p2=b}], project=[x]]]"));
 			results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[1, 2]", results.toString());
 
@@ -277,7 +278,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 1"));
+			assertTrue(optimizedPlan, optimizedPlan.contains(
+					"table=[[test-catalog, db1, part, partitions=[{p1=4, p2=c:2}], project=[x]]]"));
 			results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[4]", results.toString());
 
@@ -285,7 +287,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			explain = query.explain().split("==.*==\n");
 			assertFalse(catalog.fallback);
 			optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 0"));
+			assertTrue(optimizedPlan, optimizedPlan.contains("table=[[test-catalog, db1, part, partitions=[], project=[x]]]"));
 			results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[]", results.toString());
 		} finally {
@@ -315,7 +317,8 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			String[] explain = query.explain().split("==.*==\n");
 			assertTrue(catalog.fallback);
 			String optimizedPlan = explain[2];
-			assertTrue(optimizedPlan, optimizedPlan.contains("PartitionPruned: true, PartitionNums: 1"));
+			assertTrue(optimizedPlan, optimizedPlan.contains(
+					"table=[[test-catalog, db1, part, partitions=[{p1=2018-08-10, p2=2018-08-08 08:08:10.0}]"));
 			List<Row> results = CollectionUtil.iteratorToList(query.execute().collect());
 			assertEquals("[3]", results.toString());
 
@@ -344,11 +347,9 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			String[] explain = table.explain().split("==.*==\n");
 			assertEquals(4, explain.length);
 			String logicalPlan = explain[2];
-			String physicalPlan = explain[3];
 			String expectedExplain =
-					"HiveTableSource(x, y, p1, p2) TablePath: default.src, PartitionPruned: false, PartitionNums: null, ProjectedFields: [2, 1]";
+					"table=[[hive, default, src, project=[p1, y]]]";
 			assertTrue(logicalPlan, logicalPlan.contains(expectedExplain));
-			assertTrue(physicalPlan, physicalPlan.contains(expectedExplain));
 
 			List<Row> rows = CollectionUtil.iteratorToList(table.execute().collect());
 			assertEquals(2, rows.size());
@@ -376,11 +377,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 			String[] explain = table.explain().split("==.*==\n");
 			assertEquals(4, explain.length);
 			String logicalPlan = explain[2];
-			String physicalPlan = explain[3];
-			String expectedExplain = "HiveTableSource(a) TablePath: default.src, PartitionPruned: false, " +
-									"PartitionNums: null, LimitPushDown true, Limit 1";
-			assertTrue(logicalPlan.contains(expectedExplain));
-			assertTrue(physicalPlan.contains(expectedExplain));
+			assertTrue(logicalPlan, logicalPlan.contains("table=[[hive, default, src, limit=[1]]]"));
 
 			List<Row> rows = CollectionUtil.iteratorToList(table.execute().collect());
 			assertEquals(1, rows.size());
@@ -567,7 +564,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 	}
 
 	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {
-		HiveTableFactory tableFactorySpy = spy((HiveTableFactory) hiveCatalog.getTableFactory().get());
+		HiveDynamicTableFactory tableFactorySpy = spy((HiveDynamicTableFactory) hiveCatalog.getFactory().get());
 
 		doAnswer(invocation -> {
 			TableSourceFactory.Context context = invocation.getArgument(0);
@@ -578,7 +575,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 					context.getTable(),
 					fallbackMR,
 					inferParallelism);
-		}).when(tableFactorySpy).createTableSource(any(TableSourceFactory.Context.class));
+		}).when(tableFactorySpy).createDynamicTableSource(any(DynamicTableFactory.Context.class));
 
 		HiveCatalog catalogSpy = spy(hiveCatalog);
 		doReturn(Optional.of(tableFactorySpy)).when(catalogSpy).getTableFactory();
@@ -654,7 +651,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		}
 
 		@Override
-		protected DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+		public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
 			DataStreamSource<RowData> dataStream = (DataStreamSource<RowData>) super.getDataStream(execEnv);
 			int parallelism = dataStream.getTransformation().getParallelism();
 			assertEquals(inferParallelism ? 1 : 2, parallelism);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -654,7 +654,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		}
 
 		@Override
-		public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+		protected DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
 			DataStreamSource<RowData> dataStream = (DataStreamSource<RowData>) super.getDataStream(execEnv);
 			int parallelism = dataStream.getTransformation().getParallelism();
 			assertEquals(inferParallelism ? 1 : 2, parallelism);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -238,7 +238,6 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			List<String> inputFieldNames) {
 		// get partitions from table/catalog and prune
 		Optional<Catalog> catalogOptional = context.getCatalogManager().getCatalog(tableSourceTable.tableIdentifier().getCatalogName());
-		List<Map<String, String>> remainingPartitions;
 
 		DynamicTableSource dynamicTableSource = tableSourceTable.tableSource();
 		ObjectIdentifier identifier = tableSourceTable.tableIdentifier();
@@ -315,8 +314,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			ObjectPath tablePath,
 			Function<List<Map<String, String>>, List<Map<String, String>>> pruner)
 			throws TableNotExistException, CatalogException, TableNotPartitionedException {
-		List<Map<String, String>> allPartitions, remainingPartitions;
-		allPartitions = catalog.listPartitions(tablePath)
+		List<Map<String, String>> allPartitions = catalog.listPartitions(tablePath)
 			.stream()
 			.map(CatalogPartitionSpec::getPartitionSpec)
 			.collect(Collectors.toList());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -148,7 +148,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			partitions,
 			finalPartitionPredicate);
 		// prune partitions
-		Optional<List<Map<String, String>>> remainingPartitions =
+		List<Map<String, String>> remainingPartitions =
 			readPartitionsAndPrune(
 					rexBuilder,
 					context,
@@ -158,7 +158,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 					inputFieldNames);
 		// apply push down
 		DynamicTableSource dynamicTableSource = tableSourceTable.tableSource().copy();
-		remainingPartitions.ifPresent(((SupportsPartitionPushDown) dynamicTableSource)::applyPartitions);
+		((SupportsPartitionPushDown) dynamicTableSource).applyPartitions(remainingPartitions);
 
 		// build new statistic
 		TableStats newTableStat = null;
@@ -166,8 +166,8 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 		ObjectPath tablePath = identifier.toObjectPath();
 		Optional<Catalog> catalogOptional = context.getCatalogManager().getCatalog(identifier.getCatalogName());
 		Optional<TableStats> partitionStats;
-		if (remainingPartitions.isPresent() && catalogOptional.isPresent()) {
-			for (Map<String, String> partition: remainingPartitions.get()) {
+		if (catalogOptional.isPresent()) {
+			for (Map<String, String> partition: remainingPartitions) {
 				partitionStats = getPartitionStats(catalogOptional.get(), tablePath, partition);
 				if (!partitionStats.isPresent()) {
 					// clear all information before
@@ -183,12 +183,12 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			.tableStats(newTableStat)
 			.build();
 
-		String extraDigest = remainingPartitions.map(partition -> ("partitions=[" +
-			String.join(", ", partition
-				.stream()
-				.map(Object::toString)
-				.toArray(String[]::new)) +
-			"]")).orElse("partitions=[]");
+		String extraDigest = "partitions=[" +
+				String.join(", ", remainingPartitions
+						.stream()
+						.map(Object::toString)
+						.toArray(String[]::new)) +
+				"]";
 		TableSourceTable newTableSourceTable = tableSourceTable.copy(dynamicTableSource, newStatistic, new String[]{extraDigest});
 		LogicalTableScan newScan = LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
 
@@ -229,7 +229,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 		});
 	}
 
-	private Optional<List<Map<String, String>>> readPartitionsAndPrune(
+	private List<Map<String, String>> readPartitionsAndPrune(
 			RexBuilder rexBuilder,
 			FlinkContext context,
 			TableSourceTable tableSourceTable,
@@ -244,12 +244,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 		ObjectIdentifier identifier = tableSourceTable.tableIdentifier();
 		Optional<List<Map<String, String>>> optionalPartitions = ((SupportsPartitionPushDown) dynamicTableSource).listPartitions();
 		if (optionalPartitions.isPresent()) {
-			if (optionalPartitions.get().isEmpty()) {
-				return Optional.empty();
-			} else {
-				remainingPartitions = pruner.apply(optionalPartitions.get());
-				return remainingPartitions != null ? Optional.of(remainingPartitions) : Optional.empty();
-			}
+			return pruner.apply(optionalPartitions.get());
 		} else {
 			// check catalog whether is available
 			// we will read partitions from catalog if table doesn't support listPartitions.
@@ -277,7 +272,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 		}
 	}
 
-	private Optional<List<Map<String, String>>> readPartitionFromCatalogAndPrune(
+	private List<Map<String, String>> readPartitionFromCatalogAndPrune(
 			RexBuilder rexBuilder,
 			FlinkContext context,
 			Catalog catalog,
@@ -306,17 +301,16 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			}
 		}
 		try {
-			List<Map<String, String>> remainingPartitions = catalog.listPartitionsByFilter(tablePath, partitionFilters)
+			return catalog.listPartitionsByFilter(tablePath, partitionFilters)
 				.stream()
 				.map(CatalogPartitionSpec::getPartitionSpec)
 				.collect(Collectors.toList());
-			return Optional.of(remainingPartitions);
 		} catch (UnsupportedOperationException e) {
 			return readPartitionFromCatalogWithoutFilterAndPrune(catalog, tablePath, pruner);
 		}
 	}
 
-	private Optional<List<Map<String, String>>> readPartitionFromCatalogWithoutFilterAndPrune(
+	private List<Map<String, String>> readPartitionFromCatalogWithoutFilterAndPrune(
 			Catalog catalog,
 			ObjectPath tablePath,
 			Function<List<Map<String, String>>, List<Map<String, String>>> pruner)
@@ -327,12 +321,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			.map(CatalogPartitionSpec::getPartitionSpec)
 			.collect(Collectors.toList());
 		// prune partitions
-		if (allPartitions.size() > 0) {
-			remainingPartitions = pruner.apply(allPartitions);
-			return remainingPartitions != null ? Optional.of(remainingPartitions) : Optional.empty();
-		} else {
-			return Optional.empty();
-		}
+		return pruner.apply(allPartitions);
 	}
 
 	private Optional<TableStats> getPartitionStats(Catalog catalog, ObjectPath tablePath, Map<String, String> partition) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -184,11 +184,11 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			.build();
 
 		String extraDigest = "partitions=[" +
-				String.join(", ", remainingPartitions
-						.stream()
-						.map(Object::toString)
-						.toArray(String[]::new)) +
-				"]";
+			String.join(", ", remainingPartitions
+				.stream()
+				.map(Object::toString)
+				.toArray(String[]::new)) +
+			"]";
 		TableSourceTable newTableSourceTable = tableSourceTable.copy(dynamicTableSource, newStatistic, new String[]{extraDigest});
 		LogicalTableScan newScan = LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
 
@@ -250,24 +250,24 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
 			// we will read partitions from catalog if table doesn't support listPartitions.
 			if (!catalogOptional.isPresent()) {
 				throw new TableException(
-						String.format("Table %s must from a catalog, but %s is not a catalog",
-								identifier.asSummaryString(), identifier.getCatalogName()));
+					String.format("Table %s must from a catalog, but %s is not a catalog",
+						identifier.asSummaryString(), identifier.getCatalogName()));
 			}
 			try {
 				return readPartitionFromCatalogAndPrune(
-						rexBuilder,
-						context,
-						catalogOptional.get(),
-						identifier,
-						inputFieldNames,
-						partitionPredicate,
-						pruner);
+					rexBuilder,
+					context,
+					catalogOptional.get(),
+					identifier,
+					inputFieldNames,
+					partitionPredicate,
+					pruner);
 			} catch (TableNotExistException tableNotExistException) {
 				throw new TableException(String.format("Table %s is not found in catalog.", identifier.asSummaryString()));
 			} catch (TableNotPartitionedException tableNotPartitionedException) {
 				throw new TableException(
-						String.format("Table %s is not a partitionable source. Validator should have checked it.", identifier.asSummaryString()),
-						tableNotPartitionedException);
+					String.format("Table %s is not a partitionable source. Validator should have checked it.", identifier.asSummaryString()),
+					tableNotPartitionedException);
 			}
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -750,7 +750,7 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		@Override
 		public Optional<List<Map<String, String>>> listPartitions() {
 			if (allPartitions.isEmpty()) {
-				throw new UnsupportedOperationException("Please use catalog to read partitions");
+				return Optional.empty();
 			}
 			return Optional.of(allPartitions);
 		}


### PR DESCRIPTION

## What is the purpose of the change

Migrate Hive connector to new table source sink interface

## Brief change log

- Remove `HiveTableFactory` Hive logical
- Implement Hive table source/sink logical in `HiveDynamicTableFactory`
- Modify `HiveTableSource`
- Modify `HiveTableSink`

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no