### PR TITLE
[FLINK-19569][table] Upgrade ICU4J to 67.1

### DIFF
--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -67,7 +67,7 @@ under the License.
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>65.1</version>
+			<version>67.1</version>
 			<!-- set provided here, and will package it into planner jar -->
 			<scope>provided</scope>
 		</dependency>

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -213,7 +213,7 @@ under the License.
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>65.1</version>
+			<version>67.1</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -27,4 +27,4 @@ See bundled license files for details
 This project bundles the following dependencies under the ICU license.
 See bundled license files for details
 
-- com.ibm.icu:icu4j:65.1
+- com.ibm.icu:icu4j:67.1

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -198,7 +198,7 @@ under the License.
 		<dependency>
 			<groupId>com.ibm.icu</groupId>
 			<artifactId>icu4j</artifactId>
-			<version>65.1</version>
+			<version>67.1</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -27,4 +27,4 @@ See bundled license files for details
 This project bundles the following dependencies under the ICU license.
 See bundled license files for details
 
-- com.ibm.icu:icu4j:65.1
+- com.ibm.icu:icu4j:67.1


### PR DESCRIPTION


## What is the purpose of the change

*Upgrade ICU4J to 67.1 due to https://nvd.nist.gov/vuln/detail/CVE-2020-10531*


## Brief change log

  - *update icu4j to 67.1 in the pom and notice file*


## Verifying this change


This change is already covered by existing tests, such as *PrintUtilsTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
