### PR TITLE
[FLINK-19811][table-planner-blink] Simplify SEARCHes in FlinkRexUtil#simplify

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/FlinkRexSimplifySearchUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/FlinkRexSimplifySearchUtil.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.rex;
+
+import com.google.common.collect.Range;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.util.Sarg;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class to simplify SEARCH rex nodes.
+ *
+ * <p>This class is a temporary solution for CALCITE-4364 and FLINK-19811.
+ * When CALCITE-4364 is fixed, all commits of FLINK-19811 should be reverted.
+ */
+public class FlinkRexSimplifySearchUtil {
+
+	public static RexNode simplify(RexBuilder builder, RexNode rex) {
+		if (rex.isA(SqlKind.AND)) {
+			List<RexNode> operands = RelOptUtil.conjunctions(rex).stream()
+				.map(operand -> simplify(builder, operand))
+				.collect(Collectors.toList());
+
+			SargCollector sargCollector = new SargCollector(builder, true);
+			List<RexNode> simplifiedOperands = collectSarg(builder, operands, sargCollector);
+			return RexUtil.composeConjunction(builder, simplifiedOperands);
+		} else if (rex.isA(SqlKind.OR)) {
+			List<RexNode> operands = RelOptUtil.disjunctions(rex).stream()
+				.map(operand -> simplify(builder, operand))
+				.collect(Collectors.toList());
+
+			SargCollector sargCollector = new SargCollector(builder, false);
+			List<RexNode> simplifiedOperands = collectSarg(builder, operands, sargCollector);
+			return RexUtil.composeDisjunction(builder, simplifiedOperands);
+		} else {
+			return rex;
+		}
+	}
+
+	private static List<RexNode> collectSarg(RexBuilder builder, List<RexNode> operands, SargCollector sargCollector) {
+		// the following code are copied and modified
+		// from RexSimplify#simplifyAnd and RexSimplify#simplifyOrs
+		List<RexNode> terms = new ArrayList<>();
+		operands.forEach(t -> sargCollector.accept(t, terms));
+
+		// NOTE: Ideally we should treat each value in the map of sargCollector separately and
+		// extract sargs out of searches if the complexity of that search is not more than 1.
+		//
+		// However if we do so and if there exists an value whose complexity is more than 1,
+		// Calcite's RexSimplify#simplifyAnd and RexSimplify#simplifyOrs will change it back
+		// (see similar line with the line below in these methods),
+		// causing our SimplifyFilterConditionRule to be applied again and again.
+		//
+		// So we can only do this simplification if none of the complexity exceed 1.
+		boolean canSimplify = sargCollector.map.values().stream().noneMatch(b -> b.complexity() > 1);
+		return terms.stream()
+			.map(t -> {
+				RexNode fixed = sargCollector.fix(builder, t);
+				if (canSimplify
+					&& t instanceof RexSimplify.RexSargBuilder
+					&& ((RexSimplify.RexSargBuilder) t).complexity() <= 1) {
+					// we only simplify searches if they're not changed to ANDs and ORs,
+					// otherwise Calcite's simplify method may change them back and cause
+					// infinite loop.
+					RexNode expanded = RexUtil.expandSearch(builder, null, fixed);
+					if (!expanded.isA(SqlKind.AND) && !expanded.isA(SqlKind.OR)) {
+						fixed = expanded;
+					}
+				}
+				return fixed;
+			})
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * This class is directly copied from {@link RexSimplify.SargCollector}
+	 * to work around the private access of "accept" method.
+	 *
+	 * <p>Gathers expressions that can be converted into {@link Sarg search arguments}.
+	 */
+	static class SargCollector {
+		final Map<RexNode, RexSimplify.RexSargBuilder> map = new HashMap<>();
+		private final RexBuilder rexBuilder;
+		private final boolean negate;
+
+		SargCollector(RexBuilder rexBuilder, boolean negate) {
+			this.rexBuilder = rexBuilder;
+			this.negate = negate;
+		}
+
+		private void accept(RexNode term, List<RexNode> newTerms) {
+			if (!accept_(term, newTerms)) {
+				newTerms.add(term);
+			}
+		}
+
+		private boolean accept_(RexNode e, List<RexNode> newTerms) {
+			switch (e.getKind()) {
+				case LESS_THAN:
+				case LESS_THAN_OR_EQUAL:
+				case GREATER_THAN:
+				case GREATER_THAN_OR_EQUAL:
+				case EQUALS:
+				case NOT_EQUALS:
+				case SEARCH:
+					return accept2(((RexCall) e).operands.get(0),
+						((RexCall) e).operands.get(1), e.getKind(), newTerms);
+				case IS_NULL:
+					if (negate) {
+						return false;
+					}
+					final RexNode arg = ((RexCall) e).operands.get(0);
+					return accept1(arg, e.getKind(),
+						rexBuilder.makeNullLiteral(arg.getType()), newTerms);
+				default:
+					return false;
+			}
+		}
+
+		private boolean accept2(RexNode left, RexNode right, SqlKind kind, List<RexNode> newTerms) {
+			switch (left.getKind()) {
+				case INPUT_REF:
+				case FIELD_ACCESS:
+					switch (right.getKind()) {
+						case LITERAL:
+							return accept1(left, kind, (RexLiteral) right, newTerms);
+					}
+					return false;
+				case LITERAL:
+					switch (right.getKind()) {
+						case INPUT_REF:
+						case FIELD_ACCESS:
+							return accept1(right, kind.reverse(), (RexLiteral) left, newTerms);
+					}
+					return false;
+			}
+			return false;
+		}
+
+		private static <E> E addFluent(List<? super E> list, E e) {
+			list.add(e);
+			return e;
+		}
+
+		// always returns true
+		private boolean accept1(RexNode e, SqlKind kind, @Nonnull RexLiteral literal, List<RexNode> newTerms) {
+			final RexSimplify.RexSargBuilder b =
+				map.computeIfAbsent(e, e2 ->
+					addFluent(newTerms, new RexSimplify.RexSargBuilder(e2, rexBuilder, negate)));
+			if (negate) {
+				kind = kind.negateNullSafe();
+			}
+			final Comparable value = literal.getValueAs(Comparable.class);
+			switch (kind) {
+				case LESS_THAN:
+					b.addRange(Range.lessThan(value), literal.getType());
+					return true;
+				case LESS_THAN_OR_EQUAL:
+					b.addRange(Range.atMost(value), literal.getType());
+					return true;
+				case GREATER_THAN:
+					b.addRange(Range.greaterThan(value), literal.getType());
+					return true;
+				case GREATER_THAN_OR_EQUAL:
+					b.addRange(Range.atLeast(value), literal.getType());
+					return true;
+				case EQUALS:
+					b.addRange(Range.singleton(value), literal.getType());
+					return true;
+				case NOT_EQUALS:
+					b.addRange(Range.lessThan(value), literal.getType());
+					b.addRange(Range.greaterThan(value), literal.getType());
+					return true;
+				case SEARCH:
+					final Sarg sarg = literal.getValueAs(Sarg.class);
+					b.addSarg(sarg, negate, literal.getType());
+					return true;
+				case IS_NULL:
+					if (negate) {
+						throw new AssertionError("negate is not supported for IS_NULL");
+					}
+					b.containsNull = true;
+					return true;
+				default:
+					throw new AssertionError("unexpected " + kind);
+			}
+		}
+
+		/** If a term is a call to {@code SEARCH} on a {@link RexSimplify.RexSargBuilder},
+		 * converts it to a {@code SEARCH} on a {@link Sarg}. */
+		RexNode fix(RexBuilder rexBuilder, RexNode term) {
+			if (term instanceof RexSimplify.RexSargBuilder) {
+				RexSimplify.RexSargBuilder sargBuilder = (RexSimplify.RexSargBuilder) term;
+				return rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, sargBuilder.ref,
+					rexBuilder.makeSearchArgumentLiteral(sargBuilder.build(negate),
+						term.getType()));
+			}
+			return term;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkCalcMergeRule.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.RelOptUtil.InputFinder
@@ -25,7 +26,6 @@ import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.core.{Calc, RelFactories}
 import org.apache.calcite.rex.{RexNode, RexOver, RexProgramBuilder, RexUtil}
 import org.apache.calcite.tools.RelBuilderFactory
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
 
 import scala.collection.JavaConversions._
 
@@ -120,7 +120,11 @@ class FlinkCalcMergeRule(relBuilderFactory: RelBuilderFactory) extends RelOptRul
 
     val newMergedProgram = if (mergedProgram.getCondition != null) {
       val condition = mergedProgram.expandLocalRef(mergedProgram.getCondition)
-      val simplifiedCondition = FlinkRexUtil.simplify(rexBuilder, condition)
+      val conf = FlinkRelOptUtil.getTableConfigFromContext(topCalc)
+      val simplifiedCondition = FlinkRexUtil.simplify(
+        rexBuilder,
+        condition,
+        conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH))
       if (simplifiedCondition.toString == condition.toString) {
         mergedProgram
       } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionEqualityTransferRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionEqualityTransferRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
@@ -91,8 +91,12 @@ class JoinConditionEqualityTransferRule extends RelOptRule(
       rexCalls.foreach(call => newEquiJoinFilters += call)
     }
 
+    val conf = FlinkRelOptUtil.getTableConfigFromContext(join)
     val newJoinFilter = builder.and(remainFilters :+
-      FlinkRexUtil.simplify(rexBuilder, builder.and(newEquiJoinFilters)))
+      FlinkRexUtil.simplify(
+        rexBuilder,
+        builder.and(newEquiJoinFilters),
+        conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH)))
     val newJoin = join.copy(
       join.getTraitSet,
       newJoinFilter,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionTypeCoerceRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionTypeCoerceRule.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
@@ -86,8 +86,12 @@ class JoinConditionTypeCoerceRule extends RelOptRule(
         newJoinFilters += r
     }
 
+    val conf = FlinkRelOptUtil.getTableConfigFromContext(join)
     val newCondExp = builder.and(
-      FlinkRexUtil.simplify(rexBuilder, builder.and(newJoinFilters)))
+      FlinkRexUtil.simplify(
+        rexBuilder,
+        builder.and(newJoinFilters),
+        conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH)))
 
     val newJoin = join.copy(
       join.getTraitSet,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
@@ -112,9 +112,11 @@ class JoinDependentConditionDerivationRule
     }
 
     if (additionalConditions.nonEmpty) {
+      val conf = FlinkRelOptUtil.getTableConfigFromContext(join)
       val newCondExp = FlinkRexUtil.simplify(
         builder.getRexBuilder,
-        builder.and(conjunctions ++ additionalConditions))
+        builder.and(conjunctions ++ additionalConditions),
+        conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH))
 
       if (!newCondExp.toString.equals(join.getCondition.toString)) {
         val newJoin = join.copy(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyFilterConditionRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyFilterConditionRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -60,7 +60,11 @@ class SimplifyFilterConditionRule(
     }
 
     val rexBuilder = filter.getCluster.getRexBuilder
-    val simplifiedCondition = FlinkRexUtil.simplify(rexBuilder, condition)
+    val conf = FlinkRelOptUtil.getTableConfigFromContext(filter)
+    val simplifiedCondition = FlinkRexUtil.simplify(
+      rexBuilder,
+      condition,
+      conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH))
     val newCondition = RexUtil.pullFactors(rexBuilder, simplifiedCondition)
 
     if (!changed.head && !RexUtil.eq(condition, newCondition)) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SimplifyJoinConditionRule.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, FlinkRexUtil}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -45,7 +45,11 @@ class SimplifyJoinConditionRule
       return
     }
 
