### PR TITLE
[FLINK-19233][python] Support distinct and filter keywords on Python UDAF

### DIFF
--- a/flink-python/pyflink/fn_execution/aggregate.py
+++ b/flink-python/pyflink/fn_execution/aggregate.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Dict, Tuple
 
 from apache_beam.coders import PickleCoder, Coder
 
@@ -287,7 +287,10 @@ class SimpleAggsHandleFunction(AggsHandleFunction):
                  udfs: List[AggregateFunction],
                  input_extractors: List,
                  index_of_count_star: int,
-                 udf_data_view_specs: List[List[DataViewSpec]]):
+                 udf_data_view_specs: List[List[DataViewSpec]],
+                 filter_args: List[int],
+                 distinct_mapping: List[int],
+                 distinct_view_reuse_descriptors: Dict[int, Tuple['function', List[int]]]):
         self._udfs = udfs
         self._input_extractors = input_extractors
         self._accumulators = None  # type: Row
@@ -297,6 +300,10 @@ class SimpleAggsHandleFunction(AggsHandleFunction):
             self._get_value_indexes.remove(index_of_count_star)
         self._udf_data_view_specs = udf_data_view_specs
         self._udf_data_views = []
+        self._filter_args = filter_args
+        self._distinct_mapping = distinct_mapping
+        self._distinct_view_reuse_descriptors = distinct_view_reuse_descriptors
+        self._distinct_data_view = {}
 
     def open(self, state_data_view_store):
         for udf in self._udfs:
@@ -317,17 +324,68 @@ class SimpleAggsHandleFunction(AggsHandleFunction):
                             PickleCoder(),
                             PickleCoder())
             self._udf_data_views.append(data_views)
+        for key in self._distinct_view_reuse_descriptors.keys():
+            self._distinct_data_view[key] = state_data_view_store.get_state_map_view(
+                "agg%ddistinct" % key,
+                PickleCoder(),
+                PickleCoder())
 
     def accumulate(self, input_data: Row):
         for i in range(len(self._udfs)):
+            if i in self._distinct_data_view:
+                if len(self._distinct_view_reuse_descriptors[i][1]) == 0:
+                    filtered = False
+                else:
+                    filtered = True
+                    for filter_arg in self._distinct_view_reuse_descriptors[i][1]:
+                        if input_data[filter_arg]:
+                            filtered = False
+                            break
+                if not filtered:
+                    input_extractor = self._distinct_view_reuse_descriptors[i][0]
+                    args = input_extractor(input_data)
+                    if args in self._distinct_data_view[i]:
+                        self._distinct_data_view[i][args] += 1
+                    else:
+                        self._distinct_data_view[i][args] = 1
+            if self._filter_args[i] >= 0 and not input_data[self._filter_args[i]]:
+                continue
             input_extractor = self._input_extractors[i]
             args = input_extractor(input_data)
+            if self._distinct_mapping[i] >= 0:
+                if args in self._distinct_data_view[self._distinct_mapping[i]]:
+                    if self._distinct_data_view[self._distinct_mapping[i]][args] > 1:
+                        continue
+                else:
+                    raise Exception(
+                        "The args are not in the distinct data view, this should not happen.")
             self._udfs[i].accumulate(self._accumulators[i], *args)
 
     def retract(self, input_data: Row):
         for i in range(len(self._udfs)):
+            if i in self._distinct_data_view:
+                if len(self._distinct_view_reuse_descriptors[i][1]) == 0:
+                    filtered = False
+                else:
+                    filtered = True
+                    for filter_arg in self._distinct_view_reuse_descriptors[i][1]:
+                        if input_data[filter_arg]:
+                            filtered = False
+                            break
+                if not filtered:
+                    input_extractor = self._distinct_view_reuse_descriptors[i][0]
+                    args = input_extractor(input_data)
+                    if args in self._distinct_data_view[i]:
+                        self._distinct_data_view[i][args] -= 1
+                        if self._distinct_data_view[i][args] == 0:
+                            del self._distinct_data_view[i][args]
+            if self._filter_args[i] >= 0 and not input_data[self._filter_args[i]]:
+                continue
             input_extractor = self._input_extractors[i]
             args = input_extractor(input_data)
