### PR TITLE
[FLINK-19781] Upgrade commons-codec to 1.13

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
 - io.netty:netty:3.10.6.Final
 - io.netty:netty-buffer:4.1.44.Final

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2
 - org.apache.httpcomponents:httpclient:4.5.3

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - com.github.spullara.mustache.java:compiler:0.9.6
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.4
 - org.apache.httpcomponents:httpclient:4.5.3

--- a/flink-connectors/flink-sql-connector-hbase-1.4/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - com.google.guava:guava:12.0.1
 - com.yammer.metrics:metrics-core:2.2.0
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-configuration:commons-configuration:1.7
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3

--- a/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
- - commons-codec:commons-codec:jar:1.10
+ - commons-codec:commons-codec:jar:1.13
  - commons-lang:commons-lang:2.6
  - commons-logging:commons-logging:1.2
  - io.netty:netty-all:jar:4.1.44.Final

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:11.0.2
 - com.microsoft.azure:azure-keyvault-core:0.8.0
 - com.microsoft.azure:azure-storage:5.4.0
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-logging:commons-logging:1.1.3
 - org.apache.hadoop:hadoop-azure:3.1.0
 - org.apache.httpcomponents:httpclient:4.5.3

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.aliyun:aliyun-java-sdk-ecs:jar:4.2.0
 - com.aliyun:aliyun-java-sdk-ram:jar:3.0.0
 - com.aliyun:aliyun-java-sdk-sts:jar:3.0.0
-- commons-codec:commons-codec:jar:1.10
+- commons-codec:commons-codec:jar:1.13
 - commons-logging:commons-logging:jar:1.1.3
 - org.apache.hadoop:hadoop-aliyun:jar:3.1.0
 - org.apache.httpcomponents:httpclient:jar:4.5.3

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:11.0.2
 - commons-beanutils:commons-beanutils:1.9.3
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.4
 - commons-lang:commons-lang:2.6

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - commons-beanutils:commons-beanutils:1.9.3
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.4
 - commons-lang:commons-lang:2.6

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-math3:3.5
 - commons-beanutils:commons-beanutils:1.8.3
 - commons-cli:commons-cli:1.3.1
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-configuration:commons-configuration:1.7
 - commons-digester:commons-digester:1.8.1

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -15,7 +15,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-core:1.26.0
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 - commons-io:commons-io:2.4
 
 This project bundles the following dependencies under the BSD license.

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-core:1.26.0
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
-- commons-codec:commons-codec:1.10
+- commons-codec:commons-codec:1.13
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details

--- a/pom.xml
+++ b/pom.xml
@@ -595,7 +595,7 @@ under the License.
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.10</version>
+				<version>1.13</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
The upgrade is necessary due to a vulnerability.