### PR TITLE
[FLINK-19464][runtime] Rename CheckpointStorage interface to Checkpoi…

### DIFF
--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/StubStateBackend.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -64,7 +64,7 @@ final class StubStateBackend implements StateBackend {
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 		return backend.createCheckpointStorage(jobId);
 	}
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 import org.apache.flink.util.LambdaUtil;
 import org.apache.flink.util.Preconditions;
@@ -86,7 +86,7 @@ public class SavepointOutputFormat extends RichOutputFormat<CheckpointMetadata> 
 	public void close() {}
 
 	private static CheckpointStorageLocation createSavepointLocation(Path location) throws IOException {
-		final CheckpointStorageLocationReference reference = AbstractFsCheckpointStorage.encodePathAsReference(location);
+		final CheckpointStorageLocationReference reference = AbstractFsCheckpointStorageAccess.encodePathAsReference(location);
 		return new FsCheckpointStorageLocation(
 			location.getFileSystem(),
 			location,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -50,7 +50,7 @@ public final class SnapshotUtils {
 
 		CheckpointOptions options = new CheckpointOptions(
 			CheckpointType.SAVEPOINT,
-			AbstractFsCheckpointStorage.encodePathAsReference(savepointPath),
+			AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
 			isExactlyOnceMode,
 			isUnalignedCheckpoint);
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointLoader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointLoader.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -46,7 +46,7 @@ public final class SavepointLoader {
 	 *     the path points to a location that does not seem to be a savepoint.
 	 */
 	public static CheckpointMetadata loadSavepointMetadata(String savepointPath) throws IOException {
-		CompletedCheckpointStorageLocation location = AbstractFsCheckpointStorage
+		CompletedCheckpointStorageLocation location = AbstractFsCheckpointStorageAccess
 			.resolveCheckpointPointer(savepointPath);
 
 		try (DataInputStream stream = new DataInputStream(location.getMetadataHandle().openInputStream())) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -623,7 +623,7 @@ public abstract class MetadataV2V3SerializerBase {
 
 		private static Path createExclusiveDirPath(String externalPointer) throws IOException {
 			try {
-				return AbstractFsCheckpointStorage.resolveCheckpointPointer(externalPointer).getExclusiveCheckpointDir();
+				return AbstractFsCheckpointStorageAccess.resolveCheckpointPointer(externalPointer).getExclusiveCheckpointDir();
 			} catch (IOException e) {
 				throw new IOException("Could not parse external pointer as state base path", e);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageAccess.java
@@ -23,5 +23,5 @@ package org.apache.flink.runtime.state;
  * which defined in {@link CheckpointStorageCoordinatorView}. And also implement methods acting as a worker role,
  * which defined in {@link CheckpointStorageWorkerView}.
  */
-public interface CheckpointStorage extends CheckpointStorageCoordinatorView, CheckpointStorageWorkerView {
+public interface CheckpointStorageAccess extends CheckpointStorageCoordinatorView, CheckpointStorageWorkerView {
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLocation.java
@@ -25,8 +25,8 @@ import java.io.IOException;
  * and lifecycle/cleanup methods.
  *
  * <p>CheckpointStorageLocations are typically created and initialized via
- * {@link CheckpointStorage#initializeLocationForCheckpoint(long)} or
- * {@link CheckpointStorage#initializeLocationForSavepoint(long, String)}.
+ * {@link CheckpointStorageAccess#initializeLocationForCheckpoint(long)} or
+ * {@link CheckpointStorageAccess#initializeLocationForSavepoint(long, String)}.
  */
 public interface CheckpointStorageLocation extends CheckpointStreamFactory {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
@@ -28,8 +28,8 @@ import java.io.OutputStream;
 /**
  * A factory for checkpoint output streams, which are used to persist data for checkpoints.
  *
- * <p>Stream factories can be created from the {@link CheckpointStorage} through
- * {@link CheckpointStorage#resolveCheckpointStorageLocation(long, CheckpointStorageLocationReference)}.
+ * <p>Stream factories can be created from the {@link CheckpointStorageAccess} through
+ * {@link CheckpointStorageAccess#resolveCheckpointStorageLocation(long, CheckpointStorageLocationReference)}.
  */
 public interface CheckpointStreamFactory {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -115,7 +115,7 @@ public interface StateBackend extends java.io.Serializable {
 	 *
 	 * @throws IOException Thrown if the checkpoint storage cannot be initialized.
 	 */
-	CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException;
+	CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException;
 
 	// ------------------------------------------------------------------------
 	//  Structure Backends 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
@@ -63,7 +63,7 @@ import java.net.URI;
  * <h1>Metadata File</h1>
  *
  * <p>A completed checkpoint writes its metadata into a file
- * '{@value AbstractFsCheckpointStorage#METADATA_FILE_NAME}'.
+ * '{@value AbstractFsCheckpointStorageAccess#METADATA_FILE_NAME}'.
  */
 @PublicEvolving
 public abstract class AbstractFileStateBackend extends AbstractStateBackend {
@@ -162,7 +162,7 @@ public abstract class AbstractFileStateBackend extends AbstractStateBackend {
 
 	@Override
 	public CompletedCheckpointStorageLocation resolveCheckpoint(String pointer) throws IOException {
-		return AbstractFsCheckpointStorage.resolveCheckpointPointer(pointer);
+		return AbstractFsCheckpointStorageAccess.resolveCheckpointPointer(pointer);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorageAccess.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -41,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An implementation of durable checkpoint storage to file systems.
  */
-public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
+public abstract class AbstractFsCheckpointStorageAccess implements CheckpointStorageAccess {
 
 	// ------------------------------------------------------------------------
 	//  Constants
@@ -79,7 +79,7 @@ public abstract class AbstractFsCheckpointStorage implements CheckpointStorage {
 	 * @param jobId The ID of the job that writes the checkpoints.
 	 * @param defaultSavepointDirectory The default location for savepoints, or null, if none is set.
 	 */
-	protected AbstractFsCheckpointStorage(
+	protected AbstractFsCheckpointStorageAccess(
 			JobID jobId,
 			@Nullable Path defaultSavepointDirectory) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -38,7 +38,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An implementation of durable checkpoint storage to file systems.
  */
-public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
+public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess {
 
 	private final FileSystem fileSystem;
 
@@ -54,7 +54,7 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 
 	private boolean baseLocationsInitialized = false;
 
-	public FsCheckpointStorage(
+	public FsCheckpointStorageAccess(
 			Path checkpointBaseDirectory,
 			@Nullable Path defaultSavepointDirectory,
 			JobID jobId,
@@ -69,7 +69,7 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 				writeBufferSize);
 	}
 
-	public FsCheckpointStorage(
+	public FsCheckpointStorageAccess(
 			FileSystem fs,
 			Path checkpointBaseDirectory,
 			@Nullable Path defaultSavepointDirectory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -75,7 +75,7 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 		// the metadata file should not have entropy in its path
 		Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
 
-		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
+		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
 		this.fileStateSizeThreshold = fileStateSizeThreshold;
 		this.writeBufferSize = writeBufferSize;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.BackendBuildingException;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -491,9 +491,9 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 	// ------------------------------------------------------------------------
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 		checkNotNull(jobId, "jobId");
-		return new FsCheckpointStorage(
+		return new FsCheckpointStorageAccess(
 			getCheckpointPath(),
 			getSavepointPath(),
 			jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryBackendCheckpointStorageAccess.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCheckpointOutputStream;
 
 import javax.annotation.Nullable;
@@ -41,7 +41,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * Depending on whether this is created with a checkpoint location, the setup supports
  * durable checkpoints (durable metadata) or not.
  */
-public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage {
+public class MemoryBackendCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess {
 
 	/** The target directory for checkpoints (here metadata files only). Null, if not configured. */
 	@Nullable
@@ -66,7 +66,7 @@ public class MemoryBackendCheckpointStorage extends AbstractFsCheckpointStorage 
 	 * @throws IOException Thrown if a checkpoint base directory is given configured and the
 	 *                     checkpoint directory cannot be created within that directory.
 	 */
-	public MemoryBackendCheckpointStorage(
+	public MemoryBackendCheckpointStorageAccess(
 			JobID jobId,
 			@Nullable Path checkpointsBaseDirectory,
 			@Nullable Path defaultSavepointLocation,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.BackendBuildingException;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -291,8 +291,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 	// ------------------------------------------------------------------------
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-		return new MemoryBackendCheckpointStorage(jobId, getCheckpointPath(), getSavepointPath(), maxStateSize);
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+		return new MemoryBackendCheckpointStorageAccess(jobId, getCheckpointPath(), getSavepointPath(), maxStateSize);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/PersistentMetadataCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/PersistentMetadataCheckpointStorageLocation.java
@@ -23,7 +23,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage;
+import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointMetadataOutputStream;
 
 import java.io.IOException;
@@ -60,7 +60,7 @@ public class PersistentMetadataCheckpointStorageLocation
 
 		this.fileSystem = checkNotNull(fileSystem);
 		this.checkpointDirectory = checkNotNull(checkpointDir);
-		this.metadataFilePath = new Path(checkpointDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
+		this.metadataFilePath = new Path(checkpointDir, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -39,7 +39,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -53,7 +53,7 @@ import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStorageLocation;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
@@ -2485,8 +2485,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 				// Throw exception when finalizing the checkpoint.
 				@Override
-				public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-					return new MemoryBackendCheckpointStorage(jobId, null, null, 100) {
+				public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+					return new MemoryBackendCheckpointStorageAccess(jobId, null, null, 100) {
 						@Override
 						public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) throws IOException {
 							return new NonPersistentMetadataCheckpointStorageLocation(1000) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -40,7 +40,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -170,8 +170,8 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
 		}
 
 		@Override
-		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-			return mock(CheckpointStorage.class);
+		public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+			return mock(CheckpointStorageAccess.class);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class ChannelStateWriteRequestDispatcherImplTest {
 	}
 
 	private void testBuffersRecycled(Function<NetworkBuffer[], ChannelStateWriteRequest> requestBuilder) throws Exception {
-		ChannelStateWriteRequestDispatcher dispatcher = new ChannelStateWriteRequestDispatcherImpl(new MemoryBackendCheckpointStorage(new JobID(), null, null, 1), new ChannelStateSerializerImpl());
+		ChannelStateWriteRequestDispatcher dispatcher = new ChannelStateWriteRequestDispatcherImpl(new MemoryBackendCheckpointStorageAccess(new JobID(), null, null, 1), new ChannelStateSerializerImpl());
 		ChannelStateWriteResult result = new ChannelStateWriteResult();
 		dispatcher.dispatch(ChannelStateWriteRequest.start(1L, result, CheckpointStorageLocationReference.getDefault()));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -42,7 +42,7 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.runtime.state.TestingCheckpointStorageCoordinatorView;
+import org.apache.flink.runtime.state.TestingCheckpointStorageAccessCoordinatorView;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -438,7 +438,7 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		final byte[] savepointMetadata = serializeAsCheckpointMetadata(testOperatorId, coordinatorState);
 		final String savepointPointer = "testingSavepointPointer";
 
-		final TestingCheckpointStorageCoordinatorView storage = new TestingCheckpointStorageCoordinatorView();
+		final TestingCheckpointStorageAccessCoordinatorView storage = new TestingCheckpointStorageAccessCoordinatorView();
 		storage.registerSavepoint(savepointPointer, savepointMetadata);
 
 		final Consumer<JobGraph> savepointConfigurer = (jobGraph) -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1168,10 +1168,10 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
 	private CheckpointStreamFactory createStreamFactory() throws Exception {
 		if (checkpointStorageLocation == null) {
-			CheckpointStorage checkpointStorage = getStateBackend()
+			CheckpointStorageAccess checkpointStorageAccess = getStateBackend()
 				.createCheckpointStorage(new JobID());
-			checkpointStorage.initializeBaseLocations();
-			checkpointStorageLocation = checkpointStorage
+			checkpointStorageAccess.initializeBaseLocations();
+			checkpointStorageLocation = checkpointStorageAccess
 				.initializeLocationForCheckpoint(1L);
 		}
 		return checkpointStorageLocation;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
  * A testing implementation of the {@link CheckpointStorageCoordinatorView}.
  */
 @SuppressWarnings("serial")
-public class TestingCheckpointStorageCoordinatorView implements CheckpointStorage, java.io.Serializable {
+public class TestingCheckpointStorageAccessCoordinatorView implements CheckpointStorageAccess, java.io.Serializable {
 
 	private final HashMap<String, TestingCompletedCheckpointStorageLocation> registeredSavepoints = new HashMap<>();
 
@@ -151,9 +151,9 @@ public class TestingCheckpointStorageCoordinatorView implements CheckpointStorag
 	 */
 	private static final class FactoringStateBackend implements StateBackend {
 
-		private final TestingCheckpointStorageCoordinatorView testingCoordinatorView;
+		private final TestingCheckpointStorageAccessCoordinatorView testingCoordinatorView;
 
-		private FactoringStateBackend(TestingCheckpointStorageCoordinatorView testingCoordinatorView) {
+		private FactoringStateBackend(TestingCheckpointStorageAccessCoordinatorView testingCoordinatorView) {
 			this.testingCoordinatorView = testingCoordinatorView;
 		}
 
@@ -164,7 +164,7 @@ public class TestingCheckpointStorageCoordinatorView implements CheckpointStorag
 		}
 
 		@Override
-		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+		public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 			return testingCoordinatorView;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -58,7 +58,7 @@ public class FsStateBackendEntropyTest {
 		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
 		final String checkpointDirStr = checkpointDir.toString();
 
-		final FsCheckpointStorage storage = new FsCheckpointStorage(
+		final FsCheckpointStorageAccess storage = new FsCheckpointStorageAccess(
 				fs, checkpointDir, null, new JobID(), fileSizeThreshold, 4096);
 		storage.initializeBaseLocations();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStorageLocationReferenceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStorageLocationReferenceTest.java
@@ -27,8 +27,8 @@ import org.junit.Test;
 
 import java.util.Random;
 
-import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage.decodePathFromReference;
-import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorage.encodePathAsReference;
+import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess.decodePathFromReference;
+import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess.encodePathAsReference;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageAccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/MemoryCheckpointStorageAccessTest.java
@@ -21,12 +21,12 @@ package org.apache.flink.runtime.state.memory;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.runtime.state.filesystem.AbstractFileCheckpointStorageTestBase;
+import org.apache.flink.runtime.state.filesystem.AbstractFileCheckpointStorageAccessTestBase;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory.MemoryCheckpointOutputStream;
 
 import org.junit.Test;
@@ -45,10 +45,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for the {@link MemoryBackendCheckpointStorage}, which implements the checkpoint storage
+ * Tests for the {@link MemoryBackendCheckpointStorageAccess}, which implements the checkpoint storage
  * aspects of the {@link MemoryStateBackend}.
  */
-public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTestBase {
+public class MemoryCheckpointStorageAccessTest extends AbstractFileCheckpointStorageAccessTestBase {
 
 	private static final int DEFAULT_MAX_STATE_SIZE = MemoryStateBackend.DEFAULT_MAX_STATE_SIZE;
 
@@ -57,13 +57,13 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected CheckpointStorage createCheckpointStorage(Path checkpointDir) throws Exception {
-		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, null, DEFAULT_MAX_STATE_SIZE);
+	protected CheckpointStorageAccess createCheckpointStorage(Path checkpointDir) throws Exception {
+		return new MemoryBackendCheckpointStorageAccess(new JobID(), checkpointDir, null, DEFAULT_MAX_STATE_SIZE);
 	}
 
 	@Override
-	protected CheckpointStorage createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
-		return new MemoryBackendCheckpointStorage(new JobID(), checkpointDir, savepointDir, DEFAULT_MAX_STATE_SIZE);
+	protected CheckpointStorageAccess createCheckpointStorageWithSavepointDir(Path checkpointDir, Path savepointDir) throws Exception {
+		return new MemoryBackendCheckpointStorageAccess(new JobID(), checkpointDir, savepointDir, DEFAULT_MAX_STATE_SIZE);
 	}
 
 	// ------------------------------------------------------------------------
@@ -76,8 +76,8 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 
 		MemoryStateBackend backend = new MemoryStateBackend();
 
-		MemoryBackendCheckpointStorage storage =
-				(MemoryBackendCheckpointStorage) backend.createCheckpointStorage(jid);
+		MemoryBackendCheckpointStorageAccess storage =
+				(MemoryBackendCheckpointStorageAccess) backend.createCheckpointStorage(jid);
 
 		assertFalse(storage.supportsHighlyAvailableStorage());
 		assertFalse(storage.hasDefaultSavepointLocation());
@@ -94,8 +94,8 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		MemoryStateBackend backend = new MemoryStateBackend(
 				checkpointPath.toString(), savepointPath.toString());
 
-		MemoryBackendCheckpointStorage storage =
-				(MemoryBackendCheckpointStorage) backend.createCheckpointStorage(jid);
+		MemoryBackendCheckpointStorageAccess storage =
+				(MemoryBackendCheckpointStorageAccess) backend.createCheckpointStorage(jid);
 
 		assertTrue(storage.supportsHighlyAvailableStorage());
 		assertTrue(storage.hasDefaultSavepointLocation());
@@ -109,15 +109,15 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 		final int maxSize = 17;
 
 		MemoryStateBackend backend = new MemoryStateBackend(maxSize);
-		MemoryBackendCheckpointStorage storage =
-				(MemoryBackendCheckpointStorage) backend.createCheckpointStorage(new JobID());
+		MemoryBackendCheckpointStorageAccess storage =
+				(MemoryBackendCheckpointStorageAccess) backend.createCheckpointStorage(new JobID());
 
 		assertEquals(maxSize, storage.getMaxStateSize());
 	}
 
 	@Test
 	public void testNonPersistentCheckpointLocation() throws Exception {
-		MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+		MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
 
 		CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(9);
@@ -142,7 +142,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	public void testLocationReference() throws Exception {
 		// non persistent memory state backend for checkpoint
 		{
-			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+			MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
 			CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
 			assertTrue(location.getLocationReference().isDefaultReference());
@@ -150,7 +150,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 
 		// non persistent memory state backend for checkpoint
 		{
-			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+			MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 					new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
 			CheckpointStorageLocation location = storage.initializeLocationForCheckpoint(42);
 			assertTrue(location.getLocationReference().isDefaultReference());
@@ -158,7 +158,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 
 		// memory state backend for savepoint
 		{
-			MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+			MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 					new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
 			CheckpointStorageLocation location = storage.initializeLocationForSavepoint(
 					1337, randomTempPath().toString());
@@ -170,7 +170,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	public void testTaskOwnedStateStream() throws Exception {
 		final List<String> state = Arrays.asList("Flopsy", "Mopsy", "Cotton Tail", "Peter");
 
-		final MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+		final MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 				new JobID(), null, null, DEFAULT_MAX_STATE_SIZE);
 
 		StreamStateHandle stateHandle;
@@ -193,7 +193,7 @@ public class MemoryCheckpointStorageTest extends AbstractFileCheckpointStorageTe
 	 */
 	@Test
 	public void testStorageLocationMkdirs() throws Exception {
-		MemoryBackendCheckpointStorage storage = new MemoryBackendCheckpointStorage(
+		MemoryBackendCheckpointStorageAccess storage = new MemoryBackendCheckpointStorageAccess(
 			new JobID(), randomTempPath(), null, DEFAULT_MAX_STATE_SIZE);
 
 		File baseDir = new File(storage.getCheckpointsDirectory().getPath());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/BackendForTestStream.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state.testutils;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -61,8 +61,8 @@ public class BackendForTestStream extends MemoryStateBackend {
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) {
-		return new TestCheckpointStorage();
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+		return new TestCheckpointStorageAccess();
 	}
 
 	// ------------------------------------------------------------------------
@@ -72,7 +72,7 @@ public class BackendForTestStream extends MemoryStateBackend {
 
 	// ------------------------------------------------------------------------
 
-	private final class TestCheckpointStorage implements CheckpointStorage {
+	private final class TestCheckpointStorageAccess implements CheckpointStorageAccess {
 
 		@Override
 		public boolean supportsHighlyAvailableStorage() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -56,8 +56,8 @@ public class MockStateBackend extends AbstractStateBackend {
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) {
-		return new CheckpointStorage() {
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+		return new CheckpointStorageAccess() {
 			@Override
 			public boolean supportsHighlyAvailableStorage() {
 				return false;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractManagedMemoryStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
@@ -462,7 +462,7 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend imple
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 		return checkpointStreamBackend.createCheckpointStorage(jobId);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
@@ -49,8 +49,8 @@ public class BatchExecutionStateBackend implements StateBackend {
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) {
-		return new NonCheckpointingStorage();
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+		return new NonCheckpointingStorageAccess();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorageAccess.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/NonCheckpointingStorageAccess.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sorted.state;
 
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -27,9 +27,9 @@ import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import javax.annotation.Nullable;
 
 /**
- * A dummy {@link CheckpointStorage} which does not perform checkpoints.
+ * A dummy {@link CheckpointStorageAccess} which does not perform checkpoints.
  */
-class NonCheckpointingStorage implements CheckpointStorage {
+class NonCheckpointingStorageAccess implements CheckpointStorageAccess {
 	@Override
 	public boolean supportsHighlyAvailableStorage() {
 		return false;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -139,7 +139,7 @@ public class StreamTaskStateInitializerImplTest {
 			}
 
 			@Override
-			public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+			public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 				throw new UnsupportedOperationException();
 			}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 import org.apache.flink.util.function.BiFunctionWithException;
 
 import java.io.IOException;
@@ -79,7 +79,7 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
 			this.environment = MockEnvironment.builder().build();
 		}
 		if (checkpointStorage == null) {
-			this.checkpointStorage = new MemoryBackendCheckpointStorage(environment.getJobID(), null, null, 1024);
+			this.checkpointStorage = new MemoryBackendCheckpointStorageAccess(environment.getJobID(), null, null, 1024);
 		}
 		if (asyncExceptionHandler == null) {
 			this.asyncExceptionHandler = new NonHandleAsyncException();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -52,7 +52,7 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -62,7 +62,7 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.TestTaskStateManager;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.PartitionProducerStateChecker;
@@ -263,8 +263,8 @@ public class StreamTaskTerminationTest extends TestLogger {
 		}
 
 		@Override
-		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-			return new MemoryBackendCheckpointStorage(jobId, null, null, Integer.MAX_VALUE);
+		public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+			return new MemoryBackendCheckpointStorageAccess(jobId, null, null, Integer.MAX_VALUE);
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -95,7 +95,7 @@ public class TestSpyWrapperStateBackend extends AbstractStateBackend {
 	}
 
 	@Override
-	public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
+	public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
 		return spy(delegate.createCheckpointStorage(jobId));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -129,7 +129,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	// use this as default for tests
 	protected StateBackend stateBackend = new MemoryStateBackend();
 
-	private CheckpointStorage checkpointStorage = stateBackend.createCheckpointStorage(new JobID());
+	private CheckpointStorageAccess checkpointStorageAccess = stateBackend.createCheckpointStorage(new JobID());
 
 	private final Object checkpointLock;
 
@@ -295,7 +295,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			.setConfig(config)
 			.setExecutionConfig(executionConfig)
 			.setStreamTaskStateInitializer(streamTaskStateInitializer)
-			.setCheckpointStorage(checkpointStorage)
+			.setCheckpointStorage(checkpointStorageAccess)
 			.setTimerService(processingTimeService)
 			.setHandleAsyncException(handleAsyncException)
 			.setTaskMailbox(taskMailbox)
@@ -319,7 +319,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		this.stateBackend = stateBackend;
 
 		try {
-			this.checkpointStorage = stateBackend.createCheckpointStorage(new JobID());
+			this.checkpointStorageAccess = stateBackend.createCheckpointStorage(new JobID());
 		} catch (IOException e) {
 			throw new RuntimeException(e.getMessage(), e);
 		}
@@ -637,7 +637,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 			checkpointId,
 			timestamp,
 			CheckpointOptions.forCheckpointWithDefaultLocation(),
-			checkpointStorage.resolveCheckpointStorageLocation(checkpointId, CheckpointStorageLocationReference.getDefault()));
+			checkpointStorageAccess.resolveCheckpointStorageLocation(checkpointId, CheckpointStorageLocationReference.getDefault()));
 
 		return new OperatorSnapshotFinalizer(operatorStateResult);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -21,7 +21,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
@@ -93,8 +93,8 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
-	public MockStreamTaskBuilder setCheckpointStorage(CheckpointStorage checkpointStorage) {
-		this.checkpointStorage = checkpointStorage;
+	public MockStreamTaskBuilder setCheckpointStorage(CheckpointStorageAccess checkpointStorageAccess) {
+		this.checkpointStorage = checkpointStorageAccess;
 		return this;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -31,14 +31,14 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -107,8 +107,8 @@ public class StateBackendITCase extends AbstractTestBase {
 		}
 
 		@Override
-		public CheckpointStorage createCheckpointStorage(JobID jobId) throws IOException {
-			return new MemoryBackendCheckpointStorage(jobId, null, null, 1_000_000);
+		public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+			return new MemoryBackendCheckpointStorageAccess(jobId, null, null, 1_000_000);
 		}
 
 		@Override


### PR DESCRIPTION
…ntStorageAccess


## What is the purpose of the change

This is a trivial renaming of CheckpointStorage to CheckpointStorageAccess so we can use the former name as a public interface. This PR is just a result of IntelliJ rename. I decided to make it its own PR since the diff is trivial but rather large. This is prereq work for FLIP-142

## Brief change log

- Rename interface

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