+            if self._distinct_mapping[i] >= 0 and \
+                    args in self._distinct_data_view[self._distinct_mapping[i]]:
+                continue
             self._udfs[i].retract(self._accumulators[i], *args)
 
     def merge(self, accumulators: Row):

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc4\x05\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"N\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\"\xc9\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\x9b\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x88\x06\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\xc5\x02\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x82\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc4\x05\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"N\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\x9b\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x88\x06\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\xc5\x02\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x82\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -214,8 +214,8 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4432,
-  serialized_end=4721,
+  serialized_start=4470,
+  serialized_end=4759,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -304,8 +304,8 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5242,
-  serialized_end=5500,
+  serialized_start=5280,
+  serialized_end=5538,
 )
 _sym_db.RegisterEnumDescriptor(_TYPEINFO_TYPENAME)
 
@@ -682,8 +682,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_LISTVIEW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2025,
-  serialized_end=2109,
+  serialized_start=2063,
+  serialized_end=2147,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_MAPVIEW = _descriptor.Descriptor(
@@ -719,8 +719,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_MAPVIEW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2112,
-  serialized_end=2263,
+  serialized_start=2150,
+  serialized_end=2301,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC = _descriptor.Descriptor(
@@ -773,8 +773,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC = _descriptor.Descriptor(
       name='data_view', full_name='org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.data_view',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1762,
-  serialized_end=2276,
+  serialized_start=1800,
+  serialized_end=2314,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION = _descriptor.Descriptor(
@@ -805,6 +805,20 @@ _USERDEFINEDAGGREGATEFUNCTION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='filter_arg', full_name='org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.filter_arg', index=3,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='distinct', full_name='org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.distinct', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -818,7 +832,7 @@ _USERDEFINEDAGGREGATEFUNCTION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1563,
-  serialized_end=2276,
+  serialized_end=2314,
 )
 
 
@@ -911,8 +925,8 @@ _USERDEFINEDAGGREGATEFUNCTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2279,
-  serialized_end=2690,
+  serialized_start=2317,
+  serialized_end=2728,
 )
 
 
@@ -949,8 +963,8 @@ _SCHEMA_MAPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2768,
-  serialized_end=2919,
+  serialized_start=2806,
+  serialized_end=2957,
 )
 
 _SCHEMA_TIMEINFO = _descriptor.Descriptor(
@@ -979,8 +993,8 @@ _SCHEMA_TIMEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2921,
-  serialized_end=2950,
+  serialized_start=2959,
+  serialized_end=2988,
 )
 
 _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
@@ -1009,8 +1023,8 @@ _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2952,
-  serialized_end=2986,
+  serialized_start=2990,
+  serialized_end=3024,
 )
 
 _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1039,8 +1053,8 @@ _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2988,
-  serialized_end=3032,
+  serialized_start=3026,
+  serialized_end=3070,
 )
 
 _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1069,8 +1083,8 @@ _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3034,
-  serialized_end=3073,
+  serialized_start=3072,
+  serialized_end=3111,
 )
 
 _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
@@ -1106,8 +1120,8 @@ _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3075,
-  serialized_end=3122,
+  serialized_start=3113,
+  serialized_end=3160,
 )
 
 _SCHEMA_BINARYINFO = _descriptor.Descriptor(
@@ -1136,8 +1150,8 @@ _SCHEMA_BINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3124,
-  serialized_end=3152,
+  serialized_start=3162,
+  serialized_end=3190,
 )
 
 _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
@@ -1166,8 +1180,8 @@ _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3154,
-  serialized_end=3185,
+  serialized_start=3192,
+  serialized_end=3223,
 )
 
 _SCHEMA_CHARINFO = _descriptor.Descriptor(
@@ -1196,8 +1210,8 @@ _SCHEMA_CHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3187,
-  serialized_end=3213,
+  serialized_start=3225,
+  serialized_end=3251,
 )
 
 _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
