### PR TITLE
[FLINK-19831][coordination] Implement SlotManager#setFailUnfulfillableRequest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -915,6 +915,15 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
 	@Test
 	public void testNotificationAboutNotEnoughResources() throws Exception {
+		testNotificationAboutNotEnoughResources(false);
+	}
+
+	@Test
+	public void testGracePeriodForNotificationAboutNotEnoughResources() throws Exception {
+		testNotificationAboutNotEnoughResources(true);
+	}
+
+	private static void testNotificationAboutNotEnoughResources(boolean withNotificationGracePeriod) throws Exception {
 		final JobID jobId = new JobID();
 		final int numRequiredSlots = 3;
 		final int numExistingSlots = 1;
@@ -928,6 +937,11 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder()
 			.buildAndStart(ResourceManagerId.generate(), new ManuallyTriggeredScheduledExecutor(), resourceManagerActions)) {
 
+			if (withNotificationGracePeriod) {
+				// this should disable notifications
+				slotManager.setFailUnfulfillableRequest(false);
+			}
+
 			final ResourceID taskExecutorResourceId = ResourceID.generate();
 			final TaskExecutorConnection taskExecutionConnection = new TaskExecutorConnection(taskExecutorResourceId, new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
 			final SlotReport slotReport = createSlotReport(taskExecutorResourceId, numExistingSlots);
@@ -936,6 +950,13 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 			ResourceRequirements resourceRequirements = createResourceRequirements(jobId, numRequiredSlots);
 			slotManager.processResourceRequirements(resourceRequirements);
 
+			if (withNotificationGracePeriod) {
+				assertThat(notEnoughResourceNotifications, empty());
+
+				// re-enable notifications which should also trigger another resource check
+				slotManager.setFailUnfulfillableRequest(true);
+			}
+
 			assertThat(notEnoughResourceNotifications, hasSize(1));
 			Tuple2<JobID, Collection<ResourceRequirement>> notification = notEnoughResourceNotifications.get(0);
 			assertThat(notification.f0, is(jobId));
@@ -943,7 +964,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 		}
 	}
 
-	private SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots) {
+	private static SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots) {
 		final Set<SlotStatus> slotStatusSet = new HashSet<>(numberSlots);
 		for (int i = 0; i < numberSlots; i++) {
 			slotStatusSet.add(createFreeSlotStatus(new SlotID(taskExecutorResourceId, i)));
@@ -971,7 +992,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 			.buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions);
 	}
 
-	private DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder() {
+	private static DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder() {
 		return DeclarativeSlotManagerBuilder.newBuilder().setDefaultWorkerResourceSpec(WORKER_RESOURCE_SPEC);
 	}
 


### PR DESCRIPTION
The declarative slot manager now implements `SlotManager#setFailUnfulfillableRequest`, which controls whether it sends notifications to the JM if not enough resources are available.