### PR TITLE
[FLINK-19748] Iterating key groups in raw keyed stream on restore fails if some key groups weren't written

### DIFF
--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -257,6 +257,8 @@ Set the configuration option `state.backend.rocksdb.timer-service.factory` to `h
 
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state. Other state like keyed state is still snapshotted asynchronously.*
 
+<span class="label label-info">Note</span> *When using RocksDB state backend with heap-based timers, checkpointing and taking savepoints is expected to fail if there are operators in application that write to raw keyed state.*
+
 ### Enabling RocksDB Native Metrics
 
 You can optionally access RockDB's native metrics through Flink's metrics system, by enabling certain metrics selectively.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -261,6 +262,29 @@ public abstract class AbstractStreamOperator<OUT>
 		timeServiceManager = context.internalTimerServiceManager();
 		stateHandler.initializeOperatorState(this);
 		runtimeContext.setKeyedStateStore(stateHandler.getKeyedStateStore().orElse(null));
+	}
+
+	/**
+	 * Indicates whether or not implementations of this class is writing to the raw keyed state streams
+	 * on snapshots, using {@link #snapshotState(StateSnapshotContext)}. If yes, subclasses should
+	 * override this method to return {@code true}.
+	 *
+	 * <p>Subclasses need to explicitly indicate the use of raw keyed state because, internally,
+	 * the {@link AbstractStreamOperator} may attempt to read from it as well to restore heap-based timers and
+	 * ultimately fail with read errors. By setting this flag to {@code true}, this allows the
+	 * {@link AbstractStreamOperator} to know that the data written in the raw keyed states were
+	 * not written by the timer services, and skips the timer restore attempt.
+	 *
+	 * <p>Please refer to FLINK-19741 for further details.
+	 *
+	 * <p>TODO: this method can be removed once all timers are moved to be managed by state backends.
+	 *
+	 * @return flag indicating whether or not this operator is writing to raw keyed
+	 *         state via {@link #snapshotState(StateSnapshotContext)}.
+	 */
+	@Internal
+	protected boolean isUsingCustomRawKeyedState() {
+		return false;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -256,7 +256,8 @@ public abstract class AbstractStreamOperator<OUT>
 				config.getManagedMemoryFractionOperatorUseCaseOfSlot(
 					ManagedMemoryUseCase.STATE_BACKEND,
 					runtimeContext.getTaskManagerRuntimeInfo().getConfiguration(),
-					runtimeContext.getUserCodeClassLoader()));
+					runtimeContext.getUserCodeClassLoader()),
+				isUsingCustomRawKeyedState());
 
 		stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), streamTaskCloseableRegistry);
 		timeServiceManager = context.internalTimerServiceManager();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -46,6 +46,8 @@ public interface StreamTaskStateInitializer {
 	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
 	 * @param metricGroup the parent metric group for all statebackend metrics
 	 * @param managedMemoryFraction the managed memory fraction of the operator for state backend
+	 * @param isUsingCustomRawKeyedState flag indicating whether or not the {@link AbstractStreamOperator} is writing
+	 *                                   custom raw keyed state.
 	 * @return a context from which the given operator can initialize everything related to state.
 	 * @throws Exception when something went wrong while creating the context.
 	 */
@@ -57,5 +59,42 @@ public interface StreamTaskStateInitializer {
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
 		@Nonnull MetricGroup metricGroup,
-		double managedMemoryFraction) throws Exception;
+		double managedMemoryFraction,
+		boolean isUsingCustomRawKeyedState) throws Exception;
+
+	/**
+	 * Returns the {@link StreamOperatorStateContext} for an {@link AbstractStreamOperator} that runs in the stream
+	 * task that owns this manager.
+	 *
+	 * @param operatorID the id of the operator for which the context is created. Cannot be null.
+	 * @param operatorClassName the classname of the operator instance for which the context is created. Cannot be null.
+	 * @param processingTimeService
+	 * @param keyContext the key context of the operator instance for which the context is created Cannot be null.
+	 * @param keySerializer the key-serializer for the operator. Can be null.
+	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
+	 * @param metricGroup the parent metric group for all statebackend metrics
+	 * @param managedMemoryFraction the managed memory fraction of the operator for state backend
+	 * @return a context from which the given operator can initialize everything related to state.
+	 * @throws Exception when something went wrong while creating the context.
+	 */
+	default StreamOperatorStateContext streamOperatorStateContext(
+			@Nonnull OperatorID operatorID,
+			@Nonnull String operatorClassName,
+			@Nonnull ProcessingTimeService processingTimeService,
+			@Nonnull KeyContext keyContext,
+			@Nullable TypeSerializer<?> keySerializer,
+			@Nonnull CloseableRegistry streamTaskCloseableRegistry,
+			@Nonnull MetricGroup metricGroup,
+			double managedMemoryFraction) throws Exception {
+		return streamOperatorStateContext(
+			operatorID,
+			operatorClassName,
+			processingTimeService,
+			keyContext,
+			keySerializer,
+			streamTaskCloseableRegistry,
+			metricGroup,
+			managedMemoryFraction,
+			false);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -124,7 +124,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
 		@Nonnull MetricGroup metricGroup,
-		double managedMemoryFraction) throws Exception {
+		double managedMemoryFraction,
+		boolean isUsingCustomRawKeyedState) throws Exception {
 
 		TaskInfo taskInfo = environment.getTaskInfo();
 		OperatorSubtaskDescriptionText operatorSubtaskDescription =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -58,6 +58,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -174,12 +175,22 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 			// -------------- Internal Timer Service Manager --------------
 			if (keyedStatedBackend != null) {
+
+				// if the operator indicates that it is using custom raw keyed state,
+				// then whatever was written in the raw keyed state snapshot was NOT written
+				// by the internal timer services (because there is only ever one user of raw keyed state);
+				// in this case, timers should not attempt to restore timers from the raw keyed state.
+				final Iterable<KeyGroupStatePartitionStreamProvider> restoredRawKeyedStateTimers =
+					(prioritizedOperatorSubtaskStates.isRestored() && !isUsingCustomRawKeyedState)
+						? rawKeyedStateInputs
+						: Collections.emptyList();
+
 				timeServiceManager = timeServiceManagerProvider.create(
 					keyedStatedBackend,
 					environment.getUserCodeClassLoader().asClassLoader(),
 					keyContext,
 					processingTimeService,
-					rawKeyedStateInputs);
+					restoredRawKeyedStateTimers);
 			} else {
 				timeServiceManager = null;
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -37,8 +37,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-
 import org.apache.flink.util.Preconditions;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -445,39 +445,65 @@ public class AbstractStreamOperatorTest {
 		final int maxParallelism = 10;
 		final int numSubtasks = 1;
 		final int subtaskIndex = 0;
-		final List<Integer> keyGroupsToWrite = Arrays.asList(2, 3, 8);
-
+		final Iterable<Integer> allKeyGroups = KeyGroupRange.of(0, maxParallelism - 1);
 		final byte[] testSnapshotData = "TEST".getBytes();
+
+		final Map<Integer, byte[]> restored = snapshotAndRestoreRawKeyedState(
+			maxParallelism, numSubtasks, subtaskIndex, testSnapshotData, allKeyGroups);
+		assertThat(restored, hasRestoredKeyGroupsWith(testSnapshotData, allKeyGroups));
+	}
+
+	@Test
+	public void testCustomRawKeyedStateSnapshotAndRestorePartialWrittenKeyGroups() throws Exception {
+		// setup: 10 key groups, all assigned to single subtask
+		final int maxParallelism = 10;
+		final int numSubtasks = 1;
+		final int subtaskIndex = 0;
+		final List<Integer> keyGroupsToWrite = Arrays.asList(2, 3, 8);
+		final byte[] testSnapshotData = "TEST".getBytes();
+
+		final Map<Integer, byte[]> restored = snapshotAndRestoreRawKeyedState(
+			maxParallelism, numSubtasks, subtaskIndex, testSnapshotData, keyGroupsToWrite);
+		assertThat(restored, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupsToWrite));
+	}
+
+	private Map<Integer, byte[]> snapshotAndRestoreRawKeyedState(
+			int maxParallelism,
+			int numSubtasks,
+			int subtaskIndex,
+			byte[] testSnapshotData,
+			Iterable<Integer> keyGroupsToWrite) throws Exception {
+
 		final CustomRawKeyedStateTestOperator testOperator =
 			new CustomRawKeyedStateTestOperator(testSnapshotData, keyGroupsToWrite);
 
 		// snapshot and then restore
 		OperatorSubtaskState snapshot;
 		try (KeyedOneInputStreamOperatorTestHarness<String, String, String> testHarness = createTestHarness(
-				maxParallelism,
-				numSubtasks,
-				subtaskIndex,
-				testOperator,
-				input -> input,
-				BasicTypeInfo.STRING_TYPE_INFO)) {
+			maxParallelism,
+			numSubtasks,
+			subtaskIndex,
+			testOperator,
+			input -> input,
+			BasicTypeInfo.STRING_TYPE_INFO)) {
 			testHarness.setup();
 			testHarness.open();
 			snapshot = testHarness.snapshot(0, 0);
 		}
 
 		try (KeyedOneInputStreamOperatorTestHarness<String, String, String> testHarness = createTestHarness(
-				maxParallelism,
-				numSubtasks,
-				subtaskIndex,
-				testOperator,
-				input -> input,
-				BasicTypeInfo.STRING_TYPE_INFO)) {
+			maxParallelism,
+			numSubtasks,
+			subtaskIndex,
+			testOperator,
+			input -> input,
+			BasicTypeInfo.STRING_TYPE_INFO)) {
 			testHarness.setup();
 			testHarness.initializeState(snapshot);
 			testHarness.open();
 		}
 
-		assertThat(testOperator.restoredRawKeyedState, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupsToWrite));
+		return testOperator.restoredRawKeyedState;
 	}
 
 	/**
@@ -581,11 +607,11 @@ public class AbstractStreamOperatorTest {
 		private static final long serialVersionUID = 1L;
 
 		private final byte[] snapshotBytes;
-		private final List<Integer> keyGroupsToWrite;
+		private final Iterable<Integer> keyGroupsToWrite;
 
 		private Map<Integer, byte[]> restoredRawKeyedState;
 
-		CustomRawKeyedStateTestOperator(byte[] snapshotBytes, List<Integer> keyGroupsToWrite) {
+		CustomRawKeyedStateTestOperator(byte[] snapshotBytes, Iterable<Integer> keyGroupsToWrite) {
 			this.snapshotBytes = Arrays.copyOf(snapshotBytes, snapshotBytes.length);
 			this.keyGroupsToWrite = Preconditions.checkNotNull(keyGroupsToWrite);
 		}
@@ -633,21 +659,19 @@ public class AbstractStreamOperatorTest {
 		return result;
 	}
 
-	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, List<Integer> writtenKeyGroups) {
+	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, Iterable<Integer> writtenKeyGroups) {
 		return new TypeSafeMatcher<Map<Integer, byte[]>>() {
 			@Override
 			protected boolean matchesSafely(Map<Integer, byte[]> restored) {
-				if (restored.size() != writtenKeyGroups.size()) {
-					return false;
-				}
-
+				int numWrittenKeyGroups = 0;
 				for (int writtenKeyGroupId : writtenKeyGroups) {
+					numWrittenKeyGroups++;
 					if (!Arrays.equals(restored.get(writtenKeyGroupId), testSnapshotData)) {
 						return false;
 					}
 				}
 
-				return true;
+				return restored.size() == numWrittenKeyGroups;
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
+import org.apache.flink.util.Preconditions;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -444,10 +445,11 @@ public class AbstractStreamOperatorTest {
 		final int maxParallelism = 10;
 		final int numSubtasks = 1;
 		final int subtaskIndex = 0;
-		final KeyGroupRange keyGroupRange = KeyGroupRange.of(0, maxParallelism - 1);
+		final List<Integer> keyGroupsToWrite = Arrays.asList(2, 3, 8);
 
 		final byte[] testSnapshotData = "TEST".getBytes();
-		final CustomRawKeyedStateTestOperator testOperator = new CustomRawKeyedStateTestOperator(testSnapshotData);
+		final CustomRawKeyedStateTestOperator testOperator =
+			new CustomRawKeyedStateTestOperator(testSnapshotData, keyGroupsToWrite);
 
 		// snapshot and then restore
 		OperatorSubtaskState snapshot;
@@ -475,7 +477,7 @@ public class AbstractStreamOperatorTest {
 			testHarness.open();
 		}
 
-		assertThat(testOperator.restoredRawKeyedState, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupRange));
+		assertThat(testOperator.restoredRawKeyedState, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupsToWrite));
 	}
 
 	/**
@@ -579,11 +581,13 @@ public class AbstractStreamOperatorTest {
 		private static final long serialVersionUID = 1L;
 
 		private final byte[] snapshotBytes;
+		private final List<Integer> keyGroupsToWrite;
 
 		private Map<Integer, byte[]> restoredRawKeyedState;
 
-		CustomRawKeyedStateTestOperator(byte[] snapshotBytes) {
+		CustomRawKeyedStateTestOperator(byte[] snapshotBytes, List<Integer> keyGroupsToWrite) {
 			this.snapshotBytes = Arrays.copyOf(snapshotBytes, snapshotBytes.length);
+			this.keyGroupsToWrite = Preconditions.checkNotNull(keyGroupsToWrite);
 		}
 
 		@Override
@@ -600,7 +604,7 @@ public class AbstractStreamOperatorTest {
 		public void snapshotState(StateSnapshotContext context) throws Exception {
 			super.snapshotState(context);
 			KeyedStateCheckpointOutputStream rawKeyedStateStream = context.getRawKeyedOperatorStateOutput();
-			for (int keyGroupId : rawKeyedStateStream.getKeyGroupList()) {
+			for (int keyGroupId : keyGroupsToWrite) {
 				rawKeyedStateStream.startNewKeyGroup(keyGroupId);
 				rawKeyedStateStream.write(snapshotBytes);
 			}
@@ -629,15 +633,15 @@ public class AbstractStreamOperatorTest {
 		return result;
 	}
 
-	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, KeyGroupRange range) {
+	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, List<Integer> writtenKeyGroups) {
 		return new TypeSafeMatcher<Map<Integer, byte[]>>() {
 			@Override
 			protected boolean matchesSafely(Map<Integer, byte[]> restored) {
-				if (restored.size() != range.getNumberOfKeyGroups()) {
+				if (restored.size() != writtenKeyGroups.size()) {
 					return false;
 				}
 
-				for (int writtenKeyGroupId : range) {
+				for (int writtenKeyGroupId : writtenKeyGroups) {
 					if (!Arrays.equals(restored.get(writtenKeyGroupId), testSnapshotData)) {
 						return false;
 					}
@@ -648,7 +652,7 @@ public class AbstractStreamOperatorTest {
 
 			@Override
 			public void describeTo(Description description) {
-				description.appendText("Key groups: " + range + " with snapshot data " + Arrays.toString(testSnapshotData));
+				description.appendText("Key groups: " + writtenKeyGroups + " with snapshot data " + Arrays.toString(testSnapshotData));
 			}
 		};
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1529,7 +1529,15 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 			final StreamTaskStateInitializer streamTaskStateManager = super.createStreamTaskStateInitializer();
-			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup, fraction) -> {
+			return (operatorID,
+					operatorClassName,
+					processingTimeService,
+					keyContext,
+					keySerializer,
+					closeableRegistry,
+					metricGroup,
+					fraction,
+					isUsingCustomRawKeyedState) -> {
 
 				final StreamOperatorStateContext controller = streamTaskStateManager.streamOperatorStateContext(
 					operatorID,
@@ -1539,7 +1547,8 @@ public class StreamTaskTest extends TestLogger {
 					keySerializer,
 					closeableRegistry,
 					metricGroup,
-					fraction);
+					fraction,
+					isUsingCustomRawKeyedState);
 
 				return new StreamOperatorStateContext() {
 					@Override


### PR DESCRIPTION
This PR is based on top of #13761, since a new test was added in #13761 that would also cover the fix in this PR.
Only the last 2 commits are relevant.

## What is the purpose of the change

When iterating through key groups in restored raw keyed state streams, the iterator (`StreamTaskStateInitializerImpl#KeyGroupStreamIterator`) doesn't respect that fact that some key groups were skipped and were not written, .e.g:
```
// on snapshots
KeyedStateCheckpointOutputStream rawKeyedStream = snapshotContext.getRawKeyedOperatorStateOutput();
rawKeyedStream.startNewKeyGroup(0);
rawKeyedStream.startNewKeyGroup(3); // skipped key groups 1 and 2
```