-    val simpleCondExp = FlinkRexUtil.simplify(join.getCluster.getRexBuilder, condition)
+    val conf = FlinkRelOptUtil.getTableConfigFromContext(join)
+    val simpleCondExp = FlinkRexUtil.simplify(
+      join.getCluster.getRexBuilder,
+      condition,
+      conf.getConfiguration.getBoolean(FlinkRexUtil.TABLE_OPTIMIZER_SIMPLIFY_SEARCH))
     val newCondExp = RexUtil.pullFactors(join.getCluster.getRexBuilder, simpleCondExp)
 
     if (newCondExp.toString.equals(condition.toString)) {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/calcite/rex/FlinkRexSimplifySearchUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/calcite/rex/FlinkRexSimplifySearchUtilTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.calcite.rex;
+
+import org.apache.flink.table.planner.calcite.FlinkRexBuilder;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+
+import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Tests for {@link FlinkRexSimplifySearchUtil}.
+ */
+public class FlinkRexSimplifySearchUtilTest {
+
+	private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(new FlinkTypeSystem());
+	private final RexBuilder rexBuilder = new FlinkRexBuilder(typeFactory);
+
+	@Test
+	public void testSimplifySearchInAnd() {
+		RexInputRef a = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0);
+
+		// a = 0 AND SEARCH(a, [0, 1]) -> a = 0
+		RexNode equals = rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, a, intLiteral(0));
+		RexNode predicate = rexBuilder.makeCall(
+			SqlStdOperatorTable.AND,
+			equals,
+			rexBuilder.makeIn(a, Arrays.asList(intLiteral(0), intLiteral(1))));
+
+		assertSimplify(equals, predicate);
+	}
+
+	@Test
+	public void testSimplifySearchInOr() {
+		RexInputRef a = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0);
+
+		// a > 0 OR SEARCH(a, [1, 2]) -> a > 0
+		RexNode greaterThan = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, a, intLiteral(0));
+		RexNode predicate = rexBuilder.makeCall(
+			SqlStdOperatorTable.OR,
+			greaterThan,
+			rexBuilder.makeIn(a, Arrays.asList(intLiteral(1), intLiteral(2))));
+
+		assertSimplify(greaterThan, predicate);
+	}
+
+	@Test
+	public void testSimplifySearchInNestedAndsAndOrs() {
+		RexInputRef a = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0);
+
+		// a > 0 AND (
+		//   SEARCH(a, [0, 1]) OR (
+		//     SEARCH(a, [1, 2] AND a < 2)))
+		// -> a = 1
+		RexNode layer2 = rexBuilder.makeCall(
+			SqlStdOperatorTable.AND,
+			rexBuilder.makeIn(a, Arrays.asList(intLiteral(1), intLiteral(2))),
+			rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN, a, intLiteral(2)));
+		RexNode layer1 = rexBuilder.makeCall(
+			SqlStdOperatorTable.OR,
+			rexBuilder.makeIn(a, Arrays.asList(intLiteral(0), intLiteral(1))),
+			layer2);
+		RexNode predicate = rexBuilder.makeCall(
+			SqlStdOperatorTable.AND,
+			rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, a, intLiteral(0)),
+			layer1);
+
+		assertSimplify(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, a, intLiteral(1)), predicate);
+	}
+
+	@Test
+	public void testNotSimplifyComplexSearch() {
+		RexInputRef a = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0);
+		RexInputRef b = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1);
+
+		// SEARCH(a, [0, 2, 4]) OR SEARCH(b, [6])
+		RexNode search1 = rexBuilder.makeIn(a, Arrays.asList(intLiteral(0), intLiteral(2), intLiteral(4)));
+		RexNode search2 = rexBuilder.makeIn(b, Collections.singletonList(intLiteral(6)));
+		RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.OR, search1, search2);
+		Assert.assertEquals(
+			predicate.toString(),
+			FlinkRexSimplifySearchUtil.simplify(rexBuilder, predicate).toString());
+	}
+
+	@Test
+	public void testNotExtractSearch() {
+		RexInputRef a = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 0);
+		RexInputRef b = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 1);
+
+		// SEARCH(a, [0..3]) OR SEARCH(b, [4..7])
+		RexSimplify calciteSimplifier = new RexSimplify(
+			rexBuilder,
+			RelOptPredicateList.EMPTY,
+			true,
+			RexUtil.EXECUTOR);
+
+		RexNode search1 = calciteSimplifier.simplify(rexBuilder.makeCall(
+			SqlStdOperatorTable.AND,
+			rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, a, intLiteral(0)),
+			rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, a, intLiteral(3))
+		));
+		Assert.assertTrue(search1.isA(SqlKind.SEARCH));
+
+		RexNode search2 = calciteSimplifier.simplify(rexBuilder.makeCall(
+			SqlStdOperatorTable.AND,
+			rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, b, intLiteral(4)),
+			rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, b, intLiteral(7))
+		));
+		Assert.assertTrue(search2.isA(SqlKind.SEARCH));
+
+		RexNode predicate = rexBuilder.makeCall(SqlStdOperatorTable.OR, search1, search2);
+		Assert.assertEquals(
+			predicate.toString(),
+			FlinkRexSimplifySearchUtil.simplify(rexBuilder, predicate).toString());
+	}
+
+	private void assertSimplify(RexNode expected, RexNode toSimplify) {
+		RexNode actual = FlinkRexSimplifySearchUtil.simplify(rexBuilder, toSimplify);
+		Assert.assertEquals(expected.toString(), actual.toString());
+
+		RexSimplify calciteSimplifier = new RexSimplify(
+			rexBuilder,
+			RelOptPredicateList.EMPTY,
+			true,
+			RexUtil.EXECUTOR);
+		RexNode calciteActual = calciteSimplifier.simplify(toSimplify);
+		// this will fail when CALCITE-4364 is fixed,
+		// at that time the commits for FLINK-19811 should be reverted
+		Assert.assertNotEquals(expected.toString(), calciteActual.toString());
+	}
+
+	private RexLiteral intLiteral(int x) {
+		return rexBuilder.makeExactLiteral(BigDecimal.valueOf(x));
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.xml
@@ -70,18 +70,18 @@ Calc(select=[name, id, amount, price], where=[OR(>(amount, 2), >(price, 10))])
   </TestCase>
   <TestCase name="testFilterCannotPushDown3">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM FilterableTable WHERE amount > 2 OR amount < 10]]>
