### PR TITLE
[FLINK-19839][e2e] Properly forward test exit code to CI system

### DIFF
--- a/tools/azure-pipelines/e2e_uploading_watchdog.sh
+++ b/tools/azure-pipelines/e2e_uploading_watchdog.sh
@@ -66,3 +66,7 @@ log_upload_watchdog &
 
 # ts from moreutils prepends the time to each line
 ( $COMMAND & PID=$! ; wait $PID ) | ts | tee $OUTPUT_FILE
+TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+# properly forward exit code
+exit $TEST_EXIT_CODE


### PR DESCRIPTION
Due to a recent change, the exit code of e2e tests was not forwarded properly anymore. 

This CI build demonstrates that failures are forwarded properly: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8556&view=results