### PR TITLE
[FLINK-19835] Don't emit intermediate watermarks from sources in BATCH execution mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
@@ -81,13 +80,14 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 	public DataStreamSource(
 			StreamExecutionEnvironment environment,
 			Source<T, ?, ?> source,
-			WatermarkStrategy<T> timestampsAndWatermarks,
+			WatermarkStrategy<T> watermarkStrategy,
 			TypeInformation<T> outTypeInfo,
 			String sourceName) {
 		super(environment,
 				new SourceTransformation<>(
 						sourceName,
-						new SourceOperatorFactory<>(source, timestampsAndWatermarks),
+						source,
+						watermarkStrategy,
 						outTypeInfo,
 						environment.getParallelism()));
 		this.isParallel = true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
 @Experimental
 public abstract class AbstractStreamOperatorFactory<OUT> implements StreamOperatorFactory<OUT>, ProcessingTimeServiceAware {
 
-	protected ChainingStrategy chainingStrategy = ChainingStrategy.ALWAYS;
+	protected ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
 
 	protected transient ProcessingTimeService processingTimeService;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ChainingStrategy.java
@@ -57,4 +57,6 @@ public enum ChainingStrategy {
 	 * sources into one task.
 	 */
 	HEAD_WITH_SOURCES;
+
+	public static final ChainingStrategy DEFAULT_CHAINING_STRATEGY = ALWAYS;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -164,7 +164,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 		// in the future when we support both batch and streaming modes for the source operator,
 		// and when this one is migrated to the "eager initialization" operator (StreamOperatorV2),
 		// then we should evaluate this during operator construction.
-		eventTimeLogic = TimestampsAndWatermarks.createStreamingEventTimeLogic(
+		eventTimeLogic = TimestampsAndWatermarks.createProgressiveEventTimeLogic(
 				watermarkStrategy,
 				metricGroup,
 				getProcessingTimeService(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -30,21 +30,21 @@ import org.apache.flink.streaming.runtime.tasks.ExceptionInChainedOperatorExcept
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * An implementation of {@link TimestampsAndWatermarks} to be used during batch execution of a
- * program. Batch execution has no watermarks, so all watermark related operations in this
- * implementation are no-ops.
+ * An implementation of {@link TimestampsAndWatermarks} where all watermarking/event-time operations
+ * are no-ops. This should be used in execution contexts where no watermarks are needed, for example
+ * in BATCH execution mode.
  *
  * @param <T> The type of the emitted records.
  */
 @Internal
-public class BatchTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T> {
+public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T> {
 
 	private final TimestampAssigner<T> timestamps;
 
 	/**
-	 * Creates a new BatchTimestampsAndWatermarks with the given TimestampAssigner.
+	 * Creates a new {@link NoOpTimestampsAndWatermarks} with the given TimestampAssigner.
 	 */
-	public BatchTimestampsAndWatermarks(TimestampAssigner<T> timestamps) {
+	public NoOpTimestampsAndWatermarks(TimestampAssigner<T> timestamps) {
 		this.timestamps = checkNotNull(timestamps);
 	}
 
@@ -56,12 +56,12 @@ public class BatchTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<
 
 	@Override
 	public void startPeriodicWatermarkEmits() {
-		// no periodic watermarks in batch processing
+		// no periodic watermarks
 	}
 
 	@Override
 	public void stopPeriodicWatermarkEmits() {
-		// no periodic watermarks in batch processing
+		// no periodic watermarks
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -39,12 +39,14 @@ import java.util.concurrent.ScheduledFuture;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * An implementation of timestamp extraction and watermark generation logic for streaming sources.
+ * An implementation of {@link TimestampsAndWatermarks} that does periodic watermark emission and
+ * keeps track of watermarks on a per-split basis. This should be used in execution contexts where
+ * watermarks are important for efficiency/correctness, for example in STREAMING execution mode.
  *
  * @param <T> The type of the emitted records.
  */
 @Internal
-public class StreamingTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T> {
+public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T> {
 
 	private final TimestampAssigner<T> timestampAssigner;
 
@@ -65,7 +67,7 @@ public class StreamingTimestampsAndWatermarks<T> implements TimestampsAndWaterma
 	@Nullable
 	private ScheduledFuture<?> periodicEmitHandle;
 
-	public StreamingTimestampsAndWatermarks(
+	public ProgressiveTimestampsAndWatermarks(
 			TimestampAssigner<T> timestampAssigner,
 			WatermarkGeneratorSupplier<T> watermarksFactory,
 			WatermarkGeneratorSupplier.Context watermarksContext,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/SourceOutputWithWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/SourceOutputWithWatermarks.java
@@ -47,10 +47,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * we want to have only a single implementation of these two methods, across all classes.
  * That way, the JIT compiler can de-virtualize (and inline) them better.
  *
- * <p>Currently, we have one implementation of these methods in the batch case (see class
- * {@link BatchTimestampsAndWatermarks}) and one for the streaming case (this class). When the JVM
- * is dedicated to a single job (or type of job) only one of these classes will be loaded. In mixed
- * job setups, we still have a bimorphic method (rather than a poly/-/mega-morphic method).
+ * <p>Currently, we have one implementation of these methods for the case where we don't need
+ * watermarks (see class {@link NoOpTimestampsAndWatermarks}) and one for the case where we do (this
+ * class). When the JVM is dedicated to a single job (or type of job) only one of these classes will
+ * be loaded. In mixed job setups, we still have a bimorphic method (rather than a
+ * poly/-/mega-morphic method).
  *
  * @param <T> The type of emitted records.
  */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -67,7 +67,7 @@ public interface TimestampsAndWatermarks<T> {
 	//  factories
 	// ------------------------------------------------------------------------
 
-	static <E> TimestampsAndWatermarks<E> createStreamingEventTimeLogic(
+	static <E> TimestampsAndWatermarks<E> createProgressiveEventTimeLogic(
 			WatermarkStrategy<E> watermarkStrategy,
 			MetricGroup metrics,
 			ProcessingTimeService timeService,
@@ -76,17 +76,17 @@ public interface TimestampsAndWatermarks<T> {
 		final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
 		final TimestampAssigner<E> timestampAssigner = watermarkStrategy.createTimestampAssigner(context);
 
-		return new StreamingTimestampsAndWatermarks<>(
+		return new ProgressiveTimestampsAndWatermarks<>(
 			timestampAssigner, watermarkStrategy, context, timeService, Duration.ofMillis(periodicWatermarkIntervalMillis));
 	}
 
-	static <E> TimestampsAndWatermarks<E> createBatchEventTimeLogic(
+	static <E> TimestampsAndWatermarks<E> createNoOpEventTimeLogic(
 			WatermarkStrategy<E> watermarkStrategy,
 			MetricGroup metrics) {
 
 		final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
 		final TimestampAssigner<E> timestampAssigner = watermarkStrategy.createTimestampAssigner(context);
 
-		return new BatchTimestampsAndWatermarks<>(timestampAssigner);
+		return new NoOpTimestampsAndWatermarks<>(timestampAssigner);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -41,7 +41,7 @@ public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT> ext
 	private final Source<OUT, SplitT, EnumChkT> source;
 	private final WatermarkStrategy<OUT> watermarkStrategy;
 
-	private ChainingStrategy chainingStrategy = ChainingStrategy.ALWAYS;
+	private ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
 
 	/**
 	 * Creates a new {@code Transformation} with the given name, output type and parallelism.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -19,13 +19,13 @@
 package org.apache.flink.streaming.api.transformations;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
-import org.apache.flink.streaming.api.operators.SourceOperator;
-import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,35 +34,45 @@ import java.util.List;
  * A {@link PhysicalTransformation} for {@link Source}.
  */
 @Internal
-public class SourceTransformation<OUT> extends PhysicalTransformation<OUT> implements WithBoundedness {
-	private final SourceOperatorFactory<OUT> sourceFactory;
+public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT> extends PhysicalTransformation<OUT> implements WithBoundedness {
+
+	private final Source<OUT, SplitT, EnumChkT> source;
+	private final WatermarkStrategy<OUT> watermarkStrategy;
+
+	private ChainingStrategy chainingStrategy = ChainingStrategy.ALWAYS;
+
 	/**
 	 * Creates a new {@code Transformation} with the given name, output type and parallelism.
 	 *
-	 * @param name            The name of the {@code Transformation}, this will be shown in Visualizations and the Log
-	 * @param sourceFactory   The operator factory for {@link SourceOperator}.
-	 * @param outputType      The output type of this {@code Transformation}
-	 * @param parallelism     The parallelism of this {@code Transformation}
+	 * @param name The name of the {@code Transformation}, this will be shown in Visualizations
+	 * 		and the Log
+	 * @param source The {@link Source} itself
+	 * @param watermarkStrategy The {@link WatermarkStrategy} to use
+	 * @param outputType The output type of this {@code Transformation}
+	 * @param parallelism The parallelism of this {@code Transformation}
 	 */
 	public SourceTransformation(
 			String name,
-			SourceOperatorFactory<OUT> sourceFactory,
+			Source<OUT, SplitT, EnumChkT> source,
+			WatermarkStrategy<OUT> watermarkStrategy,
 			TypeInformation<OUT> outputType,
 			int parallelism) {
 		super(name, outputType, parallelism);
-		this.sourceFactory = sourceFactory;
+		this.source = source;
+		this.watermarkStrategy = watermarkStrategy;
+	}
+
+	public Source<OUT, SplitT, EnumChkT> getSource() {
+		return source;
+	}
+
+	public WatermarkStrategy<OUT> getWatermarkStrategy() {
+		return watermarkStrategy;
 	}
 
 	@Override
 	public Boundedness getBoundedness() {
-		return sourceFactory.getBoundedness();
-	}
-
-	/**
-	 * Returns the {@code StreamOperatorFactory} of this {@code LegacySourceTransformation}.
-	 */
-	public SourceOperatorFactory<OUT> getOperatorFactory() {
-		return sourceFactory;
+		return source.getBoundedness();
 	}
 
 	@Override
@@ -76,7 +86,11 @@ public class SourceTransformation<OUT> extends PhysicalTransformation<OUT> imple
 	}
 
 	@Override
-	public final void setChainingStrategy(ChainingStrategy strategy) {
-		sourceFactory.setChainingStrategy(strategy);
+	public void setChainingStrategy(ChainingStrategy chainingStrategy) {
+		this.chainingStrategy = chainingStrategy;
+	}
+
+	public ChainingStrategy getChainingStrategy() {
+		return chainingStrategy;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -30,6 +30,8 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link PhysicalTransformation} for {@link Source}.
  */
@@ -87,7 +89,7 @@ public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT> ext
 
 	@Override
 	public void setChainingStrategy(ChainingStrategy chainingStrategy) {
-		this.chainingStrategy = chainingStrategy;
+		this.chainingStrategy = checkNotNull(chainingStrategy);
 	}
 
 	public ChainingStrategy getChainingStrategy() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
-import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 
@@ -47,7 +46,7 @@ public class SourceTransformationTranslator<OUT, SplitT extends SourceSplit, Enu
 			final SourceTransformation<OUT, SplitT, EnumChkT> transformation,
 			final Context context) {
 
-		return translateInternal(transformation, context);
+		return translateInternal(transformation, context, false /* emit progressive watermarks */);
 	}
 
 	@Override
@@ -55,12 +54,13 @@ public class SourceTransformationTranslator<OUT, SplitT extends SourceSplit, Enu
 			final SourceTransformation<OUT, SplitT, EnumChkT> transformation,
 			final Context context) {
 
-		return translateInternal(transformation, context);
+		return translateInternal(transformation, context, true /* don't emit progressive watermarks */);
 	}
 
 	private Collection<Integer> translateInternal(
 			final SourceTransformation<OUT, SplitT, EnumChkT> transformation,
-			final Context context) {
+			final Context context,
+			boolean emitProgressiveWatermarks) {
 		checkNotNull(transformation);
 		checkNotNull(context);
 
@@ -71,7 +71,8 @@ public class SourceTransformationTranslator<OUT, SplitT extends SourceSplit, Enu
 
 		SourceOperatorFactory<OUT> operatorFactory = new SourceOperatorFactory<>(
 				transformation.getSource(),
-				transformation.getWatermarkStrategy());
+				transformation.getWatermarkStrategy(),
+				emitProgressiveWatermarks);
 
 		operatorFactory.setChainingStrategy(transformation.getChainingStrategy());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
@@ -46,7 +46,6 @@ import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
-import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -396,10 +395,11 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
 	@Test
 	public void testFeedbackThrowsExceptionInBatch() {
-		final SourceTransformation<Integer> bounded =
+		final SourceTransformation<Integer, ?, ?> bounded =
 				new SourceTransformation<>(
 						"Bounded Source",
-						new SourceOperatorFactory<>(new MockSource(Boundedness.BOUNDED, 100), WatermarkStrategy.noWatermarks()),
+						new MockSource(Boundedness.BOUNDED, 100),
+						WatermarkStrategy.noWatermarks(),
 						IntegerTypeInfo.of(Integer.class),
 						1);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.util.TestLogger;
@@ -158,11 +157,11 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
 	@Test
 	public void testDetectionThroughTransitivePredecessors() {
-		final SourceTransformation<Integer> bounded =
+		final SourceTransformation<Integer, ?, ?> bounded =
 				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
 		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
 
-		final SourceTransformation<Integer> unbounded = getSourceTransformation(
+		final SourceTransformation<Integer, ?, ?> unbounded = getSourceTransformation(
 				"Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
 		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
 
@@ -186,7 +185,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
 	@Test
 	public void testBoundedDetection() {
-		final SourceTransformation<Integer> bounded =
+		final SourceTransformation<Integer, ?, ?> bounded =
 				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
 		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
 
@@ -202,7 +201,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
 	@Test
 	public void testUnboundedDetection() {
-		final SourceTransformation<Integer> unbounded =
+		final SourceTransformation<Integer, ?, ?> unbounded =
 				getSourceTransformation("Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
 		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
 
@@ -218,11 +217,11 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
 	@Test
 	public void testMixedDetection() {
-		final SourceTransformation<Integer> unbounded =
+		final SourceTransformation<Integer, ?, ?> unbounded =
 				getSourceTransformation("Unbounded Source", Boundedness.CONTINUOUS_UNBOUNDED);
 		assertEquals(Boundedness.CONTINUOUS_UNBOUNDED, unbounded.getBoundedness());
 
-		final SourceTransformation<Integer> bounded =
+		final SourceTransformation<Integer, ?, ?> bounded =
 				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
 		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
 
@@ -238,7 +237,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
 	@Test
 	public void testExplicitOverridesDetectedMode() {
-		final SourceTransformation<Integer> bounded =
+		final SourceTransformation<Integer, ?, ?> bounded =
 				getSourceTransformation("Bounded Source", Boundedness.BOUNDED);
 		assertEquals(Boundedness.BOUNDED, bounded.getBoundedness());
 
@@ -277,12 +276,13 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 		return streamGraphGenerator.generate();
 	}
 
-	private SourceTransformation<Integer> getSourceTransformation(
+	private SourceTransformation<Integer, ?, ?> getSourceTransformation(
 			final String name,
 			final Boundedness boundedness) {
 		return new SourceTransformation<>(
 				name,
-				new SourceOperatorFactory<>(new MockSource(boundedness, 100), WatermarkStrategy.noWatermarks()),
+				new MockSource(boundedness, 100),
+				WatermarkStrategy.noWatermarks(),
 				IntegerTypeInfo.of(Integer.class),
 				1);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -71,7 +71,7 @@ public class SourceOperatorTest {
 	public void setup() {
 		this.mockSourceReader = new MockSourceReader();
 		this.mockGateway = new MockOperatorEventGateway();
-		this.operator = new TestingSourceOperator<>(mockSourceReader, mockGateway, SUBTASK_INDEX);
+		this.operator = new TestingSourceOperator<>(mockSourceReader, mockGateway, SUBTASK_INDEX, true /* emit progressive watermarks */);
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Tests that validate correct handling of watermark generation in the {@link ReaderOutput} as created
- * by the {@link StreamingTimestampsAndWatermarks}.
+ * by the {@link ProgressiveTimestampsAndWatermarks}.
  */
 public class SourceOperatorEventTimeTest {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -35,9 +35,15 @@ import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
-import org.junit.Test;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -52,7 +58,19 @@ import static org.junit.Assert.assertThat;
  * Tests that validate correct handling of watermark generation in the {@link ReaderOutput} as created
  * by the {@link ProgressiveTimestampsAndWatermarks}.
  */
+@RunWith(Parameterized.class)
 public class SourceOperatorEventTimeTest {
+
+	@Parameterized.Parameters(name = "Emit progressive watermarks: {0}")
+	public static Collection<Boolean> parameters () {
+		return Arrays.asList(true, false);
+	}
+
+	private final boolean emitProgressiveWatermarks;
+
+	public SourceOperatorEventTimeTest(boolean emitProgressiveWatermarks) {
+		this.emitProgressiveWatermarks = emitProgressiveWatermarks;
+	}
 
 	@Test
 	public void testMainOutputPeriodicWatermarks() throws Exception {
@@ -60,17 +78,18 @@ public class SourceOperatorEventTimeTest {
 				WatermarkStrategy
 						.forGenerator((ctx) -> new OnPeriodicTestWatermarkGenerator<>());
 
-		final List<Watermark> result = testSequenceOfWatermarks(watermarkStrategy,
+		final List<Watermark> result = testSequenceOfWatermarks(
+			emitProgressiveWatermarks,
+			watermarkStrategy,
 			(output) -> output.collect(0, 100L),
 			(output) -> output.collect(0, 120L),
 			(output) -> output.collect(0, 110L)
 		);
 
-		assertThat(result, contains(
-			new Watermark(100L),
-			new Watermark(120L),
-			Watermark.MAX_WATERMARK
-		));
+		assertWatermarksOrEmpty(
+				result,
+				new Watermark(100L),
+				new Watermark(120L));
 	}
 
 	@Test
@@ -79,17 +98,18 @@ public class SourceOperatorEventTimeTest {
 				WatermarkStrategy
 						.forGenerator((ctx) -> new OnEventTestWatermarkGenerator<>());
 
-		final List<Watermark> result = testSequenceOfWatermarks(watermarkStrategy,
+		final List<Watermark> result = testSequenceOfWatermarks(
+			emitProgressiveWatermarks,
+			watermarkStrategy,
 			(output) -> output.collect(0, 100L),
 			(output) -> output.collect(0, 120L),
 			(output) -> output.collect(0, 110L)
 		);
 
-		assertThat(result, contains(
-			new Watermark(100L),
-			new Watermark(120L),
-			Watermark.MAX_WATERMARK
-		));
+		assertWatermarksOrEmpty(
+				result,
+				new Watermark(100L),
+				new Watermark(120L));
 	}
 
 	@Test
@@ -98,7 +118,9 @@ public class SourceOperatorEventTimeTest {
 				WatermarkStrategy
 						.forGenerator((ctx) -> new OnPeriodicTestWatermarkGenerator<>());
 
-		final List<Watermark> result = testSequenceOfWatermarks(watermarkStrategy,
+		final List<Watermark> result = testSequenceOfWatermarks(
+			emitProgressiveWatermarks,
+			watermarkStrategy,
 			(output) -> {
 				output.createOutputForSplit("A");
 				output.createOutputForSplit("B");
@@ -110,12 +132,11 @@ public class SourceOperatorEventTimeTest {
 			(output) -> output.createOutputForSplit("B").collect(0, 200L)
 		);
 
-		assertThat(result, contains(
-			new Watermark(100L),
-			new Watermark(150L),
-			new Watermark(200L),
-			Watermark.MAX_WATERMARK
-		));
+		assertWatermarksOrEmpty(
+				result,
+				new Watermark(100L),
+				new Watermark(150L),
+				new Watermark(200L));
 	}
 
 	@Test
@@ -124,7 +145,9 @@ public class SourceOperatorEventTimeTest {
 				WatermarkStrategy
 						.forGenerator((ctx) -> new OnEventTestWatermarkGenerator<>());
 
-		final List<Watermark> result = testSequenceOfWatermarks(watermarkStrategy,
+		final List<Watermark> result = testSequenceOfWatermarks(
+			emitProgressiveWatermarks,
+			watermarkStrategy,
 			(output) -> {
 				output.createOutputForSplit("one");
 				output.createOutputForSplit("two");
@@ -136,25 +159,41 @@ public class SourceOperatorEventTimeTest {
 			(output) -> output.createOutputForSplit("two").collect(0, 200L)
 		);
 
-		assertThat(result, contains(
-			new Watermark(100L),
-			new Watermark(150L),
-			new Watermark(200L),
-			Watermark.MAX_WATERMARK
-		));
+		assertWatermarksOrEmpty(
+				result,
+				new Watermark(100L),
+				new Watermark(150L),
+				new Watermark(200L));
 	}
 
 	// ------------------------------------------------------------------------
 	//   test execution helpers
 	// ------------------------------------------------------------------------
 
+	/**
+	 * Asserts that the given expected watermarks are present in the actual watermarks in STREAMING
+	 * mode. Otherwise, asserts that the list of actual watermarks is empty in BATCH mode.
+	 */
+	private void assertWatermarksOrEmpty(List<Watermark> actualWatermarks, Watermark... expectedWatermarks) {
+		// We add the expected Long.MAX_VALUE watermark to the end. We expect that for both
+		// "STREAMING" and "BATCH" mode.
+		if (emitProgressiveWatermarks) {
+			ArrayList<Watermark> watermarks = Lists.newArrayList(expectedWatermarks);
+			watermarks.add(new Watermark(Long.MAX_VALUE));
+			assertThat(actualWatermarks, contains(watermarks.toArray()));
+		} else {
+			assertThat(actualWatermarks, contains(new Watermark(Long.MAX_VALUE)));
+		}
+	}
+
 	@SuppressWarnings("FinalPrivateMethod")
 	@SafeVarargs
 	private final List<Watermark> testSequenceOfWatermarks(
+			final boolean emitProgressiveWatermarks,
 			final WatermarkStrategy<Integer> watermarkStrategy,
 			final Consumer<ReaderOutput<Integer>>... actions) throws Exception {
 
-		final List<Object> allEvents = testSequenceOfEvents(watermarkStrategy, actions);
+		final List<Object> allEvents = testSequenceOfEvents(emitProgressiveWatermarks, watermarkStrategy, actions);
 
 		return allEvents.stream()
 				.filter((evt) -> evt instanceof org.apache.flink.streaming.api.watermark.Watermark)
@@ -165,7 +204,8 @@ public class SourceOperatorEventTimeTest {
 	@SuppressWarnings("FinalPrivateMethod")
 	@SafeVarargs
 	private final List<Object> testSequenceOfEvents(
-			WatermarkStrategy<Integer> watermarkStrategy,
+			final boolean emitProgressiveWatermarks,
+			final WatermarkStrategy<Integer> watermarkStrategy,
 			final Consumer<ReaderOutput<Integer>>... actions) throws Exception {
 
 		final CollectingDataOutput<Integer> out = new CollectingDataOutput<>();
@@ -176,7 +216,7 @@ public class SourceOperatorEventTimeTest {
 		final SourceReader<Integer, MockSourceSplit> reader = new InterpretingSourceReader(actions);
 
 		final SourceOperator<Integer, MockSourceSplit> sourceOperator =
-				createTestOperator(reader, watermarkStrategy, timeService);
+				createTestOperator(reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
 
 		while (sourceOperator.emitNext(out) != InputStatus.END_OF_INPUT) {
 			timeService.setCurrentTime(timeService.getCurrentProcessingTime() + 100);
@@ -192,7 +232,8 @@ public class SourceOperatorEventTimeTest {
 	private static <T> SourceOperator<T, MockSourceSplit> createTestOperator(
 			SourceReader<T, MockSourceSplit> reader,
 			WatermarkStrategy<T> watermarkStrategy,
-			ProcessingTimeService timeService) throws Exception {
+			ProcessingTimeService timeService,
+			boolean emitProgressiveWatermarks) throws Exception {
 
 		final OperatorStateStore operatorStateStore =
 				new MemoryStateBackend().createOperatorStateBackend(
@@ -205,7 +246,7 @@ public class SourceOperatorEventTimeTest {
 			false, operatorStateStore, null, null, null);
 
 		final SourceOperator<T, MockSourceSplit> sourceOperator =
-				new TestingSourceOperator<>(reader, watermarkStrategy, timeService);
+				new TestingSourceOperator<>(reader, watermarkStrategy, timeService, emitProgressiveWatermarks);
 		sourceOperator.initializeState(stateContext);
 		sourceOperator.open();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -46,17 +46,19 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 	public TestingSourceOperator(
 			SourceReader<T, MockSourceSplit> reader,
 			WatermarkStrategy<T> watermarkStrategy,
-			ProcessingTimeService timeService) {
+			ProcessingTimeService timeService,
+			boolean emitProgressiveWatermarks) {
 
-		this(reader, watermarkStrategy, timeService, new MockOperatorEventGateway(), 1, 5);
+		this(reader, watermarkStrategy, timeService, new MockOperatorEventGateway(), 1, 5, emitProgressiveWatermarks);
 	}
 
 	public TestingSourceOperator(
 			SourceReader<T, MockSourceSplit> reader,
 			OperatorEventGateway eventGateway,
-			int subtaskIndex) {
+			int subtaskIndex,
+			boolean emitProgressiveWatermarks) {
 
-		this(reader, WatermarkStrategy.noWatermarks(), new TestProcessingTimeService(), eventGateway, subtaskIndex, 5);
+		this(reader, WatermarkStrategy.noWatermarks(), new TestProcessingTimeService(), eventGateway, subtaskIndex, 5, emitProgressiveWatermarks);
 	}
 
 	public TestingSourceOperator(
@@ -65,7 +67,8 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 			ProcessingTimeService timeService,
 			OperatorEventGateway eventGateway,
 			int subtaskIndex,
-			int parallelism) {
+			int parallelism,
+			boolean emitProgressiveWatermarks) {
 
 		super(
 			(context) -> reader,
@@ -74,7 +77,8 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 			watermarkStrategy,
 			timeService,
 			new Configuration(),
-			"localhost");
+			"localhost",
+			emitProgressiveWatermarks);
 
 		this.subtaskIndex = subtaskIndex;
 		this.parallelism = parallelism;


### PR DESCRIPTION
## What is the purpose of the change

Currently, both sources and watermark/timestamp operators can emit watermarks that we don't really need. We only need a final watermark in BATCH execution mode.

**Note to reviewers: I'm not sure whether to add a new RuntimeMode enum or use the existing RuntimeExecutionMode for this.**

## Brief change log

* turn SourceTransformation into a logical transformation and only create the operator in the Translator
* make source aware of BATCH/STREAMING mode

## Verifying this change

* new tests that verify we don't emit watermarks in BATCH mode

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