+      <![CDATA[SELECT * FROM FilterableTable WHERE amount > 20 OR amount < 10]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
++- LogicalFilter(condition=[OR(>($2, 20), <($2, 10))])
    +- LogicalTableScan(table=[[default_catalog, default_database, FilterableTable, source: [filterPushedDown=[false], filter=[]]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[name, id, amount, price], where=[OR(>(amount, 2), <(amount, 10))])
+Calc(select=[name, id, amount, price], where=[SEARCH(amount, Sarg[(-∞..10), (20..+∞)])])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, FilterableTable, source: [filterPushedDown=[true], filter=[]]]], fields=[name, id, amount, price])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRuleTest.xml
@@ -120,7 +120,7 @@ LogicalProject(a=[$0], d=[$3])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(a=[$0], d=[$3])
-+- LogicalJoin(condition=[AND(OR(AND(=($0, 1), =($3, 2)), AND(=($0, 2), =($3, 1))), OR(AND(=($0, 3), =($3, 4)), AND(=($0, 4), =($3, 3))), SEARCH($0, Sarg[1, 2]), SEARCH($3, Sarg[1, 2]), SEARCH($0, Sarg[3, 4]), SEARCH($3, Sarg[3, 4]))], joinType=[inner])
++- LogicalJoin(condition=[false], joinType=[inner])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(a, b, c)]]])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -58,31 +58,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
   </TestCase>
   <TestCase name="testCannotPushDown3">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR amount < 10]]>
