### PR TITLE
[FLINK-19862][coordination] Check for null

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -197,6 +197,10 @@ public class DeclarativeSlotManager implements SlotManager {
 	 */
 	@Override
 	public void suspend() {
+		if (!started) {
+			return;
+		}
+
 		LOG.info("Suspending the slot manager.");
 
 		resourceTracker.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -44,6 +44,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,6 +68,7 @@ public class DeclarativeSlotManager implements SlotManager {
 	private final SlotTracker slotTracker;
 	private final ResourceTracker resourceTracker;
 	private final BiFunction<Executor, ResourceActions, TaskExecutorManager> taskExecutorManagerFactory;
+	@Nullable
 	private TaskExecutorManager taskExecutorManager;
 
 	/** Timeout for slot requests to the task manager. */
@@ -79,12 +82,15 @@ public class DeclarativeSlotManager implements SlotManager {
 	private final HashMap<SlotID, CompletableFuture<Acknowledge>> pendingSlotAllocationFutures;
 
 	/** ResourceManager's id. */
+	@Nullable
 	private ResourceManagerId resourceManagerId;
 
 	/** Executor for future callbacks which have to be "synchronized". */
+	@Nullable
 	private Executor mainThreadExecutor;
 
 	/** Callbacks for resource (de-)allocations. */
+	@Nullable
 	private ResourceActions resourceActions;
 
 	/** True iff the component has been started. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -200,10 +200,12 @@ public class DeclarativeSlotManager implements SlotManager {
 		LOG.info("Suspending the slot manager.");
 
 		resourceTracker.clear();
-		taskExecutorManager.close();
+		if (taskExecutorManager != null) {
+			taskExecutorManager.close();
 
-		for (InstanceID registeredTaskManager : taskExecutorManager.getTaskExecutors()) {
-			unregisterTaskManager(registeredTaskManager, new SlotManagerException("The slot manager is being suspended."));
+			for (InstanceID registeredTaskManager : taskExecutorManager.getTaskExecutors()) {
+				unregisterTaskManager(registeredTaskManager, new SlotManagerException("The slot manager is being suspended."));
+			}
 		}
 
 		taskExecutorManager = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -95,6 +95,13 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 		.setManagedMemoryMB(10000)
 		.build();
 
+	@Test
+	public void testCloseAfterSuspendDoesNotThrowException() throws Exception {
+		try (DeclarativeSlotManager slotManager = createDeclarativeSlotManagerBuilder().buildAndStartWithDirectExec()) {
+			slotManager.suspend();
+		}
+	}
+
 	/**
 	 * Tests that we can register task manager and their slots at the slot manager.
 	 */


### PR DESCRIPTION
Fixes a small issue where the calling `close()` on a suspended `DeclarativeSlotManager` would result in an NPE.