### PR TITLE
[FLINK-19834] Make the TestSink reusable in all the sink related tests.

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -29,12 +28,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -64,7 +61,7 @@ public class BatchCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commit() throws Exception {
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 
@@ -78,8 +75,11 @@ public class BatchCommitterOperatorTest extends TestLogger {
 		testHarness.endInput();
 		testHarness.close();
 
-		assertThat(committer.getCommittedData(), equalTo(expectedCommittedData));
-		assertThat(testHarness.getOutput().toArray(), equalTo(expectedCommittedData
+		assertThat(
+				committer.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
+
+		assertThat(testHarness.getOutput(), containsInAnyOrder(expectedCommittedData
 				.stream()
 				.map(StreamRecord::new)
 				.toArray()));
@@ -87,7 +87,7 @@ public class BatchCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void close() throws Exception {
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 		testHarness.initializeEmptyState();
@@ -99,13 +99,11 @@ public class BatchCommitterOperatorTest extends TestLogger {
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new BatchCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> DEFAULT_WRITER,
-								() -> Optional.ofNullable(committer),
-								() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE),
-								() -> Optional.empty(),
-								() -> Optional.empty())),
+				new BatchCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addCommitter(committer)
+						.setCommittableSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -29,11 +28,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
-import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -63,7 +61,7 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void endOfInput() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
 				createTestHarness(globalCommitter);
 		final List<String> inputs = Arrays.asList("compete", "swear", "shallow");
@@ -71,9 +69,10 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 		testHarness.initializeEmptyState();
 		testHarness.open();
 
-		testHarness.processElement(new StreamRecord<>("compete"));
-		testHarness.processElement(new StreamRecord<>("swear"));
-		testHarness.processElement(new StreamRecord<>("shallow"));
+		testHarness.processElements(inputs
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
 
 		testHarness.endInput();
 
@@ -81,7 +80,9 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 				globalCommitter.combine(inputs),
 				"end of input");
 
-		assertThat(globalCommitter.getCommittedData(), equalTo(expectedCommittedData));
+		assertThat(
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
 
 		testHarness.close();
 
@@ -89,7 +90,7 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void close() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
 				createTestHarness(globalCommitter);
 		testHarness.initializeEmptyState();
@@ -103,12 +104,11 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 			GlobalCommitter<String, String> globalCommitter) throws Exception {
 
 		return new OneInputStreamOperatorTestHarness<>(
-				new BatchGlobalCommitterOperatorFactory<>(TestSink.create(
-						() -> DEFAULT_WRITER,
-						() -> Optional.empty(),
-						() -> Optional.empty(),
-						() -> Optional.ofNullable(globalCommitter),
-						() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE))),
+				new BatchGlobalCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addGlobalCommitter(globalCommitter)
+						.setGlobalCommittableSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -31,14 +31,12 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
@@ -50,7 +48,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutSerializer() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(new TestSink.TestGlobalCommitter(""), null);
+				createTestHarness(new TestSink.DefaultGlobalCommitter(), null);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -58,7 +56,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutCommitter() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+				createTestHarness(null, TestSink.StringCommittableSerializer.INSTANCE);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -84,7 +82,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void closeCommitter() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
 		testHarness.initializeEmptyState();
@@ -106,7 +104,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 				createTestHarness(),
 				input2);
 
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
 
@@ -121,8 +119,8 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 		testHarness.open();
 
 		final List<String> expectedOutput = new ArrayList<>();
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
 
 		testHarness.snapshot(1L, 1L);
 		testHarness.notifyOfCompletedCheckpoint(1L);
@@ -136,7 +134,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commitMultipleStagesTogether() throws Exception {
 
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 
 		final List<String> input1 = Arrays.asList("cautious", "nature");
 		final List<String> input2 = Arrays.asList("count", "over");
@@ -144,9 +142,9 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 		final List<String> expectedOutput = new ArrayList<>();
 
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input3));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input3));
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
@@ -158,13 +156,11 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(1L, 1L);
-
 		testHarness.processElements(input2
 				.stream()
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(2L, 2L);
-
 		testHarness.processElements(input3
 				.stream()
 				.map(StreamRecord::new)
@@ -176,23 +172,24 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 		testHarness.close();
 
 		assertThat(
-				testHarness.getOutput().toArray(),
-				equalTo(expectedOutput.stream().map(StreamRecord::new).toArray()));
+				testHarness.getOutput(),
+				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
 
 		assertThat(
-				globalCommitter.getCommittedData().toArray(),
-				equalTo(expectedOutput.toArray()));
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedOutput.toArray()));
 	}
 
 	@Test
 	public void filterRecoveredCommittables() throws Exception {
 		final List<String> input = Arrays.asList("silent", "elder", "patience");
-		final String successCommittedCommittable = TestSink.TestGlobalCommitter.COMBINER.apply(input);
+		final String successCommittedCommittable = TestSink.DefaultGlobalCommitter.COMBINER.apply(
+				input);
 
 		final OperatorSubtaskState operatorSubtaskState = buildSubtaskState(
 				createTestHarness(),
 				input);
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter(
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
 				successCommittedCommittable);
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
@@ -210,7 +207,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void endOfInput() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter();
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
@@ -227,26 +224,24 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
 		return createTestHarness(
-				new TestSink.TestGlobalCommitter(""),
-				SimpleVersionedStringSerializer.INSTANCE);
+				new TestSink.DefaultGlobalCommitter(),
+				TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter) throws Exception {
-		return createTestHarness(globalCommitter, SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(globalCommitter, TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter,
-			SimpleVersionedStringSerializer serializer) throws Exception {
+			SimpleVersionedSerializer<String> serializer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new GlobalStreamingCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> TestSink.DEFAULT_WRITER,
-								() -> Optional.empty(),
-								() -> Optional.empty(),
-								() -> Optional.ofNullable(globalCommitter),
-								() -> Optional.ofNullable(serializer))),
+				new GlobalStreamingCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addGlobalCommitter(globalCommitter)
+						.setGlobalCommittableSerializer(serializer)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperatorTest.java
@@ -38,8 +38,7 @@ import static org.junit.Assert.assertThat;
 public class StatefulWriterOperatorTest extends WriterOperatorTestBase {
 
 	@Override
-	protected <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
-			TestSink<InputT, CommT, ?, ?> sink) {
+	protected AbstractWriterOperatorFactory createWriterOperator(TestSink sink) {
 		return new StatefulWriterOperatorFactory<>(sink);
 	}
 
@@ -47,10 +46,13 @@ public class StatefulWriterOperatorTest extends WriterOperatorTestBase {
 	public void stateIsRestored() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(
-						SnapshottingBufferingWriter::new,
-						stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new SnapshottingBufferingWriter())
+						.withWriterState()
+						.build());
+
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -68,10 +70,12 @@ public class StatefulWriterOperatorTest extends WriterOperatorTestBase {
 
 		testHarness.close();
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> restoredTestHarness =
-				createTestHarness(TestSink.create(
-						SnapshottingBufferingWriter::new,
-						stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> restoredTestHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new SnapshottingBufferingWriter())
+						.withWriterState()
+						.build());
 
 		restoredTestHarness.initializeState(snapshot);
 		restoredTestHarness.open();
@@ -82,21 +86,23 @@ public class StatefulWriterOperatorTest extends WriterOperatorTestBase {
 		assertThat(
 				restoredTestHarness.getOutput(),
 				contains(
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	/**
 	 * A {@link Writer} buffers elements and snapshots them when asked.
 	 */
 	static class SnapshottingBufferingWriter extends BufferingWriter {
-		public SnapshottingBufferingWriter(List<Tuple3<Integer, Long, Long>> state) {
-			this.elements = state;
+
+		@Override
+		public List<String> snapshotState() {
+			return elements;
 		}
 
 		@Override
-		public List<Tuple3<Integer, Long, Long>> snapshotState() {
-			return elements;
+		void restoredFrom(List<String> states) {
+			this.elements = states;
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
@@ -26,8 +26,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
  */
 public class StatelessWriterOperatorTest extends WriterOperatorTestBase {
 	@Override
-	protected <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
-			TestSink<InputT, CommT, ?, ?> sink) {
+	protected AbstractWriterOperatorFactory<Integer, String> createWriterOperator(TestSink sink) {
 		return new StatelessWriterOperatorFactory<>(sink);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
@@ -52,7 +51,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutSerializer() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(new TestSink.TestCommitter(), null);
+				createTestHarness(new TestSink.DefaultCommitter(), null);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -60,7 +59,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutCommitter() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+				createTestHarness(null, TestSink.StringCommittableSerializer.INSTANCE);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -85,7 +84,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void closeCommitter() throws Exception {
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 		testHarness.initializeEmptyState();
@@ -107,7 +106,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 				createTestHarness(),
 				input2);
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 
@@ -142,7 +141,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commitMultipleStagesTogether() throws Exception {
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 
 		final List<String> input1 = Arrays.asList("cautious", "nature");
 		final List<String> input2 = Arrays.asList("count", "over");
@@ -164,13 +163,11 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(1L, 1L);
-
 		testHarness.processElements(input2
 				.stream()
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(2L, 2L);
-
 		testHarness.processElements(input3
 				.stream()
 				.map(StreamRecord::new)
@@ -192,25 +189,24 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
-		return createTestHarness(new TestSink.TestCommitter(), SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(
+				new TestSink.DefaultCommitter(),
+				TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
-		return createTestHarness(committer, SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(committer, TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			Committer<String> committer,
-			SimpleVersionedStringSerializer serializer) throws Exception {
+			SimpleVersionedSerializer<String> serializer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new StreamingCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> TestSink.DEFAULT_WRITER,
-								() -> Optional.ofNullable(committer),
-								() -> Optional.ofNullable(serializer),
-								// Can not use method reference because compiler cant not speculate the type
-								() -> Optional.empty(),
-								() -> Optional.empty())),
+				new StreamingCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addCommitter(committer)
+						.setCommittableSerializer(serializer)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -22,173 +22,222 @@ import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
- * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
- * under test.
+ * A {@link Sink TestSink} for all the sink related tests.
  */
-class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
-		implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+public class TestSink implements Sink<Integer, String, String, String> {
 
-	static final DefaultWriter<String> DEFAULT_WRITER = new DefaultWriter<>();
+	private final DefaultWriter writer;
 
-	private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
+	@Nullable
+	private final SimpleVersionedSerializer<String> writerStateSerializer;
 
-	private final Supplier<Optional<Committer<CommT>>> committerSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier;
+	@Nullable
+	private final Committer<String> committer;
 
-	private final Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier;
+	@Nullable
+	private final SimpleVersionedSerializer<String> committableSerializer;
 
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
-		// We cannot replace this by a method reference because the Java compiler will not be
-		// able to typecheck it.
-		//noinspection Convert2MethodRef
-		return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
-	}
+	@Nullable
+	private final GlobalCommitter<String, String> globalCommitter;
 
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
-	}
-
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		return new TestSink<>(writer, writerStateSerializerSupplier);
-	}
-
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<Committer<CommT>>> committerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
-			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommittableSerializer) {
-		return new TestSink<>(
-				(s) -> writer.get(),
-				() -> Optional.empty(),
-				committerSupplier,
-				committableSerializerSupplier,
-				globalCommitterSupplier,
-				globalCommittableSerializer);
-	}
+	@Nullable
+	private final SimpleVersionedSerializer<String> globalCommittableSerializer;
 
 	private TestSink(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier,
-			Supplier<Optional<Committer<CommT>>> committerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
-			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier) {
-		this.writerSupplier = writerSupplier;
-		this.writerStateSerializerSupplier = writerStateSerializerSupplier;
-		this.committerSupplier = committerSupplier;
-		this.committableSerializerSupplier = committableSerializerSupplier;
-		this.globalCommitterSupplier = globalCommitterSupplier;
-		this.globalCommitterSerializerSupplier = globalCommitterSerializerSupplier;
-	}
-
-	private TestSink(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		this(
-				writer,
-				writerStateSerializerSupplier,
-				Optional::empty,
-				Optional::empty,
-				Optional::empty,
-				Optional::empty);
+			DefaultWriter writer,
+			@Nullable SimpleVersionedSerializer<String> writerStateSerializer,
+			@Nullable Committer<String> committer,
+			@Nullable SimpleVersionedSerializer<String> committableSerializer,
+			@Nullable GlobalCommitter<String, String> globalCommitter,
+			@Nullable SimpleVersionedSerializer<String> globalCommittableSerializer) {
+		this.writer = writer;
+		this.writerStateSerializer = writerStateSerializer;
+		this.committer = committer;
+		this.committableSerializer = committableSerializer;
+		this.globalCommitter = globalCommitter;
+		this.globalCommittableSerializer = globalCommittableSerializer;
 	}
 
 	@Override
-	public Writer<InputT, CommT, WriterStateT> createWriter(
-			InitContext context,
-			List<WriterStateT> states) {
-		return writerSupplier.apply(states);
+	public Writer<Integer, String, String> createWriter(InitContext context, List<String> states) {
+		writer.restoredFrom(states);
+		return writer;
 	}
 
 	@Override
-	public Optional<Committer<CommT>> createCommitter() {
-		return committerSupplier.get();
+	public Optional<Committer<String>> createCommitter() {
+		return Optional.ofNullable(committer);
 	}
 
 	@Override
-	public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
-		return globalCommitterSupplier.get();
+	public Optional<GlobalCommitter<String, String>> createGlobalCommitter() {
+		return Optional.ofNullable(globalCommitter);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
-		return committableSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getCommittableSerializer() {
+		return Optional.ofNullable(committableSerializer);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
-		return globalCommitterSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getGlobalCommittableSerializer() {
+		return Optional.ofNullable(globalCommittableSerializer);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
-		return writerStateSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getWriterStateSerializer() {
+		return Optional.ofNullable(writerStateSerializer);
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
 	}
 
 	/**
-	 * This is default writer used for testing {@link Committer} and {@link GlobalCommitter}'s operator.
+	 * A builder class for {@link TestSink}.
 	 */
-	static class DefaultWriter<CommT> implements Writer<CommT, CommT, CommT> {
+	public static class Builder {
 
-		@Override
-		public void write(CommT element, Context context) {
-			//do nothing
+		private DefaultWriter writer = new DefaultWriter();
+
+		private SimpleVersionedSerializer<String> writerStateSerializer;
+
+		private Committer<String> committer;
+
+		private SimpleVersionedSerializer<String> committableSerializer;
+
+		private GlobalCommitter<String, String> globalCommitter;
+
+		private SimpleVersionedSerializer<String> globalCommittableSerializer;
+
+		public Builder addWriter(DefaultWriter writer) {
+			this.writer = checkNotNull(writer);
+			return this;
+		}
+
+		public Builder withWriterState() {
+			this.writerStateSerializer = StringCommittableSerializer.INSTANCE;
+			return this;
+		}
+
+		public Builder addCommitter(Committer<String> committer) {
+			this.committer = committer;
+			return this;
+		}
+
+		public Builder setCommittableSerializer(SimpleVersionedSerializer<String> committableSerializer) {
+			this.committableSerializer = committableSerializer;
+			return this;
+		}
+
+		public Builder addGlobalCommitter(GlobalCommitter<String, String> globalCommitter) {
+			this.globalCommitter = globalCommitter;
+			return this;
+		}
+
+		public Builder setGlobalCommittableSerializer(SimpleVersionedSerializer<String> globalCommittableSerializer) {
+			this.globalCommittableSerializer = globalCommittableSerializer;
+			return this;
+		}
+
+		public TestSink build() {
+			return new TestSink(
+					writer,
+					writerStateSerializer,
+					committer,
+					committableSerializer,
+					globalCommitter,
+					globalCommittableSerializer);
+		}
+	}
+
+	// -------------------------------------- Sink Writer ------------------------------------------
+
+	/**
+	 * Base class for out testing {@link Writer Writers}.
+	 */
+	static class DefaultWriter implements Writer<Integer, String, String> {
+
+		protected List<String> elements;
+
+		DefaultWriter() {
+			this.elements = new ArrayList<>();
 		}
 
 		@Override
-		public List<CommT> prepareCommit(boolean flush) {
-			return Collections.emptyList();
+		public void write(Integer element, Context context) {
+			elements.add(Tuple3
+					.of(element, context.timestamp(), context.currentWatermark())
+					.toString());
 		}
 
 		@Override
-		public List<CommT> snapshotState() {
+		public List<String> prepareCommit(boolean flush) {
+			List<String> result = elements;
+			elements = new ArrayList<>();
+			return result;
+		}
+
+		@Override
+		public List<String> snapshotState() {
 			return Collections.emptyList();
 		}
 
 		@Override
 		public void close() throws Exception {
+		}
+
+		void restoredFrom(List<String> states) {
 
 		}
 	}
 
+	// -------------------------------------- Sink Committer ---------------------------------------
+
 	/**
 	 * Base class for testing {@link Committer} and {@link GlobalCommitter}.
 	 */
-	abstract static class AbstractTestCommitter<CommT> implements Committer<CommT> {
+	static class DefaultCommitter implements Committer<String>, Serializable {
 
-		protected List<CommT> committedData;
+		private final Queue<String> committedData;
 
 		private boolean isClosed;
 
-		public AbstractTestCommitter() {
-			this.committedData = new ArrayList<>();
+		public DefaultCommitter() {
+			this.committedData = new ConcurrentLinkedQueue<>();
 			this.isClosed = false;
 		}
 
-		public List<CommT> getCommittedData() {
-			return committedData;
+		public List<String> getCommittedData() {
+			return new ArrayList<>(committedData);
 		}
 
 		@Override
+		public List<String> commit(List<String> committables) {
+			committedData.addAll(committables);
+			return Collections.emptyList();
+		}
+
 		public void close() throws Exception {
 			isClosed = true;
 		}
@@ -199,23 +248,9 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 	}
 
 	/**
-	 * The class used for normal committer test.
+	 * A {@link Committer} that always re-commits the committables data it received.
 	 */
-	static class TestCommitter extends AbstractTestCommitter<String> {
-
-		@Override
-		public List<String> commit(List<String> committables) {
-			if (committedData != null) {
-				committedData.addAll(committables);
-			}
-			return Collections.emptyList();
-		}
-	}
-
-	/**
-	 * This committer always re-commits the committables data it received.
-	 */
-	static class AlwaysRetryCommitter extends AbstractTestCommitter<String> {
+	static class AlwaysRetryCommitter extends DefaultCommitter implements Committer<String> {
 
 		@Override
 		public List<String> commit(List<String> committables) {
@@ -223,16 +258,26 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 		}
 	}
 
-	/**
-	 * The class used for normal global committer test.
-	 */
-	static class TestGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
+	// ------------------------------------- Sink Global Committer ---------------------------------
 
-		static final Function<List<String>, String> COMBINER = (x) -> String.join("+", x);
+	/**
+	 * A {@link GlobalCommitter} that always commits global committables successfully.
+	 */
+	static class DefaultGlobalCommitter extends DefaultCommitter implements GlobalCommitter<String, String> {
+
+		static final Function<List<String>, String> COMBINER = strings -> {
+			//we sort here because we want to have a deterministic result during the unit test
+			Collections.sort(strings);
+			return String.join("+", strings);
+		};
 
 		private final String committedSuccessData;
 
-		TestGlobalCommitter(String committedSuccessData) {
+		DefaultGlobalCommitter() {
+			this("");
+		}
+
+		DefaultGlobalCommitter(String committedSuccessData) {
 			this.committedSuccessData = committedSuccessData;
 		}
 
@@ -249,19 +294,21 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 
 		@Override
 		public String combine(List<String> committables) {
+			//we sort here because we want to have a deterministic result during the unit test
+			Collections.sort(committables);
 			return COMBINER.apply(committables);
 		}
 
 		@Override
 		public void endOfInput() {
-			this.committedData.add("end of input");
+			commit(Collections.singletonList("end of input"));
 		}
 	}
 
 	/**
-	 * This global committer always re-commits the committables data it received.
+	 * A {@link GlobalCommitter} that always re-commits global committables it received.
 	 */
-	static class AlwaysRetryGlobalCommitter extends AbstractTestCommitter<String> implements GlobalCommitter<String, String> {
+	static class AlwaysRetryGlobalCommitter extends DefaultGlobalCommitter {
 
 		@Override
 		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
@@ -281,6 +328,30 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 		@Override
 		public List<String> commit(List<String> committables) {
 			return committables;
+		}
+	}
+
+	/**
+	 * We introduce this {@link StringCommittableSerializer} is because that all the fields of {@link TestSink} should be
+	 * serializable.
+	 */
+	public static class StringCommittableSerializer implements SimpleVersionedSerializer<String>, Serializable {
+
+		public static final StringCommittableSerializer INSTANCE = new StringCommittableSerializer();
+
+		@Override
+		public int getVersion() {
+			return SimpleVersionedStringSerializer.INSTANCE.getVersion();
+		}
+
+		@Override
+		public byte[] serialize(String obj) throws IOException {
+			return SimpleVersionedStringSerializer.INSTANCE.serialize(obj);
+		}
+
+		@Override
+		public String deserialize(int version, byte[] serialized) throws IOException {
+			return SimpleVersionedStringSerializer.INSTANCE.deserialize(version, serialized);
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
@@ -19,27 +19,18 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.api.connector.sink.GlobalCommitter;
-import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.Writer;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
@@ -49,15 +40,18 @@ import static org.junit.Assert.assertThat;
  */
 public abstract class WriterOperatorTestBase extends TestLogger {
 
-	protected abstract <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
-			TestSink<InputT, CommT, ?, ?> sink);
+	protected abstract AbstractWriterOperatorFactory<Integer, String> createWriterOperator(TestSink sink);
 
 	@Test
 	public void nonBufferingWriterEmitsWithoutFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new NonBufferingWriter())
+						.withWriterState()
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -71,16 +65,20 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	@Test
 	public void nonBufferingWriterEmitsOnFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new NonBufferingWriter())
+						.withWriterState()
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -93,16 +91,20 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	@Test
 	public void bufferingWriterDoesNotEmitWithoutFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new BufferingWriter())
+						.withWriterState()
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -122,8 +124,12 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 	public void bufferingWriterEmitsOnFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new BufferingWriter())
+						.withWriterState()
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -136,18 +142,18 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	/**
 	 * A {@link Writer} that returns all committables from {@link #prepareCommit(boolean)} without
 	 * waiting for {@code flush} to be {@code true}.
 	 */
-	static class NonBufferingWriter extends TestWriter {
+	static class NonBufferingWriter extends TestSink.DefaultWriter {
 		@Override
-		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
-			List<Tuple3<Integer, Long, Long>> result = elements;
+		public List<String> prepareCommit(boolean flush) {
+			List<String> result = elements;
 			elements = new ArrayList<>();
 			return result;
 		}
@@ -157,157 +163,19 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 	 * A {@link Writer} that only returns committables from {@link #prepareCommit(boolean)} when
 	 * {@code flush} is {@code true}.
 	 */
-	static class BufferingWriter extends TestWriter {
+	static class BufferingWriter extends TestSink.DefaultWriter {
 		@Override
-		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
-			if (flush) {
-				List<Tuple3<Integer, Long, Long>> result = elements;
-				elements = new ArrayList<>();
-				return result;
-			} else {
+		public List<String> prepareCommit(boolean flush) {
+			if (!flush) {
 				return Collections.emptyList();
 			}
+			List<String> result = elements;
+			elements = new ArrayList<>();
+			return result;
 		}
 	}
 
-	/**
-	 * Base class for out testing {@link Writer Writers}.
-	 */
-	abstract static class TestWriter
-			implements Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> {
-
-		// element, timestamp, watermark
-		protected List<Tuple3<Integer, Long, Long>> elements;
-
-		TestWriter() {
-			this.elements = new ArrayList<>();
-		}
-
-		@Override
-		public void write(Integer element, Context context) {
-			elements.add(Tuple3.of(element, context.timestamp(), context.currentWatermark()));
-		}
-
-		@Override
-		public List<Tuple3<Integer, Long, Long>> snapshotState() {
-			return Collections.emptyList();
-		}
-
-		@Override
-		public void close() throws Exception {
-		}
-	}
-
-	/**
-	 * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
-	 * under test.
-	 */
-	protected static class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
-			implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
-
-		private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
-		private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
-			// We cannot replace this by a method reference because the Java compiler will not be
-			// able to typecheck it.
-			//noinspection Convert2MethodRef
-			return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
-		}
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
-		}
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			return new TestSink<>(writer, writerStateSerializerSupplier);
-		}
-
-		private TestSink(
-				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			this.writerSupplier = writer;
-			this.writerStateSerializerSupplier = writerStateSerializerSupplier;
-		}
-
-		public Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> getWriterSupplier() {
-			return writerSupplier;
-		}
-
-		public Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> getWriterStateSerializerSupplier() {
-			return writerStateSerializerSupplier;
-		}
-
-		@Override
-		public Writer<InputT, CommT, WriterStateT> createWriter(
-				InitContext context,
-				List<WriterStateT> states) {
-			return writerSupplier.apply(states);
-		}
-
-		@Override
-		public Optional<Committer<CommT>> createCommitter() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
-			return writerStateSerializerSupplier.get();
-		}
-	}
-
-	public static Supplier<Optional<SimpleVersionedSerializer<Tuple3<Integer, Long, Long>>>> stateSerializer() {
-		return () -> Optional.of(new WriterStateSerializer());
-	}
-
-	static final class WriterStateSerializer implements SimpleVersionedSerializer<Tuple3<Integer, Long, Long>> {
-
-		@Override
-		public int getVersion() {
-			return 0;
-		}
-
-		@Override
-		public byte[] serialize(Tuple3<Integer, Long, Long> tuple3) throws IOException {
-			return InstantiationUtil.serializeObject(tuple3);
-
-		}
-
-		@Override
-		public Tuple3<Integer, Long, Long> deserialize(
-				int version,
-				byte[] serialized) throws IOException {
-			try {
-				return InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
-			} catch (ClassNotFoundException e) {
-				throw new RuntimeException("Failed to deserialize the writer's state.", e);
-			}
-		}
-	}
-
-	protected <CommT> OneInputStreamOperatorTestHarness<Integer, CommT> createTestHarness(
-			TestSink<Integer, CommT, ?, ?> sink) throws Exception {
-
+	protected OneInputStreamOperatorTestHarness<Integer, String> createTestHarness(TestSink sink) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
 				createWriterOperator(sink),
 				IntSerializer.INSTANCE);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make the TestSink reusable in all the sink related tests.



## Brief change log

1. Change the `Supplier&Function` fields to normal object fields, which makes the sink serializable easily
2. Introduce the TestSink.Builder to create the test sink object.
3. Change the TestSink from a generic class to a normal class, which make extract TypeInformation possible.


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
