### PR TITLE
[FLINK-14482][rocksdb] Bump FRocksDB verion to base on RocksDB-6.11.6

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -55,9 +55,9 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>com.data-artisans</groupId>
+			<groupId>io.github.myasuka</groupId>
 			<artifactId>frocksdbjni</artifactId>
-			<version>5.17.2-artisans-2.0</version>
+			<version>6.11.6-ververica-1.0</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>io.github.myasuka</groupId>
 			<artifactId>frocksdbjni</artifactId>
-			<version>6.11.6-ververica-1.0</version>
+			<version>6.11.6-ververica-2.0</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -27,6 +27,7 @@ import org.rocksdb.RocksIteratorInterface;
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 
 /**
  * This is a wrapper around {@link RocksIterator} to check the iterator status for all the methods mentioned
@@ -74,6 +75,18 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
 	}
 
 	@Override
+	public void seek(ByteBuffer target) {
+		iterator.seek(target);
+		status();
+	}
+
+	@Override
+	public void seekForPrev(ByteBuffer target) {
+		iterator.seekForPrev(target);
+		status();
+	}
+
+	@Override
 	public void next() {
 		iterator.next();
 		status();
@@ -92,6 +105,12 @@ public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
 		} catch (RocksDBException ex) {
 			throw new FlinkRuntimeException("Internal exception found in RocksDB", ex);
 		}
+	}
+
+	@Override
+	public void refresh() throws RocksDBException {
+		iterator.refresh();
+		status();
 	}
 
 	public byte[] key() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -164,7 +164,7 @@ public class RocksDBResourceContainerTest {
 		}
 		Field cacheField = null;
 		try {
-			cacheField = BlockBasedTableConfig.class.getDeclaredField("blockCache_");
+			cacheField = BlockBasedTableConfig.class.getDeclaredField("blockCache");
 		} catch (NoSuchFieldException e) {
 			fail("blockCache_ is not defined");
 		}


### PR DESCRIPTION
## What is the purpose of the change

Bump FRocksDB version to base on RocksDB-6.11.6


## Brief change log

  - Bump FRocksDB version to base on RocksDB-6.11.6


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable