### PR TITLE
[FLINK-19856][network] Emit EndOfChannelRecoveryEvent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
@@ -30,7 +30,7 @@ public interface SequentialChannelStateReader extends AutoCloseable {
 
 	void readInputData(InputGate[] inputGates) throws IOException, InterruptedException;
 
-	void readOutputData(ResultPartitionWriter[] writers) throws IOException, InterruptedException;
+	void readOutputData(ResultPartitionWriter[] writers, boolean notifyAndBlockOnCompletion) throws IOException, InterruptedException;
 
 	@Override
 	void close() throws Exception;
@@ -42,7 +42,7 @@ public interface SequentialChannelStateReader extends AutoCloseable {
 		}
 
 		@Override
-		public void readOutputData(ResultPartitionWriter[] writers) {
+		public void readOutputData(ResultPartitionWriter[] writers, boolean notifyAndBlockOnCompletion) {
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImpl.java
@@ -65,8 +65,8 @@ public class SequentialChannelStateReaderImpl implements SequentialChannelStateR
 	}
 
 	@Override
-	public void readOutputData(ResultPartitionWriter[] writers) throws IOException, InterruptedException {
-		try (ResultSubpartitionRecoveredStateHandler stateHandler = new ResultSubpartitionRecoveredStateHandler(writers)) {
+	public void readOutputData(ResultPartitionWriter[] writers, boolean notifyAndBlockOnCompletion) throws IOException, InterruptedException {
+		try (ResultSubpartitionRecoveredStateHandler stateHandler = new ResultSubpartitionRecoveredStateHandler(writers, notifyAndBlockOnCompletion)) {
 			read(stateHandler, groupByDelegate(streamSubtaskStates(), OperatorSubtaskState::getResultSubpartitionState));
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultPartition.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import java.io.IOException;
+
 /**
  * Interface for partitions that are checkpointed, meaning they store data as part of unaligned checkpoints.
  */
@@ -28,4 +30,5 @@ public interface CheckpointedResultPartition {
 	 */
 	CheckpointedResultSubpartition getCheckpointedSubpartition(int subpartitionIndex);
 
+	void finishReadRecoveredState(boolean notifyAndBlockOnCompletion) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/CheckpointedResultSubpartition.java
@@ -34,4 +34,6 @@ public interface CheckpointedResultSubpartition {
 	BufferBuilder requestBufferBuilderBlocking() throws IOException, RuntimeException, InterruptedException;
 
 	boolean add(BufferConsumer bufferConsumer, int partialRecordLength) throws IOException;
+
+	void finishReadRecoveredState(boolean notifyAndBlockOnCompletion) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -87,7 +87,7 @@ public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
 			readView = null;
 
 			isPartialBufferCleanupRequired = true;
-			isBlockedByCheckpoint = false;
+			isBlocked = false;
 			sequenceNumber = 0;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
@@ -162,4 +162,11 @@ public class PipelinedResultPartition extends BufferWritingResultPartition
 			type == ResultPartitionType.PIPELINED_APPROXIMATE);
 		return type;
 	}
+
+	@Override
+	public void finishReadRecoveredState(boolean notifyAndBlockOnCompletion) throws IOException {
+		for (ResultSubpartition subpartition : subpartitions) {
+			((CheckpointedResultSubpartition) subpartition).finishReadRecoveredState(notifyAndBlockOnCompletion);
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EndOfChannelStateEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EndOfChannelStateEvent.java
@@ -23,7 +23,8 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.event.RuntimeEvent;
 
 /**
- * This event marks a {@link RecoveredInputChannel} as fully consumed.
+ * Marks the end of recovered state of {@link RecoveredInputChannel} of this subtask or {@link
+ * org.apache.flink.runtime.io.network.partition.ResultSubpartition ResultSubpartition} on the upstream.
  */
 public class EndOfChannelStateEvent extends RuntimeEvent {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -206,6 +206,11 @@ public class ConsumableNotifyingResultPartitionWriterDecorator {
 			partitionWriter.close();
 		}
 
+		@Override
+		public void finishReadRecoveredState(boolean notifyAndBlockOnCompletion) throws IOException {
+			getCheckpointablePartition().finishReadRecoveredState(notifyAndBlockOnCompletion);
+		}
+
 		/**
 		 * Notifies pipelined consumers of this result partition once.
 		 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
@@ -112,7 +112,7 @@ public class SequentialChannelStateReaderImplTest {
 		SequentialChannelStateReader reader = new SequentialChannelStateReaderImpl(buildSnapshot(writePermuted(inputChannelsData, resultPartitionsData)));
 
 		withResultPartitions(resultPartitions -> {
-			reader.readOutputData(resultPartitions);
+			reader.readOutputData(resultPartitions, false);
 			assertBuffersEquals(resultPartitionsData, collectBuffers(resultPartitions));
 		});
 
@@ -130,7 +130,9 @@ public class SequentialChannelStateReaderImplTest {
 				ResultSubpartitionInfo info = resultPartition.getAllPartitions()[i].getSubpartitionInfo();
 				ResultSubpartitionView view = resultPartition.createSubpartitionView(info.getSubPartitionIdx(), new NoOpBufferAvailablityListener());
 				for (BufferAndBacklog buffer = view.getNextBuffer(); buffer != null; buffer = view.getNextBuffer()) {
-					actual.computeIfAbsent(info, unused -> new ArrayList<>()).add(buffer.buffer());
+					if (buffer.buffer().isBuffer()) {
+						actual.computeIfAbsent(info, unused -> new ArrayList<>()).add(buffer.buffer());
+					}
 				}
 			}
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -88,14 +88,16 @@ public class InputProcessorUtil {
 			mailboxExecutor,
 			inputGates,
 			taskIOMetricGroup,
-			barrierHandler);
+			barrierHandler,
+			config);
 	}
 
 	public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
 			MailboxExecutor mailboxExecutor,
 			List<IndexedInputGate>[] inputGates,
 			TaskIOMetricGroup taskIOMetricGroup,
-			CheckpointBarrierHandler barrierHandler) {
+			CheckpointBarrierHandler barrierHandler,
+			StreamConfig config) {
 
 		registerCheckpointMetrics(taskIOMetricGroup, barrierHandler);
 
@@ -104,7 +106,11 @@ public class InputProcessorUtil {
 			.toArray(InputGate[]::new);
 
 		return Arrays.stream(unionedInputGates)
-			.map(unionedInputGate -> new CheckpointedInputGate(unionedInputGate, barrierHandler, mailboxExecutor))
+			.map(unionedInputGate -> new CheckpointedInputGate(
+				unionedInputGate,
+				barrierHandler,
+				mailboxExecutor,
+				config.isGraphContainingLoops() ? UpstreamRecoveryTracker.NO_OP : UpstreamRecoveryTracker.forInputGate(unionedInputGate)))
 			.toArray(CheckpointedInputGate[]::new);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UpstreamRecoveryTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UpstreamRecoveryTracker.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+@Internal
+interface UpstreamRecoveryTracker {
+
+	void handleEndOfRecovery(InputChannelInfo channelInfo) throws IOException;
+
+	boolean allChannelsRecovered();
+
+	static UpstreamRecoveryTracker forInputGate(InputGate inputGate) {
+		return new UpstreamRecoveryTrackerImpl(inputGate);
+	}
+
+	UpstreamRecoveryTracker NO_OP = new UpstreamRecoveryTracker() {
+		@Override
+		public void handleEndOfRecovery(InputChannelInfo channelInfo) {
+		}
+
+		@Override
+		public boolean allChannelsRecovered() {
+			return true;
+		}
+	};
+}
+
+final class UpstreamRecoveryTrackerImpl implements UpstreamRecoveryTracker {
+	private final HashSet<InputChannelInfo> restoredChannels;
+	private int numUnrestoredChannels;
+	private final InputGate inputGate;
+
+	UpstreamRecoveryTrackerImpl(InputGate inputGate) {
+		this.restoredChannels = new HashSet<>();
+		this.numUnrestoredChannels = inputGate.getNumberOfInputChannels();
+		this.inputGate = inputGate;
+	}
+
+	@Override
+	public void handleEndOfRecovery(InputChannelInfo channelInfo) throws IOException {
+		if (numUnrestoredChannels > 0) {
+			Preconditions.checkState(!restoredChannels.contains(channelInfo), "already restored: %s", channelInfo);
+			restoredChannels.add(channelInfo);
+			numUnrestoredChannels--;
+			if (numUnrestoredChannels == 0) {
+				for (InputChannelInfo inputChannelInfo : inputGate.getChannelInfos()) {
+					inputGate.resumeConsumption(inputChannelInfo);
+				}
+				restoredChannels.clear();
+			}
+		}
+	}
+
+	@Override
+	public boolean allChannelsRecovered() {
+		return numUnrestoredChannels == 0;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -131,7 +131,8 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			mainMailboxExecutor,
 			inputGates,
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
-			checkpointBarrierHandler);
+			checkpointBarrierHandler,
+			configuration);
 
 		inputProcessor = StreamMultipleInputProcessorFactory.create(
 			this,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -512,7 +512,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	private void readRecoveredChannelState() throws IOException, InterruptedException {
 		SequentialChannelStateReader reader = getEnvironment().getTaskStateManager().getSequentialChannelStateReader();
-		reader.readOutputData(getEnvironment().getAllWriters());
+		reader.readOutputData(getEnvironment().getAllWriters(), !configuration.isGraphContainingLoops());
 		channelIOExecutor.execute(() -> {
 			try {
 				reader.readInputData(getEnvironment().getAllInputGates());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGateTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.PartitionRequestClient;
+import org.apache.flink.runtime.io.network.TestingConnectionManager;
+import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link CheckpointedInputGate} test.
+ */
+public class CheckpointedInputGateTest {
+	@Test
+	public void testUpstreamResumedUponEndOfRecovery() throws Exception {
+		int numberOfChannels = 11;
+		NetworkBufferPool bufferPool = new NetworkBufferPool(numberOfChannels * 3, 1024);
+		try {
+			ResumeCountingConnectionManager resumeCounter = new ResumeCountingConnectionManager();
+			CheckpointedInputGate gate = setupInputGate(numberOfChannels, bufferPool, resumeCounter);
+			assertFalse(gate.pollNext().isPresent());
+			for (int channelIndex = 0; channelIndex < numberOfChannels - 1; channelIndex++) {
+				emitEndOfState(gate, channelIndex);
+				assertFalse("should align (block all channels)", gate.pollNext().isPresent());
+			}
+
+			emitEndOfState(gate, numberOfChannels - 1);
+			Optional<BufferOrEvent> polled = gate.pollNext();
+			assertTrue(polled.isPresent());
+			assertTrue(polled.get().isEvent());
+			assertEquals(EndOfChannelStateEvent.INSTANCE, polled.get().getEvent());
+			assertEquals(numberOfChannels, resumeCounter.getNumResumed());
+			assertFalse("should only be a single event no matter of what is the number of channels", gate.pollNext().isPresent());
+		} finally {
+			bufferPool.destroy();
+		}
+	}
+
+	private void emitEndOfState(CheckpointedInputGate checkpointedInputGate, int channelIndex) throws IOException {
+		((RemoteInputChannel) checkpointedInputGate.getChannel(channelIndex))
+			.onBuffer(EventSerializer.toBuffer(EndOfChannelStateEvent.INSTANCE, false), 0, 0);
+	}
+
+	private CheckpointedInputGate setupInputGate(int numberOfChannels, NetworkBufferPool networkBufferPool, ResumeCountingConnectionManager connectionManager) throws Exception {
+		SingleInputGate singleInputGate = new SingleInputGateBuilder()
+			.setBufferPoolFactory(networkBufferPool.createBufferPool(numberOfChannels, Integer.MAX_VALUE))
+			.setSegmentProvider(networkBufferPool)
+			.setChannelFactory((builder, gate) -> builder.setConnectionManager(connectionManager).buildRemoteChannel(gate))
+			.setNumberOfChannels(numberOfChannels)
+			.build();
+		singleInputGate.setup();
+		CheckpointBarrierTracker barrierHandler = new CheckpointBarrierTracker(numberOfChannels, new AbstractInvokable(new DummyEnvironment()) {
+			@Override
+			public void invoke() {
+			}
+		});
+		MailboxExecutorImpl mailboxExecutor = new MailboxExecutorImpl(new TaskMailboxImpl(), 0, StreamTaskActionExecutor.IMMEDIATE);
+
+		CheckpointedInputGate checkpointedInputGate = new CheckpointedInputGate(
+			singleInputGate,
+			barrierHandler,
+			mailboxExecutor,
+			UpstreamRecoveryTracker.forInputGate(singleInputGate));
+		for (int i = 0; i < numberOfChannels; i++) {
+			((RemoteInputChannel) checkpointedInputGate.getChannel(i)).requestSubpartition(0);
+		}
+		return checkpointedInputGate;
+	}
+
+	private static class ResumeCountingConnectionManager extends TestingConnectionManager {
+		private int numResumed;
+
+		@Override
+		public PartitionRequestClient createPartitionRequestClient(ConnectionID connectionId) {
+			return new TestingPartitionRequestClient() {
+				@Override
+				public void resumeConsumption(RemoteInputChannel inputChannel) {
+					numResumed++;
+					super.resumeConsumption(inputChannel);
+				}
+			};
+		}
+
+		private int getNumResumed() {
+			return numResumed;
+		}
+	}
+}
+


### PR DESCRIPTION
Dependencies:
- #13821
- #13866
- #13878

## What is the purpose of the change

The emitted event would allow to tear down "virtual channels" used to read channel state on recovery with unaligned checkpoints and rescaling.

Upstream subpartitions are blocked upon sending this event and unblocked by the downstream when all channels receive it.

## Verifying this change
 - Added `ChannelPersistenceITCase.testUpstreamBlocksAfterRecoveringState` to test emission and blocking on the upstream side
 - Added `CheckpointedInputGateTest` to test alignment and unblocking on the downstream side

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
