### PR TITLE
[FLINK-19791][network][test] Connect to an opened port instead of 8080

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.util.NetUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
@@ -220,6 +221,13 @@ public class NettyTestUtil {
 
 		NettyClient client() {
 			return client;
+		}
+
+		ConnectionID getConnectionID(int connectionIndex) {
+			return new ConnectionID(new InetSocketAddress(
+				server.getConfig().getServerAddress(),
+				server.getConfig().getServerPort()),
+				connectionIndex);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -98,10 +98,8 @@ public class PartitionRequestClientFactoryTest {
 		UnstableNettyClient unstableNettyClient = new UnstableNettyClient(serverAndClient.client(), 2);
 
 		PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
-		ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
-			serverAndClient.server().getConfig().getServerPort()), 0);
 
-		factory.createPartitionRequestClient(serverAddress);
+		factory.createPartitionRequestClient(serverAndClient.getConnectionID(0));
 
 		serverAndClient.client().shutdown();
 		serverAndClient.server().shutdown();
@@ -126,10 +124,8 @@ public class PartitionRequestClientFactoryTest {
 
 		try {
 			PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
-			ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
-				serverAndClient.server().getConfig().getServerPort()), 0);
 
-			factory.createPartitionRequestClient(serverAddress);
+			factory.createPartitionRequestClient(serverAndClient.getConnectionID(0));
 
 		} catch (Exception e) {
 			throw e;
@@ -145,8 +141,6 @@ public class PartitionRequestClientFactoryTest {
 		UnstableNettyClient unstableNettyClient = new UnstableNettyClient(serverAndClient.client(), 2);
 
 		PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
-		ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
-			serverAndClient.server().getConfig().getServerPort()), 0);
 
 		ExecutorService threadPoolExecutor = Executors.newFixedThreadPool(10);
 		List<Future<NettyPartitionRequestClient>> futures = new ArrayList<>();
@@ -157,7 +151,7 @@ public class PartitionRequestClientFactoryTest {
 				public NettyPartitionRequestClient call() {
 					NettyPartitionRequestClient client = null;
 					try {
-						client = factory.createPartitionRequestClient(serverAddress);
+						client = factory.createPartitionRequestClient(serverAndClient.getConnectionID(0));
 					} catch (Exception e) {
 						fail(e.getMessage());
 					}


### PR DESCRIPTION
## What is the purpose of the change

A recently added `PartitionRequestClientFactoryTest.testInterruptsNotCached` fails
if failure is detected before `NetworkClientHandler` was obtained.

This PR fixes this by connecting to an opened port.

## Verifying this change

This change is a test fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