+      <![CDATA[SELECT * FROM MyTable WHERE amount > 20 OR amount < 10]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
++- LogicalFilter(condition=[OR(>($2, 20), <($2, 10))])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
++- LogicalFilter(condition=[OR(<($2, 10), >($2, 20))])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testCannotPushDown3WithVirtualColumn">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 OR amount < 10]]>
+      <![CDATA[SELECT * FROM VirtualTable WHERE amount > 20 OR amount < 10]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
++- LogicalFilter(condition=[OR(>($2, 20), <($2, 10))])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
       +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
 ]]>
@@ -91,7 +91,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
+   +- LogicalFilter(condition=[OR(<($2, 10), >($2, 20))])
       +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[]]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
@@ -70,18 +70,18 @@ Calc(select=[name, id, amount, price], where=[OR(>(amount, 2), >(price, 10))])
   </TestCase>
   <TestCase name="testFilterCannotPushDown3">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM FilterableTable WHERE amount > 2 OR amount < 10]]>
+      <![CDATA[SELECT * FROM FilterableTable WHERE amount > 20 OR amount < 10]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
++- LogicalFilter(condition=[OR(>($2, 20), <($2, 10))])
    +- LogicalTableScan(table=[[default_catalog, default_database, FilterableTable, source: [filterPushedDown=[false], filter=[]]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[name, id, amount, price], where=[OR(>(amount, 2), <(amount, 10))])
+Calc(select=[name, id, amount, price], where=[OR(<(amount, 10), >(amount, 20))])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, FilterableTable, source: [filterPushedDown=[true], filter=[]]]], fields=[name, id, amount, price])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/LegacyTableSourceTest.scala
@@ -149,7 +149,7 @@ class LegacyTableSourceTest extends TableTestBase {
 
   @Test
   def testFilterCannotPushDown3(): Unit = {
-    util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 2 OR amount < 10")
+    util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 20 OR amount < 10")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
@@ -124,12 +124,12 @@ class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
 
   @Test
   def testCannotPushDown3(): Unit = {
-    util.verifyPlan("SELECT * FROM MyTable WHERE amount > 2 OR amount < 10")
+    util.verifyPlan("SELECT * FROM MyTable WHERE amount > 20 OR amount < 10")
   }
 
   @Test
   def testCannotPushDown3WithVirtualColumn(): Unit = {
-    util.verifyPlan("SELECT * FROM VirtualTable WHERE amount > 2 OR amount < 10")
+    util.verifyPlan("SELECT * FROM VirtualTable WHERE amount > 20 OR amount < 10")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.scala
@@ -369,7 +369,7 @@ class LegacyTableSourceTest extends TableTestBase {
 
   @Test
   def testFilterCannotPushDown3(): Unit = {
-    util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 2 OR amount < 10")
+    util.verifyPlan("SELECT * FROM FilterableTable WHERE amount > 20 OR amount < 10")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
@@ -18,13 +18,11 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.planner.calcite.{FlinkRexBuilder, FlinkTypeFactory, FlinkTypeSystem}
-
-import org.apache.calcite.rex.RexUtil
+import org.apache.calcite.rex.{RexLiteral, RexUtil}
 import org.apache.calcite.sql.`type`.SqlTypeName._
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.junit.Assert.{assertEquals, assertFalse}
 import org.junit.Test
-
 import java.math.BigDecimal
 
 class FlinkRexUtilTest {
@@ -402,6 +400,58 @@ class FlinkRexUtilTest {
     val predicate16 = rexBuilder.makeCall(LESS_THAN, a, a)
     val newPredicate16 = FlinkRexUtil.simplify(rexBuilder, predicate16)
     assertEquals(rexBuilder.makeLiteral(false).toString, newPredicate16.toString)
+
+    // c = 0 AND SEARCH(c, [0, 1])
+    val predicate17Equals = rexBuilder.makeCall(EQUALS, c, intLiteral(0))
+    val predicate17 = rexBuilder.makeCall(
+      AND,
+      predicate17Equals,
+      rexBuilder.makeIn(c, java.util.Arrays.asList(
+        intLiteral(0),
+        intLiteral(1))))
+    val newPredicate17 = FlinkRexUtil.simplify(rexBuilder, predicate17)
+    assertEquals(predicate17Equals.toString, newPredicate17.toString)
+    val samePredicate17 = FlinkRexUtil.simplify(rexBuilder, predicate17, false)
+    assertEquals(predicate17.toString, samePredicate17.toString)
+
+    // c = 0 OR SEARCH(c, [0, 1])
+    val predicate18Search = rexBuilder.makeIn(c, java.util.Arrays.asList(
+      intLiteral(0),
+      intLiteral(1)))
+    val predicate18 = rexBuilder.makeCall(
+      OR,
+      rexBuilder.makeCall(EQUALS, c, intLiteral(0)),
+      predicate18Search)
+    val newPredicate18 = FlinkRexUtil.simplify(rexBuilder, predicate18)
+    assertEquals(predicate18Search.toString, newPredicate18.toString)
+
+    // c > 0 AND (
+    //   SEARCH(c, [0, 1]) OR (
+    //     SEARCH(c, [1, 2]) AND c < 2))
+    val predicate19Layer2 = rexBuilder.makeCall(
+      AND,
+      rexBuilder.makeIn(c, java.util.Arrays.asList(
+        intLiteral(1),
+        intLiteral(2))),
+      rexBuilder.makeCall(LESS_THAN, c, intLiteral(2)))
+    val predicate19Layer1 = rexBuilder.makeCall(
+      OR,
+      rexBuilder.makeIn(c, java.util.Arrays.asList(
+        intLiteral(0),
+        intLiteral(1))),
+      predicate19Layer2)
+    val predicate19 = rexBuilder.makeCall(
+      AND,
+      rexBuilder.makeCall(GREATER_THAN, c, intLiteral(0)),
+      predicate19Layer1)
+    val newPredicate19 = FlinkRexUtil.simplify(rexBuilder, predicate19)
+    assertEquals(
+      rexBuilder.makeCall(EQUALS, c, intLiteral(1)).toString,
+      newPredicate19.toString)
+    val samePredicate19 = FlinkRexUtil.simplify(rexBuilder, predicate19, false)
+    assertEquals(predicate19.toString, samePredicate19.toString)
   }
 
+  def intLiteral(x: Int): RexLiteral =
+    rexBuilder.makeExactLiteral(BigDecimal.valueOf(x))
 }


### PR DESCRIPTION
## What is the purpose of the change

The new version of Calcite introduces the `SEARCH` rex call to express range conditions. However `SEARCH`es in conjunctions are currently not simplified. For example, `AND(=($2, 2020), SEARCH($2, Sarg[2020, 2021]))` is not simplified while it should be simplified to `=($2, 2020)`.

This PR expands the `SEARCH` rex calls in `FlinkRexUtil#simplify` to achieve this. `RexSimplify#simplify` in Calcite will do the rest of the work.

## Brief change log

 - Simplify `SEARCH`es in conjunctions in `FlinkRexUtil#simplify`

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
