### PR TITLE
[BP-1.11][FLINK-19777][table-runtime-blink] Fix NullPointException for WindowOperator.close()

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -305,7 +305,9 @@ public abstract class WindowOperator<K, W extends Window>
 		collector = null;
 		triggerContext = null;
 		functionsClosed = true;
-		windowAggregator.close();
+		if (windowAggregator != null) {
+			windowAggregator.close();
+		}
 	}
 
 	@Override
@@ -315,7 +317,9 @@ public abstract class WindowOperator<K, W extends Window>
 		triggerContext = null;
 		if (!functionsClosed) {
 			functionsClosed = true;
-			windowAggregator.close();
+			if (windowAggregator != null) {
+				windowAggregator.close();
+			}
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.JoinedRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.RowDataUtil;
 import org.apache.flink.table.runtime.dataview.StateDataViewStore;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceTableAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunctionBase;
 import org.apache.flink.table.runtime.generated.NamespaceTableAggsHandleFunction;
@@ -1123,6 +1124,26 @@ public class WindowOperatorTest {
 
 		// we close once in the rest...
 		assertEquals("Close was not called.", 2, closeCalled.get());
+	}
+
+	@Test
+	public void testWindowCloseWithoutOpen() throws Exception {
+		final int windowSize = 3;
+		LogicalType[] windowTypes = new LogicalType[] { new BigIntType() };
+
+		WindowOperator operator = WindowOperatorBuilder
+			.builder()
+			.withInputFields(inputFieldTypes)
+			.countWindow(windowSize)
+			.aggregate(
+				new GeneratedNamespaceTableAggsHandleFunction<>("MockClass", "MockCode", new Object[]{}),
+				accTypes,
+				aggResultTypes,
+				windowTypes)
+			.build();
+
+		// close() before open() called
+		operator.close();
 	}
 
 	// --------------------------------------------------------------------------------


### PR DESCRIPTION
This is a cherry pick for release-1.11 branch.