### PR TITLE
[FLINK-18122][e2e] Make K8s test more resilient by retrying and failing docker image build (2nd try)

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
@@ -23,6 +23,8 @@ CLUSTER_ROLE_BINDING="flink-role-binding-default"
 CLUSTER_ID="flink-native-k8s-application-1"
 FLINK_IMAGE_NAME="test_kubernetes_application"
 LOCAL_LOGS_PATH="${TEST_DATA_DIR}/log"
+IMAGE_BUILD_RETRIES=3
+IMAGE_BUILD_BACKOFF=2
 
 function internal_cleanup {
     kubectl delete deployment ${CLUSTER_ID}
@@ -31,7 +33,10 @@ function internal_cleanup {
 
 start_kubernetes
 
-build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
+if ! retry_times $IMAGE_BUILD_RETRIES $IMAGE_BUILD_BACKOFF "build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)"; then
+	echo "ERROR: Could not build image. Aborting..."
+	exit 1
+fi
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -26,6 +26,9 @@ export OUTPUT_FILE=kubernetes_wc_out
 export FLINK_JOB_PARALLELISM=1
 export FLINK_JOB_ARGUMENTS='"--output", "/cache/kubernetes_wc_out"'
 
+IMAGE_BUILD_RETRIES=3
+IMAGE_BUILD_BACKOFF=2
+
 function internal_cleanup {
     kubectl delete job flink-job-cluster
     kubectl delete service flink-job-cluster
@@ -36,7 +39,10 @@ start_kubernetes
 
 mkdir -p $OUTPUT_VOLUME
 
-build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
+if ! retry_times $IMAGE_BUILD_RETRIES $IMAGE_BUILD_BACKOFF "build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)"; then
+    echo "ERROR: Could not build image. Aborting..."
+    exit 1
+fi
 
 export USER_LIB=${FLINK_DIR}/examples/batch
 kubectl create -f ${CONTAINER_SCRIPTS}/job-cluster-service.yaml

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -25,6 +25,8 @@ CLUSTER_ID="flink-native-k8s-pyflink-application-1"
 PURE_FLINK_IMAGE_NAME="test_kubernetes_application-1"
 PYFLINK_IMAGE_NAME="test_kubernetes_pyflink_application"
 LOCAL_LOGS_PATH="${TEST_DATA_DIR}/log"
+IMAGE_BUILD_RETRIES=3
+IMAGE_BUILD_BACKOFF=2
 
 function internal_cleanup {
     kubectl delete deployment ${CLUSTER_ID}
@@ -33,7 +35,10 @@ function internal_cleanup {
 
 start_kubernetes
 
-build_image ${PURE_FLINK_IMAGE_NAME}
+if ! retry_times $IMAGE_BUILD_RETRIES $IMAGE_BUILD_BACKOFF "build_image ${PURE_FLINK_IMAGE_NAME}"; then
+	echo "ERROR: Could not build image. Aborting..."
+	exit 1
+fi
 
 FLINK_PYTHON_DIR=`cd "${CURRENT_DIR}/../../flink-python" && pwd -P`
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
@@ -25,6 +25,8 @@ FLINK_IMAGE_NAME="test_kubernetes_session"
 LOCAL_OUTPUT_PATH="${TEST_DATA_DIR}/out/wc_out"
 OUTPUT_PATH="/tmp/wc_out"
 OUTPUT_ARGS="--output ${OUTPUT_PATH}"
+IMAGE_BUILD_RETRIES=3
+IMAGE_BUILD_BACKOFF=2
 
 INPUT_TYPE=${1:-embedded}
 case $INPUT_TYPE in
@@ -52,7 +54,10 @@ function internal_cleanup {
 
 start_kubernetes
 
-build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)
+if ! retry_times $IMAGE_BUILD_RETRIES $IMAGE_BUILD_BACKOFF "build_image ${FLINK_IMAGE_NAME} $(get_host_machine_address)"; then
+    echo "ERROR: Could not build image. Aborting..."
+    exit 1
+fi
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
 


### PR DESCRIPTION

## What is the purpose of the change

This is a follow up to https://github.com/apache/flink/pull/13779, which has been reverted due to a build failure.