@@ -1226,8 +1240,8 @@ _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3215,
-  serialized_end=3244,
+  serialized_start=3253,
+  serialized_end=3282,
 )
 
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
@@ -1350,8 +1364,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3247,
-  serialized_end=4319,
+  serialized_start=3285,
+  serialized_end=4357,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -1394,8 +1408,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4321,
-  serialized_end=4429,
+  serialized_start=4359,
+  serialized_end=4467,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -1425,8 +1439,8 @@ _SCHEMA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2693,
-  serialized_end=4721,
+  serialized_start=2731,
+  serialized_end=4759,
 )
 
 
@@ -1480,8 +1494,8 @@ _TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=4802,
-  serialized_end=5127,
+  serialized_start=4840,
+  serialized_end=5165,
 )
 
 _TYPEINFO_FIELD = _descriptor.Descriptor(
@@ -1524,8 +1538,8 @@ _TYPEINFO_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5129,
-  serialized_end=5239,
+  serialized_start=5167,
+  serialized_end=5277,
 )
 
 _TYPEINFO = _descriptor.Descriptor(
@@ -1555,8 +1569,8 @@ _TYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4724,
-  serialized_end=5500,
+  serialized_start=4762,
+  serialized_end=5538,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -557,21 +557,21 @@ class InternalSynchronousMapRuntimeState(object):
 
     def get(self, map_key):
         if self._is_empty:
-            raise KeyError("Map key %s not found!" % map_key)
+            raise KeyError("Map key %s not found!" % str(map_key))
         if map_key in self._write_cache:
             exists, value = self._write_cache[map_key]
             if exists:
                 return value
             else:
-                raise KeyError("Map key %s not found!" % map_key)
+                raise KeyError("Map key %s not found!" % str(map_key))
         if self._cleared:
-            raise KeyError("Map key %s not found!" % map_key)
+            raise KeyError("Map key %s not found!" % str(map_key))
         exists, value = self._map_state_handler.blocking_get(
             self._state_key, map_key, self._map_key_coder_impl, self._map_value_coder_impl)
         if exists:
             return value
         else:
-            raise KeyError("Map key %s not found!" % map_key)
+            raise KeyError("Map key %s not found!" % str(map_key))
 
     def put(self, map_key, map_value):
         self._write_cache[map_key] = (True, map_value)

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -131,6 +131,10 @@ message UserDefinedAggregateFunction {
   repeated Input inputs = 2;
 
   repeated DataViewSpec specs = 3;
+
+  int32 filter_arg = 4;
+
+  bool distinct = 5;
 }
 
 // A list of the user-defined aggregate functions to be executed in a group aggregate operation.

--- a/flink-python/pyflink/table/tests/test_aggregate.py
+++ b/flink-python/pyflink/table/tests/test_aggregate.py
@@ -83,6 +83,32 @@ class SumAggregateFunction(AggregateFunction):
 class ConcatAggregateFunction(AggregateFunction):
 
     def get_value(self, accumulator):
+        str_list = [i for i in accumulator[0]]
+        str_list.sort()
+        return accumulator[1].join(str_list)
+
+    def create_accumulator(self):
+        return Row([], '')
+
+    def accumulate(self, accumulator, *args):
+        accumulator[1] = args[1]
+        accumulator[0].append(args[0])
+
+    def retract(self, accumulator, *args):
+        accumulator[0].remove(args[0])
+
+    def get_accumulator_type(self):
+        return DataTypes.ROW([
+            DataTypes.FIELD("f0", DataTypes.ARRAY(DataTypes.STRING())),
+            DataTypes.FIELD("f1", DataTypes.BIGINT())])
+
+    def get_result_type(self):
+        return DataTypes.STRING()
+
+
+class ListViewConcatAggregateFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
         return accumulator[1].join(accumulator[0])
 
     def create_accumulator(self):
@@ -96,7 +122,9 @@ class ConcatAggregateFunction(AggregateFunction):
         raise NotImplementedError
 
     def get_accumulator_type(self):
-        return DataTypes.ROW([DataTypes.FIELD("f0", DataTypes.LIST_VIEW(DataTypes.STRING()))])
+        return DataTypes.ROW([
+            DataTypes.FIELD("f0", DataTypes.LIST_VIEW(DataTypes.STRING())),
+            DataTypes.FIELD("f1", DataTypes.BIGINT())])
 
     def get_result_type(self):
         return DataTypes.STRING()
@@ -241,7 +269,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         self.assertEqual(result_type, DataTypes.INT())
 
     def test_list_view(self):
-        my_concat = udaf(ConcatAggregateFunction())
+        my_concat = udaf(ListViewConcatAggregateFunction())
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "2")
         # trigger the cache eviction in a bundle.
