### PR TITLE
[FLINK-19479][DataStream] Allow explicitly configuring time behaviour on KeyedStream.intervalJoin()

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -19,7 +19,6 @@ package org.apache.flink.test.streaming.runtime;
 
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.UnsupportedTimeCharacteristicException;
@@ -385,7 +384,6 @@ public class IntervalJoinITCase {
 	@Test(expected = UnsupportedTimeCharacteristicException.class)
 	public void testExecutionFailsInProcessingTime() throws Exception {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 		env.setParallelism(1);
 
 		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(Tuple2.of("1", 1));
@@ -393,6 +391,7 @@ public class IntervalJoinITCase {
 
 		streamOne.keyBy(new Tuple2KeyExtractor())
 			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.inProcessingTime()
 			.between(Time.milliseconds(0), Time.milliseconds(0))
 			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
 				@Override


### PR DESCRIPTION
## What is the purpose of the change

*With the deprecation of `StreamExecutionEnvironment.setStreamTimeCharacteristic()`, we need a way of explicitly configuring the time behaviour of these join operations. Currently, all join operations use the characteristic to configure themselves. `IntervalJoin` in `KeyedStream` could add `inProcessingTIme` and `inEventTime` that specify time behaviour to processing time or event time.*

## Brief change log

  - *`IntervalJoin` adds `inProcessingTIme` and `inEventTime` method that specify time behaviour of join operations to processing time or event time.*

## Verifying this change

  - *Modify `testExecutionFailsInProcessingTime` of `IntervalJoinITCase` test case to verify the `inProcessingTIme` of `IntervalJoin` whether could configure the time behaviour of join operations to processing time.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)