### PR TITLE
[BP-1.11][FLINK-19587][table-planner-blink] Fix error result when casting binary as varchar

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -959,7 +959,7 @@ object ScalarOperatorGens {
       generateCastArrayToString(ctx, operand, operand.resultType.asInstanceOf[ArrayType])
 
     // Byte array -> String UTF-8
-    case (VARBINARY, VARCHAR | CHAR) =>
+    case (BINARY | VARBINARY, VARCHAR | CHAR) =>
       val charset = classOf[StandardCharsets].getCanonicalName
       generateStringResultCallIfArgsNotNull(ctx, Seq(operand)) {
         terms => s"(new String(${terms.head}, $charset.UTF_8))"

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
@@ -32,7 +32,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     )
 
     testSqlApi(
-      "CAST(f0 AS DECIMAL) IN (42.0, 2.00, 3.01, 1.000000)", // SQL would downcast otherwise
+      "CAST (f0 AS DECIMAL) IN (42.0, 2.00, 3.01, 1.000000)", // SQL would downcast otherwise
       "true"
     )
 
@@ -63,6 +63,32 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
   }
 
   @Test
+  def testCast(): Unit = {
+
+    // binary -> varchar
+    testSqlApi(
+      "CAST (f18 as varchar)",
+      "hello world")
+    testSqlApi(
+      "CAST (CAST (x'68656C6C6F20636F6465' as binary) as varchar)",
+      "hello code")
+
+    // varbinary -> varchar
+    testSqlApi(
+      "CAST (f19 as varchar)",
+      "hello flink")
+    testSqlApi(
+      "CAST (CAST (x'68656C6C6F2063617374' as varbinary) as varchar)",
+      "hello cast")
+
+    // null case
+    testSqlApi("CAST (NULL AS INT)", "null")
+    testSqlApi(
+      "CAST (NULL AS VARCHAR) = ''",
+      "null")
+  }
+
+  @Test
   def testOtherExpressions(): Unit = {
 
     // nested field null type
@@ -88,12 +114,6 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "tRuE",
       "true")
 
-    // null
-    testSqlApi("CAST(NULL AS INT)", "null")
-    testSqlApi(
-      "CAST(NULL AS VARCHAR) = ''",
-      "null")
-
     // case when
     testSqlApi("CASE 11 WHEN 1 THEN 'a' ELSE 'b' END", "b")
     testSqlApi("CASE 2 WHEN 1 THEN 'a' ELSE 'b' END", "b")