@@ -357,6 +385,48 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
                 ["hello,hello2", "1,3", 'hello:3,hello2:1', 2, "hello"],
                 ["Hi,Hi2,Hi3", "1,2,3", "Hi:3,Hi2:2,Hi3:1", 3, "hi"]],
                 columns=['a', 'b', 'c', 'd', 'e']))
+
+    def test_distinct_and_filter(self):
+        self.t_env.create_temporary_system_function(
+            "concat",
+            ConcatAggregateFunction())
+        self.t_env.get_config().get_configuration().set_string(
+            "python.fn-execution.bundle.size", "2")
+        # trigger the cache eviction in a bundle.
+        self.t_env.get_config().get_configuration().set_string(
+            "python.state.cache-size", "2")
+        self.t_env.get_config().get_configuration().set_string(
+            "python.map-state.read-cache-size", "2")
+        self.t_env.get_config().get_configuration().set_string(
+            "python.map-state.write-cache-size", "2")
+        t = self.t_env.from_elements(
+            [(1, 'Hi_', 'hi'),
+             (1, 'Hi', 'hi'),
+             (2, 'hello', 'hello'),
+             (3, 'Hi_', 'hi'),
+             (3, 'Hi', 'hi'),
+             (4, 'hello', 'hello'),
+             (5, 'Hi2_', 'hi'),
+             (5, 'Hi2', 'hi'),
+             (6, 'hello2', 'hello'),
+             (7, 'Hi', 'hi'),
+             (8, 'hello', 'hello'),
+             (9, 'Hi2', 'hi'),
+             (13, 'Hi3', 'hi')], ['a', 'b', 'c'])
+        self.t_env.create_temporary_view("source", t)
+        table_with_retract_message = self.t_env.sql_query(
+            "select LAST_VALUE(b) as b, LAST_VALUE(c) as c from source group by a")
+        self.t_env.create_temporary_view("retract_table", table_with_retract_message)
+        result = self.t_env.sql_query(
+            "select concat(distinct b, '.') as a, "
+            "concat(distinct b, ',') filter (where c = 'hi') as b, "
+            "concat(distinct b, ',') filter (where c = 'hello') as c, "
+            "c as d "
+            "from retract_table group by c")
+        assert_frame_equal(result.to_pandas().sort_values(by='a').reset_index(drop=True),
+                           pd.DataFrame([["Hi.Hi2.Hi3", "Hi,Hi2,Hi3", "", "hi"],
+                                         ["hello.hello2", "", "hello,hello2", "hello"]],
+                                        columns=['a', 'b', 'c', 'd']))
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_aggregate.py
+++ b/flink-python/pyflink/table/tests/test_aggregate.py
@@ -390,15 +390,6 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         self.t_env.create_temporary_system_function(
             "concat",
             ConcatAggregateFunction())
