### PR TITLE
[FLINK-19782][python] Remove antlr traces in flink-python

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -334,6 +334,7 @@ under the License.
 									<excludes>
 										<exclude>org/apache/beam/vendor/bytebuddy/**</exclude>
 										<exclude>org/apache/beam/repackaged/core/org/antlr/**</exclude>
+										<exclude>META-INF/maven/org.antlr/antlr4-runtime/**</exclude>
 										<exclude>org/apache/beam/repackaged/core/org/apache/commons/compress/**</exclude>
 										<exclude>org/apache/beam/repackaged/core/org/apache/commons/lang3/**</exclude>
 									</excludes>


### PR DESCRIPTION


## What is the purpose of the change

A user found that we are using antlr in flink-python (with a vulnerability). We are not using antlr in flink-python, there are just some metadata files which were not properly removed from the shading.
