### PR TITLE
[HotFix][docs] Fix broken link of docker.md

### DIFF
--- a/docs/ops/deployment/docker.md
+++ b/docs/ops/deployment/docker.md
@@ -282,7 +282,7 @@ You can customize the Flink image in several ways:
 
 * **override the container entry point** with a custom script where you can run any bootstrap actions.
 At the end you can call the standard `/docker-entrypoint.sh` script of the Flink image with the same arguments
-as described in [how to run the Flink image](#how-to-run-flink-image).
+as described in [how to run the Flink image](#how-to-run-a-flink-image).
 
   The following example creates a custom entry point script which enables more libraries and plugins.
   The custom script, custom library and plugin are provided from a mounted volume.


### PR DESCRIPTION
## What is the purpose of the change

Fix broken link of docker.md

The page url is https://ci.apache.org/projects/flink/flink-docs-master/ops/deployment/docker.html

The markdown file is located in flink/docs/ops/deployment/docker.md

The "how to run the Flink image" link in the Advanced customization chapter of docker.md cannot be redirected normally。

## Brief change log

- Fix broken link of `flink/docs/ops/deployment/docker.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? no