In this case, the offsets for key groups 1 and 2 written in the checkpoint metadata will be `-1` (meaning, an undefined offset).
On restore, however, the iterator still attempts to seek the restored keyed state streams with the offsets, ultimately failing with a position out of bounds when it attempts to seek to position `-1`.

The usage behaviour of skipping key groups when writing to the raw keyed state stream is currently completely valid as the `KeyedStateCheckpointOutputStream` API does not forbid it. StateFun, for example, did exactly that.

## Solution

This PR solves the issue by modifying `StreamTaskStateInitializerImpl#KeyGroupStreamIterator` to skip key groups with undefined offsets (i.e. `-1`).
The changes are isolated such that is should only affect the restore of raw keyed state streams, and does not affect the restore of state backends.

## Brief change log

- a130d84 Wraps the original key group offsets iterator to filter out key groups with undefined offsets.
- c6bae68 Adjusts the existing `AbstractStreamOperatorTest.testCustomRawKeyedStateSnapshotAndRestore` test to only write some key groups, and not all of them.


## Verifying this change

- The new `AbstractStreamOperatorTest.testCustomRawKeyedStateSnapshotAndRestore` test should pass.
- There are existing integration tests that test snapshotting and restoring of heap-based timers, which should cover the current usage of the raw keyed state stream in Flink.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
