### PR TITLE
[backport-1.11] [FLINK-19748] Iterating key groups in raw keyed stream on restore fails if some key groups weren't written

### DIFF
--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -257,6 +257,8 @@ Set the configuration option `state.backend.rocksdb.timer-service.factory` to `h
 
 <span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state. Other state like keyed state is still snapshotted asynchronously.*
 
+<span class="label label-info">Note</span> *When using RocksDB state backend with heap-based timers, checkpointing and taking savepoints is expected to fail if there are operators in application that write to raw keyed state.*
+
 ### Enabling RocksDB Native Metrics
 
 You can optionally access RockDB's native metrics through Flink's metrics system, by enabling certain metrics selectively.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -257,6 +258,29 @@ public abstract class AbstractStreamOperator<OUT>
 		timeServiceManager = context.internalTimerServiceManager();
 		stateHandler.initializeOperatorState(this);
 		runtimeContext.setKeyedStateStore(stateHandler.getKeyedStateStore().orElse(null));
+	}
+
+	/**
+	 * Indicates whether or not implementations of this class is writing to the raw keyed state streams
+	 * on snapshots, using {@link #snapshotState(StateSnapshotContext)}. If yes, subclasses should
+	 * override this method to return {@code true}.
+	 *
+	 * <p>Subclasses need to explicitly indicate the use of raw keyed state because, internally,
+	 * the {@link AbstractStreamOperator} may attempt to read from it as well to restore heap-based timers and
+	 * ultimately fail with read errors. By setting this flag to {@code true}, this allows the
+	 * {@link AbstractStreamOperator} to know that the data written in the raw keyed states were
+	 * not written by the timer services, and skips the timer restore attempt.
+	 *
+	 * <p>Please refer to FLINK-19741 for further details.
+	 *
+	 * <p>TODO: this method can be removed once all timers are moved to be managed by state backends.
+	 *
+	 * @return flag indicating whether or not this operator is writing to raw keyed
+	 *         state via {@link #snapshotState(StateSnapshotContext)}.
+	 */
+	@Internal
+	protected boolean isUsingCustomRawKeyedState() {
+		return false;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -252,7 +252,8 @@ public abstract class AbstractStreamOperator<OUT>
 				this,
 				keySerializer,
 				streamTaskCloseableRegistry,
-				metrics);
+				metrics,
+				isUsingCustomRawKeyedState());
 
 		stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), streamTaskCloseableRegistry);
 		timeServiceManager = context.internalTimerServiceManager();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -45,6 +45,8 @@ public interface StreamTaskStateInitializer {
 	 * @param keySerializer the key-serializer for the operator. Can be null.
 	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
 	 * @param metricGroup the parent metric group for all statebackend metrics
+	 * @param isUsingCustomRawKeyedState flag indicating whether or not the {@link AbstractStreamOperator} is writing
+	 *                                   custom raw keyed state.
 	 * @return a context from which the given operator can initialize everything related to state.
 	 * @throws Exception when something went wrong while creating the context.
 	 */
@@ -55,5 +57,39 @@ public interface StreamTaskStateInitializer {
 		@Nonnull KeyContext keyContext,
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
-		@Nonnull MetricGroup metricGroup) throws Exception;
+		@Nonnull MetricGroup metricGroup,
+		boolean isUsingCustomRawKeyedState) throws Exception;
+
+	/**
+	 * Returns the {@link StreamOperatorStateContext} for an {@link AbstractStreamOperator} that runs in the stream
+	 * task that owns this manager.
+	 *
+	 * @param operatorID the id of the operator for which the context is created. Cannot be null.
+	 * @param operatorClassName the classname of the operator instance for which the context is created. Cannot be null.
+	 * @param processingTimeService
+	 * @param keyContext the key context of the operator instance for which the context is created Cannot be null.
+	 * @param keySerializer the key-serializer for the operator. Can be null.
+	 * @param streamTaskCloseableRegistry the closeable registry to which created closeable objects will be registered.
+	 * @param metricGroup the parent metric group for all statebackend metrics
+	 * @return a context from which the given operator can initialize everything related to state.
+	 * @throws Exception when something went wrong while creating the context.
+	 */
+	default StreamOperatorStateContext streamOperatorStateContext(
+			@Nonnull OperatorID operatorID,
+			@Nonnull String operatorClassName,
+			@Nonnull ProcessingTimeService processingTimeService,
+			@Nonnull KeyContext keyContext,
+			@Nullable TypeSerializer<?> keySerializer,
+			@Nonnull CloseableRegistry streamTaskCloseableRegistry,
+			@Nonnull MetricGroup metricGroup) throws Exception {
+		return streamOperatorStateContext(
+			operatorID,
+			operatorClassName,
+			processingTimeService,
+			keyContext,
+			keySerializer,
+			streamTaskCloseableRegistry,
+			metricGroup,
+			false);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -117,7 +117,8 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		@Nonnull KeyContext keyContext,
 		@Nullable TypeSerializer<?> keySerializer,
 		@Nonnull CloseableRegistry streamTaskCloseableRegistry,
-		@Nonnull MetricGroup metricGroup) throws Exception {
+		@Nonnull MetricGroup metricGroup,
+		boolean isUsingCustomRawKeyedState) throws Exception {
 
 		TaskInfo taskInfo = environment.getTaskInfo();
 		OperatorSubtaskDescriptionText operatorSubtaskDescription =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
@@ -62,6 +63,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.StreamSupport;
 
 /**
  * This class is the main implementation of a {@link StreamTaskStateInitializer}. This class obtains the state to create
@@ -432,13 +434,21 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			while (stateHandleIterator.hasNext()) {
 				currentStateHandle = stateHandleIterator.next();
 				if (currentStateHandle.getKeyGroupRange().getNumberOfKeyGroups() > 0) {
-					currentOffsetsIterator = currentStateHandle.getGroupRangeOffsets().iterator();
+					currentOffsetsIterator = unsetOffsetsSkippingIterator(currentStateHandle);
 
-					return true;
+					if (currentOffsetsIterator.hasNext()) {
+						return true;
+					}
 				}
 			}
 
 			return false;
+		}
+
+		private static Iterator<Tuple2<Integer, Long>> unsetOffsetsSkippingIterator(KeyGroupsStateHandle keyGroupsStateHandle) {
+			return StreamSupport.stream(keyGroupsStateHandle.getGroupRangeOffsets().spliterator(), false)
+				.filter(keyGroupIdAndOffset -> keyGroupIdAndOffset.f1 != KeyedStateCheckpointOutputStream.NO_OFFSET_SET)
+				.iterator();
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
+import org.apache.flink.util.Preconditions;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -443,10 +444,11 @@ public class AbstractStreamOperatorTest {
 		final int maxParallelism = 10;
 		final int numSubtasks = 1;
 		final int subtaskIndex = 0;
-		final KeyGroupRange keyGroupRange = KeyGroupRange.of(0, maxParallelism - 1);
+		final List<Integer> keyGroupsToWrite = Arrays.asList(2, 3, 8);
 
 		final byte[] testSnapshotData = "TEST".getBytes();
-		final CustomRawKeyedStateTestOperator testOperator = new CustomRawKeyedStateTestOperator(testSnapshotData);
+		final CustomRawKeyedStateTestOperator testOperator =
+			new CustomRawKeyedStateTestOperator(testSnapshotData, keyGroupsToWrite);
 
 		// snapshot and then restore
 		OperatorSubtaskState snapshot;
@@ -474,7 +476,7 @@ public class AbstractStreamOperatorTest {
 			testHarness.open();
 		}
 
-		assertThat(testOperator.restoredRawKeyedState, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupRange));
+		assertThat(testOperator.restoredRawKeyedState, hasRestoredKeyGroupsWith(testSnapshotData, keyGroupsToWrite));
 	}
 
 	/**
@@ -578,11 +580,13 @@ public class AbstractStreamOperatorTest {
 		private static final long serialVersionUID = 1L;
 
 		private final byte[] snapshotBytes;
+		private final List<Integer> keyGroupsToWrite;
 
 		private Map<Integer, byte[]> restoredRawKeyedState;
 
-		CustomRawKeyedStateTestOperator(byte[] snapshotBytes) {
+		CustomRawKeyedStateTestOperator(byte[] snapshotBytes, List<Integer> keyGroupsToWrite) {
 			this.snapshotBytes = Arrays.copyOf(snapshotBytes, snapshotBytes.length);
+			this.keyGroupsToWrite = Preconditions.checkNotNull(keyGroupsToWrite);
 		}
 
 		@Override
@@ -599,7 +603,7 @@ public class AbstractStreamOperatorTest {
 		public void snapshotState(StateSnapshotContext context) throws Exception {
 			super.snapshotState(context);
 			KeyedStateCheckpointOutputStream rawKeyedStateStream = context.getRawKeyedOperatorStateOutput();
-			for (int keyGroupId : rawKeyedStateStream.getKeyGroupList()) {
+			for (int keyGroupId : keyGroupsToWrite) {
 				rawKeyedStateStream.startNewKeyGroup(keyGroupId);
 				rawKeyedStateStream.write(snapshotBytes);
 			}
@@ -628,15 +632,15 @@ public class AbstractStreamOperatorTest {
 		return result;
 	}
 
-	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, KeyGroupRange range) {
+	private static Matcher<Map<Integer, byte[]>> hasRestoredKeyGroupsWith(byte[] testSnapshotData, List<Integer> writtenKeyGroups) {
 		return new TypeSafeMatcher<Map<Integer, byte[]>>() {
 			@Override
 			protected boolean matchesSafely(Map<Integer, byte[]> restored) {
-				if (restored.size() != range.getNumberOfKeyGroups()) {
+				if (restored.size() != writtenKeyGroups.size()) {
 					return false;
 				}
 
-				for (int writtenKeyGroupId : range) {
+				for (int writtenKeyGroupId : writtenKeyGroups) {
 					if (!Arrays.equals(restored.get(writtenKeyGroupId), testSnapshotData)) {
 						return false;
 					}
@@ -647,7 +651,7 @@ public class AbstractStreamOperatorTest {
 
 			@Override
 			public void describeTo(Description description) {
-				description.appendText("Key groups: " + range + " with snapshot data " + Arrays.toString(testSnapshotData));
+				description.appendText("Key groups: " + writtenKeyGroups + " with snapshot data " + Arrays.toString(testSnapshotData));
 			}
 		};
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1601,7 +1601,7 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public StreamTaskStateInitializer createStreamTaskStateInitializer() {
 			final StreamTaskStateInitializer streamTaskStateManager = super.createStreamTaskStateInitializer();
-			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup) -> {
+			return (operatorID, operatorClassName, processingTimeService, keyContext, keySerializer, closeableRegistry, metricGroup, isUsingCustomRawKeyedState) -> {
 
 				final StreamOperatorStateContext controller = streamTaskStateManager.streamOperatorStateContext(
 					operatorID,
@@ -1610,7 +1610,8 @@ public class StreamTaskTest extends TestLogger {
 					keyContext,
 					keySerializer,
 					closeableRegistry,
-					metricGroup);
+					metricGroup,
+					isUsingCustomRawKeyedState);
 
 				return new StreamOperatorStateContext() {
 					@Override


### PR DESCRIPTION
This is a backport of #13772 to `release-1.11`. Only the last 2 commits are relevant for FLINK-19748.
Please see #13772 for a detailed description.