### PR TITLE
[FLINK-19465][runtime / statebackends] Add CheckpointStorage interface and wire through runtime

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -34,6 +34,16 @@ public class CheckpointingOptions {
                     .noDefaultValue()
                     .withDescription("The state backend to be used to store and checkpoint state.");
 
+    /** The checkpoint storage used to checkpoint state. */
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS, position = 2)
+    @Documentation.ExcludeFromDocumentation(
+            "Hidden until FileSystemStorage and JobManagerStorage are implemented")
+    public static final ConfigOption<String> CHECKPOINT_STORAGE =
+            ConfigOptions.key("state.checkpoint-storage")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The state backend to be used to checkpoint state.");
+
     /** The maximum number of completed checkpoints to retain. */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS =

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/output/SnapshotUtilsTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
+import org.apache.flink.runtime.state.ttl.mock.MockCheckpointStorage;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
@@ -56,7 +56,7 @@ public class SnapshotUtilsTest {
     public void testSnapshotUtilsLifecycle() throws Exception {
         StreamOperator<Void> operator = new LifecycleOperator();
         CheckpointStorageWorkerView storage =
-                new MockStateBackend().createCheckpointStorage(new JobID());
+                new MockCheckpointStorage().createCheckpointStorage(new JobID());
 
         Path path = new Path(folder.newFolder().getAbsolutePath());
 

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1240,6 +1240,9 @@
         "state_backend" : {
           "type" : "string"
         },
+        "checkpoint_storage" : {
+          "type" : "string"
+        },
         "unaligned_checkpoints" : {
           "type" : "boolean"
         },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -139,7 +140,7 @@ public class CheckpointCoordinator {
      * The root checkpoint state backend, which is responsible for initializing the checkpoint,
      * storing the metadata, and cleaning up the checkpoint.
      */
-    private final CheckpointStorageCoordinatorView checkpointStorage;
+    private final CheckpointStorageCoordinatorView checkpointStorageView;
 
     /** A list of recent checkpoint IDs, to identify late messages (vs invalid ones). */
     private final ArrayDeque<Long> recentPendingCheckpoints;
@@ -234,6 +235,46 @@ public class CheckpointCoordinator {
             Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
             CheckpointIDCounter checkpointIDCounter,
             CompletedCheckpointStore completedCheckpointStore,
+            CheckpointStorage checkpointStorage,
+            Executor executor,
+            CheckpointsCleaner checkpointsCleaner,
+            ScheduledExecutor timer,
+            SharedStateRegistryFactory sharedStateRegistryFactory,
+            CheckpointFailureManager failureManager) {
+
+        this(
+                job,
+                chkConfig,
+                tasksToTrigger,
+                tasksToWaitFor,
+                tasksToCommitTo,
+                coordinatorsToCheckpoint,
+                checkpointIDCounter,
+                completedCheckpointStore,
+                null,
+                executor,
+                checkpointsCleaner,
+                timer,
+                sharedStateRegistryFactory,
+                failureManager,
+                SystemClock.getInstance());
+    }
+
+    /**
+     * @deprecated Please pass a {@link CheckpointStorage} object directly. This constructor only
+     *     exists for to keep coordinator tests passing and may be dropped once concrete checkpoint
+     *     storage classes are implemented.
+     */
+    @Deprecated
+    public CheckpointCoordinator(
+            JobID job,
+            CheckpointCoordinatorConfiguration chkConfig,
+            ExecutionVertex[] tasksToTrigger,
+            ExecutionVertex[] tasksToWaitFor,
+            ExecutionVertex[] tasksToCommitTo,
+            Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
+            CheckpointIDCounter checkpointIDCounter,
+            CompletedCheckpointStore completedCheckpointStore,
             StateBackend checkpointStateBackend,
             Executor executor,
             CheckpointsCleaner checkpointsCleaner,
@@ -250,7 +291,7 @@ public class CheckpointCoordinator {
                 coordinatorsToCheckpoint,
                 checkpointIDCounter,
                 completedCheckpointStore,
-                checkpointStateBackend,
+                asCheckpointStorage(checkpointStateBackend),
                 executor,
                 checkpointsCleaner,
                 timer,
@@ -269,7 +310,7 @@ public class CheckpointCoordinator {
             Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
             CheckpointIDCounter checkpointIDCounter,
             CompletedCheckpointStore completedCheckpointStore,
-            StateBackend checkpointStateBackend,
+            CheckpointStorage checkpointStorage,
             Executor executor,
             CheckpointsCleaner checkpointsCleaner,
             ScheduledExecutor timer,
@@ -278,7 +319,7 @@ public class CheckpointCoordinator {
             Clock clock) {
 
         // sanity checks
-        checkNotNull(checkpointStateBackend);
+        checkNotNull(checkpointStorage);
 
         // max "in between duration" can be one year - this is to prevent numeric overflows
         long minPauseBetweenCheckpoints = chkConfig.getMinPauseBetweenCheckpoints();
@@ -325,8 +366,8 @@ public class CheckpointCoordinator {
                 CheckpointProperties.forCheckpoint(chkConfig.getCheckpointRetentionPolicy());
 
         try {
-            this.checkpointStorage = checkpointStateBackend.createCheckpointStorage(job);
-            checkpointStorage.initializeBaseLocations();
+            this.checkpointStorageView = checkpointStorage.createCheckpointStorage(job);
+            checkpointStorageView.initializeBaseLocations();
         } catch (IOException e) {
             throw new FlinkRuntimeException(
                     "Failed to create checkpoint storage at checkpoint coordinator side.", e);
@@ -683,9 +724,9 @@ public class CheckpointCoordinator {
 
                         CheckpointStorageLocation checkpointStorageLocation =
                                 props.isSavepoint()
-                                        ? checkpointStorage.initializeLocationForSavepoint(
+                                        ? checkpointStorageView.initializeLocationForSavepoint(
                                                 checkpointID, externalSavepointLocation)
-                                        : checkpointStorage.initializeLocationForCheckpoint(
+                                        : checkpointStorageView.initializeLocationForCheckpoint(
                                                 checkpointID);
 
                         return new CheckpointIdAndStorageLocation(
@@ -1620,7 +1661,7 @@ public class CheckpointCoordinator {
                 (allowNonRestored ? "allowing non restored state" : ""));
 
         final CompletedCheckpointStorageLocation checkpointLocation =
-                checkpointStorage.resolveCheckpoint(savepointPointer);
+                checkpointStorageView.resolveCheckpoint(savepointPointer);
 
         // Load the savepoint as a checkpoint into the system
         CompletedCheckpoint savepoint =
@@ -1675,7 +1716,7 @@ public class CheckpointCoordinator {
     }
 
     public CheckpointStorageCoordinatorView getCheckpointStorage() {
-        return checkpointStorage;
+        return checkpointStorageView;
     }
 
     public CompletedCheckpointStore getCheckpointStore() {
@@ -2100,5 +2141,14 @@ public class CheckpointCoordinator {
 
         /** Coordinators are not restored during this checkpoint restore. */
         SKIP;
+    }
+
+    private static CheckpointStorage asCheckpointStorage(StateBackend backend) {
+        if (backend instanceof CheckpointStorage) {
+            return (CheckpointStorage) backend;
+        }
+
+        throw new IllegalStateException(
+                "Provided state backend does not implement checkpoint storage");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -42,7 +42,6 @@ import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
-import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -251,47 +250,7 @@ public class CheckpointCoordinator {
                 coordinatorsToCheckpoint,
                 checkpointIDCounter,
                 completedCheckpointStore,
-                null,
-                executor,
-                checkpointsCleaner,
-                timer,
-                sharedStateRegistryFactory,
-                failureManager,
-                SystemClock.getInstance());
-    }
-
-    /**
-     * @deprecated Please pass a {@link CheckpointStorage} object directly. This constructor only
-     *     exists for to keep coordinator tests passing and may be dropped once concrete checkpoint
-     *     storage classes are implemented.
-     */
-    @Deprecated
-    public CheckpointCoordinator(
-            JobID job,
-            CheckpointCoordinatorConfiguration chkConfig,
-            ExecutionVertex[] tasksToTrigger,
-            ExecutionVertex[] tasksToWaitFor,
-            ExecutionVertex[] tasksToCommitTo,
-            Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
-            CheckpointIDCounter checkpointIDCounter,
-            CompletedCheckpointStore completedCheckpointStore,
-            StateBackend checkpointStateBackend,
-            Executor executor,
-            CheckpointsCleaner checkpointsCleaner,
-            ScheduledExecutor timer,
-            SharedStateRegistryFactory sharedStateRegistryFactory,
-            CheckpointFailureManager failureManager) {
-
-        this(
-                job,
-                chkConfig,
-                tasksToTrigger,
-                tasksToWaitFor,
-                tasksToCommitTo,
-                coordinatorsToCheckpoint,
-                checkpointIDCounter,
-                completedCheckpointStore,
-                asCheckpointStorage(checkpointStateBackend),
+                checkpointStorage,
                 executor,
                 checkpointsCleaner,
                 timer,
@@ -2141,14 +2100,5 @@ public class CheckpointCoordinator {
 
         /** Coordinators are not restored during this checkpoint restore. */
         SKIP;
-    }
-
-    private static CheckpointStorage asCheckpointStorage(StateBackend backend) {
-        if (backend instanceof CheckpointStorage) {
-            return (CheckpointStorage) backend;
-        }
-
-        throw new IllegalStateException(
-                "Provided state backend does not implement checkpoint storage");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -345,8 +345,7 @@ public class Checkpoints {
         CheckpointStorage checkpointStorage = null;
         try {
             checkpointStorage =
-                    CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
-                            null, backend, configuration, classLoader, null);
+                    CheckpointStorageLoader.load(null, backend, configuration, classLoader, null);
         } catch (Throwable t) {
             // catches exceptions and errors (like linking errors)
             if (logger != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.checkpoint.metadata.MetadataV3Serializer;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
@@ -231,15 +233,15 @@ public class Checkpoints {
     // ------------------------------------------------------------------------
 
     public static void disposeSavepoint(
-            String pointer, StateBackend stateBackend, ClassLoader classLoader)
+            String pointer, CheckpointStorage checkpointStorage, ClassLoader classLoader)
             throws IOException, FlinkException {
 
         checkNotNull(pointer, "location");
-        checkNotNull(stateBackend, "stateBackend");
+        checkNotNull(checkpointStorage, "stateBackend");
         checkNotNull(classLoader, "classLoader");
 
         final CompletedCheckpointStorageLocation checkpointLocation =
-                stateBackend.resolveCheckpoint(pointer);
+                checkpointStorage.resolveCheckpoint(pointer);
 
         final StreamStateHandle metadataHandle = checkpointLocation.getMetadataHandle();
 
@@ -293,9 +295,9 @@ public class Checkpoints {
         checkNotNull(configuration, "configuration");
         checkNotNull(classLoader, "classLoader");
 
-        StateBackend backend = loadStateBackend(configuration, classLoader, logger);
+        CheckpointStorage storage = loadCheckpointStorage(configuration, classLoader, logger);
 
-        disposeSavepoint(pointer, backend, classLoader);
+        disposeSavepoint(pointer, storage, classLoader);
     }
 
     @Nonnull
@@ -329,6 +331,31 @@ public class Checkpoints {
             backend = new MemoryStateBackend();
         }
         return backend;
+    }
+
+    @Nonnull
+    public static CheckpointStorage loadCheckpointStorage(
+            Configuration configuration, ClassLoader classLoader, @Nullable Logger logger) {
+        StateBackend backend = loadStateBackend(configuration, classLoader, logger);
+
+        if (logger != null) {
+            logger.info("Attempting to load configured checkpoint storage for savepoint disposal");
+        }
+
+        CheckpointStorage checkpointStorage = null;
+        try {
+            checkpointStorage =
+                    CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                            null, backend, configuration, classLoader, null);
+        } catch (Throwable t) {
+            // catches exceptions and errors (like linking errors)
+            if (logger != null) {
+                logger.info("Could not load configured state backend.");
+                logger.debug("Detailed exception:", t);
+            }
+        }
+
+        return checkpointStorage;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -172,4 +172,11 @@ public interface AccessExecutionGraph extends JobStatusProvider {
      * @return The state backend name, or an empty Optional in the case of batch jobs
      */
     Optional<String> getStateBackendName();
+
+    /**
+     * Returns the checkpoint storage name for this ExecutionGraph.
+     *
+     * @return The checkpoint storage name, or an empty Optional in the case of batch jobs
+     */
+    Optional<String> getCheckpointStorageName();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -95,6 +95,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 
     @Nullable private final String stateBackendName;
 
+    @Nullable private final String checkpointStorageName;
+
     public ArchivedExecutionGraph(
             JobID jobID,
             String jobName,
@@ -110,7 +112,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
             boolean isStoppable,
             @Nullable CheckpointCoordinatorConfiguration jobCheckpointingConfiguration,
             @Nullable CheckpointStatsSnapshot checkpointStatsSnapshot,
-            @Nullable String stateBackendName) {
+            @Nullable String stateBackendName,
+            @Nullable String checkpointStorageName) {
 
         this.jobID = Preconditions.checkNotNull(jobID);
         this.jobName = Preconditions.checkNotNull(jobName);
@@ -127,6 +130,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
         this.jobCheckpointingConfiguration = jobCheckpointingConfiguration;
         this.checkpointStatsSnapshot = checkpointStatsSnapshot;
         this.stateBackendName = stateBackendName;
+        this.checkpointStorageName = checkpointStorageName;
     }
 
     // --------------------------------------------------------------------------------------------
@@ -257,6 +261,11 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
         return Optional.ofNullable(stateBackendName);
     }
 
+    @Override
+    public Optional<String> getCheckpointStorageName() {
+        return Optional.ofNullable(checkpointStorageName);
+    }
+
     class AllVerticesIterator implements Iterator<ArchivedExecutionVertex> {
 
         private final Iterator<ArchivedExecutionJobVertex> jobVertices;
@@ -346,7 +355,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 executionGraph.isStoppable(),
                 executionGraph.getCheckpointCoordinatorConfiguration(),
                 executionGraph.getCheckpointStatsSnapshot(),
-                executionGraph.getStateBackendName().orElse(null));
+                executionGraph.getStateBackendName().orElse(null),
+                executionGraph.getCheckpointStorageName().orElse(null));
     }
 
     /**
@@ -393,6 +403,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 serializedUserAccumulators,
                 new ExecutionConfig().archive(),
                 false,
+                null,
                 null,
                 null,
                 null);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -67,6 +67,7 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
@@ -272,6 +273,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
     // ------ Fields that are only relevant for archived execution graphs ------------
     @Nullable private String stateBackendName;
 
+    @Nullable private String checkpointStorageName;
+
     private String jsonPlan;
 
     /** Shuffle master to register partitions for task deployment. */
@@ -396,6 +399,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
         return Optional.ofNullable(stateBackendName);
     }
 
+    @Override
+    public Optional<String> getCheckpointStorageName() {
+        return Optional.ofNullable(checkpointStorageName);
+    }
+
     public void enableCheckpointing(
             CheckpointCoordinatorConfiguration chkConfig,
             List<ExecutionJobVertex> verticesToTrigger,
@@ -405,6 +413,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
             CheckpointIDCounter checkpointIDCounter,
             CompletedCheckpointStore checkpointStore,
             StateBackend checkpointStateBackend,
+            CheckpointStorage checkpointStorage,
             CheckpointStatsTracker statsTracker,
             CheckpointsCleaner checkpointsCleaner) {
 
@@ -486,6 +495,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
         }
 
         this.stateBackendName = checkpointStateBackend.getClass().getSimpleName();
+        this.checkpointStorageName = checkpointStorageName.getClass().getSimpleName();
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -467,7 +467,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
                         operatorCoordinators,
                         checkpointIDCounter,
                         checkpointStore,
-                        checkpointStateBackend,
+                        checkpointStorage,
                         ioExecutor,
                         checkpointsCleaner,
                         new ScheduledExecutorServiceAdapter(checkpointCoordinatorTimer),
@@ -495,7 +495,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
         }
 
         this.stateBackendName = checkpointStateBackend.getClass().getSimpleName();
-        this.checkpointStorageName = checkpointStorageName.getClass().getSimpleName();
+        this.checkpointStorageName = checkpointStorage.getClass().getSimpleName();
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -48,6 +48,8 @@ import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.util.DynamicCodeLoadingException;
@@ -241,6 +243,39 @@ public class ExecutionGraphBuilder {
                         jobId, "Could not instantiate configured state backend", e);
             }
 
+            // load the checkpoint storage from the application settings
+            final CheckpointStorage applicationConfiguredStorage;
+            final SerializedValue<CheckpointStorage> serializedAppConfiguredStorage =
+                    snapshotSettings.getDefaultCheckpointStorage();
+
+            if (serializedAppConfiguredStorage == null) {
+                applicationConfiguredStorage = null;
+            } else {
+                try {
+                    applicationConfiguredStorage =
+                            serializedAppConfiguredStorage.deserializeValue(classLoader);
+                } catch (IOException | ClassNotFoundException e) {
+                    throw new JobExecutionException(
+                            jobId,
+                            "Could not deserialize application-defined checkpoint storage.",
+                            e);
+                }
+            }
+
+            final CheckpointStorage rootStorage;
+            try {
+                rootStorage =
+                        CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                                applicationConfiguredStorage,
+                                rootBackend,
+                                jobManagerConfig,
+                                classLoader,
+                                log);
+            } catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
+                throw new JobExecutionException(
+                        jobId, "Could not instantiate configured checkpoint storage", e);
+            }
+
             // instantiate the user-defined checkpoint hooks
 
             final SerializedValue<MasterTriggerRestoreHook.Factory[]> serializedHooks =
@@ -284,6 +319,7 @@ public class ExecutionGraphBuilder {
                     checkpointIdCounter,
                     completedCheckpointStore,
                     rootBackend,
+                    rootStorage,
                     checkpointStatsTracker,
                     checkpointsCleaner);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -265,13 +265,13 @@ public class ExecutionGraphBuilder {
             final CheckpointStorage rootStorage;
             try {
                 rootStorage =
-                        CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                        CheckpointStorageLoader.load(
                                 applicationConfiguredStorage,
                                 rootBackend,
                                 jobManagerConfig,
                                 classLoader,
                                 log);
-            } catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
+            } catch (IllegalConfigurationException | DynamicCodeLoadingException e) {
                 throw new JobExecutionException(
                         jobId, "Could not instantiate configured checkpoint storage", e);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobCheckpointingSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobCheckpointingSettings.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -52,6 +53,9 @@ public class JobCheckpointingSettings implements Serializable {
     /** The default state backend, if configured by the user in the job */
     @Nullable private final SerializedValue<StateBackend> defaultStateBackend;
 
+    /** The default checkpoint storage, if configured by the user in the job */
+    @Nullable private final SerializedValue<CheckpointStorage> defaultCheckpointStorage;
+
     /** (Factories for) hooks that are executed on the checkpoint coordinator */
     @Nullable private final SerializedValue<MasterTriggerRestoreHook.Factory[]> masterHooks;
 
@@ -68,6 +72,7 @@ public class JobCheckpointingSettings implements Serializable {
                 verticesToConfirm,
                 checkpointCoordinatorConfiguration,
                 defaultStateBackend,
+                null,
                 null);
     }
 
@@ -77,6 +82,7 @@ public class JobCheckpointingSettings implements Serializable {
             List<JobVertexID> verticesToConfirm,
             CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration,
             @Nullable SerializedValue<StateBackend> defaultStateBackend,
+            @Nullable SerializedValue<CheckpointStorage> defaultCheckpointStorage,
             @Nullable SerializedValue<MasterTriggerRestoreHook.Factory[]> masterHooks) {
 
         this.verticesToTrigger = requireNonNull(verticesToTrigger);
@@ -85,6 +91,7 @@ public class JobCheckpointingSettings implements Serializable {
         this.checkpointCoordinatorConfiguration =
                 Preconditions.checkNotNull(checkpointCoordinatorConfiguration);
         this.defaultStateBackend = defaultStateBackend;
+        this.defaultCheckpointStorage = defaultCheckpointStorage;
         this.masterHooks = masterHooks;
     }
 
@@ -109,6 +116,11 @@ public class JobCheckpointingSettings implements Serializable {
     @Nullable
     public SerializedValue<StateBackend> getDefaultStateBackend() {
         return defaultStateBackend;
+    }
+
+    @Nullable
+    public SerializedValue<CheckpointStorage> getDefaultCheckpointStorage() {
+        return defaultCheckpointStorage;
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointConfigHandler.java
@@ -116,6 +116,7 @@ public class CheckpointConfigHandler
                             retentionPolicy != CheckpointRetentionPolicy.RETAIN_ON_CANCELLATION);
 
             String stateBackendName = executionGraph.getStateBackendName().orElse(null);
+            String checkpointStorageName = executionGraph.getCheckpointStorageName().orElse(null);
 
             return new CheckpointConfigInfo(
                     checkpointCoordinatorConfiguration.isExactlyOnce()
@@ -127,6 +128,7 @@ public class CheckpointConfigHandler
                     checkpointCoordinatorConfiguration.getMaxConcurrentCheckpoints(),
                     externalizedCheckpointInfo,
                     stateBackendName,
+                    checkpointStorageName,
                     checkpointCoordinatorConfiguration.isUnalignedCheckpointsEnabled(),
                     checkpointCoordinatorConfiguration.getTolerableCheckpointFailureNumber());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -53,6 +53,8 @@ public class CheckpointConfigInfo implements ResponseBody {
 
     public static final String FIELD_NAME_STATE_BACKEND = "state_backend";
 
+    public static final String FIELD_NAME_CHECKPOINT_STORAGE = "checkpoint_storage";
+
     public static final String FIELD_NAME_UNALIGNED_CHECKPOINTS = "unaligned_checkpoints";
 
     public static final String FIELD_NAME_TOLERABLE_FAILED_CHECKPOINTS =
@@ -79,6 +81,9 @@ public class CheckpointConfigInfo implements ResponseBody {
     @JsonProperty(FIELD_NAME_STATE_BACKEND)
     private final String stateBackend;
 
+    @JsonProperty(FIELD_NAME_CHECKPOINT_STORAGE)
+    private final String checkpointStorage;
+
     @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINTS)
     private final boolean unalignedCheckpoints;
 
@@ -95,6 +100,7 @@ public class CheckpointConfigInfo implements ResponseBody {
             @JsonProperty(FIELD_NAME_EXTERNALIZED_CHECKPOINT_CONFIG)
                     ExternalizedCheckpointInfo externalizedCheckpointInfo,
             @JsonProperty(FIELD_NAME_STATE_BACKEND) String stateBackend,
+            @JsonProperty(FIELD_NAME_CHECKPOINT_STORAGE) String checkpointStorage,
             @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINTS) boolean unalignedCheckpoints,
             @JsonProperty(FIELD_NAME_TOLERABLE_FAILED_CHECKPOINTS) int tolerableFailedCheckpoints) {
         this.processingMode = Preconditions.checkNotNull(processingMode);
@@ -104,6 +110,7 @@ public class CheckpointConfigInfo implements ResponseBody {
         this.maxConcurrentCheckpoints = maxConcurrentCheckpoints;
         this.externalizedCheckpointInfo = Preconditions.checkNotNull(externalizedCheckpointInfo);
         this.stateBackend = Preconditions.checkNotNull(stateBackend);
+        this.checkpointStorage = Preconditions.checkNotNull(checkpointStorage);
         this.unalignedCheckpoints = unalignedCheckpoints;
         this.tolerableFailedCheckpoints = tolerableFailedCheckpoints;
     }
@@ -124,6 +131,7 @@ public class CheckpointConfigInfo implements ResponseBody {
                 && processingMode == that.processingMode
                 && Objects.equals(externalizedCheckpointInfo, that.externalizedCheckpointInfo)
                 && Objects.equals(stateBackend, that.stateBackend)
+                && Objects.equals(checkpointStorage, that.checkpointStorage)
                 && unalignedCheckpoints == that.unalignedCheckpoints
                 && tolerableFailedCheckpoints == that.tolerableFailedCheckpoints;
     }
@@ -138,6 +146,7 @@ public class CheckpointConfigInfo implements ResponseBody {
                 maxConcurrentCheckpoints,
                 externalizedCheckpointInfo,
                 stateBackend,
+                checkpointStorage,
                 unalignedCheckpoints,
                 tolerableFailedCheckpoints);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorage.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
+
+import java.io.IOException;
+
+/**
+ * CheckpointStorage defines how checkpoint snapshots are persisted for fault tolerance. Various
+ * implementations store their checkpoints in different fashions and have different requirements and
+ * availability guarantees.
+ *
+ * <p>For example, JobManagerCheckpointStorage stores checkpoints in the memory of the JobManager.
+ * It is lightweight and without additional dependencies but is not highly available and only
+ * supports small state sizes. This checkpoint storage policy is convenient for local testing and
+ * development.
+ *
+ * <p>FileSystemCheckpointStorage stores checkpoints in a filesystem. For systems like HDFS, NFS
+ * Drives, S3, and GCS, this storage policy supports large state size, in the magnitude of many
+ * terabytes while providing a highly available foundation for stateful applications. This
+ * checkpoint storage policy is recommended for most production deployments.
+ */
+@PublicEvolving
+public interface CheckpointStorage extends java.io.Serializable {
+
+    /**
+     * Resolves the given pointer to a checkpoint/savepoint into a checkpoint location. The location
+     * supports reading the checkpoint metadata, or disposing the checkpoint storage location.
+     *
+     * <p>If the state backend cannot understand the format of the pointer (for example because it
+     * was created by a different state backend) this method should throw an {@code IOException}.
+     *
+     * @param externalPointer The external checkpoint pointer to resolve.
+     * @return The checkpoint location handle.
+     * @throws IOException Thrown, if the state backend does not understand the pointer, or if the
+     *     pointer could not be resolved due to an I/O error.
+     */
+    CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException;
+
+    /**
+     * Creates a storage for checkpoints for the given job. The checkpoint storage is used to write
+     * checkpoint data and metadata.
+     *
+     * @param jobId The job to store checkpoint data for.
+     * @return A checkpoint storage for the given job.
+     * @throws IOException Thrown if the checkpoint storage cannot be initialized.
+     */
+    CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+
+import java.io.IOException;
+
+/**
+ * A factory to create a specific {@link CheckpointStorage}. The storage creation gets a
+ * configuration object that can be used to read further config values.
+ *
+ * <p>The checkpoint storage factory is typically specified in the configuration to produce a
+ * configured storage backend.
+ *
+ * @param <T> The type of the checkpoint storage created.
+ */
+@PublicEvolving
+public interface CheckpointStorageFactory<T extends CheckpointStorage> {
+
+    /**
+     * Creates the checkpoint storage, optionally using the given configuration.
+     *
+     * @param config The Flink configuration (loaded by the TaskManager).
+     * @param classLoader The clsas loader that should be used to load the checkpoint storage.
+     * @return The created checkpoint storage.
+     * @throws IllegalConfigurationException If the configuration misses critical values, or
+     *     specifies invalid values
+     * @throws IOException If the checkpoint storage initialization failed due to an I/O exception.
+     */
+    T createFromConfig(ReadableConfig config, ClassLoader classLoader)
+            throws IllegalConfigurationException, IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageFactory.java
@@ -22,8 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 
-import java.io.IOException;
-
 /**
  * A factory to create a specific {@link CheckpointStorage}. The storage creation gets a
  * configuration object that can be used to read further config values.
@@ -44,8 +42,7 @@ public interface CheckpointStorageFactory<T extends CheckpointStorage> {
      * @return The created checkpoint storage.
      * @throws IllegalConfigurationException If the configuration misses critical values, or
      *     specifies invalid values
-     * @throws IOException If the checkpoint storage initialization failed due to an I/O exception.
      */
     T createFromConfig(ReadableConfig config, ClassLoader classLoader)
-            throws IllegalConfigurationException, IOException;
+            throws IllegalConfigurationException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.DynamicCodeLoadingException;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** This class contains utility methods to load checkpoint storage from configurations. */
+public class CheckpointStorageLoader {
+
+    public static final String JOB_MANAGER_STORAGE_NAME = "jobmanager";
+
+    public static final String FILE_SYSTEM_STORAGE_NAME = "filesystem";
+
+    /**
+     * Loads the checkpoint storage from the configuration, from the parameter
+     * 'state.checkpoint-storage', as defined in {@link CheckpointingOptions#CHECKPOINT_STORAGE}.
+     *
+     * <p>The state backends can be specified either via their shortcut name, or via the class name
+     * of a {@link CheckpointStorageFactory}. If a CheckpointStorageFactory class name is specified,
+     * the factory is instantiated (via its zero-argument constructor) and its {@link
+     * CheckpointStorageFactory#createFromConfig(ReadableConfig, ClassLoader)} method is called.
+     *
+     * <p>Recognized shortcut names are '{@value #JOB_MANAGER_STORAGE_NAME}', and '{@value
+     * #FILE_SYSTEM_STORAGE_NAME}'.
+     *
+     * @param config The configuration to load the checkpoint storage from
+     * @param classLoader The class loader that should be used to load the checkpoint storage
+     * @param logger Optionally, a logger to log actions to (may be null)
+     * @return The instantiated checkpoint storage.
+     * @throws DynamicCodeLoadingException Thrown if a checkpoint storage factory is configured and
+     *     the factory class was not found or the factory could not be instantiated
+     * @throws IllegalConfigurationException May be thrown by the CheckpointStorageFactory when
+     *     creating / configuring the checkpoint storage in the factory
+     * @throws IOException May be thrown by the CheckpointStorageFactory when instantiating the
+     *     checkpoint storage
+     */
+    public static CheckpointStorage loadCheckpointStorageFromConfig(
+            ReadableConfig config, ClassLoader classLoader, @Nullable Logger logger)
+            throws IllegalStateException, DynamicCodeLoadingException, IOException {
+
+        Preconditions.checkNotNull(config, "config");
+        Preconditions.checkNotNull(classLoader, "classLoader");
+
+        final String storageName = config.get(CheckpointingOptions.CHECKPOINT_STORAGE);
+        if (storageName == null) {
+            return null;
+        }
+
+        switch (storageName.toLowerCase()) {
+            case JOB_MANAGER_STORAGE_NAME:
+                throw new IllegalStateException(
+                        "JobManagerCheckpointStorage is not yet implemented");
+
+            case FILE_SYSTEM_STORAGE_NAME:
+                throw new IllegalStateException(
+                        "FileSystemCheckpointStorage is not yet implemented");
+
+            default:
+                if (logger != null) {
+                    logger.info("Loading state backend via factory {}", storageName);
+                }
+
+                CheckpointStorageFactory<?> factory;
+                try {
+                    @SuppressWarnings("rawtypes")
+                    Class<? extends CheckpointStorageFactory> clazz =
+                            Class.forName(storageName, false, classLoader)
+                                    .asSubclass(CheckpointStorageFactory.class);
+
+                    factory = clazz.newInstance();
+                } catch (ClassNotFoundException e) {
+                    throw new DynamicCodeLoadingException(
+                            "Cannot find configured state backend factory class: " + storageName,
+                            e);
+                } catch (ClassCastException | InstantiationException | IllegalAccessException e) {
+                    throw new DynamicCodeLoadingException(
+                            "The class configured under '"
+                                    + CheckpointingOptions.CHECKPOINT_STORAGE.key()
+                                    + "' is not a valid checkpoint storage factory ("
+                                    + storageName
+                                    + ')',
+                            e);
+                }
+
+                return factory.createFromConfig(config, classLoader);
+        }
+    }
+
+    public static CheckpointStorage fromApplicationOrConfigOrDefault(
+            @Nullable CheckpointStorage fromApplication,
+            StateBackend configuredStateBackend,
+            Configuration config,
+            ClassLoader classLoader,
+            @Nullable Logger logger)
+            throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+        Preconditions.checkNotNull(config, "config");
+        Preconditions.checkNotNull(classLoader, "classLoader");
+        Preconditions.checkNotNull(configuredStateBackend, "statebackend");
+
+        // (1) Legacy state backends always take precedence
+        // for backwards compatibility.
+        if (configuredStateBackend instanceof CheckpointStorage) {
+            if (logger != null) {
+                logger.info(
+                        "Using legacy state backend {} as Job checkpoint storage",
+                        configuredStateBackend);
+            }
+
+            return (CheckpointStorage) configuredStateBackend;
+        }
+
+        CheckpointStorage storage;
+
+        // (2) Application defined checkpoint storage
+        if (fromApplication != null) {
+            // see if this is supposed to pick up additional configuration parameters
+            if (fromApplication instanceof ConfigurableCheckpointStorage) {
+                // needs to pick up configuration
+                if (logger != null) {
+                    logger.info(
+                            "Using job/cluster config to configure application-defined checkpoint storage: {}",
+                            fromApplication);
+                }
+
+                storage =
+                        ((ConfigurableCheckpointStorage) fromApplication)
+                                .configure(config, classLoader);
+            } else {
+                // keep as is!
+                storage = fromApplication;
+            }
+
+            if (logger != null) {
+                logger.info("Using application defined checkpoint storage: {}", storage);
+            }
+        } else {
+            // (3) check if the config defines a checkpoint storage instance
+            final CheckpointStorage fromConfig =
+                    loadCheckpointStorageFromConfig(config, classLoader, logger);
+            if (fromConfig != null) {
+                storage = fromConfig;
+            } else {
+                // (4) use the default
+                throw new IllegalStateException(
+                        "No checkpoint storage defined. Flink currently only supports legacy "
+                                + "state backends, this case should never be reached.");
+            }
+        }
+
+        return storage;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
@@ -27,7 +27,7 @@ import org.apache.flink.configuration.ReadableConfig;
  * configuration.
  */
 @Internal
-public interface ConfigurableCheckpointStorage {
+public interface ConfigurableCheckpointStorage extends CheckpointStorage {
 
     /**
      * Creates a variant of the checkpoint storage that applies additional configuration parameters.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableCheckpointStorage.java
@@ -1,0 +1,31 @@
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+
+/**
+ * An interface for checkpoint storage types that pick up additional parameters from a
+ * configuration.
+ */
+@Internal
+public interface ConfigurableCheckpointStorage {
+
+    /**
+     * Creates a variant of the checkpoint storage that applies additional configuration parameters.
+     *
+     * <p>Settings that were directly done on the original checkpoint storage object in the
+     * application program typically have precedence over setting picked up from the configuration.
+     *
+     * <p>If no configuration is applied, or if the method directly applies configuration values to
+     * the (mutable) checkpoint storage object, this method may return the original checkpoint
+     * storage object. Otherwise it typically returns a modified copy.
+     *
+     * @param config The configuration to pick the values from.
+     * @param classLoader The class loader that should be used to load the checkpoint storage.
+     * @return A reconfigured checkpoint storage.
+     * @throws IllegalConfigurationException Thrown if the configuration contained invalid entries.
+     */
+    CheckpointStorage configure(ReadableConfig config, ClassLoader classLoader)
+            throws IllegalConfigurationException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -90,37 +89,6 @@ import java.util.Collection;
 @PublicEvolving
 public interface StateBackend extends java.io.Serializable {
 
-    // ------------------------------------------------------------------------
-    //  Checkpoint storage - the durable persistence of checkpoint data
-    // ------------------------------------------------------------------------
-
-    /**
-     * Resolves the given pointer to a checkpoint/savepoint into a checkpoint location. The location
-     * supports reading the checkpoint metadata, or disposing the checkpoint storage location.
-     *
-     * <p>If the state backend cannot understand the format of the pointer (for example because it
-     * was created by a different state backend) this method should throw an {@code IOException}.
-     *
-     * @param externalPointer The external checkpoint pointer to resolve.
-     * @return The checkpoint location handle.
-     * @throws IOException Thrown, if the state backend does not understand the pointer, or if the
-     *     pointer could not be resolved due to an I/O error.
-     */
-    CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) throws IOException;
-
-    /**
-     * Creates a storage for checkpoints for the given job. The checkpoint storage is used to write
-     * checkpoint data and metadata.
-     *
-     * @param jobId The job to store checkpoint data for.
-     * @return A checkpoint storage for the given job.
-     * @throws IOException Thrown if the checkpoint storage cannot be initialized.
-     */
-    CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException;
-
-    // ------------------------------------------------------------------------
-    //  Structure Backends
-    // ------------------------------------------------------------------------
     /**
      * Creates a new {@link CheckpointableKeyedStateBackend} that is responsible for holding
      * <b>keyed state</b> and checkpointing it.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 
 import javax.annotation.Nullable;
@@ -67,7 +68,8 @@ import java.net.URI;
  * AbstractFsCheckpointStorageAccess#METADATA_FILE_NAME}'.
  */
 @PublicEvolving
-public abstract class AbstractFileStateBackend extends AbstractStateBackend {
+public abstract class AbstractFileStateBackend extends AbstractStateBackend
+        implements CheckpointStorage {
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2953,7 +2953,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .setCoordinatorsToCheckpoint(
                                 Collections.singleton(coordinatorCheckpointContext))
-                        .setStateBackEnd(
+                        .setCheckpointStorage(
                                 new MemoryStateBackend() {
                                     private static final long serialVersionUID =
                                             8134582566514272546L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.state.ChainedStateHandle;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
@@ -53,7 +54,6 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
-import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -646,7 +646,7 @@ public class CheckpointCoordinatorTestingUtils {
         private CompletedCheckpointStore completedCheckpointStore =
                 new StandaloneCompletedCheckpointStore(1);
 
-        private StateBackend checkpointStateBackend = new MemoryStateBackend();
+        private CheckpointStorage checkpointStorage = new MemoryStateBackend();
 
         private Executor ioExecutor = Executors.directExecutor();
 
@@ -719,12 +719,6 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinatorBuilder setCheckpointStateBackend(
-                StateBackend checkpointStateBackend) {
-            this.checkpointStateBackend = checkpointStateBackend;
-            return this;
-        }
-
         public CheckpointCoordinatorBuilder setIoExecutor(Executor ioExecutor) {
             this.ioExecutor = ioExecutor;
             return this;
@@ -747,8 +741,8 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinatorBuilder setStateBackEnd(StateBackend stateBackEnd) {
-            this.checkpointStateBackend = stateBackEnd;
+        public CheckpointCoordinatorBuilder setCheckpointStorage(CheckpointStorage stateBackEnd) {
+            this.checkpointStorage = stateBackEnd;
             return this;
         }
 
@@ -762,7 +756,7 @@ public class CheckpointCoordinatorTestingUtils {
                     coordinatorsToCheckpoint,
                     checkpointIDCounter,
                     completedCheckpointStore,
-                    checkpointStateBackend,
+                    checkpointStorage,
                     ioExecutor,
                     checkpointsCleaner,
                     timer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -91,6 +92,8 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
                                 false,
                                 0),
                         new SerializedValue<StateBackend>(new CustomStateBackend(outOfClassPath)),
+                        new SerializedValue<CheckpointStorage>(
+                                new CustomCheckpointStorage(outOfClassPath)),
                         serHooks);
 
         final JobGraph jobGraph = new JobGraph(new JobID(), "test job");
@@ -182,6 +185,29 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
                 CloseableRegistry cancelStreamRegistry)
                 throws Exception {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class CustomCheckpointStorage implements CheckpointStorage {
+
+        private static final long serialVersionUID = -6107964383429395816L;
+        /** Simulate a custom option that is not in the normal classpath. */
+        @SuppressWarnings("unused")
+        private Serializable customOption;
+
+        public CustomCheckpointStorage(Serializable customOption) {
+            this.customOption = customOption;
+        }
+
+        @Override
+        public CompletedCheckpointStorageLocation resolveCheckpoint(String pointer)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+            return mock(CheckpointStorageAccess.class);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -150,17 +150,6 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
         }
 
         @Override
-        public CompletedCheckpointStorageLocation resolveCheckpoint(String pointer)
-                throws IOException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
-            return mock(CheckpointStorageAccess.class);
-        }
-
-        @Override
         public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
                 Environment env,
                 JobID jobID,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -84,7 +84,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -569,7 +568,6 @@ public class DispatcherTest extends TestLogger {
 
     /** Tests that we can dispose a savepoint. */
     @Test
-    @Ignore("Ignored until MemoryStateBackend implements CheckpointStorage")
     public void testSavepointDisposal() throws Exception {
         final URI externalPointer = createTestingSavepoint();
         final Path savepointPath = Paths.get(externalPointer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -64,10 +64,10 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobGraphStore;
@@ -84,6 +84,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -568,6 +569,7 @@ public class DispatcherTest extends TestLogger {
 
     /** Tests that we can dispose a savepoint. */
     @Test
+    @Ignore("Ignored until MemoryStateBackend implements CheckpointStorage")
     public void testSavepointDisposal() throws Exception {
         final URI externalPointer = createTestingSavepoint();
         final Path savepointPath = Paths.get(externalPointer);
@@ -591,11 +593,11 @@ public class DispatcherTest extends TestLogger {
 
     @Nonnull
     private URI createTestingSavepoint() throws IOException, URISyntaxException {
-        final StateBackend stateBackend =
-                Checkpoints.loadStateBackend(
+        final CheckpointStorage storage =
+                Checkpoints.loadCheckpointStorage(
                         configuration, Thread.currentThread().getContextClassLoader(), log);
         final CheckpointStorageCoordinatorView checkpointStorage =
-                stateBackend.createCheckpointStorage(jobGraph.getJobID());
+                storage.createCheckpointStorage(jobGraph.getJobID());
         final File savepointFile = temporaryFolder.newFolder();
         final long checkpointId = 1L;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
@@ -28,6 +32,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -38,12 +43,20 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestingCheckpointStorageAccessCoordinatorView;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.ExceptionUtils;
@@ -56,11 +69,13 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Random;
@@ -609,7 +624,8 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 
         final Consumer<JobGraph> savepointConfigurer =
                 (jobGraph) -> {
-                    SchedulerTestingUtils.enableCheckpointing(jobGraph, storage.asStateBackend());
+                    SchedulerTestingUtils.enableCheckpointing(
+                            jobGraph, new ModernStateBackend(), storage.asCheckpointStorage());
                     jobGraph.setSavepointRestoreSettings(
                             SavepointRestoreSettings.forPath(savepointPointer));
                 };
@@ -909,6 +925,36 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
         public CompletableFuture<Acknowledge> sendOperatorEventToTask(
                 ExecutionAttemptID task, OperatorID operator, SerializedValue<OperatorEvent> evt) {
             return FutureUtils.completedExceptionally(new TestException());
+        }
+    }
+
+    private static class ModernStateBackend implements StateBackend {
+
+        @Override
+        public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @Nonnull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                @Nonnull Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
@@ -321,7 +321,8 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
                     false,
                     null,
                     null,
-                    "stateBackendName");
+                    "stateBackendName",
+                    "checkpointStorageName");
 
             jobStatus = super.getState();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -157,6 +157,7 @@ public class ArchivedExecutionGraphBuilder {
                 isStoppable,
                 null,
                 null,
-                "stateBackendName");
+                "stateBackendName",
+                "checkpointStorageName");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfoTest.java
@@ -41,6 +41,7 @@ public class CheckpointConfigInfoTest
                 4,
                 externalizedCheckpointInfo,
                 "stateBackendName",
+                "checkpointStorageName",
                 true,
                 3);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
@@ -48,7 +48,7 @@ public class CheckpointStorageLoadingTest {
     @Test
     public void testNoCheckpointStorageDefined() throws Exception {
         assertNull(
-                CheckpointStorageLoader.loadCheckpointStorageFromConfig(
+                CheckpointStorageLoader.fromConfig(
                         new Configuration(), cl, null));
     }
 
@@ -118,7 +118,7 @@ public class CheckpointStorageLoadingTest {
             CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
                     null, new ModernStateBackend(), config, cl, null);
             Assert.fail("should fail with exception");
-        } catch (IOException e) {
+        } catch (IllegalConfigurationException e) {
             // expected
         }
     }
@@ -212,7 +212,7 @@ public class CheckpointStorageLoadingTest {
 
         @Override
         public MockStorage createFromConfig(ReadableConfig config, ClassLoader classLoader)
-                throws IllegalConfigurationException, IOException {
+                throws IllegalConfigurationException {
             return new MockStorage();
         }
     }
@@ -221,8 +221,8 @@ public class CheckpointStorageLoadingTest {
 
         @Override
         public CheckpointStorage createFromConfig(ReadableConfig config, ClassLoader classLoader)
-                throws IllegalConfigurationException, IOException {
-            throw new IOException("fail!");
+                throws IllegalConfigurationException {
+            throw new IllegalConfigurationException("fail!");
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoadingTest.java
@@ -167,17 +167,6 @@ public class CheckpointStorageLoadingTest {
     static final class ModernStateBackend implements StateBackend {
 
         @Override
-        public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer)
-                throws IOException {
-            return null;
-        }
-
-        @Override
-        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
-            return null;
-        }
-
-        @Override
         public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
                 Environment env,
                 JobID jobID,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoadingTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.DynamicCodeLoadingException;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.junit.Assert.assertNull;
+
+/** This test validates that checkpoint storage is properly loaded from configuration. */
+public class CheckpointStorageLoadingTest {
+
+    private final ClassLoader cl = getClass().getClassLoader();
+
+    @Test
+    public void testNoCheckpointStorageDefined() throws Exception {
+        assertNull(
+                CheckpointStorageLoader.loadCheckpointStorageFromConfig(
+                        new Configuration(), cl, null));
+    }
+
+    @Test
+    public void testLegacyStateBackendTakesPrecedence() throws Exception {
+        StateBackend legacy = new LegacyStateBackend();
+        CheckpointStorage storage = new MockStorage();
+
+        CheckpointStorage configured =
+                CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                        storage, legacy, new Configuration(), cl, null);
+
+        Assert.assertEquals(
+                "Legacy state backends should always take precendence", legacy, configured);
+    }
+
+    @Test
+    public void testModernStateBackendDoesNotTakePrecedence() throws Exception {
+        StateBackend legacy = new ModernStateBackend();
+        CheckpointStorage storage = new MockStorage();
+
+        CheckpointStorage configured =
+                CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                        storage, legacy, new Configuration(), cl, null);
+
+        Assert.assertEquals(
+                "Modern state backends should never take precendence", storage, configured);
+    }
+
+    @Test
+    public void testLoadingFromFactory() throws Exception {
+        final Configuration config = new Configuration();
+
+        config.setString(CheckpointingOptions.CHECKPOINT_STORAGE, WorkingFactory.class.getName());
+        CheckpointStorage storage =
+                CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                        null, new ModernStateBackend(), config, cl, null);
+        Assert.assertThat(storage, Matchers.instanceOf(MockStorage.class));
+    }
+
+    @Test
+    public void testLoadingFails() throws Exception {
+        final Configuration config = new Configuration();
+
+        config.setString(CheckpointingOptions.CHECKPOINT_STORAGE, "does.not.exist");
+        try {
+            CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                    null, new ModernStateBackend(), config, cl, null);
+            Assert.fail("should fail with exception");
+        } catch (DynamicCodeLoadingException e) {
+            // expected
+        }
+
+        // try a class that is not a factory
+        config.setString(CheckpointingOptions.CHECKPOINT_STORAGE, java.io.File.class.getName());
+        try {
+            CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                    null, new ModernStateBackend(), config, cl, null);
+            Assert.fail("should fail with exception");
+        } catch (DynamicCodeLoadingException e) {
+            // expected
+        }
+
+        // try a factory that fails
+        config.setString(CheckpointingOptions.CHECKPOINT_STORAGE, FailingFactory.class.getName());
+        try {
+            CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                    null, new ModernStateBackend(), config, cl, null);
+            Assert.fail("should fail with exception");
+        } catch (IOException e) {
+            // expected
+        }
+    }
+
+    // A state backend that also implements checkpoint storage.
+    static final class LegacyStateBackend implements StateBackend, CheckpointStorage {
+        @Override
+        public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+            return null;
+        }
+
+        @Override
+        public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            return null;
+        }
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            return null;
+        }
+    }
+
+    static final class ModernStateBackend implements StateBackend {
+
+        @Override
+        public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+            return null;
+        }
+
+        @Override
+        public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            return null;
+        }
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry)
+                throws Exception {
+            return null;
+        }
+    }
+
+    static final class MockStorage implements CheckpointStorage {
+
+        @Override
+        public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer)
+                throws IOException {
+            return null;
+        }
+
+        @Override
+        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
+            return null;
+        }
+    }
+
+    static final class WorkingFactory implements CheckpointStorageFactory<MockStorage> {
+
+        @Override
+        public MockStorage createFromConfig(ReadableConfig config, ClassLoader classLoader)
+                throws IllegalConfigurationException, IOException {
+            return new MockStorage();
+        }
+    }
+
+    static final class FailingFactory implements CheckpointStorageFactory<CheckpointStorage> {
+
+        @Override
+        public CheckpointStorage createFromConfig(ReadableConfig config, ClassLoader classLoader)
+                throws IllegalConfigurationException, IOException {
+            throw new IOException("fail!");
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -75,6 +75,18 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
     protected abstract B getStateBackend() throws Exception;
 
+    protected CheckpointStorage getCheckpointStorage() throws Exception {
+        StateBackend stateBackend = getStateBackend();
+        if (stateBackend instanceof CheckpointStorage) {
+            return (CheckpointStorage) stateBackend;
+        }
+
+        throw new IllegalStateException(
+                "The state backend under test does not implement CheckpointStorage."
+                        + "Please override 'createCheckpointStorage' and provide an appropriate"
+                        + "checkpoint storage instance");
+    }
+
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
@@ -1245,7 +1257,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
     private CheckpointStreamFactory createStreamFactory() throws Exception {
         if (checkpointStorageLocation == null) {
             CheckpointStorageAccess checkpointStorageAccess =
-                    getStateBackend().createCheckpointStorage(new JobID());
+                    getCheckpointStorage().createCheckpointStorage(new JobID());
             checkpointStorageAccess.initializeBaseLocations();
             checkpointStorageLocation = checkpointStorageAccess.initializeLocationForCheckpoint(1L);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -165,12 +165,24 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     protected abstract B getStateBackend() throws Exception;
 
+    protected CheckpointStorage getCheckpointStorage() throws Exception {
+        StateBackend stateBackend = getStateBackend();
+        if (stateBackend instanceof CheckpointStorage) {
+            return (CheckpointStorage) stateBackend;
+        }
+
+        throw new IllegalStateException(
+                "The state backend under test does not implement CheckpointStorage."
+                        + "Please override 'createCheckpointStorage' and provide an appropriate"
+                        + "checkpoint storage instance");
+    }
+
     protected abstract boolean isSerializerPresenceRequiredOnRestore();
 
     protected CheckpointStreamFactory createStreamFactory() throws Exception {
         if (checkpointStreamFactory == null) {
             checkpointStreamFactory =
-                    getStateBackend()
+                    getCheckpointStorage()
                             .createCheckpointStorage(new JobID())
                             .resolveCheckpointStorageLocation(
                                     1L, CheckpointStorageLocationReference.getDefault());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingCheckpointStorageAccessCoordinatorView.java
@@ -19,21 +19,13 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStorageLocation;
-import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 
 /** A testing implementation of the {@link CheckpointStorageCoordinatorView}. */
@@ -109,8 +101,8 @@ public class TestingCheckpointStorageAccessCoordinatorView
     //  Utils
     // ------------------------------------------------------------------------
 
-    public StateBackend asStateBackend() {
-        return new FactoringStateBackend(this);
+    public CheckpointStorage asCheckpointStorage() {
+        return new FactoringCheckpointStorage(this);
     }
 
     // ------------------------------------------------------------------------
@@ -151,11 +143,11 @@ public class TestingCheckpointStorageAccessCoordinatorView
     // ------------------------------------------------------------------------
 
     /** A StateBackend whose only purpose is to create a given CheckpointStorage. */
-    private static final class FactoringStateBackend implements StateBackend {
+    private static final class FactoringCheckpointStorage implements CheckpointStorage {
 
         private final TestingCheckpointStorageAccessCoordinatorView testingCoordinatorView;
 
-        private FactoringStateBackend(
+        private FactoringCheckpointStorage(
                 TestingCheckpointStorageAccessCoordinatorView testingCoordinatorView) {
             this.testingCoordinatorView = testingCoordinatorView;
         }
@@ -169,33 +161,6 @@ public class TestingCheckpointStorageAccessCoordinatorView
         @Override
         public CheckpointStorageAccess createCheckpointStorage(JobID jobId) throws IOException {
             return testingCoordinatorView;
-        }
-
-        @Override
-        public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
-                Environment env,
-                JobID jobID,
-                String operatorIdentifier,
-                TypeSerializer<K> keySerializer,
-                int numberOfKeyGroups,
-                KeyGroupRange keyGroupRange,
-                TaskKvStateRegistry kvStateRegistry,
-                TtlTimeProvider ttlTimeProvider,
-                MetricGroup metricGroup,
-                @Nonnull Collection<KeyedStateHandle> stateHandles,
-                CloseableRegistry cancelStreamRegistry)
-                throws Exception {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public OperatorStateBackend createOperatorStateBackend(
-                Environment env,
-                String operatorIdentifier,
-                @Nonnull Collection<OperatorStateHandle> stateHandles,
-                CloseableRegistry cancelStreamRegistry)
-                throws Exception {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -71,9 +72,20 @@ public abstract class StateBackendTestContext {
 
     protected abstract StateBackend createStateBackend();
 
+    protected CheckpointStorage createCheckpointStorage() {
+        if (stateBackend instanceof CheckpointStorage) {
+            return (CheckpointStorage) stateBackend;
+        }
+
+        throw new IllegalStateException(
+                "The state backend under test does not implement CheckpointStorage."
+                        + "Please override 'createCheckpointStorage' and provide an appropriate"
+                        + "checkpoint storage instance");
+    }
+
     private CheckpointStreamFactory createCheckpointStreamFactory() {
         try {
-            return stateBackend
+            return createCheckpointStorage()
                     .createCheckpointStorage(new JobID())
                     .resolveCheckpointStorageLocation(2L, checkpointOptions.getTargetLocation());
         } catch (IOException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockCheckpointStorage.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockCheckpointStorage.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.ttl.mock;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
+import org.apache.flink.runtime.state.CheckpointStorageLocation;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+
+import javax.annotation.Nullable;
+
+public class MockCheckpointStorage implements CheckpointStorage {
+    @Override
+    public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+        return new CheckpointStorageAccess() {
+            @Override
+            public boolean supportsHighlyAvailableStorage() {
+                return false;
+            }
+
+            @Override
+            public boolean hasDefaultSavepointLocation() {
+                return false;
+            }
+
+            @Override
+            public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+                return null;
+            }
+
+            @Override
+            public void initializeBaseLocations() {}
+
+            @Override
+            public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
+                return new CheckpointStorageLocation() {
+
+                    @Override
+                    public CheckpointStateOutputStream createCheckpointStateOutputStream(
+                            CheckpointedStateScope scope) {
+                        return null;
+                    }
+
+                    @Override
+                    public CheckpointMetadataOutputStream createMetadataOutputStream() {
+                        return null;
+                    }
+
+                    @Override
+                    public void disposeOnFailure() {}
+
+                    @Override
+                    public CheckpointStorageLocationReference getLocationReference() {
+                        return null;
+                    }
+                };
+            }
+
+            @Override
+            public CheckpointStorageLocation initializeLocationForSavepoint(
+                    long checkpointId, @Nullable String externalLocationPointer) {
+                return null;
+            }
+
+            @Override
+            public CheckpointStreamFactory resolveCheckpointStorageLocation(
+                    long checkpointId, CheckpointStorageLocationReference reference) {
+                return null;
+            }
+
+            @Override
+            public CheckpointStreamFactory.CheckpointStateOutputStream
+                    createTaskOwnedStateStream() {
+                return null;
+            }
+        };
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -28,13 +28,6 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorageAccess;
-import org.apache.flink.runtime.state.CheckpointStorageLocation;
-import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.CheckpointedStateScope;
-import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -42,84 +35,12 @@ import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.Collection;
 
 /** mack state backend. */
 public class MockStateBackend extends AbstractStateBackend {
     private static final long serialVersionUID = 995676510267499393L;
-
-    @Override
-    public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
-        return new CheckpointStorageAccess() {
-            @Override
-            public boolean supportsHighlyAvailableStorage() {
-                return false;
-            }
-
-            @Override
-            public boolean hasDefaultSavepointLocation() {
-                return false;
-            }
-
-            @Override
-            public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
-                return null;
-            }
-
-            @Override
-            public void initializeBaseLocations() {}
-
-            @Override
-            public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId) {
-                return new CheckpointStorageLocation() {
-
-                    @Override
-                    public CheckpointStateOutputStream createCheckpointStateOutputStream(
-                            CheckpointedStateScope scope) {
-                        return null;
-                    }
-
-                    @Override
-                    public CheckpointMetadataOutputStream createMetadataOutputStream() {
-                        return null;
-                    }
-
-                    @Override
-                    public void disposeOnFailure() {}
-
-                    @Override
-                    public CheckpointStorageLocationReference getLocationReference() {
-                        return null;
-                    }
-                };
-            }
-
-            @Override
-            public CheckpointStorageLocation initializeLocationForSavepoint(
-                    long checkpointId, @Nullable String externalLocationPointer) {
-                return null;
-            }
-
-            @Override
-            public CheckpointStreamFactory resolveCheckpointStorageLocation(
-                    long checkpointId, CheckpointStorageLocationReference reference) {
-                return null;
-            }
-
-            @Override
-            public CheckpointStreamFactory.CheckpointStateOutputStream
-                    createTaskOwnedStateStream() {
-                return null;
-            }
-        };
-    }
 
     @Override
     public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.util.CorruptConfigurationException;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.util.ClassLoaderUtil;
 import org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils;
@@ -94,6 +95,7 @@ public class StreamConfig implements Serializable {
     private static final String CHECKPOINTING_ENABLED = "checkpointing";
     private static final String CHECKPOINT_MODE = "checkpointMode";
 
+    private static final String CHECKPOINT_STORAGE = "checkpointstorage";
     private static final String STATE_BACKEND = "statebackend";
     private static final String TIMER_SERVICE_PROVIDER = "timerservice";
     private static final String STATE_PARTITIONER = "statePartitioner";
@@ -560,6 +562,24 @@ public class StreamConfig implements Serializable {
             return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
         } catch (Exception e) {
             throw new StreamTaskException("Could not instantiate statehandle provider.", e);
+        }
+    }
+
+    public void setCheckpointStorage(CheckpointStorage storage) {
+        if (storage != null) {
+            try {
+                InstantiationUtil.writeObjectToConfig(storage, config, CHECKPOINT_STORAGE);
+            } catch (Exception e) {
+                throw new StreamTaskException("Could not serialize checkpoint storage.", e);
+            }
+        }
+    }
+
+    public CheckpointStorage getCheckpointStorage(ClassLoader cl) {
+        try {
+            return InstantiationUtil.readObjectFromConfig(this.config, CHECKPOINT_STORAGE, cl);
+        } catch (Exception e) {
+            throw new StreamTaskException("Could not instantiate checkpoint storage.", e);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -113,6 +114,7 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
+    private CheckpointStorage checkpointStorage;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
     private InternalTimeServiceManager.Provider timerServiceProvider;
 
@@ -174,6 +176,14 @@ public class StreamGraph implements Pipeline {
 
     public StateBackend getStateBackend() {
         return this.stateBackend;
+    }
+
+    public void setCheckpointStorage(CheckpointStorage checkpointStorage) {
+        this.checkpointStorage = checkpointStorage;
+    }
+
+    public CheckpointStorage getCheckpointStorage() {
+        return this.checkpointStorage;
     }
 
     public InternalTimeServiceManager.Provider getTimerServiceProvider() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionCheckpointStorage;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionInternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
 import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
@@ -328,6 +329,7 @@ public class StreamGraphGenerator {
         if (useStateBackend) {
             LOG.debug("Using BATCH execution state backend and timer service.");
             graph.setStateBackend(new BatchExecutionStateBackend());
+            graph.setCheckpointStorage(new BatchExecutionCheckpointStorage());
             graph.setTimerServiceProvider(BatchExecutionInternalTimeServiceManager::create);
         } else {
             graph.setStateBackend(stateBackend);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -30,6 +30,7 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -137,6 +138,8 @@ public class StreamGraphGenerator {
     private final ReadableConfig configuration;
 
     private StateBackend stateBackend;
+
+    private CheckpointStorage checkpointStorage;
 
     private boolean chaining = true;
 
@@ -301,6 +304,7 @@ public class StreamGraphGenerator {
             setBatchStateBackendAndTimerService(graph);
         } else {
             graph.setStateBackend(stateBackend);
+            graph.setCheckpointStorage(checkpointStorage);
             graph.setScheduleMode(ScheduleMode.EAGER);
 
             if (checkpointConfig.isApproximateLocalRecoveryEnabled()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -695,6 +695,7 @@ public class StreamingJobGraphGenerator {
         final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 
         config.setStateBackend(streamGraph.getStateBackend());
+        config.setCheckpointStorage(streamGraph.getCheckpointStorage());
         config.setGraphContainingLoops(streamGraph.isIterative());
         config.setTimerServiceProvider(streamGraph.getTimerServiceProvider());
         config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
@@ -1293,9 +1294,8 @@ public class StreamingJobGraphGenerator {
             try {
                 serializedCheckpointStorage =
                         new SerializedValue<>(streamGraph.getCheckpointStorage());
-            }
-            catch (IOException e) {
-                throw new FlinkRuntimeException("State backend is not serializable", e);
+            } catch (IOException e) {
+                throw new FlinkRuntimeException("Checkpoint storage is not serializable", e);
             }
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroupImpl;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.util.TaskConfig;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -1283,6 +1284,21 @@ public class StreamingJobGraphGenerator {
             }
         }
 
+        // because the checkpoint storage can have user-defined code, it needs to be stored as
+        // eagerly serialized value
+        final SerializedValue<CheckpointStorage> serializedCheckpointStorage;
+        if (streamGraph.getCheckpointStorage() == null) {
+            serializedCheckpointStorage = null;
+        } else {
+            try {
+                serializedCheckpointStorage =
+                        new SerializedValue<>(streamGraph.getCheckpointStorage());
+            }
+            catch (IOException e) {
+                throw new FlinkRuntimeException("State backend is not serializable", e);
+            }
+        }
+
         //  --- done, put it all together ---
 
         JobCheckpointingSettings settings =
@@ -1305,6 +1321,7 @@ public class StreamingJobGraphGenerator {
                                 .setAlignmentTimeout(cfg.getAlignmentTimeout())
                                 .build(),
                         serializedStateBackend,
+                        serializedCheckpointStorage,
                         serializedHooks);
 
         jobGraph.setSnapshotSettings(settings);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionCheckpointStorage.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionCheckpointStorage.java
@@ -16,28 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.ttl;
+package org.apache.flink.streaming.api.operators.sorted.state;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.state.CheckpointStorage;
-import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.ttl.mock.MockCheckpointStorage;
-import org.apache.flink.runtime.state.ttl.mock.MockStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
+import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 
-/** Test suite for mock state TTL. */
-public class MockTtlStateTest extends TtlStateTestBase {
+/** A simple {@link CheckpointStorage} which is used in a BATCH style execution. */
+public class BatchExecutionCheckpointStorage implements CheckpointStorage {
 
     @Override
-    protected StateBackendTestContext createStateBackendTestContext(TtlTimeProvider timeProvider) {
-        return new StateBackendTestContext(timeProvider) {
-            @Override
-            protected StateBackend createStateBackend() {
-                return new MockStateBackend();
-            }
+    public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+        throw new UnsupportedOperationException(
+                "Checkpoints are not supported in a batch execution");
+    }
 
-            @Override
-            protected CheckpointStorage createCheckpointStorage() {
-                return new MockCheckpointStorage();
-            }
-        };
+    @Override
+    public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+        return new NonCheckpointingStorageAccess();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
@@ -24,9 +24,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
-import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -41,16 +39,6 @@ import java.util.Collection;
 
 /** A simple {@link StateBackend} which is used in a BATCH style execution. */
 public class BatchExecutionStateBackend implements StateBackend {
-    @Override
-    public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
-        throw new UnsupportedOperationException(
-                "Checkpoints are not supported in a single key state backend");
-    }
-
-    @Override
-    public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
-        return new NonCheckpointingStorageAccess();
-    }
 
     @Override
     public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1151,7 +1151,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         final CheckpointStorage fromApplication =
                 configuration.getCheckpointStorage(getUserCodeClassLoader());
 
-        return CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+        return CheckpointStorageLoader.load(
                 fromApplication,
                 backend,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -52,6 +52,8 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.security.FlinkSecurityManager;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
@@ -183,8 +185,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     /** The configuration of this streaming task. */
     protected final StreamConfig configuration;
 
-    /** Our state backend. We use this to create checkpoint streams and a keyed state backend. */
+    /** Our state backend. We use this to create a keyed state backend. */
     protected final StateBackend stateBackend;
+
+    /** Our checkpoint storage. We use this to create checkpoint streams. */
+    protected final CheckpointStorage checkpointStorage;
 
     private final SubtaskCheckpointCoordinator subtaskCheckpointCoordinator;
 
@@ -315,10 +320,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                         new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));
 
         this.stateBackend = createStateBackend();
+        this.checkpointStorage = createCheckpointStorage(stateBackend);
 
         this.subtaskCheckpointCoordinator =
                 new SubtaskCheckpointCoordinatorImpl(
-                        stateBackend.createCheckpointStorage(getEnvironment().getJobID()),
+                        checkpointStorage.createCheckpointStorage(getEnvironment().getJobID()),
                         getName(),
                         actionExecutor,
                         getCancelables(),
@@ -1136,6 +1142,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         return StateBackendLoader.fromApplicationOrConfigOrDefault(
                 fromApplication,
+                getEnvironment().getTaskManagerInfo().getConfiguration(),
+                getUserCodeClassLoader(),
+                LOG);
+    }
+
+
+    private CheckpointStorage createCheckpointStorage(StateBackend backend) throws Exception {
+        final CheckpointStorage fromApplication = configuration.getCheckpointStorage(getUserCodeClassLoader());
+
+        return CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
+                fromApplication,
+                backend,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),
                 getUserCodeClassLoader(),
                 LOG);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1147,9 +1147,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                 LOG);
     }
 
-
     private CheckpointStorage createCheckpointStorage(StateBackend backend) throws Exception {
-        final CheckpointStorage fromApplication = configuration.getCheckpointStorage(getUserCodeClassLoader());
+        final CheckpointStorage fromApplication =
+                configuration.getCheckpointStorage(getUserCodeClassLoader());
 
         return CheckpointStorageLoader.fromApplicationOrConfigOrDefault(
                 fromApplication,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -34,9 +34,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
-import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -62,7 +60,6 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
@@ -140,17 +137,6 @@ public class StreamTaskStateInitializerImplTest {
         StateBackend mockingBackend =
                 spy(
                         new StateBackend() {
-                            @Override
-                            public CompletedCheckpointStorageLocation resolveCheckpoint(
-                                    String pointer) throws IOException {
-                                throw new UnsupportedOperationException();
-                            }
-
-                            @Override
-                            public CheckpointStorageAccess createCheckpointStorage(JobID jobId)
-                                    throws IOException {
-                                throw new UnsupportedOperationException();
-                            }
 
                             @Override
                             public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -260,7 +261,7 @@ public class StreamTaskTerminationTest extends TestLogger {
         private static final long serialVersionUID = 4517845269225218312L;
     }
 
-    static class BlockingStateBackend implements StateBackend {
+    static class BlockingStateBackend implements StateBackend, CheckpointStorage {
 
         private static final long serialVersionUID = -5053068148933314100L;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1701,7 +1701,7 @@ public class StreamTaskTest extends TestLogger {
             return new TestSpyWrapperStateBackend(createInnerBackend(config));
         }
 
-        protected AbstractStateBackend createInnerBackend(ReadableConfig config) {
+        protected MemoryStateBackend createInnerBackend(ReadableConfig config) {
             return new MemoryStateBackend();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSpyWrapperStateBackend.java
@@ -26,12 +26,14 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.Preconditions;
 
@@ -45,11 +47,11 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 /**
  * This class wraps an {@link AbstractStateBackend} and enriches all the created objects as spies.
  */
-public class TestSpyWrapperStateBackend extends AbstractStateBackend {
+public class TestSpyWrapperStateBackend extends AbstractStateBackend implements CheckpointStorage {
 
-    private final AbstractStateBackend delegate;
+    private final MemoryStateBackend delegate;
 
-    public TestSpyWrapperStateBackend(AbstractStateBackend delegate) {
+    public TestSpyWrapperStateBackend(MemoryStateBackend delegate) {
         this.delegate = Preconditions.checkNotNull(delegate);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
@@ -128,7 +129,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
     protected StateBackend stateBackend = new MemoryStateBackend();
 
     private CheckpointStorageAccess checkpointStorageAccess =
-            stateBackend.createCheckpointStorage(new JobID());
+            new MemoryStateBackend().createCheckpointStorage(new JobID());
 
     private final Object checkpointLock;
 
@@ -306,8 +307,18 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
     public void setStateBackend(StateBackend stateBackend) {
         this.stateBackend = stateBackend;
 
+        if (stateBackend instanceof CheckpointStorage) {
+            setCheckpointStorage((CheckpointStorage) stateBackend);
+        }
+    }
+
+    public void setCheckpointStorage(CheckpointStorage storage) {
+        if (stateBackend instanceof CheckpointStorage) {
+            return;
+        }
+
         try {
-            this.checkpointStorageAccess = stateBackend.createCheckpointStorage(new JobID());
+            this.checkpointStorageAccess = storage.createCheckpointStorage(new JobID());
         } catch (IOException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
-import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.MockStreamStatusMaintainer;
@@ -61,7 +60,7 @@ public class MockStreamTaskBuilder {
         this.environment = environment;
         this.config = new StreamConfig(environment.getTaskConfiguration());
 
-        StateBackend stateBackend = new MemoryStateBackend();
+        MemoryStateBackend stateBackend = new MemoryStateBackend();
         this.checkpointStorage = stateBackend.createCheckpointStorage(new JobID());
         this.streamTaskStateInitializer =
                 new StreamTaskStateInitializerImpl(environment, stateBackend);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -69,6 +69,7 @@ public class ExecutorUtils {
         streamGraph.setAllVerticesInSameSlotSharingGroupByDefault(false);
         streamGraph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
         streamGraph.setStateBackend(null);
+        streamGraph.setCheckpointStorage(null);
         if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
             throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -96,7 +97,7 @@ public class StateBackendITCase extends AbstractTestBase {
         }
     }
 
-    private static class FailingStateBackend implements StateBackend {
+    private static class FailingStateBackend implements StateBackend, CheckpointStorage {
         private static final long serialVersionUID = 1L;
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

This adds the new `CheckpointStorage` interface as described in FLIP-142 and wires it through the runtime. Public API changes will be added in a follow-up PR. 

## Brief changelog

675d93c  Adds the new `CheckpointStorage` interface, factory, and loader.

6a41e53    Wires the `CheckpointStorage` object through the StreamGraph, ExecutionGraph, StreamTask, and CheckpointCoordinator

550bb03   Removes the checkpoint-storage related methods from `StateBackend` and adds `CheckpointStorage` as an interface to the existing state backend implementations. This commit then makes misc fixes to tests so everything passes. 

## Verifying this change

UT tests and also existing E2E tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