@@ -116,14 +136,14 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testSqlApi("CASE WHEN 'a'='a' THEN 1 END", "1")
     testSqlApi("CASE 2 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "bcd")
     testSqlApi("CASE 1 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "a")
-    testSqlApi("CASE 1 WHEN 1 THEN cast('a' as varchar(1)) WHEN 2 THEN " +
-      "cast('bcd' as varchar(3)) END", "a")
+    testSqlApi("CASE 1 WHEN 1 THEN CAST ('a' as varchar(1)) WHEN 2 THEN " +
+      "CAST ('bcd' as varchar(3)) END", "a")
     testSqlApi("CASE f2 WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END", "11")
     testSqlApi("CASE f7 WHEN 1 THEN 11 WHEN 2 THEN 4 ELSE NULL END", "null")
     testSqlApi("CASE 42 WHEN 1 THEN 'a' WHEN 2 THEN 'bcd' END", "null")
     testSqlApi("CASE 1 WHEN 1 THEN true WHEN 2 THEN false ELSE NULL END", "true")
 
-    testSqlApi("CASE WHEN f2 = 1 THEN CAST('' as INT) ELSE 0 END", "null")
-    testSqlApi("IF(true, CAST('non-numeric' AS BIGINT), 0)", "null")
+    testSqlApi("CASE WHEN f2 = 1 THEN CAST ('' as INT) ELSE 0 END", "null")
+    testSqlApi("IF(true, CAST ('non-numeric' AS BIGINT), 0)", "null")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -18,42 +18,42 @@
 
 package org.apache.flink.table.planner.expressions.utils
 
+import java.util.Collections
+
+import org.apache.calcite.plan.hep.{HepPlanner, HepProgramBuilder}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.logical.LogicalCalc
+import org.apache.calcite.rel.rules._
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
 import org.apache.flink.api.common.TaskInfo
 import org.apache.flink.api.common.functions.util.RuntimeUDFContext
 import org.apache.flink.api.common.functions.{MapFunction, RichFunction, RichMapFunction}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
-import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl
 import org.apache.flink.table.api.{EnvironmentSettings, TableConfig}
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.data.binary.BinaryRowData
+import org.apache.flink.table.data.conversion.{DataStructureConverter, DataStructureConverters}
 import org.apache.flink.table.data.util.DataFormatConverters
+import org.apache.flink.table.data.util.DataFormatConverters.DataFormatConverter
 import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, ExprCodeGenerator, FunctionCodeGenerator}
 import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
-import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.AbstractDataType
 import org.apache.flink.table.types.logical.{RowType, VarCharType}
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.types.Row
-
-import org.apache.calcite.plan.hep.{HepPlanner, HepProgramBuilder}
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.logical.{LogicalCalc, LogicalTableScan}
-import org.apache.calcite.rel.rules._
-import org.apache.calcite.rex.RexNode
-import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
-
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.rules.ExpectedException
 import org.junit.{After, Before, Rule}
 
-import java.util.Collections
-
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 
 abstract class ExpressionTestBase {
 
@@ -66,7 +66,13 @@ abstract class ExpressionTestBase {
   // use impl class instead of interface class to avoid
   // "Static methods in interface require -target:jvm-1.8"
   private val tEnv = StreamTableEnvironmentImpl.create(env, setting, config)
-  private val planner = tEnv.asInstanceOf[TableEnvironmentImpl].getPlanner.asInstanceOf[PlannerBase]
+    .asInstanceOf[StreamTableEnvironmentImpl]
+  private val resolvedDataType = if (containsLegacyTypes) {
+    TypeConversions.fromLegacyInfoToDataType(typeInfo)
+  } else {
+    tEnv.getCatalogManager.getDataTypeFactory.createDataType(testDataType)
+  }
+  private val planner = tEnv.getPlanner.asInstanceOf[PlannerBase]
   private val relBuilder = planner.getRelBuilder
   private val calcitePlanner = planner.createFlinkPlanner
   private val parser = planner.plannerContext.createCalciteParser()
@@ -82,13 +88,16 @@ abstract class ExpressionTestBase {
   @Rule
   def thrown: ExpectedException = expectedException
 
-  def functions: Map[String, ScalarFunction] = Map()
-
   @Before
   def prepare(): Unit = {
-    val ds = env.fromCollection(Collections.emptyList[Row](), typeInfo)
-    tEnv.createTemporaryView(tableName, ds)
-    functions.foreach(f => tEnv.registerFunction(f._1, f._2))
+    if (containsLegacyTypes) {
+      val ds = env.fromCollection(Collections.emptyList[Row](), typeInfo)
+      tEnv.createTemporaryView(tableName, ds)
+      functions.foreach(f => tEnv.registerFunction(f._1, f._2))
+    } else {
+      tEnv.createTemporaryView(tableName, tEnv.fromValues(resolvedDataType))
+      testSystemFunctions.asScala.foreach(e => tEnv.createTemporarySystemFunction(e._1, e._2))
+    }
 
     // prepare RelBuilder
     relBuilder.scan(tableName)
@@ -100,7 +109,11 @@ abstract class ExpressionTestBase {
   @After
   def evaluateExprs(): Unit = {
     val ctx = CodeGeneratorContext(config)
-    val inputType = fromTypeInfoToLogicalType(typeInfo)
+    val inputType = if (containsLegacyTypes) {
+      fromTypeInfoToLogicalType(typeInfo)
+    } else {
+      resolvedDataType.getLogicalType
+    }
     val exprGenerator = new ExprCodeGenerator(ctx, nullableInput = false).bindInput(inputType)
 
     // cast expressions to String
@@ -145,10 +158,18 @@ abstract class ExpressionTestBase {
       richMapper.open(new Configuration())
     }
 
-    val converter = DataFormatConverters
-      .getConverterForDataType(dataType)
-      .asInstanceOf[DataFormatConverters.DataFormatConverter[RowData, Row]]
-    val testRow = converter.toInternal(testData)
+    val testRow = if (containsLegacyTypes) {
+      val converter = DataFormatConverters
+        .getConverterForDataType(resolvedDataType)
+        .asInstanceOf[DataFormatConverter[RowData, Row]]
+      converter.toInternal(testData)
+    } else {
+      val converter = DataStructureConverters
+        .getConverter(resolvedDataType)
+        .asInstanceOf[DataStructureConverter[RowData, Row]]
+      converter.toInternalOrNull(testData)
+    }
+
     val result = mapper.map(testRow)
 
     // call close method for RichFunction
@@ -194,7 +215,7 @@ abstract class ExpressionTestBase {
     val optimized = hep.findBestExp()
 
     // throw exception if plan contains more than a calc
-    if (!optimized.getInput(0).isInstanceOf[LogicalTableScan]) {
+    if (!optimized.getInput(0).getInputs.isEmpty) {
       fail("Expression is converted into more than a Calc operation. Use a different test method.")
     }
 
@@ -210,20 +231,10 @@ abstract class ExpressionTestBase {
 
   def testAllApis(
       expr: Expression,
-      exprString: String,
       sqlExpr: String,
       expected: String): Unit = {
     addTableApiTestExpr(expr, expected)
-    addTableApiTestExpr(exprString, expected)
     addSqlTestExpr(sqlExpr, expected)
-  }
-
-  def testTableApi(
-      expr: Expression,
-      exprString: String,
-      expected: String): Unit = {
-    addTableApiTestExpr(expr, expected)
-    addTableApiTestExpr(exprString, expected)
   }
 
   def testTableApi(
@@ -252,8 +263,41 @@ abstract class ExpressionTestBase {
 
   def testData: Row
 
-  def typeInfo: RowTypeInfo
+  def testDataType: AbstractDataType[_] =
+    throw new IllegalArgumentException("Implement this if no legacy types are expected.")
 
-  def dataType: DataType = TypeConversions.fromLegacyInfoToDataType(typeInfo)
+  def testSystemFunctions: java.util.Map[String, ScalarFunction] = Collections.emptyMap();
 
+  // ----------------------------------------------------------------------------------------------
+  // Legacy type system
+  // ----------------------------------------------------------------------------------------------
+
+  def containsLegacyTypes: Boolean = true
+
+  @deprecated
+  def functions: Map[String, ScalarFunction] = Map()
+
+  @deprecated
+  def typeInfo: RowTypeInfo =
+    throw new IllegalArgumentException("Implement this if legacy types are expected.")
+
+  @deprecated
+  def testAllApis(
+      expr: Expression,
+      exprString: String,
+      sqlExpr: String,
+      expected: String): Unit = {
+    addTableApiTestExpr(expr, expected)
+    addTableApiTestExpr(exprString, expected)
+    addSqlTestExpr(sqlExpr, expected)
+  }
+
+  @deprecated
+  def testTableApi(
+      expr: Expression,
+      exprString: String,
+      expected: String): Unit = {
+    addTableApiTestExpr(expr, expected)
+    addTableApiTestExpr(exprString, expected)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarOperatorsTestBase.scala
@@ -18,18 +18,17 @@
 
 package org.apache.flink.table.planner.expressions.utils
 
-import org.apache.flink.api.common.typeinfo.Types
-import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.data.DecimalDataUtils
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
-import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo
+import org.apache.flink.table.types.AbstractDataType
 import org.apache.flink.types.Row
 
 abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val testData = new Row(18)
+    val testData = new Row(20)
     testData.setField(0, 1: Byte)
     testData.setField(1, 1: Short)
     testData.setField(2, 1)
@@ -46,33 +45,44 @@ abstract class ScalarOperatorsTestBase extends ExpressionTestBase {
     testData.setField(13, Row.of("foo", null))
     testData.setField(14, null)
     testData.setField(15, localDate("1996-11-10"))
-    testData.setField(16, DecimalDataUtils.castFrom("0.00000000", 19, 8))
-    testData.setField(17, DecimalDataUtils.castFrom("10.0", 19, 1))
+    testData.setField(16,
+        DecimalDataUtils.castFrom("0.00000000", 19, 8).toBigDecimal)
+    testData.setField(17,
+        DecimalDataUtils.castFrom("10.0", 19, 1).toBigDecimal)
+    testData.setField(18, "hello world".getBytes())
+    testData.setField(19, "hello flink".getBytes())
     testData
   }
 
-  override def typeInfo: RowTypeInfo = {
-    new RowTypeInfo(
-      /* 0 */  Types.BYTE,
-      /* 1 */  Types.SHORT,
-      /* 2 */  Types.INT,
-      /* 3 */  Types.LONG,
-      /* 4 */  Types.FLOAT,
-      /* 5 */  Types.DOUBLE,
-      /* 6 */  Types.BOOLEAN,
-      /* 7 */  Types.DOUBLE,
-      /* 8 */  Types.INT,
-      /* 9 */  Types.INT,
-      /* 10 */ Types.STRING,
-      /* 11 */ Types.BOOLEAN,
-      /* 12 */ Types.BOOLEAN,
-      /* 13 */ Types.ROW(Types.STRING, Types.STRING),
-      /* 14 */ Types.STRING,
-      /* 15 */ Types.LOCAL_DATE,
-      /* 16 */ DecimalDataTypeInfo.of(19, 8),
-      /* 17 */ DecimalDataTypeInfo.of(19, 1)
+  override def testDataType: AbstractDataType[_] = {
+    DataTypes.ROW(
+        DataTypes.FIELD("f0", DataTypes.TINYINT()),
+        DataTypes.FIELD("f1", DataTypes.SMALLINT()),
+        DataTypes.FIELD("f2", DataTypes.INT()),
+        DataTypes.FIELD("f3", DataTypes.BIGINT()),
+        DataTypes.FIELD("f4", DataTypes.FLOAT()),
+        DataTypes.FIELD("f5", DataTypes.DOUBLE()),
+        DataTypes.FIELD("f6", DataTypes.BOOLEAN()),
+        DataTypes.FIELD("f7", DataTypes.DOUBLE()),
+        DataTypes.FIELD("f8", DataTypes.INT()),
+        DataTypes.FIELD("f9", DataTypes.INT()),
+        DataTypes.FIELD("f10", DataTypes.STRING()),
+        DataTypes.FIELD("f11", DataTypes.BOOLEAN()),
+        DataTypes.FIELD("f12", DataTypes.BOOLEAN()),
+        DataTypes.FIELD("f13", DataTypes.ROW(
+            DataTypes.FIELD("f0", DataTypes.STRING()),
+            DataTypes.FIELD("f1", DataTypes.STRING()))
+        ),
+        DataTypes.FIELD("f14", DataTypes.STRING()),
+        DataTypes.FIELD("f15", DataTypes.DATE()),
+        DataTypes.FIELD("f16", DataTypes.DECIMAL(19, 8)),
+        DataTypes.FIELD("f17", DataTypes.DECIMAL(19, 1)),
+        DataTypes.FIELD("f18", DataTypes.BINARY(200)),
+        DataTypes.FIELD("f19", DataTypes.VARBINARY(200))
     )
   }
+
+  override def containsLegacyTypes: Boolean = false
 
   override def functions: Map[String, ScalarFunction] = Map(
     "shouldNotExecuteFunc" -> ShouldNotExecuteFunc


### PR DESCRIPTION
## What is the purpose of the change

1. This is a backport of FLINK-19587 for 1.11, cherry picked from commit d9b0ac97ee4675aebdab1592af663b95fdc5051b.
2. Cherry pick commit b2f88660b2b0897e57565e5b197ba83f20a03228 to support new type system for `ExpressionTestBase`. This  also allows to use new type system in `ExpressionTestBase` for 1.11 later.


## Brief change log

cherry d9b0ac97ee4675aebdab1592af663b95fdc5051b
cherry b2f88660b2b0897e57565e5b197ba83f20a03228