### PR TITLE
[FLINK-19836] Serialize the committable by the user provided serializer during network shuffle

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperatorFactory.java
@@ -30,12 +30,12 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
  * @param <InputT> The input type of the {@link Committer}.
  * @param <CommT> The committable type of the {@link Committer}.
  */
-abstract class AbstractStreamingCommitterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<CommT>
-		implements OneInputStreamOperatorFactory<InputT, CommT> {
+abstract class AbstractStreamingCommitterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<byte[]>
+		implements OneInputStreamOperatorFactory<byte[], byte[]> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends StreamOperator<CommT>> T createStreamOperator(StreamOperatorParameters<CommT> parameters) {
+	public <T extends StreamOperator<byte[]>> T createStreamOperator(StreamOperatorParameters<byte[]> parameters) {
 		final AbstractStreamingCommitterOperator<InputT, CommT> streamingCommitterOperator = createStreamingCommitterOperator();
 		streamingCommitterOperator.setup(
 				parameters.getContainingTask(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractWriterOperatorFactory.java
@@ -30,12 +30,12 @@ import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
  * @param <InputT> The input type of the {@link Writer}.
  * @param <CommT> The committable type of the {@link Writer}.
  */
-abstract class AbstractWriterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<CommT>
-	implements OneInputStreamOperatorFactory<InputT, CommT> {
+abstract class AbstractWriterOperatorFactory<InputT, CommT> extends AbstractStreamOperatorFactory<byte[]>
+	implements OneInputStreamOperatorFactory<InputT, byte[]> {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T extends StreamOperator<CommT>> T createStreamOperator(StreamOperatorParameters<CommT> parameters) {
+	public <T extends StreamOperator<byte[]>> T createStreamOperator(StreamOperatorParameters<byte[]> parameters) {
 		final AbstractWriterOperator<InputT, CommT> writerOperator = createWriterOperator();
 		writerOperator.setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
 		return (T) writerOperator;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorFactory.java
@@ -34,8 +34,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <CommT> The committable type of the {@link GlobalCommitter}
  * @param <GlobalCommT> The committable type of the {@link GlobalCommitter}
  */
-public final class BatchGlobalCommitterOperatorFactory<CommT, GlobalCommT> extends AbstractStreamOperatorFactory<GlobalCommT>
-		implements OneInputStreamOperatorFactory<CommT, GlobalCommT> {
+public final class BatchGlobalCommitterOperatorFactory<CommT, GlobalCommT> extends AbstractStreamOperatorFactory<byte[]>
+		implements OneInputStreamOperatorFactory<byte[], byte[]> {
 
 	private final Sink<?, CommT, ?, GlobalCommT> sink;
 
@@ -45,12 +45,15 @@ public final class BatchGlobalCommitterOperatorFactory<CommT, GlobalCommT> exten
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T extends StreamOperator<GlobalCommT>> T createStreamOperator(StreamOperatorParameters<GlobalCommT> parameters) {
+	public <T extends StreamOperator<byte[]>> T createStreamOperator(StreamOperatorParameters<byte[]> parameters) {
 		final BatchGlobalCommitterOperator<CommT, GlobalCommT> batchGlobalCommitterOperator =
 				new BatchGlobalCommitterOperator<>(
 						sink.createGlobalCommitter().orElseThrow(
 								() -> new IllegalStateException(
-										"Could not create global committer from the sink")));
+										"Could not create global committer from the sink")),
+						sink.getCommittableSerializer()
+								.orElseThrow(() -> new IllegalStateException(
+										"Could not get committable serializer from the sink")));
 
 		batchGlobalCommitterOperator.setup(
 				parameters.getContainingTask(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperator.java
@@ -49,8 +49,9 @@ public final class GlobalStreamingCommitterOperator<CommT, GlobalCommT> extends 
 
 	GlobalStreamingCommitterOperator(
 			GlobalCommitter<CommT, GlobalCommT> globalCommitter,
-			SimpleVersionedSerializer<GlobalCommT> committableSerializer) {
-		super(committableSerializer);
+			SimpleVersionedSerializer<GlobalCommT> globalCommittableSerializer,
+			SimpleVersionedSerializer<CommT> committableSerializer) {
+		super(committableSerializer, globalCommittableSerializer, false);
 		this.globalCommitter = checkNotNull(globalCommitter);
 
 		this.recoveredGlobalCommittables = new ArrayList<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorFactory.java
@@ -46,7 +46,9 @@ public class GlobalStreamingCommitterOperatorFactory<CommT, GlobalCommT> extends
 								"Could not create global committer from the sink")),
 				sink.getGlobalCommittableSerializer()
 						.orElseThrow(() -> new IllegalStateException(
-								"Could not create global committable serializer from the sink")));
+								"Could not get global committable serializer from the sink")),
+				sink.getCommittableSerializer().orElseThrow(() -> new IllegalStateException(
+						"Could not get committable serializer from the sink")));
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulWriterOperator.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.util.CollectionUtil;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -61,6 +63,7 @@ final class StatefulWriterOperator<InputT, CommT, WriterStateT> extends Abstract
 	StatefulWriterOperator(
 		final Sink<InputT, CommT, WriterStateT, ?> sink,
 		final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer) {
+		super(sink.getCommittableSerializer().orElse(null));
 		this.sink = sink;
 		this.writerStateSimpleVersionedSerializer = writerStateSimpleVersionedSerializer;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperator.java
@@ -38,6 +38,7 @@ final class StatelessWriterOperator<InputT, CommT> extends AbstractWriterOperato
 	private final Sink<InputT, CommT, ?, ?> sink;
 
 	StatelessWriterOperator(final Sink<InputT, CommT, ?, ?> sink) {
+		super(sink.getCommittableSerializer().orElse(null));
 		this.sink = sink;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperator.java
@@ -42,8 +42,9 @@ final class StreamingCommitterOperator<CommT> extends AbstractStreamingCommitter
 
 	StreamingCommitterOperator(
 			Committer<CommT> committer,
-			SimpleVersionedSerializer<CommT> committableSerializer) {
-		super(committableSerializer);
+			SimpleVersionedSerializer<CommT> committableSerializer,
+			boolean sendCommittables) {
+		super(committableSerializer, committableSerializer, sendCommittables);
 		this.committer = checkNotNull(committer);
 		this.recoveredCommittables = new ArrayList<>();
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorFactory.java
@@ -47,7 +47,8 @@ public class StreamingCommitterOperatorFactory<CommT> extends AbstractStreamingC
 								"Could not create committer from the sink")),
 				sink.getCommittableSerializer()
 						.orElseThrow(() -> new IllegalStateException(
-								"Could not get committable serializer from the sink")));
+								"Could not get committable serializer from the sink")),
+				sink.getGlobalCommittableSerializer().isPresent());
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -29,12 +28,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -64,7 +61,7 @@ public class BatchCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commit() throws Exception {
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 
@@ -78,8 +75,11 @@ public class BatchCommitterOperatorTest extends TestLogger {
 		testHarness.endInput();
 		testHarness.close();
 
-		assertThat(committer.getCommittedData(), equalTo(expectedCommittedData));
-		assertThat(testHarness.getOutput().toArray(), equalTo(expectedCommittedData
+		assertThat(
+				committer.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
+
+		assertThat(testHarness.getOutput(), containsInAnyOrder(expectedCommittedData
 				.stream()
 				.map(StreamRecord::new)
 				.toArray()));
@@ -87,7 +87,7 @@ public class BatchCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void close() throws Exception {
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 		testHarness.initializeEmptyState();
@@ -99,13 +99,12 @@ public class BatchCommitterOperatorTest extends TestLogger {
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new BatchCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> DEFAULT_WRITER,
-								() -> Optional.ofNullable(committer),
-								() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE),
-								() -> Optional.empty(),
-								() -> Optional.empty())),
+				new BatchCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addWriter()
+						.addCommitter(committer)
+						.setCommittableSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/BatchGlobalCommitterOperatorTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -29,11 +28,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
-import static org.apache.flink.streaming.runtime.operators.sink.TestSink.DEFAULT_WRITER;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 /**
@@ -63,7 +61,8 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void endOfInput() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
 				createTestHarness(globalCommitter);
 		final List<String> inputs = Arrays.asList("compete", "swear", "shallow");
@@ -71,9 +70,10 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 		testHarness.initializeEmptyState();
 		testHarness.open();
 
-		testHarness.processElement(new StreamRecord<>("compete"));
-		testHarness.processElement(new StreamRecord<>("swear"));
-		testHarness.processElement(new StreamRecord<>("shallow"));
+		testHarness.processElements(inputs
+				.stream()
+				.map(StreamRecord::new)
+				.collect(Collectors.toList()));
 
 		testHarness.endInput();
 
@@ -81,7 +81,9 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 				globalCommitter.combine(inputs),
 				"end of input");
 
-		assertThat(globalCommitter.getCommittedData(), equalTo(expectedCommittedData));
+		assertThat(
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedCommittedData.toArray()));
 
 		testHarness.close();
 
@@ -89,7 +91,8 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void close() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
 				createTestHarness(globalCommitter);
 		testHarness.initializeEmptyState();
@@ -103,12 +106,12 @@ public class BatchGlobalCommitterOperatorTest extends TestLogger {
 			GlobalCommitter<String, String> globalCommitter) throws Exception {
 
 		return new OneInputStreamOperatorTestHarness<>(
-				new BatchGlobalCommitterOperatorFactory<>(TestSink.create(
-						() -> DEFAULT_WRITER,
-						() -> Optional.empty(),
-						() -> Optional.empty(),
-						() -> Optional.ofNullable(globalCommitter),
-						() -> Optional.of(SimpleVersionedStringSerializer.INSTANCE))),
+				new BatchGlobalCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addWriter()
+						.addGlobalCommitter(globalCommitter)
+						.setGlobalCommittableSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
-import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -33,10 +33,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.streaming.util.SinkTestUtil.convertStringListToByteArrayList;
 import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
@@ -47,7 +49,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutSerializer() throws Exception {
-		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness =
 				createTestHarness(new TestSink.DefaultGlobalCommitter(""), null);
 		testHarness.initializeEmptyState();
 		testHarness.open();
@@ -55,7 +57,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutCommitter() throws Exception {
-		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness =
 				createTestHarness(null, TestSink.StringCommittableSerializer.INSTANCE);
 		testHarness.initializeEmptyState();
 		testHarness.open();
@@ -63,9 +65,9 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void doNotSupportRetry() throws Exception {
-		final List<String> input = Arrays.asList("lazy", "leaf");
+		final List<byte[]> input = convertStringListToByteArrayList(Arrays.asList("lazy", "leaf"));
 
-		final OneInputStreamOperatorTestHarness<String, String> testHarness =
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness =
 				createTestHarness(new TestSink.AlwaysRetryGlobalCommitter());
 
 		testHarness.initializeEmptyState();
@@ -82,8 +84,9 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void closeCommitter() throws Exception {
-		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
-		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness = createTestHarness(
 				globalCommitter);
 		testHarness.initializeEmptyState();
 		testHarness.open();
@@ -94,18 +97,23 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test
 	public void restoredFromMergedState() throws Exception {
 
-		final List<String> input1 = Arrays.asList("host", "drop");
+		final List<String> stringInput1 = Arrays.asList("host", "drop");
+		final List<String> stringInput2 = Arrays.asList("future", "evil", "how");
+
+		final List<byte[]> byteInput1 = convertStringListToByteArrayList(stringInput1);
+		final List<byte[]> byteInput2 = convertStringListToByteArrayList(stringInput2);
+
 		final OperatorSubtaskState operatorSubtaskState1 = buildSubtaskState(
 				createTestHarness(),
-				input1);
+				byteInput1);
 
-		final List<String> input2 = Arrays.asList("future", "evil", "how");
 		final OperatorSubtaskState operatorSubtaskState2 = buildSubtaskState(
 				createTestHarness(),
-				input2);
+				byteInput2);
 
-		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
-		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness = createTestHarness(
 				globalCommitter);
 
 		final OperatorSubtaskState mergedOperatorSubtaskState =
@@ -118,40 +126,43 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 						mergedOperatorSubtaskState, 2, 2, 1, 0));
 		testHarness.open();
 
-		final List<String> expectedOutput = new ArrayList<>();
-		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
+		final List<String> expectedStringOutput = new ArrayList<>();
+		expectedStringOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(stringInput1));
+		expectedStringOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(stringInput2));
+
 
 		testHarness.snapshot(1L, 1L);
 		testHarness.notifyOfCompletedCheckpoint(1L);
 		testHarness.close();
 
-		// TODO:: maybe there is no output at all
-		assertThat(
-				testHarness.getOutput(),
-				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
+		assertThat(testHarness.getOutput().size(), equalTo(0));
 
 		assertThat(
 				globalCommitter.getCommittedData(),
-				containsInAnyOrder(expectedOutput.toArray()));
+				containsInAnyOrder(expectedStringOutput.toArray()));
 	}
 
 	@Test
 	public void commitMultipleStagesTogether() throws Exception {
 
-		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
 
-		final List<String> input1 = Arrays.asList("cautious", "nature");
-		final List<String> input2 = Arrays.asList("count", "over");
-		final List<String> input3 = Arrays.asList("lawyer", "grammar");
+		final List<String> stringInput1 = Arrays.asList("cautious", "nature");
+		final List<String> stringInput2 = Arrays.asList("count", "over");
+		final List<String> stringInput3 = Arrays.asList("lawyer", "grammar");
 
-		final List<String> expectedOutput = new ArrayList<>();
+		final List<byte[]> input1 = convertStringListToByteArrayList(stringInput1);
+		final List<byte[]> input2 = convertStringListToByteArrayList(stringInput2);
+		final List<byte[]> input3 = convertStringListToByteArrayList(stringInput3);
 
-		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
-		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input3));
+		final List<String> expectedStringOutput = new ArrayList<>();
 
-		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+		expectedStringOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(stringInput1));
+		expectedStringOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(stringInput2));
+		expectedStringOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(stringInput3));
+
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness = createTestHarness(
 				globalCommitter);
 		testHarness.initializeEmptyState();
 		testHarness.open();
@@ -176,27 +187,27 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 		testHarness.close();
 
-		assertThat(
-				testHarness.getOutput(),
-				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
+		assertThat(testHarness.getOutput().size(), equalTo(0));
 
 		assertThat(
 				globalCommitter.getCommittedData(),
-				containsInAnyOrder(expectedOutput.toArray()));
+				containsInAnyOrder(expectedStringOutput.toArray()));
 	}
 
 	@Test
 	public void filterRecoveredCommittables() throws Exception {
-		final List<String> input = Arrays.asList("silent", "elder", "patience");
-		final String successCommittedCommittable = TestSink.DefaultGlobalCommitter.COMBINER.apply(input);
+		final List<String> stringInput = Arrays.asList("silent", "elder", "patience");
+		final List<byte[]> byteInput = convertStringListToByteArrayList(stringInput);
+		final String successCommittedCommittable = TestSink.DefaultGlobalCommitter.COMBINER.apply(
+				stringInput);
 
 		final OperatorSubtaskState operatorSubtaskState = buildSubtaskState(
 				createTestHarness(),
-				input);
+				byteInput);
 		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
 				successCommittedCommittable);
 
-		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness = createTestHarness(
 				globalCommitter);
 
 		// all data from previous checkpoint are expected to be committed,
@@ -211,9 +222,10 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void endOfInput() throws Exception {
-		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
+				"");
 
-		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
+		final OneInputStreamOperatorTestHarness<byte[], byte[]> testHarness = createTestHarness(
 				globalCommitter);
 		testHarness.initializeEmptyState();
 		testHarness.open();
@@ -226,27 +238,28 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 				contains("end of input"));
 	}
 
-	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
+	private OneInputStreamOperatorTestHarness<byte[], byte[]> createTestHarness() throws Exception {
 		return createTestHarness(
 				new TestSink.DefaultGlobalCommitter(""),
 				TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
-	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+	private OneInputStreamOperatorTestHarness<byte[], byte[]> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter) throws Exception {
 		return createTestHarness(globalCommitter, TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
-	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
+	private OneInputStreamOperatorTestHarness<byte[], byte[]> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter,
 			SimpleVersionedSerializer<String> serializer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
 				new GlobalStreamingCommitterOperatorFactory<>(TestSink
 						.newBuilder()
 						.addWriter()
+						.setCommittableSerializer(TestSink.StringCommittableSerializer.INSTANCE)
 						.addGlobalCommitter(globalCommitter)
 						.setGlobalCommittableSerializer(serializer)
 						.build()),
-				StringSerializer.INSTANCE);
+				BytePrimitiveArraySerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/GlobalStreamingCommitterOperatorTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -31,14 +31,12 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
@@ -50,7 +48,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutSerializer() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(new TestSink.TestGlobalCommitter(""), null);
+				createTestHarness(new TestSink.DefaultGlobalCommitter(""), null);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -58,7 +56,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutCommitter() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+				createTestHarness(null, TestSink.StringCommittableSerializer.INSTANCE);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -84,7 +82,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void closeCommitter() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
 		testHarness.initializeEmptyState();
@@ -106,7 +104,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 				createTestHarness(),
 				input2);
 
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
 
@@ -121,12 +119,17 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 		testHarness.open();
 
 		final List<String> expectedOutput = new ArrayList<>();
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
 
 		testHarness.snapshot(1L, 1L);
 		testHarness.notifyOfCompletedCheckpoint(1L);
 		testHarness.close();
+
+		// TODO:: maybe there is no output at all
+		assertThat(
+				testHarness.getOutput(),
+				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
 
 		assertThat(
 				globalCommitter.getCommittedData(),
@@ -136,7 +139,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commitMultipleStagesTogether() throws Exception {
 
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
 
 		final List<String> input1 = Arrays.asList("cautious", "nature");
 		final List<String> input2 = Arrays.asList("count", "over");
@@ -144,9 +147,9 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 		final List<String> expectedOutput = new ArrayList<>();
 
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input1));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input2));
-		expectedOutput.add(TestSink.TestGlobalCommitter.COMBINER.apply(input3));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input1));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input2));
+		expectedOutput.add(TestSink.DefaultGlobalCommitter.COMBINER.apply(input3));
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
@@ -158,13 +161,11 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(1L, 1L);
-
 		testHarness.processElements(input2
 				.stream()
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(2L, 2L);
-
 		testHarness.processElements(input3
 				.stream()
 				.map(StreamRecord::new)
@@ -176,23 +177,23 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 		testHarness.close();
 
 		assertThat(
-				testHarness.getOutput().toArray(),
-				equalTo(expectedOutput.stream().map(StreamRecord::new).toArray()));
+				testHarness.getOutput(),
+				containsInAnyOrder(expectedOutput.stream().map(StreamRecord::new).toArray()));
 
 		assertThat(
-				globalCommitter.getCommittedData().toArray(),
-				equalTo(expectedOutput.toArray()));
+				globalCommitter.getCommittedData(),
+				containsInAnyOrder(expectedOutput.toArray()));
 	}
 
 	@Test
 	public void filterRecoveredCommittables() throws Exception {
 		final List<String> input = Arrays.asList("silent", "elder", "patience");
-		final String successCommittedCommittable = TestSink.TestGlobalCommitter.COMBINER.apply(input);
+		final String successCommittedCommittable = TestSink.DefaultGlobalCommitter.COMBINER.apply(input);
 
 		final OperatorSubtaskState operatorSubtaskState = buildSubtaskState(
 				createTestHarness(),
 				input);
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter(
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter(
 				successCommittedCommittable);
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
@@ -210,7 +211,7 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void endOfInput() throws Exception {
-		final TestSink.TestGlobalCommitter globalCommitter = new TestSink.TestGlobalCommitter("");
+		final TestSink.DefaultGlobalCommitter globalCommitter = new TestSink.DefaultGlobalCommitter("");
 
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				globalCommitter);
@@ -227,26 +228,25 @@ public class GlobalStreamingCommitterOperatorTest extends TestLogger {
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
 		return createTestHarness(
-				new TestSink.TestGlobalCommitter(""),
-				SimpleVersionedStringSerializer.INSTANCE);
+				new TestSink.DefaultGlobalCommitter(""),
+				TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter) throws Exception {
-		return createTestHarness(globalCommitter, SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(globalCommitter, TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			GlobalCommitter<String, String> globalCommitter,
-			SimpleVersionedStringSerializer serializer) throws Exception {
+			SimpleVersionedSerializer<String> serializer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new GlobalStreamingCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> TestSink.DEFAULT_WRITER,
-								() -> Optional.empty(),
-								() -> Optional.empty(),
-								() -> Optional.ofNullable(globalCommitter),
-								() -> Optional.ofNullable(serializer))),
+				new GlobalStreamingCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addWriter()
+						.addGlobalCommitter(globalCommitter)
+						.setGlobalCommittableSerializer(serializer)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatelessWriterOperatorTest.java
@@ -26,8 +26,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
  */
 public class StatelessWriterOperatorTest extends WriterOperatorTestBase {
 	@Override
-	protected <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
-			TestSink<InputT, CommT, ?, ?> sink) {
+	protected AbstractWriterOperatorFactory<Integer, String> createWriterOperator(TestSink sink) {
 		return new StatelessWriterOperatorFactory<>(sink);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StreamingCommitterOperatorTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TestLogger;
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.util.TestHarnessUtil.buildSubtaskState;
@@ -52,7 +51,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutSerializer() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(new TestSink.TestCommitter(), null);
+				createTestHarness(new TestSink.DefaultCommitter(), null);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -60,7 +59,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test(expected = IllegalStateException.class)
 	public void throwExceptionWithoutCommitter() throws Exception {
 		final OneInputStreamOperatorTestHarness<String, String> testHarness =
-				createTestHarness(null, SimpleVersionedStringSerializer.INSTANCE);
+				createTestHarness(null, TestSink.StringCommittableSerializer.INSTANCE);
 		testHarness.initializeEmptyState();
 		testHarness.open();
 	}
@@ -85,7 +84,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 
 	@Test
 	public void closeCommitter() throws Exception {
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 		testHarness.initializeEmptyState();
@@ -107,7 +106,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 				createTestHarness(),
 				input2);
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 		final OneInputStreamOperatorTestHarness<String, String> testHarness = createTestHarness(
 				committer);
 
@@ -142,7 +141,7 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	@Test
 	public void commitMultipleStagesTogether() throws Exception {
 
-		final TestSink.TestCommitter committer = new TestSink.TestCommitter();
+		final TestSink.DefaultCommitter committer = new TestSink.DefaultCommitter();
 
 		final List<String> input1 = Arrays.asList("cautious", "nature");
 		final List<String> input2 = Arrays.asList("count", "over");
@@ -164,13 +163,11 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(1L, 1L);
-
 		testHarness.processElements(input2
 				.stream()
 				.map(StreamRecord::new)
 				.collect(Collectors.toList()));
 		testHarness.snapshot(2L, 2L);
-
 		testHarness.processElements(input3
 				.stream()
 				.map(StreamRecord::new)
@@ -192,25 +189,25 @@ public class StreamingCommitterOperatorTest extends TestLogger {
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness() throws Exception {
-		return createTestHarness(new TestSink.TestCommitter(), SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(
+				new TestSink.DefaultCommitter(),
+				TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(Committer<String> committer) throws Exception {
-		return createTestHarness(committer, SimpleVersionedStringSerializer.INSTANCE);
+		return createTestHarness(committer, TestSink.StringCommittableSerializer.INSTANCE);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, String> createTestHarness(
 			Committer<String> committer,
-			SimpleVersionedStringSerializer serializer) throws Exception {
+			SimpleVersionedSerializer<String> serializer) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(
-				new StreamingCommitterOperatorFactory<>(
-						TestSink.create(
-								() -> TestSink.DEFAULT_WRITER,
-								() -> Optional.ofNullable(committer),
-								() -> Optional.ofNullable(serializer),
-								// Can not use method reference because compiler cant not speculate the type
-								() -> Optional.empty(),
-								() -> Optional.empty())),
+				new StreamingCommitterOperatorFactory<>(TestSink
+						.newBuilder()
+						.addWriter()
+						.addCommitter(committer)
+						.setCommittableSerializer(serializer)
+						.build()),
 				StringSerializer.INSTANCE);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -22,173 +22,285 @@ import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.Writer;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
- * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
- * under test.
+ * A {@link Sink TestSink} for all the sink related tests.
  */
-class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
-		implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
+public class TestSink implements Sink<Integer, String, String, String> {
 
-	static final DefaultWriter<String> DEFAULT_WRITER = new DefaultWriter<>();
+	private final TestWriter writer;
 
-	private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
+	@Nullable
+	private final SimpleVersionedSerializer<String> writerStateSerializer;
 
-	private final Supplier<Optional<Committer<CommT>>> committerSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier;
+	@Nullable
+	private final Committer<String> committer;
 
-	private final Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier;
-	private final Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier;
+	@Nullable
+	private final SimpleVersionedSerializer<String> committableSerializer;
 
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
-		// We cannot replace this by a method reference because the Java compiler will not be
-		// able to typecheck it.
-		//noinspection Convert2MethodRef
-		return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
-	}
+	@Nullable
+	private final GlobalCommitter<String, String> globalCommitter;
 
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
-	}
-
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		return new TestSink<>(writer, writerStateSerializerSupplier);
-	}
-
-	public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-			Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<Committer<CommT>>> committerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
-			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommittableSerializer) {
-		return new TestSink<>(
-				(s) -> writer.get(),
-				() -> Optional.empty(),
-				committerSupplier,
-				committableSerializerSupplier,
-				globalCommitterSupplier,
-				globalCommittableSerializer);
-	}
+	@Nullable
+	private final SimpleVersionedSerializer<String> globalCommittableSerializer;
 
 	private TestSink(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier,
-			Supplier<Optional<Committer<CommT>>> committerSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<CommT>>> committableSerializerSupplier,
-			Supplier<Optional<GlobalCommitter<CommT, GlobalCommT>>> globalCommitterSupplier,
-			Supplier<Optional<SimpleVersionedSerializer<GlobalCommT>>> globalCommitterSerializerSupplier) {
-		this.writerSupplier = writerSupplier;
-		this.writerStateSerializerSupplier = writerStateSerializerSupplier;
-		this.committerSupplier = committerSupplier;
-		this.committableSerializerSupplier = committableSerializerSupplier;
-		this.globalCommitterSupplier = globalCommitterSupplier;
-		this.globalCommitterSerializerSupplier = globalCommitterSerializerSupplier;
-	}
-
-	private TestSink(
-			Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-			Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-		this(
-				writer,
-				writerStateSerializerSupplier,
-				Optional::empty,
-				Optional::empty,
-				Optional::empty,
-				Optional::empty);
+			TestWriter writer,
+			@Nullable SimpleVersionedSerializer<String> writerStateSerializer,
+			@Nullable Committer<String> committer,
+			@Nullable SimpleVersionedSerializer<String> committableSerializer,
+			@Nullable GlobalCommitter<String, String> globalCommitter,
+			@Nullable SimpleVersionedSerializer<String> globalCommittableSerializer) {
+		this.writer = writer;
+		this.writerStateSerializer = writerStateSerializer;
+		this.committer = committer;
+		this.committableSerializer = committableSerializer;
+		this.globalCommitter = globalCommitter;
+		this.globalCommittableSerializer = globalCommittableSerializer;
 	}
 
 	@Override
-	public Writer<InputT, CommT, WriterStateT> createWriter(
-			InitContext context,
-			List<WriterStateT> states) {
-		return writerSupplier.apply(states);
+	public Writer<Integer, String, String> createWriter(InitContext context, List<String> states) {
+		writer.restoredFrom(states);
+		return writer;
 	}
 
 	@Override
-	public Optional<Committer<CommT>> createCommitter() {
-		return committerSupplier.get();
+	public Optional<Committer<String>> createCommitter() {
+		return Optional.ofNullable(committer);
 	}
 
 	@Override
-	public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
-		return globalCommitterSupplier.get();
+	public Optional<GlobalCommitter<String, String>> createGlobalCommitter() {
+		return Optional.ofNullable(globalCommitter);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
-		return committableSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getCommittableSerializer() {
+		return Optional.ofNullable(committableSerializer);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
-		return globalCommitterSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getGlobalCommittableSerializer() {
+		return Optional.ofNullable(globalCommittableSerializer);
 	}
 
 	@Override
-	public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
-		return writerStateSerializerSupplier.get();
+	public Optional<SimpleVersionedSerializer<String>> getWriterStateSerializer() {
+		return Optional.ofNullable(writerStateSerializer);
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
 	}
 
 	/**
-	 * This is default writer used for testing {@link Committer} and {@link GlobalCommitter}'s operator.
+	 * A builder class for {@link TestSink}.
 	 */
-	static class DefaultWriter<CommT> implements Writer<CommT, CommT, CommT> {
+	public static class Builder {
 
-		@Override
-		public void write(CommT element, Context context) {
-			//do nothing
+		private TestWriter writer;
+
+		private SimpleVersionedSerializer<String> writerStateSerializer;
+
+		private Committer<String> committer;
+
+		private SimpleVersionedSerializer<String> committableSerializer;
+
+		private GlobalCommitter<String, String> globalCommitter;
+
+		private SimpleVersionedSerializer<String> globalCommittableSerializer;
+
+		public Builder addWriter(TestWriter writer) {
+			this.writer = checkNotNull(writer);
+			return this;
+		}
+
+		/**
+		 * Using the {@link DefaultWriter}.
+		 */
+		public Builder addWriter() {
+			this.writer = new DefaultWriter();
+			return this;
+		}
+
+		public Builder setWriterStateSerializer(SimpleVersionedSerializer<String> writerStateSerializer) {
+			this.writerStateSerializer = writerStateSerializer;
+			return this;
+		}
+
+		public Builder addCommitter(Committer<String> committer) {
+			this.committer = committer;
+			return this;
+		}
+
+		public Builder setCommittableSerializer(SimpleVersionedSerializer<String> committableSerializer) {
+			this.committableSerializer = committableSerializer;
+			return this;
+		}
+
+		/**
+		 * Add a {@link DefaultWriter}.
+		 */
+		public Builder addCommitter() {
+			this.committer = new DefaultCommitter();
+			this.committableSerializer = StringCommittableSerializer.INSTANCE;
+			return this;
+		}
+
+		/**
+		 * Add a {@link Committer} which commits data to the queue provided by the supplier.
+		 */
+		public Builder addCommitter(Supplier<Queue<String>> queueSupplier) {
+			this.committer = new DefaultCommitter(queueSupplier);
+			this.committableSerializer = StringCommittableSerializer.INSTANCE;
+			return this;
+		}
+
+		public Builder addGlobalCommitter(GlobalCommitter<String, String> globalCommitter) {
+			this.globalCommitter = globalCommitter;
+			return this;
+		}
+
+		/**
+		 * Add a {@link GlobalCommitter} which commits data to the queue provided by the supplier.
+		 */
+		public Builder addGlobalCommitter(Supplier<Queue<String>> queueSupplier) {
+			this.globalCommitter = new DefaultGlobalCommitter(queueSupplier);
+			this.globalCommittableSerializer = StringCommittableSerializer.INSTANCE;
+			return this;
+		}
+
+		public Builder setGlobalCommittableSerializer(SimpleVersionedSerializer<String> globalCommittableSerializer) {
+			this.globalCommittableSerializer = globalCommittableSerializer;
+			return this;
+		}
+
+		/**
+		 * Using the {@link DefaultGlobalCommitter}.
+		 */
+		public Builder addGlobalCommitter() {
+			this.globalCommitter = new DefaultGlobalCommitter("");
+			this.globalCommittableSerializer = StringCommittableSerializer.INSTANCE;
+			return this;
+		}
+
+		public TestSink build() {
+			return new TestSink(
+					writer,
+					writerStateSerializer,
+					committer,
+					committableSerializer,
+					globalCommitter,
+					globalCommittableSerializer);
+		}
+	}
+
+	// -------------------------------------- Sink Writer ------------------------------------------
+
+	/**
+	 * Base class for out testing {@link Writer Writers}.
+	 */
+	abstract static class TestWriter
+			implements Writer<Integer, String, String>, Serializable {
+
+		protected List<String> elements;
+
+		TestWriter() {
+			this.elements = new ArrayList<>();
 		}
 
 		@Override
-		public List<CommT> prepareCommit(boolean flush) {
-			return Collections.emptyList();
+		public void write(Integer element, Context context) {
+			elements.add(Tuple3
+					.of(element, context.timestamp(), context.currentWatermark())
+					.toString());
 		}
 
 		@Override
-		public List<CommT> snapshotState() {
+		public List<String> snapshotState() {
 			return Collections.emptyList();
 		}
 
 		@Override
 		public void close() throws Exception {
+		}
+
+		abstract void restoredFrom(List<String> states);
+	}
+
+	/**
+	 * A {@link Writer} that pre-commit all it received.
+	 */
+	static class DefaultWriter extends TestWriter {
+
+		@Override
+		public List<String> prepareCommit(boolean flush) {
+			List<String> result = elements;
+			elements = new ArrayList<>();
+			return result;
+		}
+
+		@Override
+		void restoredFrom(List<String> states) {
 
 		}
 	}
 
+	// -------------------------------------- Sink Committer ---------------------------------------
+
 	/**
 	 * Base class for testing {@link Committer} and {@link GlobalCommitter}.
 	 */
-	abstract static class AbstractTestCommitter<CommT> implements Committer<CommT> {
+	static class TestCommitter implements Serializable {
 
-		protected List<CommT> committedData;
+		private Queue<String> committedData;
 
 		private boolean isClosed;
 
-		public AbstractTestCommitter() {
-			this.committedData = new ArrayList<>();
+		private Supplier<Queue<String>> queueSupplier;
+
+		public TestCommitter() {
+			this.committedData = new ConcurrentLinkedQueue<>();
 			this.isClosed = false;
 		}
 
-		public List<CommT> getCommittedData() {
-			return committedData;
+		public TestCommitter(Supplier<Queue<String>> queueSupplier) {
+			this.queueSupplier = queueSupplier;
+			this.isClosed = false;
 		}
 
-		@Override
+		public List<String> getCommittedData() {
+			return new ArrayList<>(committedData);
+		}
+
+		public void commitData(List<String> data) {
+			if (committedData == null) {
+				committedData = queueSupplier.get();
+			}
+			committedData.addAll(data);
+		}
+
 		public void close() throws Exception {
 			isClosed = true;
 		}
@@ -199,23 +311,29 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 	}
 
 	/**
-	 * The class used for normal committer test.
+	 * A {@link Committer} that always commits committables successfully.
 	 */
-	static class TestCommitter extends AbstractTestCommitter<String> {
+	static class DefaultCommitter extends TestCommitter implements Committer<String> {
+
+		public DefaultCommitter() {
+			super();
+		}
+
+		public DefaultCommitter(Supplier<Queue<String>> queueSupplier) {
+			super(queueSupplier);
+		}
 
 		@Override
 		public List<String> commit(List<String> committables) {
-			if (committedData != null) {
-				committedData.addAll(committables);
-			}
+			commitData(committables);
 			return Collections.emptyList();
 		}
 	}
 
 	/**
-	 * This committer always re-commits the committables data it received.
+	 * A {@link Committer} that always re-commits the committables data it received.
 	 */
-	static class AlwaysRetryCommitter extends AbstractTestCommitter<String> {
+	static class AlwaysRetryCommitter extends TestCommitter implements Committer<String> {
 
 		@Override
 		public List<String> commit(List<String> committables) {
@@ -223,16 +341,27 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 		}
 	}
 
-	/**
-	 * The class used for normal global committer test.
-	 */
-	static class TestGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
+	// ------------------------------------- Sink Global Committer ---------------------------------
 
-		static final Function<List<String>, String> COMBINER = (x) -> String.join("+", x);
+	/**
+	 * A {@link GlobalCommitter} that always commits global committables successfully.
+	 */
+	static class DefaultGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
+
+		static final Function<List<String>, String> COMBINER = strings -> {
+			//we sort here because we want to have a deterministic result during the unit test
+			Collections.sort(strings);
+			return String.join("+", strings);
+		};
 
 		private final String committedSuccessData;
 
-		TestGlobalCommitter(String committedSuccessData) {
+		DefaultGlobalCommitter(Supplier<Queue<String>> queueSupplier) {
+			super(queueSupplier);
+			committedSuccessData = "";
+		}
+
+		DefaultGlobalCommitter(String committedSuccessData) {
 			this.committedSuccessData = committedSuccessData;
 		}
 
@@ -249,19 +378,27 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 
 		@Override
 		public String combine(List<String> committables) {
+			//we sort here because we want to have a deterministic result during the unit test
+			Collections.sort(committables);
 			return COMBINER.apply(committables);
 		}
 
 		@Override
+		public List<String> commit(List<String> globalCommittables) {
+			commitData(globalCommittables);
+			return Collections.emptyList();
+		}
+
+		@Override
 		public void endOfInput() {
-			this.committedData.add("end of input");
+			commitData(Collections.singletonList("end of input"));
 		}
 	}
 
 	/**
-	 * This global committer always re-commits the committables data it received.
+	 * A {@link GlobalCommitter} that always re-commits global committables it received.
 	 */
-	static class AlwaysRetryGlobalCommitter extends AbstractTestCommitter<String> implements GlobalCommitter<String, String> {
+	static class AlwaysRetryGlobalCommitter extends TestCommitter implements GlobalCommitter<String, String> {
 
 		@Override
 		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
@@ -281,6 +418,30 @@ class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
 		@Override
 		public List<String> commit(List<String> committables) {
 			return committables;
+		}
+	}
+
+	/**
+	 * We introduce this {@link StringCommittableSerializer} is because that all the fields of {@link TestSink} should be
+	 * serializable.
+	 */
+	public static class StringCommittableSerializer implements SimpleVersionedSerializer<String>, Serializable {
+
+		public static final StringCommittableSerializer INSTANCE = new StringCommittableSerializer();
+
+		@Override
+		public int getVersion() {
+			return SimpleVersionedStringSerializer.INSTANCE.getVersion();
+		}
+
+		@Override
+		public byte[] serialize(String obj) throws IOException {
+			return SimpleVersionedStringSerializer.INSTANCE.serialize(obj);
+		}
+
+		@Override
+		public String deserialize(int version, byte[] serialized) throws IOException {
+			return SimpleVersionedStringSerializer.INSTANCE.deserialize(version, serialized);
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WriterOperatorTestBase.java
@@ -19,27 +19,18 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.connector.sink.Committer;
-import org.apache.flink.api.connector.sink.GlobalCommitter;
-import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.Writer;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
@@ -49,15 +40,18 @@ import static org.junit.Assert.assertThat;
  */
 public abstract class WriterOperatorTestBase extends TestLogger {
 
-	protected abstract <InputT, CommT> AbstractWriterOperatorFactory<InputT, CommT> createWriterOperator(
-			TestSink<InputT, CommT, ?, ?> sink);
+	protected abstract AbstractWriterOperatorFactory<Integer, String> createWriterOperator(TestSink sink);
 
 	@Test
 	public void nonBufferingWriterEmitsWithoutFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new NonBufferingWriter())
+						.setWriterStateSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -71,16 +65,20 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	@Test
 	public void nonBufferingWriterEmitsOnFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(NonBufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new NonBufferingWriter())
+						.setWriterStateSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -93,16 +91,20 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	@Test
 	public void bufferingWriterDoesNotEmitWithoutFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new BufferingWriter())
+						.setWriterStateSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -122,8 +124,12 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 	public void bufferingWriterEmitsOnFlush() throws Exception {
 		final long initialTime = 0;
 
-		final OneInputStreamOperatorTestHarness<Integer, Tuple3<Integer, Long, Long>> testHarness =
-				createTestHarness(TestSink.create(BufferingWriter::new, stateSerializer()));
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.addWriter(new BufferingWriter())
+						.setWriterStateSerializer(TestSink.StringCommittableSerializer.INSTANCE)
+						.build());
 		testHarness.open();
 
 		testHarness.processWatermark(initialTime);
@@ -136,20 +142,25 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 				testHarness.getOutput(),
 				contains(
 						new Watermark(initialTime),
-						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime)),
-						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime))));
+						new StreamRecord<>(Tuple3.of(1, initialTime + 1, initialTime).toString()),
+						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
 	/**
 	 * A {@link Writer} that returns all committables from {@link #prepareCommit(boolean)} without
 	 * waiting for {@code flush} to be {@code true}.
 	 */
-	static class NonBufferingWriter extends TestWriter {
+	static class NonBufferingWriter extends TestSink.TestWriter {
 		@Override
-		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
-			List<Tuple3<Integer, Long, Long>> result = elements;
+		public List<String> prepareCommit(boolean flush) {
+			List<String> result = elements;
 			elements = new ArrayList<>();
 			return result;
+		}
+
+		@Override
+		void restoredFrom(List<String> states) {
+
 		}
 	}
 
@@ -157,156 +168,26 @@ public abstract class WriterOperatorTestBase extends TestLogger {
 	 * A {@link Writer} that only returns committables from {@link #prepareCommit(boolean)} when
 	 * {@code flush} is {@code true}.
 	 */
-	static class BufferingWriter extends TestWriter {
+	static class BufferingWriter extends TestSink.TestWriter {
 		@Override
-		public List<Tuple3<Integer, Long, Long>> prepareCommit(boolean flush) {
+		public List<String> prepareCommit(boolean flush) {
 			if (flush) {
-				List<Tuple3<Integer, Long, Long>> result = elements;
+				List<String> result = elements;
 				elements = new ArrayList<>();
 				return result;
 			} else {
 				return Collections.emptyList();
 			}
 		}
-	}
-
-	/**
-	 * Base class for out testing {@link Writer Writers}.
-	 */
-	abstract static class TestWriter
-			implements Writer<Integer, Tuple3<Integer, Long, Long>, Tuple3<Integer, Long, Long>> {
-
-		// element, timestamp, watermark
-		protected List<Tuple3<Integer, Long, Long>> elements;
-
-		TestWriter() {
-			this.elements = new ArrayList<>();
-		}
 
 		@Override
-		public void write(Integer element, Context context) {
-			elements.add(Tuple3.of(element, context.timestamp(), context.currentWatermark()));
-		}
+		void restoredFrom(List<String> states) {
 
-		@Override
-		public List<Tuple3<Integer, Long, Long>> snapshotState() {
-			return Collections.emptyList();
-		}
-
-		@Override
-		public void close() throws Exception {
 		}
 	}
 
-	/**
-	 * A {@link Sink} for testing that uses {@link Supplier Suppliers} to create various components
-	 * under test.
-	 */
-	protected static class TestSink<InputT, CommT, WriterStateT, GlobalCommT>
-			implements Sink<InputT, CommT, WriterStateT, GlobalCommT> {
-
-		private final Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writerSupplier;
-		private final Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier;
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Supplier<Writer<InputT, CommT, WriterStateT>> writer) {
-			// We cannot replace this by a method reference because the Java compiler will not be
-			// able to typecheck it.
-			//noinspection Convert2MethodRef
-			return new TestSink<>((state) -> writer.get(), () -> Optional.empty());
-		}
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Supplier<Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			return new TestSink<>((state) -> writer.get(), writerStateSerializerSupplier);
-		}
-
-		public static <InputT, CommT, WriterStateT, GlobalCommT> TestSink<InputT, CommT, WriterStateT, GlobalCommT> create(
-				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			return new TestSink<>(writer, writerStateSerializerSupplier);
-		}
-
-		private TestSink(
-				Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> writer,
-				Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> writerStateSerializerSupplier) {
-			this.writerSupplier = writer;
-			this.writerStateSerializerSupplier = writerStateSerializerSupplier;
-		}
-
-		public Function<List<WriterStateT>, Writer<InputT, CommT, WriterStateT>> getWriterSupplier() {
-			return writerSupplier;
-		}
-
-		public Supplier<Optional<SimpleVersionedSerializer<WriterStateT>>> getWriterStateSerializerSupplier() {
-			return writerStateSerializerSupplier;
-		}
-
-		@Override
-		public Writer<InputT, CommT, WriterStateT> createWriter(
-				InitContext context,
-				List<WriterStateT> states) {
-			return writerSupplier.apply(states);
-		}
-
-		@Override
-		public Optional<Committer<CommT>> createCommitter() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<GlobalCommT>> getGlobalCommittableSerializer() {
-			return Optional.empty();
-		}
-
-		@Override
-		public Optional<SimpleVersionedSerializer<WriterStateT>> getWriterStateSerializer() {
-			return writerStateSerializerSupplier.get();
-		}
-	}
-
-	public static Supplier<Optional<SimpleVersionedSerializer<Tuple3<Integer, Long, Long>>>> stateSerializer() {
-		return () -> Optional.of(new WriterStateSerializer());
-	}
-
-	static final class WriterStateSerializer implements SimpleVersionedSerializer<Tuple3<Integer, Long, Long>> {
-
-		@Override
-		public int getVersion() {
-			return 0;
-		}
-
-		@Override
-		public byte[] serialize(Tuple3<Integer, Long, Long> tuple3) throws IOException {
-			return InstantiationUtil.serializeObject(tuple3);
-
-		}
-
-		@Override
-		public Tuple3<Integer, Long, Long> deserialize(
-				int version,
-				byte[] serialized) throws IOException {
-			try {
-				return InstantiationUtil.deserializeObject(serialized, getClass().getClassLoader());
-			} catch (ClassNotFoundException e) {
-				throw new RuntimeException("Failed to deserialize the writer's state.", e);
-			}
-		}
-	}
-
-	protected <CommT> OneInputStreamOperatorTestHarness<Integer, CommT> createTestHarness(
-			TestSink<Integer, CommT, ?, ?> sink) throws Exception {
+	protected OneInputStreamOperatorTestHarness<Integer, String> createTestHarness(
+			TestSink sink) throws Exception {
 
 		return new OneInputStreamOperatorTestHarness<>(
 				createWriterOperator(sink),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SinkTestUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SinkTestUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.apache.flink.util.function.FunctionUtils;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.core.IsEqual;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utilities for testing sink.
+ */
+public class SinkTestUtil {
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static org.hamcrest.Matcher<Iterable<?>> containStreamElements(Object... items) {
+		return new IsIterableContainingInOrder(createStreamElementMatchers(items));
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public static Matcher<Iterable<?>> containsStreamElementsInAnyOrder(Object... items) {
+		return new IsIterableContainingInAnyOrder(createStreamElementMatchers(items));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<Matcher<?>> createStreamElementMatchers(Object... items) {
+		final List<Matcher<?>> matchers = new ArrayList<>();
+		for (Object item : items) {
+			if (item instanceof Watermark) {
+				matchers.add(IsEqual.equalTo(item));
+			}
+			if (item instanceof StreamRecord) {
+				StreamRecord<byte[]> streamRecord = (StreamRecord<byte[]>) item;
+				matchers.add(StreamRecordMatchers.streamRecord(
+						streamRecord.getValue(),
+						streamRecord.getTimestamp()));
+			}
+		}
+		return matchers;
+	}
+
+	public static List<byte[]> convertStringListToByteArrayList(List<String> input) {
+		return input
+				.stream()
+				.map(FunctionUtils.uncheckedFunction(TestSink.StringCommittableSerializer.INSTANCE::serialize))
+				.collect(
+						Collectors.toList());
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The behavior of the committable's serializer that is extracted by the framework might be different with the serializer provided by the user. As a result the downstream operator might get a different committable if we use the serializer extracted by the framework during network shuffle. This leads to some unexpected result.
So this patch makes the shuffle between the `writer/committer/globalcommitter` use the serializer provided by the user.



## Brief change log

1. Change the intput/output type of writer operator from `CommT` to `byte[]`
2. Change the input/output type of committer operator from `CommT` to `byte[]`
3. Change the input/output type of global committer operator from `CommT` to `byte[]`
4. All the sink operator would not send any comittables if there is no downstream operator.


## Verifying this change


This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
