### PR TITLE
[FLINK-19727][table-runtime] Implement ParallelismProvider for sink i…

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -20,19 +20,39 @@ package org.apache.flink.table.connector.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
+
+import java.util.Optional;
 
 /**
  * Provider of a {@link SinkFunction} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvider {
+public interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
 	/**
 	 * Helper method for creating a static provider.
 	 */
 	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction) {
-		return () -> sinkFunction;
+		return of(sinkFunction, Optional.empty());
+	}
+
+	/**
+	 * Helper method for creating a static provider, sink parallelism will be configured if non-empty parallelism is passed in.
+	 */
+	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction, Optional<Integer> parallelism) {
+	return new SinkFunctionProvider() {
+		@Override
+		public SinkFunction<RowData> createSinkFunction() {
+			return sinkFunction;
+		}
+
+		@Override
+		public Optional<Integer> getParallelism() {
+			return parallelism;
+		}
+	};
 	}
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -27,8 +27,7 @@ import org.apache.flink.table.data.RowData;
  * Provider of a {@link SinkFunction} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface SinkFunctionProvider
-	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
+public interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
 	/**
 	 * Helper method for creating a static provider.

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -23,36 +23,18 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
-import java.util.Optional;
-
 /**
  * Provider of a {@link SinkFunction} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
+public interface SinkFunctionProvider
+	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
 	/**
 	 * Helper method for creating a static provider.
 	 */
 	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction) {
-		return of(sinkFunction, Optional.empty());
-	}
-
-	/**
-	 * Helper method for creating a static provider, sink parallelism will be configured if non-empty parallelism is passed in.
-	 */
-	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction, Optional<Integer> parallelism) {
-	return new SinkFunctionProvider() {
-		@Override
-		public SinkFunction<RowData> createSinkFunction() {
-			return sinkFunction;
-		}
-
-		@Override
-		public Optional<Integer> getParallelism() {
-			return parallelism;
-		}
-	};
+		return () -> sinkFunction;
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -20,19 +20,39 @@ package org.apache.flink.table.connector.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
+
+import java.util.Optional;
 
 /**
  * Provider of an {@link OutputFormat} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvider {
+public interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider{
 
 	/**
 	 * Helper method for creating a static provider.
 	 */
 	static OutputFormatProvider of(OutputFormat<RowData> outputFormat) {
-		return () -> outputFormat;
+		return of(outputFormat, Optional.empty());
+	}
+
+	/**
+	 * Helper method for creating a static provider, sink parallelism will be configured if non-empty parallelism is passed in.
+	 */
+	static OutputFormatProvider of(OutputFormat<RowData> outputFormat, Optional<Integer> parallelism) {
+		return new OutputFormatProvider() {
+			@Override
+			public OutputFormat<RowData> createOutputFormat() {
+				return outputFormat;
+			}
+
+			@Override
+			public Optional<Integer> getParallelism() {
+				return parallelism;
+			}
+		};
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.data.RowData;
  */
 @PublicEvolving
 public interface OutputFormatProvider
-	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider{
+	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
 	/**
 	 * Helper method for creating a static provider.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -27,8 +27,7 @@ import org.apache.flink.table.data.RowData;
  * Provider of an {@link OutputFormat} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface OutputFormatProvider
-	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
+public interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
 	/**
 	 * Helper method for creating a static provider.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -23,36 +23,18 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
-import java.util.Optional;
-
 /**
  * Provider of an {@link OutputFormat} instance as a runtime implementation for {@link DynamicTableSink}.
  */
 @PublicEvolving
-public interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider{
+public interface OutputFormatProvider
+	extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider{
 
 	/**
 	 * Helper method for creating a static provider.
 	 */
 	static OutputFormatProvider of(OutputFormat<RowData> outputFormat) {
-		return of(outputFormat, Optional.empty());
-	}
-
-	/**
-	 * Helper method for creating a static provider, sink parallelism will be configured if non-empty parallelism is passed in.
-	 */
-	static OutputFormatProvider of(OutputFormat<RowData> outputFormat, Optional<Integer> parallelism) {
-		return new OutputFormatProvider() {
-			@Override
-			public OutputFormat<RowData> createOutputFormat() {
-				return outputFormat;
-			}
-
-			@Override
-			public Optional<Integer> getParallelism() {
-				return parallelism;
-			}
-		};
+		return () -> outputFormat;
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalSink.scala
@@ -30,8 +30,10 @@ import org.apache.flink.streaming.api.transformations.LegacySinkTransformation
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.connector.{ChangelogMode, ParallelismProvider}
 import org.apache.flink.table.connector.sink.{DataStreamSinkProvider, DynamicTableSink, OutputFormatProvider, SinkFunctionProvider}
 import org.apache.flink.table.data.RowData
+import org.apache.flink.types.RowKind
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
@@ -40,8 +42,10 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext
 import org.apache.flink.table.runtime.operators.sink.{SinkNotNullEnforcer, SinkOperator}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.utils.TableSchemaUtils
 
 import scala.collection.JavaConversions._
+import scala.collection.Set
 
 /**
  * Base physical RelNode to write data to an external sink defined by a [[DynamicTableSink]].
@@ -64,7 +68,8 @@ class CommonPhysicalSink (
       inputTransformation: Transformation[RowData],
       tableConfig: TableConfig,
       rowtimeFieldIndex: Int,
-      isBounded: Boolean): Transformation[Any] = {
+      isBounded: Boolean,
+      changelogMode:ChangelogMode): Transformation[Any] = {
     val inputTypeInfo = InternalTypeInfo.of(FlinkTypeFactory.toLogicalRowType(getInput.getRowType))
     val runtimeProvider = tableSink.getSinkRuntimeProvider(
       new SinkRuntimeProviderContext(isBounded))
@@ -79,6 +84,7 @@ class CommonPhysicalSink (
     val enforcer = new SinkNotNullEnforcer(notNullEnforcer, notNullFieldIndices, fieldNames)
 
     runtimeProvider match {
+      case _: DataStreamSinkProvider with ParallelismProvider => throw new RuntimeException("`DataStreamSinkProvider` is not allowed to work with `ParallelismProvider`, please see document of `ParallelismProvider`")
       case provider: DataStreamSinkProvider =>
         val dataStream = new DataStream(env, inputTransformation).filter(enforcer)
         provider.consumeDataStream(dataStream).getTransformation.asInstanceOf[Transformation[Any]]
@@ -99,11 +105,33 @@ class CommonPhysicalSink (
 
         val operator = new SinkOperator(env.clean(sinkFunction), rowtimeFieldIndex, enforcer)
 
+        val inputParallelism = inputTransformation.getParallelism
+        val taskParallelism = env.getParallelism
+        val parallelism = if (runtimeProvider.isInstanceOf[ParallelismProvider]) runtimeProvider.asInstanceOf[ParallelismProvider].getParallelism.orElse(inputParallelism).intValue()
+        else inputParallelism
+
+        if (implicitly[Ordering[Int]].lteq(parallelism, 0)) throw new RuntimeException(s"the configured sink parallelism: $parallelism should not be less than zero or equal to zero")
+        if (implicitly[Ordering[Int]].gt(parallelism, taskParallelism)) throw new RuntimeException(s"the configured sink parallelism: $parallelism is larger than the task max parallelism: $taskParallelism")
+
+        val primaryKeys = TableSchemaUtils.getPrimaryKeyIndices(catalogTable.getSchema)
+        val containedRowKinds = changelogMode.getContainedKinds.toSet
+        val theFinalInputTransformation = if(inputParallelism == parallelism) inputTransformation //if the parallelism is not changed, do nothing
+        else (containedRowKinds, primaryKeys.toList) match {
+        // fixme : if rowKinds only contains  delete, is there somethinng to do with? Currently do nothing.
+        case (_, _) if(containedRowKinds == Set(RowKind.DELETE)) => inputTransformation
+        case (_, _) if(containedRowKinds == Set(RowKind.INSERT)) => inputTransformation
+        // fixme: for retract mode (insert and delete contains only), is there somethinng to do with? Currently do nothing.
+        case (_, _) if(containedRowKinds == Set(RowKind.INSERT,RowKind.DELETE)) => inputTransformation
+        case (_, Nil) if(containedRowKinds.contains(RowKind.UPDATE_AFTER)) => throw new RuntimeException(s"ChangelogMode contains ${RowKind.UPDATE_AFTER}, but no primaryKeys were found")
+        case (_, _) if(containedRowKinds.contains(RowKind.UPDATE_AFTER)) => new DataStream[RowData](env,inputTransformation).keyBy(primaryKeys:_*).getTransformation
+        case _ => throw new RuntimeException(s"the changelogMode is: ${containedRowKinds.mkString(",")}, which is not supported")
+      }
+
         new LegacySinkTransformation(
-          inputTransformation,
+          theFinalInputTransformation,
           getRelDetailedDescription,
           SimpleOperatorFactory.of(operator),
-          inputTransformation.getParallelism).asInstanceOf[Transformation[Any]]
+          parallelism).asInstanceOf[Transformation[Any]]
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPhysicalSink.scala
@@ -137,10 +137,10 @@ class CommonPhysicalSink (
           case (_, _, _) if (changelogMode.containsOnly(RowKind.INSERT)) => inputTransformation
           case (_, _, Nil) =>
             throw new TableException(
-            s"Table: $tableIdentifier configured sink parallelism is: $parallelism, "+
-            s"while the input parallelism is: $inputParallelism. "+
+            s"Table: $tableIdentifier configured sink parallelism is: $parallelism, " +
+            s"while the input parallelism is: $inputParallelism. " +
             s"Since the changelog mode " +
-            s"contains [${changelogMode.getContainedKinds.toList.mkString(",")}], "+
+            s"contains [${changelogMode.getContainedKinds.toList.mkString(",")}], " +
             s"which is not INSERT_ONLY mode, " +
             s"primary key is required but no primary key is found"
           )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
@@ -83,12 +83,13 @@ class BatchExecSink(
     }
 
     // tell sink the ChangelogMode of input, batch only supports INSERT only.
-    tableSink.getChangelogMode(ChangelogMode.insertOnly())
+    val changelogMode = tableSink.getChangelogMode(ChangelogMode.insertOnly())
     createSinkTransformation(
       planner.getExecEnv,
       inputTransformation,
       planner.getTableConfig,
       -1 /* not rowtime field */,
-      isBounded = true)
+      isBounded = true,
+      changelogMode = changelogMode)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
@@ -97,7 +97,7 @@ class StreamExecSink(
     val inputChangelogMode = ChangelogPlanUtils.getChangelogMode(
       getInput.asInstanceOf[StreamPhysicalRel]).get
     // tell sink the ChangelogMode of input
-    tableSink.getChangelogMode(inputChangelogMode)
+    val changelogMode = tableSink.getChangelogMode(inputChangelogMode)
     val rowtimeFieldIndex: Int = rowtimeFields.map(_._2).headOption.getOrElse(-1)
 
     createSinkTransformation(
@@ -105,6 +105,7 @@ class StreamExecSink(
       inputTransformation,
       planner.getTableConfig,
       rowtimeFieldIndex,
-      isBounded = false)
+      isBounded = false,
+      changelogMode = changelogMode)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -26,7 +26,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.table.connector.ParallelismProvider;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink.DataStructureConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AsyncTableFunction;
@@ -44,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -100,6 +105,28 @@ final class TestValuesRuntimeFunctions {
 			globalRawResult.clear();
 			globalUpsertResult.clear();
 			globalRetractResult.clear();
+		}
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Specialized test provider implementations
+	// ------------------------------------------------------------------------------------------
+	static class InternalDataStreamSinkProviderWithParallelism implements DataStreamSinkProvider, ParallelismProvider {
+
+		private final Integer parallelism;
+
+		public InternalDataStreamSinkProviderWithParallelism(Integer parallelism) {
+			this.parallelism = parallelism;
+		}
+
+		@Override
+		public DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream) {
+			throw new UnsupportedOperationException("should not be called");
+		}
+
+		@Override
+		public Optional<Integer> getParallelism() {
+			return Optional.ofNullable(parallelism);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -398,7 +398,8 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		final Map<String, DataType> writableMetadata = convertToMetadataMap(
 			helper.getOptions().get(WRITABLE_METADATA),
 			context.getClassLoader());
-		ChangelogMode changelogMode = Optional.ofNullable(helper.getOptions().get(SINK_CHANGELOG_MODE_ENFORCED)).map(m -> parseChangelogMode(m)).orElse(null);
+		final ChangelogMode changelogMode = Optional.ofNullable(helper.getOptions()
+			.get(SINK_CHANGELOG_MODE_ENFORCED)).map(m -> parseChangelogMode(m)).orElse(null);
 
 		final DataType consumedType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
 
@@ -943,8 +944,7 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		private DataType consumedDataType;
 		private int[] primaryKeyIndices;
 		private final String tableName;
-		private final boolean
-			isInsertOnly;
+		private final boolean isInsertOnly;
 		private final String runtimeSink;
 		private final int expectedNum;
 		private final Map<String, DataType> writableMetadata;

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.planner.runtime.batch.table
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
@@ -29,7 +27,6 @@ import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.Test
 
 import scala.collection.JavaConversions._
-import scala.util.{Failure, Success, Try}
 
 class TableSinkITCase extends BatchTestBase {
 
@@ -156,115 +153,6 @@ class TableSinkITCase extends BatchTestBase {
   def testDataStreamNotNullEnforcer(): Unit = {
     innerTestNotNullEnforcer("DataStream")
   }
-
-  @Test
-  def testParallelismWithDataStream(): Unit = {
-    Try(innerTestSetParallelism("DataStreamWithParallelism", 1, index = 1)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          "`DataStreamSinkProvider` is not allowed to work with `ParallelismProvider`, please see document of `ParallelismProvider`")
-        assertTrue(exception.isPresent)
-      }
-    }
-  }
-
-  @Test
-  def testParallelismWithSinkFunction(): Unit = {
-    val taskParallelism = env.getParallelism
-    val oversizeParallelism = taskParallelism + 1
-    val negativeParallelism = -1
-    val vaildParallelism = 1
-    val index = new AtomicInteger(1)
-
-    Try(innerTestSetParallelism("SinkFunction", oversizeParallelism, index = index.getAndIncrement)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"the configured sink parallelism: ${oversizeParallelism} is larger than the task max parallelism: ${taskParallelism}")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    Try(innerTestSetParallelism("SinkFunction", negativeParallelism, index = index.getAndIncrement)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"the configured sink parallelism: ${negativeParallelism} should not be little or equal zero")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    assertTrue(Try(innerTestSetParallelism("SinkFunction", vaildParallelism, index = index.getAndIncrement)).isSuccess)
-  }
-
-  @Test
-  def testParallelismWithOutputFormat(): Unit = {
-    val taskParallelism = env.getParallelism
-    val oversizeParallelism = taskParallelism + 1
-    val negativeParallelism = -1
-    val vaildParallelism = 1
-    val index = new AtomicInteger(1)
-
-    Try(innerTestSetParallelism("OutputFormat", oversizeParallelism, index = index.getAndIncrement)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"the configured sink parallelism: ${oversizeParallelism} is larger than the task max parallelism: ${taskParallelism}")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    Try(innerTestSetParallelism("OutputFormat", negativeParallelism, index = index.getAndIncrement)) match {
-      case Success(_) => fail("this should not happen")
-      case Failure(t) => {
-        val exception = ExceptionUtils.findThrowableWithMessage(
-          t,
-          s"the configured sink parallelism: ${negativeParallelism} should not be less than zero or equal to zero")
-        assertTrue(exception.isPresent)
-      }
-    }
-
-    assertTrue(Try(innerTestSetParallelism("SinkFunction", vaildParallelism, index = index.getAndIncrement)).isSuccess)
-  }
-
-
-  def innerTestSetParallelism(provider: String, parallelism: Int, index: Int): Unit = {
-    val dataId = TestValuesTableFactory.registerData(data1)
-    val sourceTableName = s"test_para_source_${provider.toLowerCase.trim}_$index"
-    val sinkTableName = s"test_para_sink_${provider.toLowerCase.trim}_$index"
-    tEnv.executeSql(
-      s"""
-         |CREATE TABLE $sourceTableName (
-         |  the_month INT,
-         |  area STRING,
-         |  product INT
-         |) WITH (
-         |  'connector' = 'values',
-         |  'data-id' = '$dataId',
-         |  'bounded' = 'true'
-         |)
-         |""".stripMargin)
-    tEnv.executeSql(
-      s"""
-         |CREATE TABLE $sinkTableName (
-         |  the_month INT,
-         |  area STRING,
-         |  product INT
-         |) WITH (
-         |  'connector' = 'values',
-         |  'sink-insert-only' = 'true',
-         |  'runtime-sink' = '$provider',
-         |  'sink.parallelism' = '$parallelism'
-         |)
-         |""".stripMargin)
-    tEnv.executeSql(s"INSERT INTO $sinkTableName SELECT * FROM $sourceTableName").await()
-  }
-
   def innerTestNotNullEnforcer(provider: String): Unit = {
     val dataId = TestValuesTableFactory.registerData(nullData4)
     tEnv.executeSql(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -24,17 +24,17 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.{TestSinkContextTableSink, changelogRow}
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase
-import org.apache.flink.table.planner.runtime.utils.TestData.{nullData4, smallTupleData3, tupleData3, tupleData5}
+import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.util.ExceptionUtils
-
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.Test
-
 import java.lang.{Long => JLong}
 import java.math.{BigDecimal => JBigDecimal}
 import java.time.{LocalDateTime, ZoneOffset}
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConversions._
+import scala.util.{Failure, Success, Try}
 
 class TableSinkITCase extends StreamingTestBase {
 
@@ -748,6 +748,206 @@ class TableSinkITCase extends StreamingTestBase {
     val expected =
       List("1,book,12", "2,book,null", "3,fruit,44", "4,book,11", "4,fruit,null", "5,fruit,null")
     assertEquals(expected.sorted, result.sorted)
+  }
+
+
+  @Test
+  def testParallelismWithDataStream(): Unit = {
+    Try(innerTestSetParallelism(
+      "DataStreamWithParallelism",
+      1,
+      index = 1)) match {
+      case Success(_) => fail("this should not happen")
+      case Failure(t) => {
+        val exception = ExceptionUtils.findThrowableWithMessage(
+          t,
+          "`DataStreamSinkProvider` is not allowed to work with `ParallelismProvider`," +
+            " please see document of `ParallelismProvider`")
+        assertTrue(exception.isPresent)
+      }
+    }
+  }
+
+  @Test
+  def testParallelismWithSinkFunction(): Unit = {
+    val negativeParallelism = -1
+    val validParallelism = 1
+    val oversizedParallelism = Int.MaxValue
+    val index = new AtomicInteger(1)
+
+    Try(innerTestSetParallelism(
+      "SinkFunction",
+      oversizedParallelism,
+      index = index.getAndIncrement))
+    match {
+      case Success(_) => fail("this should not happen")
+      case Failure(t) => {
+        val exception = ExceptionUtils.findThrowableWithMessage(
+          t,
+          s"Failed to wait job finish")
+        assertTrue(exception.isPresent)
+      }
+    }
+
+    Try(innerTestSetParallelism(
+      "SinkFunction",
+      negativeParallelism,
+      index = index.getAndIncrement))
+    match {
+      case Success(_) => fail("this should not happen")
+      case Failure(t) => {
+        val exception = ExceptionUtils.findThrowableWithMessage(
+          t,
+          s"should not be less than zero or equal to zero")
+        assertTrue(exception.isPresent)
+      }
+    }
+
+    assertTrue(Try(innerTestSetParallelism(
+      "SinkFunction",
+      validParallelism,
+      index = index.getAndIncrement)).isSuccess)
+  }
+
+  @Test
+  def testParallelismWithOutputFormat(): Unit = {
+    val negativeParallelism = -1
+    val oversizedParallelism = Int.MaxValue
+    val validParallelism = 1
+    val index = new AtomicInteger(1)
+
+    Try(innerTestSetParallelism(
+      "OutputFormat",
+      negativeParallelism,
+      index = index.getAndIncrement))
+    match {
+      case Success(_) => fail("this should not happen")
+      case Failure(t) => {
+        val exception = ExceptionUtils.findThrowableWithMessage(
+          t,
+          s"should not be less than zero or equal to zero")
+        assertTrue(exception.isPresent)
+      }
+    }
+
+    Try(innerTestSetParallelism(
+      "SinkFunction",
+      oversizedParallelism,
+      index = index.getAndIncrement))
+    match {
+      case Success(_) => fail("this should not happen")
+      case Failure(t) => {
+        val exception = ExceptionUtils.findThrowableWithMessage(
+          t,
+          s"Failed to wait job finish")
+        assertTrue(exception.isPresent)
+      }
+    }
+
+    assertTrue(Try(innerTestSetParallelism(
+      "SinkFunction",
+      validParallelism,
+      index = index.getAndIncrement))
+      .isSuccess)
+  }
+
+  @Test
+  def testParallelismOnChangelogMode():Unit = {
+    val dataId = TestValuesTableFactory.registerData(data1)
+    val sourceTableName = s"test_para_source"
+    val sinkTableWithoutPkName = s"test_para_sink_without_pk"
+    val sinkTableWithPkName = s"test_para_sink_with_pk"
+    val sinkParallelism = 2
+
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE $sourceTableName (
+         |  the_month INT,
+         |  area STRING,
+         |  product INT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$dataId',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE $sinkTableWithoutPkName (
+         |  the_month INT,
+         |  area STRING,
+         |  product INT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'runtime-sink' = 'SinkFunction',
+         |  'sink.parallelism' = '$sinkParallelism',
+         |  'sink-changelog-mode-enforced' = 'I,D'
+         |)
+         |""".stripMargin)
+    Try(tEnv
+      .executeSql(s"INSERT INTO $sinkTableWithoutPkName SELECT * FROM $sourceTableName")
+      .await()) match {
+      case Failure(e) =>
+        val exception = ExceptionUtils
+          .findThrowableWithMessage(
+            e,
+            "which is not INSERT_ONLY mode," +
+              " primary key is required but no primary key is found")
+        assertTrue(exception.isPresent)
+    }
+
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE $sinkTableWithPkName (
+         |  the_month INT,
+         |  area STRING,
+         |  product INT,
+         |  PRIMARY KEY (area) NOT ENFORCED
+         |) WITH (
+         |  'connector' = 'values',
+         |  'runtime-sink' = 'SinkFunction',
+         |  'sink.parallelism' = '$sinkParallelism',
+         |  'sink-changelog-mode-enforced' = 'I,D'
+         |)
+         |""".stripMargin)
+
+    assertTrue(Try(tEnv
+      .executeSql(s"INSERT INTO $sinkTableWithPkName SELECT * FROM $sourceTableName")
+      .await()).isSuccess)
+
+  }
+
+
+  private def innerTestSetParallelism(provider: String, parallelism: Int, index: Int): Unit = {
+    val dataId = TestValuesTableFactory.registerData(data1)
+    val sourceTableName = s"test_para_source_${provider.toLowerCase.trim}_$index"
+    val sinkTableName = s"test_para_sink_${provider.toLowerCase.trim}_$index"
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE $sourceTableName (
+         |  the_month INT,
+         |  area STRING,
+         |  product INT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$dataId',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE $sinkTableName (
+         |  the_month INT,
+         |  area STRING,
+         |  product INT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true',
+         |  'runtime-sink' = '$provider',
+         |  'sink.parallelism' = '$parallelism'
+         |)
+         |""".stripMargin)
+    tEnv.executeSql(s"INSERT INTO $sinkTableName SELECT * FROM $sourceTableName").await()
   }
 
   // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -22,9 +22,12 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
-import org.apache.flink.table.planner.factories.TestValuesTableFactory.{TestSinkContextTableSink, changelogRow}
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+.{TestSinkContextTableSink, changelogRow}
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase
-import org.apache.flink.table.planner.runtime.utils.TestData._
+import org.apache.flink.table.planner.runtime.utils.TestData
+.{nullData4, smallTupleData3,
+tupleData3, tupleData5,data1}
 import org.apache.flink.util.ExceptionUtils
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -894,8 +894,7 @@ class TableSinkITCase extends StreamingTestBase {
         val exception = ExceptionUtils
           .findThrowableWithMessage(
             e,
-            "which is not INSERT_ONLY mode," +
-              " primary key is required but no primary key is found")
+            "primary key is required but no primary key is found")
         assertTrue(exception.isPresent)
     }
 


### PR DESCRIPTION
…n blink planner

## What is the purpose of the change

-  Implement `ParallelismProvider` for sink in blink planner 
-  `SinkFunctionProvider` and `OutputFormatProvider` work with `ParallelismProvider` by implementing `ParallelismProvider` 
- Prepare for the future work that make all the classes that implements `SinkRuntimeProvider` currently using in all kind of existing connectors implement `ParallelismProvider` in order to configure the sink parallelism 


## Brief change log

-  `CommonPhysicalSink` : get parallelism from `ParallelismProvider` if possible and configure the sink parallelism into sink transformation after validation 
-  `SinkFunctionProvider`: implements `ParallelismProvider`, add factory method to work with parameter called **parallelism** to set the specified sink parallelism 
-  `OutputFormatProvider`: implements `ParallelismProvider`, add factory method to work with parameter called **parallelism** to set the specified sink parallelism 
-  Add necessary tests and helper class for testing the new code mentioned above 

## Verifying this change

This change added tests and can be verified as follows:

  -  Add helper class `InternalDataStreamSinkProviderWithParallelism` for the convenience of testing `DataStreamSinkProvider` working with `ParallelismProvider`
  -  Add new field: `@Nullable` parallelism in `TestValuesTableSink` for the test related to  `ParallelismProvider` in sink 
  - Exception is expected if `DataStreamSinkProvider` work with `ParallelismProvider` 
  -  Test  `SinkFunctionProvider` working with `ParallelismProvider` 
  -   Test  `OutputFormatProvider` working with `ParallelismProvider` 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (*yes* / no)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes /*no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / *no* / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)