### PR TITLE
[FLINK-19855][network] Specify channel AND gate in resumeConsumption()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
@@ -30,9 +30,9 @@ import java.util.List;
  */
 @Internal
 public interface CheckpointableInput {
-	void blockConsumption(int inputChannelIdx);
+	void blockConsumption(InputChannelInfo channelInfo);
 
-	void resumeConsumption(int channelIndex) throws IOException;
+	void resumeConsumption(InputChannelInfo channelInfo) throws IOException;
 
 	List<InputChannelInfo> getChannelInfos();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
 /**
@@ -48,7 +49,7 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
 	}
 
 	@Override
-	public void blockConsumption(int inputChannelIdx) {
+	public void blockConsumption(InputChannelInfo channelInfo) {
 		// Unused. Network stack is blocking consumption automatically by revoking credits.
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -125,7 +125,7 @@ public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>,
 		return availabilityHelper.getAvailableFuture();
 	}
 
-	public abstract void resumeConsumption(int channelIndex) throws IOException;
+	public abstract void resumeConsumption(InputChannelInfo channelInfo) throws IOException;
 
 	/**
 	 * Returns the channel of this gate.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegmentProvider;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -746,13 +747,13 @@ public class SingleInputGate extends IndexedInputGate {
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) throws IOException {
+	public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
 		checkState(!isFinished(), "InputGate already finished.");
 		// BEWARE: consumption resumption only happens for streaming jobs in which all slots
 		// are allocated together so there should be no UnknownInputChannel. As a result, it
 		// is safe to not synchronize the requestLock here. We will refactor the code to not
 		// rely on this assumption in the future.
-		channels[channelIndex].resumeConsumption();
+		channels[channelInfo.getInputChannelIdx()].resumeConsumption();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
@@ -267,11 +268,11 @@ public class UnionInputGate extends InputGate {
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) throws IOException {
+	public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
 		// BEWARE: consumption resumption only happens for streaming jobs in which all
 		// slots are allocated together so there should be no UnknownInputChannel. We
 		// will refactor the code to not rely on this assumption in the future.
-		getChannel(channelIndex).resumeConsumption();
+		inputGatesByGateIndex.get(channelInfo.getGateIdx()).resumeConsumption(channelInfo);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
@@ -54,8 +55,8 @@ public class InputGateWithMetrics extends IndexedInputGate {
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) throws IOException {
-		inputGate.resumeConsumption(channelIndex);
+	public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
+		inputGate.resumeConsumption(channelInfo);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlignedController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlignedController.java
@@ -54,7 +54,7 @@ public class AlignedController implements CheckpointBarrierBehaviourController {
 			CheckpointBarrier barrier) {
 		checkState(!blockedChannels.put(channelInfo, true), "Stream corrupt: Repeated barrier for same checkpoint on input " + channelInfo);
 		CheckpointableInput input = inputs[channelInfo.getGateIdx()];
-		input.blockConsumption(channelInfo.getInputChannelIdx());
+		input.blockConsumption(channelInfo);
 	}
 
 	@Override
@@ -97,6 +97,6 @@ public class AlignedController implements CheckpointBarrierBehaviourController {
 
 	private void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
 		CheckpointableInput input = inputs[channelInfo.getGateIdx()];
-		input.resumeConsumption(channelInfo.getInputChannelIdx());
+		input.resumeConsumption(channelInfo);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -73,12 +73,12 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 	}
 
 	@Override
-	public void blockConsumption(int channelIndex) {
+	public void blockConsumption(InputChannelInfo channelInfo) {
 		isBlockedAvailability.resetUnavailable();
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) {
+	public void resumeConsumption(InputChannelInfo channelInfo) {
 		isBlockedAvailability.getUnavailableToResetAvailable().complete(null);
 	}
 
@@ -114,12 +114,12 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 	 */
 	@Override
 	public void checkpointStarted(CheckpointBarrier barrier) {
-		blockConsumption(-1);
+		blockConsumption(null);
 	}
 
 	@Override
 	public void checkpointStopped(long cancelledCheckpointId) {
-		resumeConsumption(-1);
+		resumeConsumption(null);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlignedControllerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlignedControllerMassiveRandomTest.java
@@ -223,7 +223,7 @@ public class AlignedControllerMassiveRandomTest {
 		public void sendTaskEvent(TaskEvent event) {}
 
 		@Override
-		public void resumeConsumption(int channelIndex) {
+		public void resumeConsumption(InputChannelInfo channelInfo) {
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -65,7 +65,7 @@ public class MockIndexedInputGate extends IndexedInputGate {
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) {
+	public void resumeConsumption(InputChannelInfo channelInfo) {
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -136,8 +136,8 @@ public class MockInputGate extends IndexedInputGate {
 	}
 
 	@Override
-	public void resumeConsumption(int channelIndex) {
-		lastUnblockedChannels.add(channelIndex);
+	public void resumeConsumption(InputChannelInfo channelInfo) {
+		lastUnblockedChannels.add(channelInfo.getInputChannelIdx());
 	}
 
 	public ArrayList<Integer> getAndResetLastUnblockedChannels() {


### PR DESCRIPTION
## What is the purpose of the change

Replace `channelIndex` with `ChannelInfo` in `resume/blockConsumption` methods of `InputGate` and `CheckpointableInput`.

Given channelIndex only, UnionInputGate has to guess which wrapped input
gate this channel belongs to. For that, UnionInputGate expects channel
index with an inputGate offset. This contradicts with the contract of other resumeConsumption() implementations.
UnionInputGate.resumeConsumption isn't used currently but is planned to be used in FLINK-19856.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
