### PR TITLE
[FLINK-19836] Add SimpleVersionedSerializerTypeSerializerProxy

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
@@ -28,6 +28,8 @@ import org.apache.flink.util.function.SerializableSupplier;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link TypeSerializer} that delegates to an underlying {@link SimpleVersionedSerializer}.
  *
@@ -43,7 +45,7 @@ public class SimpleVersionedSerializerTypeSerializerProxy<T> extends TypeSeriali
 
 	public SimpleVersionedSerializerTypeSerializerProxy(
 			SerializableSupplier<SimpleVersionedSerializer<T>> serializerSupplier) {
-		this.serializerSupplier = serializerSupplier;
+		this.serializerSupplier = checkNotNull(serializerSupplier, "serializerSupplier");
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/**
+ * A {@link TypeSerializer} that delegates to an underlying {@link SimpleVersionedSerializer}.
+ */
+@Internal
+public class SimpleVersionedSerializerTypeSerializerProxy<T> extends TypeSerializer<T> implements Serializable {
+
+	private final SerializableSupplier<SimpleVersionedSerializer<T>> serializerSupplier;
+	private transient SimpleVersionedSerializer<T> cachedSerializer;
+
+	public SimpleVersionedSerializerTypeSerializerProxy(
+			SerializableSupplier<SimpleVersionedSerializer<T>> serializerSupplier) {
+		this.serializerSupplier = serializerSupplier;
+	}
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public TypeSerializer<T> duplicate() {
+		final byte[] serializedSerializer;
+		try {
+			serializedSerializer = InstantiationUtil.serializeObject(serializerSupplier);
+		} catch (IOException e) {
+			throw new RuntimeException("Could not serialize SimpleVersionedSerializer.", e);
+		}
+		try {
+			return new SimpleVersionedSerializerTypeSerializerProxy<>(
+					InstantiationUtil.deserializeObject(
+							serializedSerializer,
+							serializerSupplier.getClass().getClassLoader()));
+		} catch (ClassNotFoundException | IOException e) {
+			throw new RuntimeException("Could not duplicate SimpleVersionedSerializer.", e);
+		}
+	}
+
+	@Override
+	public T createInstance() {
+		return null;
+	}
+
+	@Override
+	public T copy(T from) {
+		SimpleVersionedSerializer<T> serializer = getSerializer();
+		try {
+			byte[] serializedFrom = serializer.serialize(from);
+			return serializer.deserialize(
+					serializer.getVersion(),
+					serializedFrom);
+		} catch (IOException e) {
+			throw new RuntimeException("Could not copy element.", e);
+		}
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		// the reuse is optional, we can just ignore it
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return -1;
+	}
+
+	@Override
+	public void serialize(T record, DataOutputView target) throws IOException {
+		SimpleVersionedSerializer<T> serializer = getSerializer();
+		target.writeInt(serializer.getVersion());
+		byte[] serializedRecord = serializer.serialize(record);
+		target.writeInt(serializedRecord.length);
+		target.write(serializedRecord);
+	}
+
+	@Override
+	public T deserialize(DataInputView source) throws IOException {
+		SimpleVersionedSerializer<T> serializer = getSerializer();
+		int version = source.readInt();
+		int length = source.readInt();
+		byte[] serializedRecord = new byte[length];
+		source.readFully(serializedRecord);
+		return serializer.deserialize(version, serializedRecord);
+	}
+
+	@Override
+	public T deserialize(T reuse, DataInputView source) throws IOException {
+		// the reuse is optional, we can just ignore it
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.writeInt(source.readInt()); // version
+		int length = source.readInt();
+		target.writeInt(length); // length
+		byte[] serializedRecord = new byte[length];
+		source.readFully(serializedRecord);
+		target.write(serializedRecord);
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SimpleVersionedSerializerTypeSerializerProxy
+				&& ((SimpleVersionedSerializerTypeSerializerProxy<?>) other).serializerSupplier
+				.get()
+				.equals(serializerSupplier.get());
+	}
+
+	@Override
+	public int hashCode() {
+		return serializerSupplier.get().hashCode();
+	}
+
+	@Override
+	public TypeSerializerSnapshot<T> snapshotConfiguration() {
+		throw new UnsupportedOperationException(
+				"SimpleVersionedSerializerWrapper is not meant to be used as a general TypeSerializer for state");
+	}
+
+	private SimpleVersionedSerializer<T> getSerializer() {
+		if (cachedSerializer != null) {
+			return cachedSerializer;
+		}
+		cachedSerializer = serializerSupplier.get();
+		return cachedSerializer;
+	}
+
+	@FunctionalInterface
+	interface SerializableSupplier<T> extends Supplier<T>, Serializable {
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
@@ -33,7 +33,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A {@link TypeSerializer} that delegates to an underlying {@link SimpleVersionedSerializer}.
  *
- * <p>This should not be used as a general {@link TypeSerializer}. It's meant to be used by internal
+ * <p>This should not be used as a general {@link TypeSerializer}. It's meant to be used by
+ * internal
  * operators that need to work with both {@link SimpleVersionedSerializer} and {@link
  * TypeSerializer}.
  */
@@ -55,16 +56,10 @@ public class SimpleVersionedSerializerTypeSerializerProxy<T> extends TypeSeriali
 
 	@Override
 	public TypeSerializer<T> duplicate() {
-		final byte[] serializedSerializer;
-		try {
-			serializedSerializer = InstantiationUtil.serializeObject(serializerSupplier);
-		} catch (IOException e) {
-			throw new RuntimeException("Could not serialize SimpleVersionedSerializer.", e);
-		}
 		try {
 			return new SimpleVersionedSerializerTypeSerializerProxy<>(
-					InstantiationUtil.deserializeObject(
-							serializedSerializer,
+					InstantiationUtil.clone(
+							serializerSupplier,
 							serializerSupplier.getClass().getClassLoader()));
 		} catch (ClassNotFoundException | IOException e) {
 			throw new RuntimeException("Could not duplicate SimpleVersionedSerializer.", e);

--- a/flink-core/src/main/java/org/apache/flink/util/function/SerializableSupplier.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/SerializableSupplier.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/**
+ * A serializable {@link Supplier}.
+ *
+ * @param <T> the type of results supplied by this supplier
+ */
+@Internal
+@FunctionalInterface
+public interface SerializableSupplier<T> extends Supplier<T>, Serializable {}

--- a/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,7 +31,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.function.Supplier;
 
 /**
  * Tests for {@link ClosureCleaner}.
@@ -452,11 +452,6 @@ class OuterMapCreator implements MapCreator {
 	public MapFunction<Integer, Integer> getMap() {
 		return new OuterStaticClass().getMap();
 	}
-}
-
-@FunctionalInterface
-interface SerializableSupplier<T> extends Supplier<T>, Serializable {
-
 }
 
 class NestedSelfReferencing implements Serializable {

--- a/flink-core/src/test/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.io;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link SimpleVersionedSerializerTypeSerializerProxy}.
+ */
+public class SimpleVersionedSerializerTypeSerializerProxyTest extends SerializerTestBase<String> {
+
+	@Override
+	protected TypeSerializer<String> createSerializer() {
+		return new SimpleVersionedSerializerTypeSerializerProxy<>(TestStringSerializer::new);
+	}
+
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+
+	@Override
+	protected Class<String> getTypeClass() {
+		return String.class;
+	}
+
+	@Override
+	protected String[] getTestData() {
+		return new String[]{"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
+	}
+
+	@Override
+	public void testInstantiate() {
+		// this serializer does not support instantiation
+	}
+
+	@Override
+	public void testConfigSnapshotInstantiation() {
+		// this serializer does not support snapshots
+	}
+
+	@Override
+	public void testSnapshotConfigurationAndReconfigure() {
+		// this serializer does not support snapshots
+	}
+
+	private static final class TestStringSerializer implements SimpleVersionedSerializer<String> {
+
+		private static final int VERSION = 1;
+
+		@Override
+		public int getVersion() {
+			return VERSION;
+		}
+
+		@Override
+		public byte[] serialize(String str) {
+			return str.getBytes(StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public String deserialize(int version, byte[] serialized) {
+			assertEquals(VERSION, version);
+			return new String(serialized, StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public int hashCode() {
+			return 1;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj instanceof TestStringSerializer;
+		}
+	}
+
+}


### PR DESCRIPTION
This allows using a SimpleVersionedSerializer, which the Source and Sink
API provide, in places where we need a TypeSerializer, such as when
setting the serializer that is used for records in a DataStream/that are
send between operators.

## Brief change log

* add the class along with tests

## Verifying this change

* newly added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
