### PR TITLE
[BP-1.11][FLINK-19677][runtime] Make JobManager lazily resolve hostname of TaskManager and provide an option to turn off reverse resolution entirely

### DIFF
--- a/docs/_includes/generated/all_jobmanager_section.html
+++ b/docs/_includes/generated/all_jobmanager_section.html
@@ -27,6 +27,12 @@
             <td>This option specifies how the job computation recovers from task failures. Accepted values are:<ul><li>'full': Restarts all tasks to recover the job.</li><li>'region': Restarts all tasks that could be affected by the task failure. More details can be found <a href="../dev/task_failure_recovery.html#restart-pipelined-region-failover-strategy">here</a>.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>jobmanager.retrieve-taskmanager-hostname</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration. If the option is set to "false", TaskManager registration with JobManager could be faster, since no reverse DNS lookup is performed. However, local input split assignment (such as for HDFS files) may be impacted.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -87,6 +87,12 @@
             <td>Total Process Memory size for the JobManager. This includes all the memory that a JobManager JVM process consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. In containerized setups, this should be set to the container memory. See also 'jobmanager.memory.flink.size' for Total Flink Memory size configuration.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.retrieve-taskmanager-hostname</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration. If the option is set to "false", TaskManager registration with JobManager could be faster, since no reverse DNS lookup is performed. However, local input split assignment (such as for HDFS files) may be impacted.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -309,6 +309,19 @@ public class JobManagerOptions {
 			.withDescription("The max number of completed jobs that can be kept in the job store.");
 
 	/**
+	 * Flag indicating whether JobManager would retrieve canonical host name of TaskManager during registration.
+	 */
+	@Documentation.Section(Documentation.Sections.ALL_JOB_MANAGER)
+	public static final ConfigOption<Boolean> RETRIEVE_TASK_MANAGER_HOSTNAME =
+		key("jobmanager.retrieve-taskmanager-hostname")
+			.defaultValue(true)
+			.withDescription("Flag indicating whether JobManager would retrieve canonical "
+							+ "host name of TaskManager during registration. "
+							+ "If the option is set to \"false\", TaskManager registration with "
+							+ "JobManager could be faster, since no reverse DNS lookup is performed. "
+							+ "However, local input split assignment (such as for HDFS files) may be impacted.");
+
+	/**
 	 * The timeout in milliseconds for requesting a slot from Slot Pool.
 	 */
 	@Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -51,25 +52,48 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 * the YARN container ID, Mesos container ID, or any other unique identifier. */
 	private final ResourceID resourceID;
 
-	/** The network address that the TaskManager binds its sockets to */
+	/** The network address that the TaskManager binds its sockets to. */
 	private final InetAddress inetAddress;
 
-	/** The fully qualified host name of the TaskManager */
-	private final String fqdnHostName;
+	/** The supplier for fully qualified host name and pure hostname. */
+	private final HostNameSupplier hostNameSupplier;
 
-	/** The pure hostname, derived from the fully qualified host name. */
-	private final String hostName;
-	
-	/** The port that the TaskManager receive data transport connection requests at */
+	/** The port that the TaskManager receive data transport connection requests at. */
 	private final int dataPort;
 
-	/** The toString representation, eagerly constructed and cached to avoid repeated string building */  
-	private final String stringRepresentation;
+	/** The toString representation, eagerly constructed and cached to avoid repeated string building. */
+	private String stringRepresentation;
 
 	/**
 	 * Constructs a new instance connection info object. The constructor will attempt to retrieve the instance's
 	 * host name and domain name through the operating system's lookup mechanisms.
-	 * 
+	 *
+	 * @param inetAddress
+	 *        the network address the instance's task manager binds its sockets to
+	 * @param dataPort
+	 *        the port instance's task manager expects to receive transfer envelopes on
+	 * @param hostNameSupplier
+	 *        the supplier for obtaining fully-qualified domain name and pure hostname of the task manager
+	 */
+	@VisibleForTesting
+	public TaskManagerLocation(
+			ResourceID resourceID,
+			InetAddress inetAddress,
+			int dataPort,
+			HostNameSupplier hostNameSupplier) {
+		// -1 indicates a local instance connection info
+		checkArgument(dataPort > 0 || dataPort == -1, "dataPort must be > 0, or -1 (local)");
+
+		this.resourceID = checkNotNull(resourceID);
+		this.inetAddress = checkNotNull(inetAddress);
+		this.dataPort = dataPort;
+		this.hostNameSupplier = checkNotNull(hostNameSupplier);
+	}
+
+	/**
+	 * Constructs a new instance connection info object. The constructor will attempt to retrieve the instance's
+	 * host name and domain name through the operating system's lookup mechanisms.
+	 *
 	 * @param inetAddress
 	 *        the network address the instance's task manager binds its sockets to
 	 * @param dataPort
@@ -77,28 +101,32 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 */
 	@VisibleForTesting
 	public TaskManagerLocation(ResourceID resourceID, InetAddress inetAddress, int dataPort) {
-		// -1 indicates a local instance connection info
-		checkArgument(dataPort > 0 || dataPort == -1, "dataPort must be > 0, or -1 (local)");
-
-		this.resourceID = checkNotNull(resourceID);
-		this.inetAddress = checkNotNull(inetAddress);
-		this.dataPort = dataPort;
-
-		// get FQDN hostname on this TaskManager.
-		this.fqdnHostName = getFqdnHostName(inetAddress);
-
-		this.hostName = getHostName(inetAddress);
-
-		this.stringRepresentation = String.format(
-				"%s @ %s (dataPort=%d)", resourceID, fqdnHostName, dataPort);
+		this(resourceID, inetAddress, dataPort,	new DefaultHostNameSupplier(inetAddress));
 	}
 
-	public static TaskManagerLocation fromUnresolvedLocation(final UnresolvedTaskManagerLocation unresolvedLocation)
+	public static TaskManagerLocation fromUnresolvedLocation(
+			final UnresolvedTaskManagerLocation unresolvedLocation,
+			final ResolutionMode resolutionMode)
 		throws UnknownHostException {
-		return new TaskManagerLocation(
-			unresolvedLocation.getResourceID(),
-			InetAddress.getByName(unresolvedLocation.getExternalAddress()),
-			unresolvedLocation.getDataPort());
+
+		InetAddress inetAddress = InetAddress.getByName(unresolvedLocation.getExternalAddress());
+
+		switch (resolutionMode) {
+			case RETRIEVE_HOST_NAME:
+				return new TaskManagerLocation(
+					unresolvedLocation.getResourceID(),
+					inetAddress,
+					unresolvedLocation.getDataPort(),
+					new DefaultHostNameSupplier(inetAddress));
+			case USE_IP_ONLY:
+				return new TaskManagerLocation(
+					unresolvedLocation.getResourceID(),
+					inetAddress,
+					unresolvedLocation.getDataPort(),
+					new IpOnlyHostNameSupplier(inetAddress));
+			default:
+				throw new UnsupportedOperationException("Unsupported resolution mode provided.");
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -114,7 +142,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 *     <li>If the TaskManager is started in standalone mode, or via a MiniCluster, this is a random ID.</li>
 	 *     <li>Other deployment modes can set the resource ID in other ways.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @return The ID of the resource in which the TaskManager is started
 	 */
 	public ResourceID getResourceID() {
@@ -123,7 +151,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	/**
 	 * Returns the port instance's task manager expects to receive transfer envelopes on.
-	 * 
+	 *
 	 * @return the port instance's task manager expects to receive transfer envelopes on
 	 */
 	public int dataPort() {
@@ -132,7 +160,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	/**
 	 * Returns the network address the instance's task manager binds its sockets to.
-	 * 
+	 *
 	 * @return the network address the instance's task manager binds its sockets to
 	 */
 	public InetAddress address() {
@@ -149,31 +177,26 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	}
 
 	/**
-	 * Returns the fully-qualified domain name the TaskManager. If the name could not be
-	 * determined, the return value will be a textual representation of the TaskManager's IP address.
-	 * 
+	 * Returns the fully-qualified domain name of the TaskManager provided by {@link #hostNameSupplier}.
+	 *
 	 * @return The fully-qualified domain name of the TaskManager.
 	 */
 	public String getFQDNHostname() {
-		return fqdnHostName;
+		return hostNameSupplier.getFqdnHostName();
 	}
 
 	/**
-	 * Gets the hostname of the TaskManager. The hostname derives from the fully qualified
-	 * domain name (FQDN, see {@link #getFQDNHostname()}):
-	 * <ul>
-	 *     <li>If the FQDN is the textual IP address, then the hostname is also the IP address</li>
-	 *     <li>If the FQDN has only one segment (such as "localhost", or "host17"), then this is
-	 *         used as the hostname.</li>
-	 *     <li>If the FQDN has multiple segments (such as "worker3.subgroup.company.net"), then the first
-	 *         segment (here "worker3") will be used as the hostname.</li>
-	 * </ul>
+	 * Gets the hostname of the TaskManager from {@link #hostNameSupplier}.
 	 *
 	 * @return The hostname of the TaskManager.
 	 */
 	public String getHostname() {
-		return hostName;
+		return hostNameSupplier.getHostName();
 	}
+
+	// --------------------------------------------------------------------------------------------
+	// Utilities
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Gets the fully qualified hostname of the TaskManager based on the network address.
@@ -219,12 +242,12 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 		return hostName;
 	}
 
-	// --------------------------------------------------------------------------------------------
-	// Utilities
-	// --------------------------------------------------------------------------------------------
-
 	@Override
 	public String toString() {
+		if (stringRepresentation == null) {
+			this.stringRepresentation = String.format(
+					"%s @ %s (dataPort=%d)", resourceID, getFQDNHostname(), dataPort);
+		}
 		return stringRepresentation;
 	}
 
@@ -246,7 +269,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 	@Override
 	public int hashCode() {
-		return resourceID.hashCode() + 
+		return resourceID.hashCode() +
 				17 * inetAddress.hashCode() +
 				129 * dataPort;
 	}
@@ -287,5 +310,106 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 		} else {
 			return 0;
 		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Hostname Resolution Suppliers
+	// --------------------------------------------------------------------------------------------
+
+	public interface HostNameSupplier extends Serializable {
+		String getHostName();
+
+		String getFqdnHostName();
+	}
+
+	/**
+	 * This Supplier class could retrieve the FQDN host name of the given InetAddress on demand,
+	 * extract the pure host name and cache the results for later use.
+	 */
+	@VisibleForTesting
+	public static class DefaultHostNameSupplier implements HostNameSupplier {
+		private final InetAddress inetAddress;
+		private String hostName;
+		private String fqdnHostName;
+
+		public DefaultHostNameSupplier(InetAddress inetAddress) {
+			this.inetAddress = inetAddress;
+		}
+
+		/**
+		 * Gets the hostname of the TaskManager. The hostname derives from the fully qualified
+		 * domain name (FQDN, see {@link #getFQDNHostname()}):
+		 * <ul>
+		 *     <li>If the FQDN is the textual IP address, then the hostname is also the IP address</li>
+		 *     <li>If the FQDN has only one segment (such as "localhost", or "host17"), then this is
+		 *         used as the hostname.</li>
+		 *     <li>If the FQDN has multiple segments (such as "worker3.subgroup.company.net"), then the first
+		 *         segment (here "worker3") will be used as the hostname.</li>
+		 * </ul>
+		 *
+		 * @return The hostname of the TaskManager.
+		 */
+		@Override
+		public String getHostName() {
+			if (hostName == null) {
+				hostName = TaskManagerLocation.getHostName(inetAddress);
+			}
+			return hostName;
+		}
+
+		/**
+		 * Returns the fully-qualified domain name the TaskManager. If the name could not be
+		 * determined, the return value will be a textual representation of the TaskManager's IP address.
+		 *
+		 * @return The fully-qualified domain name of the TaskManager.
+		 */
+		@Override
+		public String getFqdnHostName() {
+			if (fqdnHostName == null) {
+				fqdnHostName = TaskManagerLocation.getFqdnHostName(inetAddress);
+			}
+			return fqdnHostName;
+		}
+	}
+
+	/**
+	 * This Supplier class returns the IP address of the given InetAddress directly,
+	 * therefore no reverse DNS lookup is required.
+	 */
+	@VisibleForTesting
+	public static class IpOnlyHostNameSupplier implements HostNameSupplier {
+		private final InetAddress inetAddress;
+
+		public IpOnlyHostNameSupplier(InetAddress inetAddress) {
+			this.inetAddress = inetAddress;
+		}
+
+		/**
+		 * Returns the textual representation of the TaskManager's IP address as host name.
+		 *
+		 * @return The textual representation of the TaskManager's IP address.
+		 */
+		@Override
+		public String getHostName() {
+			return inetAddress.getHostAddress();
+		}
+
+		/**
+		 * Returns the textual representation of the TaskManager's IP address as FQDN host name.
+		 *
+		 * @return The textual representation of the TaskManager's IP address.
+		 */
+		@Override
+		public String getFqdnHostName() {
+			return inetAddress.getHostAddress();
+		}
+	}
+
+	/**
+	 * The DNS resolution mode for TaskManager's IP address.
+	 */
+	public enum ResolutionMode {
+		RETRIEVE_HOST_NAME,
+		USE_IP_ONLY
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerLocationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -197,5 +198,21 @@ public class TaskManagerLocationTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testNotRetrieveHostName() {
+		InetAddress address = mock(InetAddress.class);
+		when(address.getCanonicalHostName()).thenReturn("worker10");
+		when(address.getHostName()).thenReturn("worker10");
+		when(address.getHostAddress()).thenReturn("127.0.0.1");
+
+		TaskManagerLocation info = new TaskManagerLocation(ResourceID.generate(), address, 19871,
+				new TaskManagerLocation.IpOnlyHostNameSupplier(address));
+
+		assertNotEquals("worker10", info.getHostname());
+		assertNotEquals("worker10", info.getFQDNHostname());
+		assertEquals("127.0.0.1", info.getHostname());
+		assertEquals("127.0.0.1", info.getFQDNHostname());
 	}
 }


### PR DESCRIPTION
Backport of #13706 to `release-1.11`.