### PR TITLE
[FLINK-19785] Upgrade to commons-io 2.7

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.typesafe.akka:akka-stream_2.11:2.5.21
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - commons-lang:commons-lang:2.6
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.3
 - com.google.guava:guava:11.0.2

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.3
 - commons-codec:commons-codec:1.10
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.3
 - commons-codec:commons-codec:1.10
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - com.amazonaws:aws-java-sdk-core:1.11.754

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-configuration:commons-configuration:1.7
 - commons-digester:commons-digester:1.8.1
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - commons-net:commons-net:3.1

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
 - commons-codec:commons-codec:1.10
-- commons-io:commons-io:2.4
+- commons-io:commons-io:2.7
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@ under the License.
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.4</version>
+				<version>2.7</version>
 			</dependency>
 
 			<!-- commons collections needs to be pinned to this critical security fix version -->


### PR DESCRIPTION
This is necessary due to a vulnerability.