### PR TITLE
[FLINK-19717][connectors/common] Fix spurious InputStatus.END_OF_INPUT from SourceReaderBase.pollNext caused by split reader exception

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -266,6 +266,8 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 			return InputStatus.NOTHING_AVAILABLE;
 		}
 		if (elementsQueue.isEmpty()) {
+			// We may reach here because of exceptional split fetcher, check it.
+			splitFetcherManager.checkErrors();
 			return InputStatus.END_OF_INPUT;
 		} else {
 			throw new IllegalStateException("Called 'finishedOrAvailableLater()' with shut-down fetchers but non-empty queue");

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -23,7 +23,6 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
-import org.apache.flink.util.ThrowableCatchingRunnable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,7 +111,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 	public abstract void addSplits(List<SplitT> splitsToAdd);
 
 	protected void startFetcher(SplitFetcher<E, SplitT> fetcher) {
-		executors.submit(new ThrowableCatchingRunnable(errorHandler, fetcher));
+		executors.submit(fetcher);
 	}
 
 	/**
@@ -133,6 +132,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 			fetcherId,
 			elementsQueue,
 			splitReader,
+			errorHandler,
 			() -> fetchers.remove(fetcherId));
 		fetchers.put(fetcherId, splitFetcher);
 		return splitFetcher;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.base.source.reader;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.TestingReaderContext;
 import org.apache.flink.api.connector.source.mocks.TestingReaderOutput;
@@ -34,6 +35,7 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
+import org.apache.flink.core.io.InputStatus;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -87,9 +90,11 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 			reader.addSplits(Collections.singletonList(getSplit(0,
 				NUM_RECORDS_PER_SPLIT,
 				Boundedness.CONTINUOUS_UNBOUNDED)));
+			reader.handleSourceEvents(new NoMoreSplitsEvent());
 			// This is not a real infinite loop, it is supposed to throw exception after two polls.
 			while (true) {
-				reader.pollNext(output);
+				InputStatus inputStatus = reader.pollNext(output);
+				assertNotEquals(InputStatus.END_OF_INPUT, inputStatus);
 				// Add a sleep to avoid tight loop.
 				Thread.sleep(1);
 			}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.connector.base.source.reader.mocks.TestingSplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Test;
 
@@ -164,6 +165,7 @@ public class SplitFetcherTest {
 						0,
 						elementQueue,
 						new MockSplitReader(2, true),
+						ExceptionUtils::rethrow,
 						() -> {});
 
 		// Prepare the splits.
@@ -252,7 +254,7 @@ public class SplitFetcherTest {
 	private static <E> SplitFetcher<E, TestingSourceSplit> createFetcher(
 			final SplitReader<E, TestingSourceSplit> reader,
 			final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> queue) {
-		return new SplitFetcher<>(0, queue, reader, () -> {});
+		return new SplitFetcher<>(0, queue, reader, ExceptionUtils::rethrow, () -> {});
 	}
 
 	private static <E> SplitFetcher<E, TestingSourceSplit> createFetcherWithSplit(


### PR DESCRIPTION
## What is the purpose of the change
Fix spurious `InputStatus.END_OF_INPUT` from `SourceReaderBase.pollNext` caused by split reader exception.

## Brief change log
* Modify `SourceReaderBaseTest.testExceptionInSplitReader` to assert that `SourceReaderBase.pollNext` will not return `InputStatus.END_OF_INPUT` in case of split reader exception.
* Move `exceptionHandler` from `ThrowableCatchingRunnable` to `SplitFetcher.errorHandler`.
* Construct happens-before relation between `SplitFetcher.errorHandler` and `SplitFetcher.shutdownHook`.
* Check `SplitFetcherManager.uncaughtFetcherException` before returning `InputStatus.END_OF_INPUT`.

## Verifying this change

This change modifies tests and can be verified as follows:
- `SourceReaderBaseTest.testExceptionInSplitReader`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
