### PR TITLE
[FLINK-19750][Kafka] Fix bug of not opening DeserializationSchema when FlinkKafkaConsumerBase recovering from state

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -690,9 +690,9 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 				LOG.info("Consumer subtask {} initially has no partitions to read from.",
 					getRuntimeContext().getIndexOfThisSubtask());
 			}
-
-			this.deserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 		}
+
+		this.deserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -852,6 +852,18 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
 		assertThat("Open method was not called", deserializationSchema.isOpenCalled(), is(true));
 	}
 
+	@Test
+	public void testOpenWithRestoreState() throws Exception {
+		MockDeserializationSchema<String> deserializationSchema = new MockDeserializationSchema<>();
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(
+				new KafkaDeserializationSchemaWrapper<>(deserializationSchema));
+
+		final TestingListState<Tuple2<KafkaTopicPartition, Long>> restoredListState = new TestingListState<>();
+		setupConsumer(consumer, true, restoredListState, true, 0, 1);
+
+		assertThat("DeserializationSchema's open method was not invoked", deserializationSchema.isOpenCalled(), is(true));
+	}
+
 	// ------------------------------------------------------------------------
 
 	private static <T> AbstractStreamOperatorTestHarness<T> createTestHarness(


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug of not invoking DeserializationSchema#open method when FlinkKafkaConsumerBase restoring state from checkpoint or savepoint. 


## Brief change log

- Move deserializationSchema.open() out of else clause to make sure it will be invoked whether the job is started from blank or recovered from state
- Add a unit test case to make sure that deserializationSchema.open() is indeed invoked when consumer is restored from state


## Verifying this change

This change added tests and can be verified as follows:
- Added unit test for initializing and opening FlinkKafkaConsumerBase with restoring state, and validate the deserializer is indeed opened

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