-        self.t_env.get_config().get_configuration().set_string(
-            "python.fn-execution.bundle.size", "2")
-        # trigger the cache eviction in a bundle.
-        self.t_env.get_config().get_configuration().set_string(
-            "python.state.cache-size", "2")
-        self.t_env.get_config().get_configuration().set_string(
-            "python.map-state.read-cache-size", "2")
-        self.t_env.get_config().get_configuration().set_string(
-            "python.map-state.write-cache-size", "2")
         t = self.t_env.from_elements(
             [(1, 'Hi_', 'hi'),
              (1, 'Hi', 'hi'),

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.utils;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.typeutils.DataViewUtils;
 
@@ -56,10 +57,12 @@ public enum PythonOperatorUtils {
 	}
 
 	public static FlinkFnApi.UserDefinedAggregateFunction getUserDefinedAggregateFunctionProto(
-		PythonFunctionInfo pythonFunctionInfo,
+		PythonAggregateFunctionInfo pythonFunctionInfo,
 		DataViewUtils.DataViewSpec[] dataViewSpecs) {
 		FlinkFnApi.UserDefinedAggregateFunction.Builder builder = FlinkFnApi.UserDefinedAggregateFunction.newBuilder();
 		builder.setPayload(ByteString.copyFrom(pythonFunctionInfo.getPythonFunction().getSerializedPythonFunction()));
+		builder.setDistinct(pythonFunctionInfo.isDistinct());
+		builder.setFilterArg(pythonFunctionInfo.getFilterArg());
 		for (Object input : pythonFunctionInfo.getInputs()) {
 			FlinkFnApi.Input.Builder inputProto =
 				FlinkFnApi.Input.newBuilder();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
@@ -45,8 +45,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.UpdatableRowData;
+import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.functions.python.PythonEnv;
-import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.planner.typeutils.DataViewUtils;
 import org.apache.flink.table.runtime.functions.CleanupState;
@@ -105,7 +105,7 @@ public class PythonStreamGroupAggregateOperator
 	 */
 	private final Map<String, String> jobOptions;
 
-	private final PythonFunctionInfo[] aggregateFunctions;
+	private final PythonAggregateFunctionInfo[] aggregateFunctions;
 
 	private final DataViewUtils.DataViewSpec[][] dataViewSpecs;
 
@@ -205,7 +205,7 @@ public class PythonStreamGroupAggregateOperator
 			Configuration config,
 			RowType inputType,
 			RowType outputType,
-			PythonFunctionInfo[] aggregateFunctions,
+			PythonAggregateFunctionInfo[] aggregateFunctions,
 			DataViewUtils.DataViewSpec[][] dataViewSpecs,
 			int[] grouping,
 			int indexOfCountStar,

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.planner.typeutils.DataViewUtils;
 import org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperatorTestBase;
@@ -251,10 +251,12 @@ public class PythonStreamGroupAggregateOperatorTest {
 			config,
 			getInputType(),
 			getOutputType(),
-			new PythonFunctionInfo[]{
-				new PythonFunctionInfo(
+			new PythonAggregateFunctionInfo[]{
+				new PythonAggregateFunctionInfo(
 					PythonScalarFunctionOperatorTestBase.DummyPythonFunction.INSTANCE,
-					new Integer[]{0})},
+					new Integer[]{0},
+					-1,
+					false)},
 			getGrouping(),
 			-1,
 			false,
@@ -269,7 +271,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 			Configuration config,
 			RowType inputType,
 			RowType outputType,
-			PythonFunctionInfo[] aggregateFunctions,
+			PythonAggregateFunctionInfo[] aggregateFunctions,
 			int[] grouping,
 			int indexOfCountStar,
 			boolean generateUpdateBefore,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.functions.python;
 import org.apache.flink.annotation.Internal;
 
 /**
- * PythonFunctionInfo contains the execution information of a Python aggregate function, such as:
- * the actual Python function, the input arguments, the filter arg, the distinct flag, etc.
+ * PythonAggregateFunctionInfo contains the execution information of a Python aggregate function, such as:
+ * the actual Python aggregation function, the input arguments, the filter arg, the distinct flag, etc.
  */
 @Internal
 public class PythonAggregateFunctionInfo extends PythonFunctionInfo {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.python;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * PythonFunctionInfo contains the execution information of a Python aggregate function, such as:
+ * the actual Python function, the input arguments, the filter arg, the distinct flag, etc.
+ */
+@Internal
+public class PythonAggregateFunctionInfo extends PythonFunctionInfo {
+
+	private final int filterArg;
+	private final boolean distinct;
+
+	public PythonAggregateFunctionInfo(
+			PythonFunction pythonFunction,
+			Object[] inputs,
+			int filterArg,
+			boolean isDistinct) {
+		super(pythonFunction, inputs);
+		this.filterArg = filterArg;
+		this.distinct = isDistinct;
+	}
+
+	public boolean isDistinct() {
+		return distinct;
+	}
+
+	public int getFilterArg() {
+		return filterArg;
+	}
+
+	public static final PythonAggregateFunctionInfo DUMMY_PLACEHOLDER = new PythonAggregateFunctionInfo(
+		new PythonFunction() {
+			@Override
+			public byte[] getSerializedPythonFunction() {
+				return new byte[0];
+			}
+
+			@Override
+			public PythonEnv getPythonEnv() {
+				return new PythonEnv(PythonEnv.ExecType.PROCESS);
+			}
+		}, new Object[0], -1, false);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionInfo.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * the actual Python function, the input arguments, etc.
  */
 @Internal
-public final class PythonFunctionInfo implements Serializable {
+public class PythonFunctionInfo implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -57,16 +57,4 @@ public final class PythonFunctionInfo implements Serializable {
 	public Object[] getInputs() {
 		return this.inputs;
 	}
-
-	public static final PythonFunctionInfo DUMMY_PLACEHOLDER = new PythonFunctionInfo(new PythonFunction() {
-		@Override
-		public byte[] getSerializedPythonFunction() {
-			return new byte[0];
-		}
-
-		@Override
-		public PythonEnv getPythonEnv() {
-			return new PythonEnv(PythonEnv.ExecType.PROCESS);
-		}
-	}, new Object[0]);
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
@@ -28,7 +28,7 @@ import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.table.functions.python.{PythonAggregateFunctionInfo, PythonFunctionInfo}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
@@ -121,13 +121,8 @@ class StreamExecPythonGroupAggregate(
 
     val inputCountIndex = aggInfoList.getIndexOfCountStar
 
-    val extractedResult: Array[(PythonFunctionInfo, Array[DataViewSpec])] =
-      aggInfoList.aggInfos.zipWithIndex.map(t =>
-        extractPythonAggregateFunctionInfosFromAggregateInfo(t._2, t._1))
-
-    val pythonFunctionInfos = extractedResult.map(_._1)
-
-    var dataViewSpecs = extractedResult.map(_._2)
+    var (pythonFunctionInfos, dataViewSpecs) =
+      extractPythonAggregateFunctionInfos(aggInfoList, aggCalls)
 
     if (dataViewSpecs.forall(_.isEmpty)) {
       dataViewSpecs = Array()
@@ -176,7 +171,7 @@ class StreamExecPythonGroupAggregate(
       config: Configuration,
       inputType: RowType,
       outputType: RowType,
-      aggregateFunctions: Array[PythonFunctionInfo],
+      aggregateFunctions: Array[PythonAggregateFunctionInfo],
       dataViewSpecs: Array[Array[DataViewSpec]],
       minIdleStateRetentionTime: Long,
       maxIdleStateRetentionTime: Long,
@@ -189,7 +184,7 @@ class StreamExecPythonGroupAggregate(
       classOf[Configuration],
       classOf[RowType],
       classOf[RowType],
-      classOf[Array[PythonFunctionInfo]],
+      classOf[Array[PythonAggregateFunctionInfo]],
       classOf[Array[Array[DataViewSpec]]],
       classOf[Array[Int]],
       classOf[Int],


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports distinct and filter keywords on Python UDAF.*


## Brief change log

  - *Support distinct keyword on Python UDAF.*
  - *support filter keyword on Python UDAF.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
