### PR TITLE
[FLINK-19806][runtime] Harden DefaultScheduler for concurrent suspending and failing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1424,7 +1424,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	}
 
 	public void failJob(Throwable cause) {
-		if (state == JobStatus.FAILING || state.isGloballyTerminalState()) {
+		if (state == JobStatus.FAILING || state.isTerminalState()) {
 			return;
 		}
 
@@ -1433,8 +1433,9 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		FutureUtils.assertNoException(
 			cancelVerticesAsync().whenComplete((aVoid, throwable) -> {
-				transitionState(JobStatus.FAILED, cause);
-				onTerminalState(JobStatus.FAILED);
+				if (transitionState(JobStatus.FAILING, JobStatus.FAILED, cause)) {
+					onTerminalState(JobStatus.FAILED);
+				}
 			}));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

SUSPENDED is a terminal state which a job is not supposed to leave this state once entering. However, ExecutionGraph#failJob() did not check it and may try to transition a job out from SUSPENDED state. This will cause unexpected errors and may lead to JM crash.
The problem can be visible if we rework ExecutionGraphSuspendTest to be based on DefaultScheduler.
This PR is to harden the check in ExecutionGraph#failJob().


## Verifying this change

This change is verified by rework ExecutionGraphSuspendTest to be based on DefaultScheduler.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
