### PR TITLE
[FLINK-18122][e2e] Make K8s test more resilient by retrying and failing docker iamge build

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -19,7 +19,8 @@
 
 source "$(dirname "$0")"/common_kubernetes.sh
 
-IMAGE_BUILD_RETRIES=3
+local IMAGE_BUILD_RETRIES=3
+local IMAGE_BUILD_BACKOFF=2
 
 export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
 export FLINK_IMAGE_NAME=test_kubernetes_embedded_job
@@ -38,7 +39,7 @@ start_kubernetes
 
 mkdir -p $OUTPUT_VOLUME
 
-if ! retry_times $IMAGE_BUILD_RETRIES 2 "build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)"; then
+if ! retry_times $IMAGE_BUILD_RETRIES $IMAGE_BUILD_BACKOFF "build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)"; then
 	echo "ERROR: Could not build image. Aborting..."
 	exit 1
 fi


### PR DESCRIPTION


## What is the purpose of the change

The Kubernetes e2e test failed once because it failed to build the docker image (network outage). This caused the test to report that the container didn't come up as expected.

With this change, we will retry if the container building failed, and we will immediately return if we could not build the image, leading to better error reporting.


