### PR TITLE
[FLINK-19870][table-planner-blink] Fix special case when the reuse of exchange causes the deadlock

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
@@ -79,7 +79,7 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 	}
 
 	@Override
-	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int conflictInput) {
+	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
 		throw new IllegalStateException("A conflict is detected. This is unexpected.");
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGenerator.java
@@ -164,7 +164,7 @@ public abstract class InputPriorityGraphGenerator {
 				linkedEdges.add(Tuple2.of(higherNode, ancestor));
 			} else {
 				// a conflict occurs, resolve it and revert all linked edges
-				resolveInputPriorityConflict(node, lowerInput);
+				resolveInputPriorityConflict(node, higherInput, lowerInput);
 				for (Tuple2<ExecNode<?, ?>, ExecNode<?, ?>> linkedEdge : linkedEdges) {
 					graph.unlink(linkedEdge.f0, linkedEdge.f1);
 				}
@@ -205,5 +205,5 @@ public abstract class InputPriorityGraphGenerator {
 		return ret;
 	}
 
-	protected abstract void resolveInputPriorityConflict(ExecNode<?, ?> node, int conflictInput);
+	protected abstract void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput);
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
@@ -21,13 +21,18 @@ package org.apache.flink.table.planner.plan.processors.utils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.TestingBatchExecNode;
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecExchange;
+
+import org.apache.flink.table.planner.plan.trait.FlinkRelDistribution;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Tests for {@link InputPriorityConflictResolver}.
@@ -85,5 +90,43 @@ public class InputPriorityConflictResolverTest {
 		Assert.assertEquals(nodes[4], nodes[7].getInputNodes().get(3).getInputNodes().get(0));
 		Assert.assertEquals(nodes[5], nodes[7].getInputNodes().get(4));
 		Assert.assertEquals(nodes[6], nodes[7].getInputNodes().get(5));
+	}
+
+	@Test
+	public void testDeadlockCausedByExchange() {
+		// P1 = PIPELINED + priority 1
+		//
+		// 0 -(P0)-> exchange --(P0)-> 1
+		//                    \-(P1)-/
+		TestingBatchExecNode[] nodes = new TestingBatchExecNode[2];
+		for (int i = 0; i < nodes.length; i++) {
+			nodes[i] = new TestingBatchExecNode();
+		}
+
+		BatchExecExchange exchange = new BatchExecExchange(
+			nodes[0].getCluster(), nodes[0].getTraitSet(), nodes[0], FlinkRelDistribution.DEFAULT());
+		exchange.setRequiredShuffleMode(ShuffleMode.BATCH);
+
+		nodes[1].addInput(exchange, ExecEdge.builder().priority(0).build());
+		nodes[1].addInput(exchange, ExecEdge.builder().priority(1).build());
+
+		InputPriorityConflictResolver resolver = new InputPriorityConflictResolver(
+			Collections.singletonList(nodes[1]),
+			ExecEdge.DamBehavior.END_INPUT,
+			ShuffleMode.BATCH);
+		resolver.detectAndResolve();
+
+		ExecNode<?, ?> input0 = nodes[1].getInputNodes().get(0);
+		ExecNode<?, ?> input1 = nodes[1].getInputNodes().get(1);
+		Assert.assertNotSame(input0, input1);
+
+		Consumer<ExecNode<?, ?>> checkExchange = execNode -> {
+			Assert.assertTrue(execNode instanceof BatchExecExchange);
+			BatchExecExchange e = (BatchExecExchange) execNode;
+			Assert.assertEquals(ShuffleMode.BATCH, e.getShuffleMode(new Configuration()));
+			Assert.assertEquals(nodes[0], e.getInput());
+		};
+		checkExchange.accept(input0);
+		checkExchange.accept(input1);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.TestingBatchExecNode;
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecExchange;
-
 import org.apache.flink.table.planner.plan.trait.FlinkRelDistribution;
 
 import org.junit.Assert;
@@ -32,7 +31,6 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Tests for {@link InputPriorityConflictResolver}.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
@@ -99,7 +99,7 @@ public class InputPriorityGraphGeneratorTest {
 		}
 
 		@Override
-		protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int conflictInput) {
+		protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
 			// do nothing
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.xml
@@ -283,6 +283,62 @@ NestedLoopJoin(joinType=[FullOuterJoin], where=[<>(cnt, cnt0)], select=[cnt, cnt
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSubplanReuse_BuildAndProbeNoCommonSuccessors_HashJoin">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (SELECT a, COUNT(*) AS cnt1 FROM x GROUP BY a),
+  T2 AS (SELECT d, COUNT(*) AS cnt2 FROM y GROUP BY d)
+SELECT * FROM
+  (SELECT cnt1, cnt2 FROM T1 LEFT JOIN T2 ON a = d)
+  UNION ALL
+  (SELECT cnt1, cnt2 FROM T2 LEFT JOIN T1 ON d = a)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[true])
+:- LogicalProject(cnt1=[$1], cnt2=[$3])
+:  +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+:     :- LogicalAggregate(group=[{0}], cnt1=[COUNT()])
+:     :  +- LogicalProject(a=[$0])
+:     :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+:     +- LogicalAggregate(group=[{0}], cnt2=[COUNT()])
+:        +- LogicalProject(d=[$0])
+:           +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]])
++- LogicalProject(cnt1=[$3], cnt2=[$1])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+      :- LogicalAggregate(group=[{0}], cnt2=[COUNT()])
+      :  +- LogicalProject(d=[$0])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]])
+      +- LogicalAggregate(group=[{0}], cnt1=[COUNT()])
+         +- LogicalProject(a=[$0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[cnt1, cnt2])
+:- Calc(select=[CAST(cnt1) AS cnt1, cnt2])
+:  +- HashJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, cnt1, d, cnt2], build=[right])
+:     :- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt1], reuse_id=[2])
+:     :  +- Exchange(distribution=[hash[a]])
+:     :     +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0])
+:     :        +- Calc(select=[a])
+:     :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+:     +- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_COUNT(count1$0) AS cnt2], reuse_id=[1])
+:        +- Exchange(distribution=[hash[d]])
+:           +- LocalHashAggregate(groupBy=[d], select=[d, Partial_COUNT(*) AS count1$0])
+:              +- Calc(select=[d])
+:                 +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
++- Calc(select=[cnt1, CAST(cnt2) AS cnt2])
+   +- HashJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, cnt2, a, cnt1], build=[right])
+      :- Exchange(distribution=[hash[d]], shuffle_mode=[BATCH])
+      :  +- Reused(reference_id=[1])
+      +- Reused(reference_id=[2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSubplanReuse_SetExchangeAsBatch_SortMergeJoin">
     <Resource name="sql">
       <![CDATA[
@@ -338,59 +394,32 @@ HashJoin(joinType=[InnerJoin], where=[=(c, c1)], select=[a, b, c, a0, b0, c0, a1
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSubplanReuse_BuildAndProbeNoCommonSuccessors_HashJoin">
+  <TestCase name="testSubplanReuse_DeadlockCausedByReusingExchange">
     <Resource name="sql">
       <![CDATA[
-WITH
-  T1 AS (SELECT a, COUNT(*) AS cnt1 FROM x GROUP BY a),
-  T2 AS (SELECT d, COUNT(*) AS cnt2 FROM y GROUP BY d)
-SELECT * FROM
-  (SELECT cnt1, cnt2 FROM T1 LEFT JOIN T2 ON a = d)
-  UNION ALL
-  (SELECT cnt1, cnt2 FROM T2 LEFT JOIN T1 ON d = a)
+WITH T1 AS (SELECT a FROM x)
+SELECT * FROM T1
+  INNER JOIN T1 AS T2 ON T1.a = T2.a
 ]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalUnion(all=[true])
-:- LogicalProject(cnt1=[$1], cnt2=[$3])
-:  +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
-:     :- LogicalAggregate(group=[{0}], cnt1=[COUNT()])
-:     :  +- LogicalProject(a=[$0])
-:     :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
-:     +- LogicalAggregate(group=[{0}], cnt2=[COUNT()])
-:        +- LogicalProject(d=[$0])
-:           +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]])
-+- LogicalProject(cnt1=[$3], cnt2=[$1])
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[left])
-      :- LogicalAggregate(group=[{0}], cnt2=[COUNT()])
-      :  +- LogicalProject(d=[$0])
-      :     +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]])
-      +- LogicalAggregate(group=[{0}], cnt1=[COUNT()])
-         +- LogicalProject(a=[$0])
-            +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+LogicalProject(a=[$0], a0=[$1])
++- LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+   :- LogicalProject(a=[$0])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+   +- LogicalProject(a=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Union(all=[true], union=[cnt1, cnt2])
-:- Calc(select=[CAST(cnt1) AS cnt1, cnt2])
-:  +- HashJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, cnt1, d, cnt2], build=[right])
-:     :- HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count1$0) AS cnt1], reuse_id=[2])
-:     :  +- Exchange(distribution=[hash[a]])
-:     :     +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(*) AS count1$0])
-:     :        +- Calc(select=[a])
-:     :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-:     +- HashAggregate(isMerge=[true], groupBy=[d], select=[d, Final_COUNT(count1$0) AS cnt2], reuse_id=[1])
-:        +- Exchange(distribution=[hash[d]])
-:           +- LocalHashAggregate(groupBy=[d], select=[d, Partial_COUNT(*) AS count1$0])
-:              +- Calc(select=[d])
-:                 +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
-+- Calc(select=[cnt1, CAST(cnt2) AS cnt2])
-   +- HashJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, cnt2, a, cnt1], build=[right])
-      :- Exchange(distribution=[hash[d]], shuffle_mode=[BATCH])
-      :  +- Reused(reference_id=[1])
-      +- Reused(reference_id=[2])
+HashJoin(joinType=[InnerJoin], where=[=(a, a0)], select=[a, a0], build=[right])
+:- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+:  +- Calc(select=[a], reuse_id=[1])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Exchange(distribution=[hash[a]])
+   +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SetOperatorsTest.xml
@@ -255,9 +255,10 @@ LogicalMinus(all=[false])
       <![CDATA[
 HashAggregate(isMerge=[false], groupBy=[a, b, c], select=[a, b, c])
 +- HashJoin(joinType=[LeftAntiJoin], where=[AND(OR(=(a, a0), AND(IS NULL(a), IS NULL(a0))), OR(=(b, b0), AND(IS NULL(b), IS NULL(b0))), OR(=(c, c0), AND(IS NULL(c), IS NULL(c0))))], select=[a, b, c], build=[left])
-   :- Exchange(distribution=[hash[a, b, c]], shuffle_mode=[BATCH], reuse_id=[1])
-   :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-   +- Reused(reference_id=[1])
+   :- Exchange(distribution=[hash[a, b, c]])
+   :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], reuse_id=[1])
+   +- Exchange(distribution=[hash[a, b, c]], shuffle_mode=[BATCH])
+      +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.xml
@@ -1024,13 +1024,14 @@ LogicalProject(a=[$0], c=[$1], c0=[$3])
       <![CDATA[
 Calc(select=[a, c, c0])
 +- HashJoin(joinType=[InnerJoin], where=[=(a, a0)], select=[a, c, a0, c0], build=[right])
-   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH], reuse_id=[1])
-   :  +- Union(all=[true], union=[a, c])
+   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+   :  +- Union(all=[true], union=[a, c], reuse_id=[1])
    :     :- Calc(select=[a, c], where=[>(b, 10)])
    :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
    :     +- Calc(select=[d, f], where=[<(e, 100)])
    :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
-   +- Reused(reference_id=[1])
+   +- Exchange(distribution=[hash[a]])
+      +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.scala
@@ -216,4 +216,19 @@ class DeadlockBreakupTest extends TableTestBase {
          |""".stripMargin
     util.verifyPlan(sqlQuery)
   }
+
+  @Test
+  def testSubplanReuse_DeadlockCausedByReusingExchange(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED, true)
+    util.tableEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,SortMergeJoin")
+    val sqlQuery =
+      s"""
+         |WITH T1 AS (SELECT a FROM x)
+         |SELECT * FROM T1
+         |  INNER JOIN T1 AS T2 ON T1.a = T2.a
+         |""".stripMargin
+    util.verifyPlan(sqlQuery)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the special case when the reuse of exchange causes the deadlock.

Currently the reuse of exchange is not considered to be a deadlock because although the exec node of an exchange is reused, its underlying transformation is not reused. However if this behavior changes a deadlock may occur.

## Brief change log

 - Fix special case when the reuse of exchange causes the deadlock

## Verifying this change

This change is already covered by existing tests, also this change added tests and can be verified by running the added cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
