### PR TITLE
[FLINK-19681][checkpointing] Timeout aligned checkpoints based on checkpointStartDelay 

### DIFF
--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -10,7 +10,7 @@
     <tbody>
         <tr>
             <td><h5>execution.checkpointing.alignment-timeout</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
+            <td style="word-wrap: break-word;">3 ms</td>
             <td>Duration</td>
             <td>Only relevant if <span markdown="span">`execution.checkpointing.unaligned`</span> is enabled.<br /><br />If timeout is 0, checkpoints will always start unaligned.<br /><br />If timeout has a positive value, checkpoints will start aligned. If during checkpointing, checkpoint start delay exceeds this timeout, alignment will timeout and checkpoint barrier will start working as unaligned checkpoint.</td>
         </tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointOptions.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Options for performing the checkpoint.
@@ -187,5 +188,15 @@ public class CheckpointOptions implements Serializable {
 			isExactlyOnceMode,
 			isUnalignedCheckpoint,
 			alignmentTimeout);
+	}
+
+	public CheckpointOptions toTimeouted() {
+		checkState(checkpointType == CheckpointType.CHECKPOINT);
+		return create(
+			checkpointType,
+			targetLocation,
+			isExactlyOnceMode,
+			true,
+			0);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -235,6 +235,9 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
 	private BufferBuilder appendUnicastDataForNewRecord(
 			final ByteBuffer record,
 			final int targetSubpartition) throws IOException {
+		if (targetSubpartition < 0 || targetSubpartition > unicastBufferBuilders.length) {
+			throw new ArrayIndexOutOfBoundsException(targetSubpartition);
+		}
 		BufferBuilder buffer = unicastBufferBuilders[targetSubpartition];
 
 		if (buffer == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -26,13 +26,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A deque-like data structure that supports prioritization of elements, such they will be polled before any
@@ -152,18 +150,17 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
 	 */
 	public T getAndRemove(Predicate<T> preCondition) {
 		Iterator<T> iterator = deque.iterator();
-		T found = null;
 		for (int i = 0; i < deque.size(); i++) {
 			T next = iterator.next();
 			if (preCondition.test(next)) {
 				if (i < numPriorityElements) {
 					numPriorityElements--;
 				}
-				found = next;
-				checkState(deque.remove(found));
+				iterator.remove();
+				return next;
 			}
 		}
-		return checkNotNull(found);
+		throw new NoSuchElementException();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -27,8 +27,12 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A deque-like data structure that supports prioritization of elements, such they will be polled before any
@@ -139,6 +143,27 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
 	 */
 	public Collection<T> asUnmodifiableCollection() {
 		return Collections.unmodifiableCollection(deque);
+	}
+
+	/**
+	 * Find first element matching the {@link Predicate}, remove it from the {@link PrioritizedDeque}
+	 * and return it.
+	 * @return removed element
+	 */
+	public T getAndRemove(Predicate<T> preCondition) {
+		Iterator<T> iterator = deque.iterator();
+		T found = null;
+		for (int i = 0; i < deque.size(); i++) {
+			T next = iterator.next();
+			if (preCondition.test(next)) {
+				if (i < numPriorityElements) {
+					numPriorityElements--;
+				}
+				found = next;
+				checkState(deque.remove(found));
+			}
+		}
+		return checkNotNull(found);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
@@ -43,4 +43,6 @@ public interface CheckpointableInput {
 	void checkpointStopped(long cancelledCheckpointId);
 
 	int getInputGateIndex();
+
+	void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
+import java.io.IOException;
+
 /**
  * An {@link InputGate} with a specific index.
  */
@@ -51,5 +53,10 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
 	@Override
 	public void blockConsumption(InputChannelInfo channelInfo) {
 		// Unused. Network stack is blocking consumption automatically by revoking credits.
+	}
+
+	@Override
+	public void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException {
+		getChannel(channelIndex).convertToPriorityEvent(sequenceNumber);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.PartitionException;
@@ -189,6 +190,9 @@ public abstract class InputChannel {
 	 * Called by task thread on cancel/complete to clean-up temporary data.
 	 */
 	public void checkpointStopped(long checkpointId) {
+	}
+
+	public void convertToPriorityEvent(int sequenceNumber) throws IOException {
 	}
 
 	// ------------------------------------------------------------------------
@@ -419,6 +423,10 @@ public abstract class InputChannel {
 			if (priorityEvent instanceof CheckpointBarrier) {
 				pendingCheckpointBarrierId = BARRIER_RECEIVED;
 				return true;
+			}
+			else if (priorityEvent instanceof EventAnnouncement) {
+				EventAnnouncement announcement = (EventAnnouncement) priorityEvent;
+				return announcement.getAnnouncedEvent() instanceof CheckpointBarrier;
 			}
 			return false;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -387,6 +387,7 @@ public abstract class InputChannel {
 
 		protected void startPersisting(long barrierId, List<Buffer> knownBuffers) {
 			checkState(isInitialized(), "Channel state writer not injected");
+			checkState(pendingCheckpointBarrierId != barrierId);
 
 			if (pendingCheckpointBarrierId != BARRIER_RECEIVED) {
 				pendingCheckpointBarrierId = barrierId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -555,6 +555,7 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 			int numPriorityElementsBeforeRemoval = receivedBuffers.getNumPriorityElements();
 			SequenceBuffer toPrioritize = receivedBuffers.getAndRemove(
 				sequenceBuffer -> sequenceBuffer.sequenceNumber == sequenceNumber);
+			checkState(lastOvertakenSequenceNumber == sequenceNumber);
 			checkState(!toPrioritize.buffer.isBuffer());
 			checkState(
 				numPriorityElementsBeforeRemoval == receivedBuffers.getNumPriorityElements(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -46,7 +46,6 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -62,7 +61,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class RemoteInputChannel extends InputChannel implements ChannelStateHolder {
 
-	public static final int ALL = -1;
 	/** ID to distinguish this channel from other channels sharing the same TCP connection. */
 	private final InputChannelID id = new InputChannelID();
 
@@ -100,9 +98,14 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 
 	private final BufferManager bufferManager;
 
-	/** Stores #overtaken buffers when a checkpoint barrier is received before task thread started checkpoint. */
+	/**
+	 * Indicates the last overtaken sequence number by the most recent {@link CheckpointBarrier}
+	 * before task thread started checkpoint, or {@code null} if {@link CheckpointBarrier} hasn't
+	 * arrived yet.
+	 */
 	@GuardedBy("receivedBuffers")
-	private int numBuffersOvertaken = ALL;
+	@Nullable
+	private Integer lastOvertakenSequenceNumber = null;
 
 	@GuardedBy("receivedBuffers")
 	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null);
@@ -125,6 +128,11 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
 		this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
+	}
+
+	@VisibleForTesting
+	void setExpectedSequenceNumber(int expectedSequenceNumber) {
+		this.expectedSequenceNumber = expectedSequenceNumber;
 	}
 
 	public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {
@@ -481,7 +489,7 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 		if (channelStatePersister.checkForBarrier(sequenceBuffer.buffer)) {
 			// checkpoint was not yet started by task thread,
 			// so remember the numbers of buffers to spill for the time when it will be started
-			numBuffersOvertaken = receivedBuffers.getNumUnprioritizedElements();
+			lastOvertakenSequenceNumber = sequenceBuffer.sequenceNumber;
 		}
 		return receivedBuffers.getNumPriorityElements() == 1;
 	}
@@ -506,41 +514,74 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 		synchronized (receivedBuffers) {
 			channelStatePersister.startPersisting(
 				barrier.getId(),
-				getInflightBuffers(numBuffersOvertaken == ALL ? receivedBuffers.getNumUnprioritizedElements() : numBuffersOvertaken));
+				getInflightBuffers());
 		}
 	}
 
 	public void checkpointStopped(long checkpointId) {
 		synchronized (receivedBuffers) {
 			channelStatePersister.stopPersisting();
-			numBuffersOvertaken = ALL;
+			lastOvertakenSequenceNumber = null;
+		}
+	}
+
+	@VisibleForTesting
+	List<Buffer> getInflightBuffers() {
+		synchronized (receivedBuffers) {
+			return getInflightBuffersUnsafe();
 		}
 	}
 
 	/**
 	 * Returns a list of buffers, checking the first n non-priority buffers, and skipping all events.
 	 */
-	private List<Buffer> getInflightBuffers(int numBuffers) {
+	private List<Buffer> getInflightBuffersUnsafe() {
 		assert Thread.holdsLock(receivedBuffers);
 
-		if (numBuffers == 0) {
-			return Collections.emptyList();
-		}
 
-		final List<Buffer> inflightBuffers = new ArrayList<>(numBuffers);
+		final List<Buffer> inflightBuffers = new ArrayList<>();
 		Iterator<SequenceBuffer> iterator = receivedBuffers.iterator();
 		// skip all priority events (only buffers are stored anyways)
 		Iterators.advance(iterator, receivedBuffers.getNumPriorityElements());
 
-		// spill number of overtaken buffers or all of them if barrier has not been seen yet
-		for (int pos = 0; pos < numBuffers; pos++) {
-			Buffer buffer = iterator.next().buffer;
-			if (buffer.isBuffer()) {
-				inflightBuffers.add(buffer.retainBuffer());
+		while (iterator.hasNext()) {
+			SequenceBuffer sequenceBuffer = iterator.next();
+			if (sequenceBuffer.buffer.isBuffer() && shouldBeSpilled(sequenceBuffer.sequenceNumber)) {
+				inflightBuffers.add(sequenceBuffer.buffer.retainBuffer());
 			}
 		}
 
+		lastOvertakenSequenceNumber = null;
+
 		return inflightBuffers;
+	}
+
+	/**
+	 * @return if given {@param sequenceNumber} should be spilled given {@link #lastOvertakenSequenceNumber}.
+	 * We might not have yet received {@link CheckpointBarrier} and we might need to spill everything.
+	 * If we have already received it, there is a bit nasty corner case of {@link SequenceBuffer#sequenceNumber}
+	 * overflowing that needs to be handled as well.
+	 */
+	private boolean shouldBeSpilled(int sequenceNumber) {
+		if (lastOvertakenSequenceNumber == null) {
+			return true;
+		}
+		checkState(
+			receivedBuffers.size() < Integer.MAX_VALUE / 2,
+			"Too many buffers for sequenceNumber overflow detection code to work correctly");
+
+		boolean possibleOverflowAfterOvertaking = Integer.MAX_VALUE / 2 < lastOvertakenSequenceNumber;
+		boolean possibleOverflowBeforeOvertaking = lastOvertakenSequenceNumber < -Integer.MAX_VALUE / 2;
+
+		if (possibleOverflowAfterOvertaking) {
+			return sequenceNumber < lastOvertakenSequenceNumber && sequenceNumber > 0;
+		}
+		else if (possibleOverflowBeforeOvertaking) {
+			return sequenceNumber < lastOvertakenSequenceNumber || sequenceNumber > 0;
+		}
+		else {
+			return sequenceNumber < lastOvertakenSequenceNumber;
+		}
 	}
 
 	public void onEmptyBuffer(int sequenceNumber, int backlog) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PrioritizedDequeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PrioritizedDequeTest.java
@@ -19,7 +19,11 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.junit.Test;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Tests PrioritizedDeque.
@@ -52,5 +56,28 @@ public class PrioritizedDequeTest {
 		deque.prioritize(3);
 
 		assertArrayEquals(new Integer[] { 3, 0, 1, 2 }, deque.asUnmodifiableCollection().toArray(new Integer[0]));
+	}
+
+	@Test
+	public void testGetAndRemove() {
+		final PrioritizedDeque<Integer> deque = new PrioritizedDeque<>();
+
+		deque.add(0);
+		deque.add(1);
+		deque.add(2);
+		deque.add(1);
+		deque.add(3);
+
+		assertEquals(1, deque.getAndRemove(v -> v == 1).intValue());
+		assertArrayEquals(new Integer[] { 0, 2, 1, 3 }, deque.asUnmodifiableCollection().toArray(new Integer[0]));
+		assertEquals(1, deque.getAndRemove(v -> v == 1).intValue());
+		assertArrayEquals(new Integer[] { 0, 2, 3 }, deque.asUnmodifiableCollection().toArray(new Integer[0]));
+		try {
+			int removed = deque.getAndRemove(v -> v == 1);
+			fail(String.format("This should not happen. Item [%s] was removed, but it shouldn't be found", removed));
+		}
+		catch (NoSuchElementException ex) {
+			// expected
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -72,6 +72,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.runtime.io.network.api.serialization.EventSerializer.toBuffer;
@@ -82,6 +83,7 @@ import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtil
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
@@ -1125,58 +1127,56 @@ public class RemoteInputChannelTest {
 
 	@Test
 	public void testPrioritySequenceNumbers() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
-		SingleInputGate inputGate = new SingleInputGateBuilder()
-			.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
-			.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
-			.setSegmentProvider(networkBufferPool)
-			.build();
-		final RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
-		inputGate.setup();
-		inputGate.requestPartitions();
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndBarrier(channel, 0);
 
-		CheckpointOptions options = new CheckpointOptions(CHECKPOINT, CheckpointStorageLocationReference.getDefault());
-		channel.onBuffer(createBuffer(1), 0, 0);
-		channel.onBuffer(toBuffer(new CheckpointBarrier(1L, 123L, options), true), 1, 0);
-		channel.onBuffer(createBuffer(1), 2, 0);
-		channel.onBuffer(createBuffer(1), 3, 0);
+		assertGetNextBufferSequenceNumbers(channel, 2, 0, 1, 3, 4);
+	}
 
-		assertEquals(1, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(0, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(2, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(3, channel.getNextBuffer().get().getSequenceNumber());
+	@Test
+	public void testGetInflightBuffers() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndBarrier(channel, 0);
+		assertInflightBufferSizes(channel, 1, 2);
+	}
+
+	@Test
+	public void testGetAllInflightBuffers() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndBarrier(channel, Integer.MAX_VALUE - 2, Optional.empty());
+		assertInflightBufferSizes(channel, 1, 2, 3, 4);
+	}
+
+	@Test
+	public void testGetInflightBuffersOverflow() throws Exception {
+		for (int startingSequence = Integer.MAX_VALUE - 10; startingSequence != Integer.MIN_VALUE + 2; startingSequence++) {
+			final RemoteInputChannel channel = buildInputGateAndGetChannel();
+			sendBuffersAndBarrier(channel, startingSequence);
+			assertThat(
+				"For starting sequence " + startingSequence,
+				toBufferSizes(channel.getInflightBuffers()),
+				contains(1, 2));
+		}
+	}
+
+	@Test
+	public void testGetInflightBuffersAfterPollingBuffer() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndBarrier(channel, 0);
+		assertGetNextBufferSequenceNumbers(channel, 2, 0);
+		assertInflightBufferSizes(channel, 2);
+	}
+
+	private static List<Integer> toBufferSizes(List<Buffer> inflightBuffers) {
+		return inflightBuffers.stream()
+			.map(buffer -> buffer.getSize())
+			.collect(Collectors.toList());
 	}
 
 	@Test
 	public void testRequiresAnnouncement() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
-		SingleInputGate inputGate = new SingleInputGateBuilder()
-				.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
-				.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
-				.setSegmentProvider(networkBufferPool)
-				.build();
-		final RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
-		inputGate.setup();
-		inputGate.requestPartitions();
-
-		final long timeout = 10;
-		CheckpointOptions options = CheckpointOptions.create(
-				CHECKPOINT,
-				CheckpointStorageLocationReference.getDefault(),
-				true,
-				true,
-				timeout);
-
-		assertTrue(options.needsAlignment());
-		assertTrue(options.isTimeoutable());
-		assertFalse(options.isUnalignedCheckpoint());
-		Buffer checkpointBarrierBuffer = toBuffer(new CheckpointBarrier(1L, 123L, options), false);
-		assertEquals(DataType.TIMEOUTABLE_ALIGNED_CHECKPOINT_BARRIER, checkpointBarrierBuffer.getDataType());
-
-		channel.onBuffer(createBuffer(1), 0, 0);
-		channel.onBuffer(createBuffer(1), 1, 0);
-		channel.onBuffer(checkpointBarrierBuffer, 2, 0);
-		channel.onBuffer(createBuffer(1), 3, 0);
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndTimeOutableBarrier(channel);
 
 		BufferAndAvailability nextBuffer = channel.getNextBuffer().get();
 		assertEquals(2, nextBuffer.getSequenceNumber());
@@ -1184,11 +1184,80 @@ public class RemoteInputChannelTest {
 		assertTrue(nextBuffer.moreAvailable());
 		assertEquals(DataType.PRIORITIZED_EVENT_BUFFER, nextBuffer.buffer().getDataType());
 
-		assertEquals(0, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(1, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(2, channel.getNextBuffer().get().getSequenceNumber());
+		assertGetNextBufferSequenceNumbers(channel, 0, 1);
+
+		nextBuffer = channel.getNextBuffer().get();
+		assertEquals(2, nextBuffer.getSequenceNumber());
+		assertEquals(DataType.TIMEOUTABLE_ALIGNED_CHECKPOINT_BARRIER, nextBuffer.buffer().getDataType());
+
 		assertEquals(3, channel.getNextBuffer().get().getSequenceNumber());
 	}
+
+	private void sendBuffersAndTimeOutableBarrier(RemoteInputChannel channel) throws IOException {
+		CheckpointOptions options = CheckpointOptions.create(
+			CHECKPOINT,
+			CheckpointStorageLocationReference.getDefault(),
+			true,
+			true,
+			10);
+		assertTrue(options.needsAlignment());
+		assertTrue(options.isTimeoutable());
+		assertFalse(options.isUnalignedCheckpoint());
+		sendBuffersAndBarrier(channel, 0, Optional.of(options));
+	}
+
+	private void sendBuffersAndBarrier(RemoteInputChannel channel, int startingSequenceNumber) throws IOException {
+		CheckpointOptions options = CheckpointOptions.create(
+			CHECKPOINT,
+			CheckpointStorageLocationReference.getDefault(),
+			true,
+			true,
+			0);
+		sendBuffersAndBarrier(
+			channel,
+			startingSequenceNumber,
+			Optional.of(options));
+	}
+
+	private void sendBuffersAndBarrier(
+			RemoteInputChannel channel,
+			int startingSequenceNumber,
+			Optional<CheckpointOptions> options) throws IOException {
+		int sequenceNumber = startingSequenceNumber;
+
+		int bufferSize = 1;
+		channel.setExpectedSequenceNumber(startingSequenceNumber);
+		channel.onBuffer(createBuffer(bufferSize++), sequenceNumber++, 0);
+		channel.checkError();
+		channel.onBuffer(createBuffer(bufferSize++), sequenceNumber++, 0);
+		channel.checkError();
+		if (options.isPresent()) {
+			channel.onBuffer(
+				toBuffer(new CheckpointBarrier(1L, 123L, options.get()), options.get().isUnalignedCheckpoint()),
+				sequenceNumber++,
+				0);
+			channel.checkError();
+		}
+		channel.onBuffer(createBuffer(bufferSize++), sequenceNumber++, 0);
+		channel.checkError();
+		channel.onBuffer(createBuffer(bufferSize++), sequenceNumber++, 0);
+		channel.checkError();
+	}
+
+	private void assertInflightBufferSizes(RemoteInputChannel channel, Integer ...bufferSizes) throws IOException {
+		assertThat(toBufferSizes(channel.getInflightBuffers()), contains(bufferSizes));
+	}
+
+	private void assertGetNextBufferSequenceNumbers(RemoteInputChannel channel, Integer ...sequenceNumbers) throws IOException {
+		List<Integer> actualSequenceNumbers = new ArrayList<>();
+		for (int i = 0; i < sequenceNumbers.length; i++) {
+			channel.getNextBuffer()
+				.map(BufferAndAvailability::getSequenceNumber)
+				.ifPresent(actualSequenceNumbers::add);
+		}
+		assertThat(actualSequenceNumbers, contains(sequenceNumbers));
+	}
+
 	// ---------------------------------------------------------------------------------------------
 
 	private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate) {
@@ -1214,6 +1283,22 @@ public class RemoteInputChannelTest {
 			.setPartitionId(partitionId)
 			.setConnectionManager(connectionManager)
 			.buildRemoteChannel(inputGate);
+	}
+
+	private RemoteInputChannel buildInputGateAndGetChannel() throws IOException {
+		return (RemoteInputChannel) buildInputGate().getChannel(0);
+	}
+
+	private SingleInputGate buildInputGate() throws IOException {
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+		SingleInputGate inputGate = new SingleInputGateBuilder()
+			.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
+			.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+			.setSegmentProvider(networkBufferPool)
+			.build();
+		inputGate.setup();
+		inputGate.requestPartitions();
+		return inputGate;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -1193,6 +1193,29 @@ public class RemoteInputChannelTest {
 		assertEquals(3, channel.getNextBuffer().get().getSequenceNumber());
 	}
 
+	@Test
+	public void testGetInflightBuffersBeforeProcessingAnnouncement() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndTimeOutableBarrier(channel);
+		assertInflightBufferSizes(channel, 1, 2);
+	}
+
+	@Test
+	public void testGetInflightBuffersAfterProcessingAnnouncement() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndTimeOutableBarrier(channel);
+		assertGetNextBufferSequenceNumbers(channel, 2);
+		assertInflightBufferSizes(channel, 1, 2);
+	}
+
+	@Test
+	public void testGetInflightBuffersAfterProcessingAnnouncementAndBuffer() throws Exception {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		sendBuffersAndTimeOutableBarrier(channel);
+		assertGetNextBufferSequenceNumbers(channel, 2, 0);
+		assertInflightBufferSizes(channel, 2);
+	}
+
 	private void sendBuffersAndTimeOutableBarrier(RemoteInputChannel channel) throws IOException {
 		CheckpointOptions options = CheckpointOptions.create(
 			CHECKPOINT,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -147,7 +147,7 @@ public class ExecutionCheckpointingOptions {
 	public static final ConfigOption<Duration> ALIGNMENT_TIMEOUT =
 		ConfigOptions.key("execution.checkpointing.alignment-timeout")
 			.durationType()
-			.defaultValue(Duration.ofSeconds(30))
+			.defaultValue(Duration.ofMillis(3))
 			.withDescription(Description.builder()
 				.text("Only relevant if %s is enabled.", TextElement.code(ENABLE_UNALIGNED.key()))
 				.linebreak()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlignedController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlignedController.java
@@ -49,6 +49,10 @@ public class AlignedController implements CheckpointBarrierBehaviourController {
 	}
 
 	@Override
+	public void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier) {
+	}
+
+	@Override
 	public void barrierReceived(
 			InputChannelInfo channelInfo,
 			CheckpointBarrier barrier) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
@@ -97,15 +97,7 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
 	public Optional<CheckpointBarrier> preProcessFirstBarrier(
 			InputChannelInfo channelInfo,
 			CheckpointBarrier barrier) throws IOException {
-		Optional<CheckpointBarrier> maybeTimedOut = maybeTimeOut(barrier);
-
-		if (maybeTimedOut.isPresent()) {
-			timeoutToUnalignedCheckpoint(channelInfo, maybeTimedOut.get());
-			return maybeTimedOut;
-		}
-		else {
-			return activeController.preProcessFirstBarrier(channelInfo, barrier);
-		}
+		return activeController.preProcessFirstBarrier(channelInfo, barrier);
 	}
 
 	private void timeoutToUnalignedCheckpoint(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingController.java
@@ -44,6 +44,11 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
 	}
 
 	@Override
+	public void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier) {
+		activeController = chooseController(barrier);
+	}
+
+	@Override
 	public void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
 		checkActiveController(barrier);
 		activeController.barrierReceived(channelInfo, barrier);
@@ -53,7 +58,7 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
 	public boolean preProcessFirstBarrier(
 			InputChannelInfo channelInfo,
 			CheckpointBarrier barrier) throws IOException {
-		activeController = chooseController(barrier);
+		checkActiveController(barrier);
 		return activeController.preProcessFirstBarrier(channelInfo, barrier);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
@@ -32,6 +32,11 @@ import java.io.IOException;
 public interface CheckpointBarrierBehaviourController {
 
 	/**
+	 * Invoked before first {@link CheckpointBarrier} or it's announcement.
+	 */
+	void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier);
+
+	/**
 	 * Invoked per every received {@link CheckpointBarrier}.
 	 */
 	void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
@@ -37,6 +37,12 @@ public interface CheckpointBarrierBehaviourController {
 	void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier);
 
 	/**
+	 * Invoked per every checkpoint barrier announcement.
+	 * @return {@code true} if this should trigger a checkpoint.
+	 */
+	boolean barrierAnnouncement(InputChannelInfo channelInfo, CheckpointBarrier announcedBarrier, int sequenceNumber) throws IOException;
+
+	/**
 	 * Invoked per every received {@link CheckpointBarrier}.
 	 */
 	void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierBehaviourController.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Controls when the checkpoint should be actually triggered.
@@ -37,29 +38,28 @@ public interface CheckpointBarrierBehaviourController {
 	void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier);
 
 	/**
-	 * Invoked per every checkpoint barrier announcement.
-	 * @return {@code true} if this should trigger a checkpoint.
+	 * Invoked per every {@link CheckpointBarrier} announcement.
 	 */
-	boolean barrierAnnouncement(InputChannelInfo channelInfo, CheckpointBarrier announcedBarrier, int sequenceNumber) throws IOException;
+	void barrierAnnouncement(InputChannelInfo channelInfo, CheckpointBarrier announcedBarrier, int sequenceNumber) throws IOException;
 
 	/**
 	 * Invoked per every received {@link CheckpointBarrier}.
 	 */
-	void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier);
+	Optional<CheckpointBarrier> barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException;
 
 	/**
 	 * Invoked once per checkpoint, before the first invocation of
 	 * {@link #barrierReceived(InputChannelInfo, CheckpointBarrier)} for that given checkpoint.
 	 * @return {@code true} if checkpoint should be triggered.
 	 */
-	boolean preProcessFirstBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException;
+	Optional<CheckpointBarrier> preProcessFirstBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException;
 
 	/**
 	 * Invoked once per checkpoint, after the last invocation of
 	 * {@link #barrierReceived(InputChannelInfo, CheckpointBarrier)} for that given checkpoint.
 	 * @return {@code true} if checkpoint should be triggered.
 	 */
-	boolean postProcessLastBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException;
+	Optional<CheckpointBarrier> postProcessLastBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException;
 
 	void abortPendingCheckpoint(long cancelledId, CheckpointException exception) throws IOException;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInpu
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -125,6 +126,10 @@ public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Check
 	@Override
 	public int getInputGateIndex() {
 		return inputGateIndex;
+	}
+
+	@Override
+	public void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException {
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
@@ -44,6 +44,10 @@ public class UnalignedController implements CheckpointBarrierBehaviourController
 	}
 
 	@Override
+	public void preProcessFirstBarrierOrAnnouncement(CheckpointBarrier barrier) {
+	}
+
+	@Override
 	public void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
@@ -48,6 +48,15 @@ public class UnalignedController implements CheckpointBarrierBehaviourController
 	}
 
 	@Override
+	public boolean barrierAnnouncement(
+			InputChannelInfo channelInfo,
+			CheckpointBarrier announcedBarrier,
+			int sequenceNumber) throws IOException {
+		inputs[channelInfo.getGateIdx()].convertToPriorityEvent(channelInfo.getInputChannelIdx(), sequenceNumber);
+		return false;
+	}
+
+	@Override
 	public void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/UnalignedController.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInpu
 import org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinator;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Controller for unaligned checkpoints.
@@ -48,31 +49,33 @@ public class UnalignedController implements CheckpointBarrierBehaviourController
 	}
 
 	@Override
-	public boolean barrierAnnouncement(
+	public void barrierAnnouncement(
 			InputChannelInfo channelInfo,
 			CheckpointBarrier announcedBarrier,
 			int sequenceNumber) throws IOException {
-		inputs[channelInfo.getGateIdx()].convertToPriorityEvent(channelInfo.getInputChannelIdx(), sequenceNumber);
-		return false;
+		inputs[channelInfo.getGateIdx()].convertToPriorityEvent(
+			channelInfo.getInputChannelIdx(),
+			sequenceNumber);
 	}
 
 	@Override
-	public void barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
+	public Optional<CheckpointBarrier> barrierReceived(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
+		return Optional.empty();
 	}
 
 	@Override
-	public boolean preProcessFirstBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException {
+	public Optional<CheckpointBarrier> preProcessFirstBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) throws IOException {
 		checkpointCoordinator.initCheckpoint(barrier.getId(), barrier.getCheckpointOptions());
 		for (final CheckpointableInput input : inputs) {
 			input.checkpointStarted(barrier);
 		}
-		return true;
+		return Optional.of(barrier);
 	}
 
 	@Override
-	public boolean postProcessLastBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
+	public Optional<CheckpointBarrier> postProcessLastBarrier(InputChannelInfo channelInfo, CheckpointBarrier barrier) {
 		resetPendingCheckpoint(barrier.getId());
-		return false;
+		return Optional.empty();
 	}
 
 	private void resetPendingCheckpoint(long cancelledId) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -86,6 +86,11 @@ public class MailboxProcessor implements Closeable {
 
 	private Meter idleTime = new MeterView(new SimpleCounter());
 
+	@VisibleForTesting
+	public MailboxProcessor() {
+		this(MailboxDefaultAction.Controller::suspendDefaultAction);
+	}
+
 	public MailboxProcessor(MailboxDefaultAction mailboxDefaultAction) {
 		this(mailboxDefaultAction, StreamTaskActionExecutor.IMMEDIATE);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/ValidatingCheckpointHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/ValidatingCheckpointHandler.java
@@ -46,7 +46,8 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
 	protected long abortedCheckpointCounter = 0;
 	protected CompletableFuture<Long> lastAlignmentDurationNanos;
 	protected CompletableFuture<Long> lastBytesProcessedDuringAlignment;
-	protected List<Long> triggeredCheckpoints = new ArrayList<>();
+	protected final List<Long> triggeredCheckpoints = new ArrayList<>();
+	protected final List<CheckpointOptions> triggeredCheckpointOptions = new ArrayList<>();
 
 	public ValidatingCheckpointHandler() {
 		this(-1);
@@ -89,6 +90,10 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
 		return lastBytesProcessedDuringAlignment;
 	}
 
+	public List<CheckpointOptions> getTriggeredCheckpointOptions() {
+		return triggeredCheckpointOptions;
+	}
+
 	@Override
 	public void invoke() {
 		throw new UnsupportedOperationException();
@@ -119,6 +124,7 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
 		lastBytesProcessedDuringAlignment = checkpointMetrics.getBytesProcessedDuringAlignment();
 
 		triggeredCheckpoints.add(checkpointMetaData.getCheckpointId());
+		triggeredCheckpointOptions.add(checkpointOptions);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/ValidatingCheckpointHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/ValidatingCheckpointHandler.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -106,8 +107,9 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
 			CheckpointMetaData checkpointMetaData,
 			CheckpointOptions checkpointOptions,
 			CheckpointMetricsBuilder checkpointMetrics) {
-		assertTrue("wrong checkpoint id", nextExpectedCheckpointId == -1L ||
-			nextExpectedCheckpointId == checkpointMetaData.getCheckpointId());
+		if (nextExpectedCheckpointId != -1L) {
+			assertEquals(nextExpectedCheckpointId, checkpointMetaData.getCheckpointId());
+		}
 		assertTrue(checkpointMetaData.getTimestamp() > 0);
 
 		nextExpectedCheckpointId = checkpointMetaData.getCheckpointId() + 1;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -74,8 +74,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 	protected long memorySize = 1024 * 1024;
 	protected int bufferSize = 1024;
 	protected Configuration jobConfig = new Configuration();
-	protected Configuration taskConfig = new Configuration();
-	protected StreamConfig streamConfig = new StreamConfig(taskConfig);
+	protected StreamConfig streamConfig = new StreamConfig(new Configuration());
 	protected LocalRecoveryConfig localRecoveryConfig = TestLocalRecoveryConfig.disabled();
 	@Nullable
 	protected StreamTestSingleInputGate[] inputGates;
@@ -138,7 +137,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 
 		StreamMockEnvironment streamMockEnvironment = new StreamMockEnvironment(
 			jobConfig,
-			taskConfig,
+			streamConfig.getConfiguration(),
 			executionConfig,
 			memorySize,
 			new MockInputSplitProvider(),

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
@@ -186,6 +186,7 @@ public class UnalignedCheckpointCompatibilityITCase extends TestLogger {
 		env.setParallelism(PARALLELISM);
 		env.setRestartStrategy(new RestartStrategies.NoRestartStrategyConfiguration());
 		env.getCheckpointConfig().enableUnalignedCheckpoints(!isAligned);
+		env.getCheckpointConfig().setAlignmentTimeout(0);
 		env.getCheckpointConfig().enableExternalizedCheckpoints(RETAIN_ON_CANCELLATION);
 		if (checkpointingInterval > 0) {
 			env.enableCheckpointing(checkpointingInterval);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -80,6 +80,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -211,7 +212,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 
 		final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);
 		env.enableCheckpointing(100);
-		env.getCheckpointConfig().setAlignmentTimeout(0);
+		env.getCheckpointConfig().setAlignmentTimeout(1);
 		env.setParallelism(parallelism);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(EXPECTED_FAILURES, Time.milliseconds(100)));
 		env.getCheckpointConfig().enableUnalignedCheckpoints(true);
@@ -464,6 +465,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 		private ListState<State> stateList;
 		private State state;
 		private final long minCheckpoints;
+		private Random random = new Random();
 
 		private VerifyingSink(long minCheckpoints) {
 			this.minCheckpoints = minCheckpoints;
@@ -472,6 +474,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 		@Override
 		public void open(Configuration parameters) throws Exception {
 			super.open(parameters);
+			random = new Random();
 			getRuntimeContext().addAccumulator(NUM_OUTPUTS, numOutputCounter);
 			getRuntimeContext().addAccumulator(NUM_OUT_OF_ORDER, outOfOrderCounter);
 			getRuntimeContext().addAccumulator(NUM_DUPLICATES, duplicatesCounter);
@@ -533,8 +536,10 @@ public class UnalignedCheckpointITCase extends TestLogger {
 			state.numOutput++;
 
 			if (state.completedCheckpoints < minCheckpoints) {
-				// induce heavy backpressure until enough checkpoints have been written
-				Thread.sleep(0, 100_000);
+				// induce backpressure until enough checkpoints have been written
+				if (random.nextInt(1000) == 42) {
+					Thread.sleep(1);
+				}
 			}
 			// after all checkpoints have been completed, the remaining data should be flushed out fairly quickly
 		}

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
Purpose of this PR is to timeout aligned checkpoints based on checkpointStartDelay.

This PR is based on https://github.com/apache/flink/pull/13741, so please ignore a couple of first commits from this review.

## Verifying this change

This PR adds a couple of tests, but also every existing test that has enabled unaligned checkpoints (there is a default timeout value of 30 seconds).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
