### PR TITLE
[FLINK-19809][coordination] Add DeclareResourceRequirementServiceConnectionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/ServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/ServiceConnectionManager.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+/**
+ * Base interface for managers of services that are explicitly connected to / disconnected from.
+ */
+public interface ServiceConnectionManager<S> {
+
+	/**
+	 * Connect to the given service.
+	 *
+	 * @param service service to connect to
+	 */
+	void connect(S service);
+
+	/**
+	 * Disconnect from the current service.
+	 */
+	void disconnect();
+
+	/**
+	 * Close the service connection manager. A closed manager must not be used again.
+	 */
+	void close();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManager.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.jobmaster.ServiceConnectionManager;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Base class for service connection managers, taking care of the connection handling.
+ */
+public class AbstractServiceConnectionManager<S> implements ServiceConnectionManager<S> {
+
+	protected final Object lock = new Object();
+
+	@Nullable
+	@GuardedBy("lock")
+	protected S service;
+
+	@GuardedBy("lock")
+	private boolean closed = false;
+
+	@Override
+	public final void connect(S service) {
+		synchronized (lock) {
+			checkNotClosed();
+			this.service = service;
+		}
+	}
+
+	@Override
+	public final void disconnect() {
+		synchronized (lock) {
+			checkNotClosed();
+			this.service = null;
+		}
+	}
+
+	@Override
+	public final void close() {
+		synchronized (lock) {
+			closed = true;
+			service = null;
+		}
+	}
+
+	protected final void checkNotClosed() {
+		if (closed) {
+			throw new IllegalStateException("This connection manager has already been closed.");
+		}
+	}
+
+	protected final boolean isConnected() {
+		return service != null;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclareResourceRequirementServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclareResourceRequirementServiceConnectionManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.jobmaster.ServiceConnectionManager;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link ServiceConnectionManager} for declaring resource requirements.
+ *
+ * <p>In practice the backing service will be the ResourceManager.
+ */
+public interface DeclareResourceRequirementServiceConnectionManager extends ServiceConnectionManager<DeclareResourceRequirementServiceConnectionManager.DeclareResourceRequirementsService> {
+
+	/**
+	 * Declares the given resource requirements at the connected service. If no
+	 * connection is established, then this call will be ignored.
+	 *
+	 * @param resourceRequirements resourceRequirements to declare at the connected service
+	 */
+	void declareResourceRequirements(ResourceRequirements resourceRequirements);
+
+	/**
+	 * Service that accepts resource requirements.
+	 */
+	interface DeclareResourceRequirementsService {
+		CompletableFuture<Acknowledge> declareResourceRequirements(ResourceRequirements resourceRequirements);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManager.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.concurrent.ExponentialBackoffRetryStrategy;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Default implementation of {@link DeclareResourceRequirementServiceConnectionManager}.
+ *
+ * <p>This connection manager is responsible for sending new
+ * resource requirements to the connected service. In case of faults it continues
+ * retrying to send the latest resource requirements to the service with
+ * an exponential backoff strategy.
+ */
+class DefaultDeclareResourceRequirementServiceConnectionManager
+		extends AbstractServiceConnectionManager<DeclareResourceRequirementServiceConnectionManager.DeclareResourceRequirementsService>
+		implements DeclareResourceRequirementServiceConnectionManager {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DefaultDeclareResourceRequirementServiceConnectionManager.class);
+
+	private final ScheduledExecutor scheduledExecutor;
+
+	@Nullable
+	@GuardedBy("lock")
+	private ResourceRequirements currentResourceRequirements;
+
+	private DefaultDeclareResourceRequirementServiceConnectionManager(ScheduledExecutor scheduledExecutor) {
+		this.scheduledExecutor = scheduledExecutor;
+	}
+
+	@Override
+	public void declareResourceRequirements(ResourceRequirements resourceRequirements) {
+		synchronized (lock) {
+			checkNotClosed();
+			if (isConnected()) {
+				currentResourceRequirements = resourceRequirements;
+
+				triggerResourceRequirementsSubmission(Duration.ofMillis(1L), Duration.ofMillis(10000L), currentResourceRequirements);
+			}
+		}
+	}
+
+	@GuardedBy("lock")
+	private void triggerResourceRequirementsSubmission(
+			Duration sleepOnError,
+			Duration maxSleepOnError,
+			ResourceRequirements resourceRequirementsToSend) {
+
+		FutureUtils.retryWithDelay(
+				() -> sendResourceRequirements(resourceRequirementsToSend),
+				new ExponentialBackoffRetryStrategy(Integer.MAX_VALUE, sleepOnError, maxSleepOnError),
+				throwable -> !(throwable instanceof CancellationException),
+				scheduledExecutor);
+	}
+
+	@GuardedBy("lock")
+	private CompletableFuture<Acknowledge> sendResourceRequirements(ResourceRequirements resourceRequirementsToSend) {
+		synchronized (lock) {
+			if (isConnected()) {
+				if (resourceRequirementsToSend == currentResourceRequirements) {
+					return service.declareResourceRequirements(resourceRequirementsToSend);
+				} else {
+					LOG.debug("Newer resource requirements found. Stop sending old requirements.");
+					return FutureUtils.completedExceptionally(new CancellationException());
+				}
+			} else {
+				LOG.debug("Stop sending resource requirements to ResourceManager because it is not connected.");
+				return FutureUtils.completedExceptionally(new CancellationException());
+			}
+		}
+	}
+
+	public static DeclareResourceRequirementServiceConnectionManager create(ScheduledExecutor scheduledExecutor) {
+		return new DefaultDeclareResourceRequirementServiceConnectionManager(scheduledExecutor);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManager.java
@@ -83,7 +83,6 @@ class DefaultDeclareResourceRequirementServiceConnectionManager
 				scheduledExecutor);
 	}
 
-	@GuardedBy("lock")
 	private CompletableFuture<Acknowledge> sendResourceRequirements(ResourceRequirements resourceRequirementsToSend) {
 		synchronized (lock) {
 			if (isConnected()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/NoOpDeclareResourceRequirementServiceConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/NoOpDeclareResourceRequirementServiceConnectionManager.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.slots.ResourceRequirements;
+
+/**
+ * No-op implementation of the {@link DeclareResourceRequirementServiceConnectionManager}.
+ */
+public enum NoOpDeclareResourceRequirementServiceConnectionManager implements DeclareResourceRequirementServiceConnectionManager {
+	INSTANCE;
+
+	@Override
+	public void connect(DeclareResourceRequirementsService declareResourceRequirementsService) {}
+
+	@Override
+	public void disconnect() {}
+
+	@Override
+	public void declareResourceRequirements(ResourceRequirements resourceRequirements) {}
+
+	@Override
+	public void close() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -148,13 +149,26 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 		}
 	}
 
-	public void triggerNonPeriodicScheduledTasks() {
+	public void triggerNonPeriodicScheduledTasksWithRecursion() {
 		while (!nonPeriodicScheduledTasks.isEmpty()) {
 			final ScheduledTask<?> scheduledTask = nonPeriodicScheduledTasks.poll();
 
 			if (!scheduledTask.isCancelled()) {
 				scheduledTask.execute();
 			}
+		}
+	}
+
+	public void triggerNonPeriodicScheduledTasks() {
+		final Iterator<ScheduledTask<?>> iterator = nonPeriodicScheduledTasks.iterator();
+
+		while (iterator.hasNext()) {
+			final ScheduledTask<?> scheduledTask = iterator.next();
+
+			if (!scheduledTask.isCancelled()) {
+				scheduledTask.execute();
+			}
+			iterator.remove();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -149,6 +149,10 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 		}
 	}
 
+	/**
+	 * Triggers all non-periodically scheduled tasks. In contrast to {@link #triggerNonPeriodicScheduledTasks()},
+	 * if such a task schedules another non-periodically schedule task, then this new task will also be triggered.
+	 */
 	public void triggerNonPeriodicScheduledTasksWithRecursion() {
 		while (!nonPeriodicScheduledTasks.isEmpty()) {
 			final ScheduledTask<?> scheduledTask = nonPeriodicScheduledTasks.poll();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -150,15 +150,12 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
 	}
 
 	public void triggerNonPeriodicScheduledTasks() {
-		final Iterator<ScheduledTask<?>> iterator = nonPeriodicScheduledTasks.iterator();
-
-		while (iterator.hasNext()) {
-			final ScheduledTask<?> scheduledTask = iterator.next();
+		while (!nonPeriodicScheduledTasks.isEmpty()) {
+			final ScheduledTask<?> scheduledTask = nonPeriodicScheduledTasks.poll();
 
 			if (!scheduledTask.isCancelled()) {
 				scheduledTask.execute();
 			}
-			iterator.remove();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link DefaultDeclareResourceRequirementServiceConnectionManager}.
+ */
+public class AbstractServiceConnectionManagerTest extends TestLogger {
+
+	@Test
+	public void testIsConnected() {
+		AbstractServiceConnectionManager<Object> connectionManager = new TestServiceConnectionManager();
+
+		assertThat(connectionManager.isConnected(), is(false));
+
+		connectionManager.connect(new Object());
+		assertThat(connectionManager.isConnected(), is(true));
+
+		connectionManager.disconnect();
+		assertThat(connectionManager.isConnected(), is(false));
+
+		connectionManager.close();
+		assertThat(connectionManager.isConnected(), is(false));
+	}
+
+	@Test
+	public void testCheckNotClosed() {
+		AbstractServiceConnectionManager<Object> connectionManager = new TestServiceConnectionManager();
+
+		connectionManager.checkNotClosed();
+
+		connectionManager.connect(new Object());
+		connectionManager.checkNotClosed();
+
+		connectionManager.disconnect();
+		connectionManager.checkNotClosed();
+
+		connectionManager.close();
+		try {
+			connectionManager.checkNotClosed();
+		} catch (IllegalStateException expected) {
+		}
+	}
+
+	private static class TestServiceConnectionManager extends AbstractServiceConnectionManager<Object> {
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractServiceConnectionManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link DefaultDeclareResourceRequirementServiceConnectionManager}.
@@ -61,6 +62,7 @@ public class AbstractServiceConnectionManagerTest extends TestLogger {
 		connectionManager.close();
 		try {
 			connectionManager.checkNotClosed();
+			fail("checkNotClosed() did not fail for a closed connection manager");
 		} catch (IllegalStateException expected) {
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManagerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link DefaultDeclareResourceRequirementServiceConnectionManager}.
+ */
+public class DefaultDeclareResourceRequirementServiceConnectionManagerTest extends TestLogger {
+
+	private final ManuallyTriggeredScheduledExecutorService scheduledExecutor = new ManuallyTriggeredScheduledExecutorService();
+	private final JobID jobId = new JobID();
+
+	@Test
+	public void testIgnoreDeclareResourceRequirementsIfNotConnected() {
+		final DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager = createResourceManagerConnectionManager();
+
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(createResourceRequirements());
+	}
+
+	@Test
+	public void testDeclareResourceRequirementsSendsRequirementsIfConnected() {
+		final DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager = createResourceManagerConnectionManager();
+
+		final CompletableFuture<ResourceRequirements> declareResourceRequirementsFuture = new CompletableFuture<>();
+		declareResourceRequirementServiceConnectionManager.connect(resourceRequirements -> {
+			declareResourceRequirementsFuture.complete(resourceRequirements);
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		});
+
+		final ResourceRequirements resourceRequirements = createResourceRequirements();
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements);
+
+		assertThat(declareResourceRequirementsFuture.join(), is(resourceRequirements));
+	}
+
+	@Test
+	public void testRetryDeclareResourceRequirementsIfTransmissionFailed() throws InterruptedException {
+		final DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager = createResourceManagerConnectionManager();
+
+		final FailingDeclareResourceRequirementsService failingDeclareResourceRequirementsService = new FailingDeclareResourceRequirementsService(4);
+		declareResourceRequirementServiceConnectionManager.connect(failingDeclareResourceRequirementsService);
+
+		final ResourceRequirements resourceRequirements = createResourceRequirements();
+
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements);
+
+		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+
+		assertThat(failingDeclareResourceRequirementsService.nextResourceRequirements(), is(resourceRequirements));
+		assertThat(failingDeclareResourceRequirementsService.hasResourceRequirements(), is(false));
+	}
+
+	@Test
+	public void testDisconnectStopsSendingResourceRequirements() throws InterruptedException {
+		runStopSendingResourceRequirementsTest(DeclareResourceRequirementServiceConnectionManager::disconnect);
+	}
+
+	@Test
+	public void testCloseStopsSendingResourceRequirements() throws InterruptedException {
+		runStopSendingResourceRequirementsTest(DeclareResourceRequirementServiceConnectionManager::close);
+	}
+
+	private void runStopSendingResourceRequirementsTest(Consumer<DeclareResourceRequirementServiceConnectionManager> testAction) throws InterruptedException {
+		final DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager = createResourceManagerConnectionManager();
+
+		final FailingDeclareResourceRequirementsService declareResourceRequirementsService = new FailingDeclareResourceRequirementsService(1);
+		declareResourceRequirementServiceConnectionManager.connect(declareResourceRequirementsService);
+
+		final ResourceRequirements resourceRequirements = createResourceRequirements();
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements);
+
+		declareResourceRequirementsService.waitForResourceRequirementsDeclaration();
+
+		testAction.accept(declareResourceRequirementServiceConnectionManager);
+		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+
+		assertThat(declareResourceRequirementsService.hasResourceRequirements(), is(false));
+	}
+
+	@Test
+	public void testNewResourceRequirementsOverrideOldRequirements() throws InterruptedException {
+		final DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager = createResourceManagerConnectionManager();
+		final ResourceRequirements resourceRequirements1 = createResourceRequirements(Arrays.asList(ResourceRequirement.create(ResourceProfile.UNKNOWN, 1)));
+		final ResourceRequirements resourceRequirements2 = createResourceRequirements(Arrays.asList(ResourceRequirement.create(ResourceProfile.UNKNOWN, 2)));
+
+		final FailingDeclareResourceRequirementsService failingDeclareResourceRequirementsService = new FailingDeclareResourceRequirementsService(1);
+		declareResourceRequirementServiceConnectionManager.connect(failingDeclareResourceRequirementsService);
+
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements1);
+
+		failingDeclareResourceRequirementsService.waitForResourceRequirementsDeclaration();
+
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements2);
+
+		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+
+		assertThat(failingDeclareResourceRequirementsService.nextResourceRequirements(), is(resourceRequirements2));
+		assertThat(failingDeclareResourceRequirementsService.hasResourceRequirements(), is(false));
+	}
+
+	@Nonnull
+	private ResourceRequirements createResourceRequirements() {
+		return createResourceRequirements(Arrays.asList(ResourceRequirement.create(ResourceProfile.UNKNOWN, 2)));
+	}
+
+	private static final class FailingDeclareResourceRequirementsService implements DeclareResourceRequirementServiceConnectionManager.DeclareResourceRequirementsService {
+
+		private final BlockingQueue<ResourceRequirements> resourceRequirements = new ArrayBlockingQueue<>(2);
+
+		private final OneShotLatch declareResourceRequirementsLatch = new OneShotLatch();
+
+		private int failureCounter;
+
+		private FailingDeclareResourceRequirementsService(int failureCounter) {
+			this.failureCounter = failureCounter;
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> declareResourceRequirements(ResourceRequirements resourceRequirements) {
+			if (failureCounter > 0) {
+				failureCounter--;
+				declareResourceRequirementsLatch.trigger();
+				return FutureUtils.completedExceptionally(new FlinkException("Test exception"));
+			} else {
+				this.resourceRequirements.offer(resourceRequirements);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			}
+		}
+
+		private boolean hasResourceRequirements() {
+			return !resourceRequirements.isEmpty();
+		}
+
+		private ResourceRequirements nextResourceRequirements() throws InterruptedException {
+			return resourceRequirements.take();
+		}
+
+		public void waitForResourceRequirementsDeclaration() throws InterruptedException {
+			declareResourceRequirementsLatch.await();
+		}
+	}
+
+	private ResourceRequirements createResourceRequirements(List<ResourceRequirement> requestedResourceRequirements) {
+		return ResourceRequirements.create(
+			jobId,
+			"localhost",
+			requestedResourceRequirements);
+	}
+
+	@Nonnull
+	private DeclareResourceRequirementServiceConnectionManager createResourceManagerConnectionManager() {
+		return DefaultDeclareResourceRequirementServiceConnectionManager.create(scheduledExecutor);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclareResourceRequirementServiceConnectionManagerTest.java
@@ -85,7 +85,7 @@ public class DefaultDeclareResourceRequirementServiceConnectionManagerTest exten
 
 		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements);
 
-		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+		scheduledExecutor.triggerNonPeriodicScheduledTasksWithRecursion();
 
 		assertThat(failingDeclareResourceRequirementsService.nextResourceRequirements(), is(resourceRequirements));
 		assertThat(failingDeclareResourceRequirementsService.hasResourceRequirements(), is(false));
@@ -113,7 +113,7 @@ public class DefaultDeclareResourceRequirementServiceConnectionManagerTest exten
 		declareResourceRequirementsService.waitForResourceRequirementsDeclaration();
 
 		testAction.accept(declareResourceRequirementServiceConnectionManager);
-		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+		scheduledExecutor.triggerNonPeriodicScheduledTasksWithRecursion();
 
 		assertThat(declareResourceRequirementsService.hasResourceRequirements(), is(false));
 	}
@@ -133,7 +133,7 @@ public class DefaultDeclareResourceRequirementServiceConnectionManagerTest exten
 
 		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(resourceRequirements2);
 
-		scheduledExecutor.triggerNonPeriodicScheduledTasks();
+		scheduledExecutor.triggerNonPeriodicScheduledTasksWithRecursion();
 
 		assertThat(failingDeclareResourceRequirementsService.nextResourceRequirements(), is(resourceRequirements2));
 		assertThat(failingDeclareResourceRequirementsService.hasResourceRequirements(), is(false));


### PR DESCRIPTION
Add a component for managing the connection to the resource manager and declaring resource requirements.

Also adjusts `ManuallyTriggeredScheduledExecutor#triggerNonPeriodicScheduledTasks` to run non-periodic tasks that were scheduled by a previously run non-periodic task.