### PR TITLE
[FLINK-18325] [table-common] Handle null when calling SqlDataTypeSpec#getNullable

### DIFF
--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
@@ -181,7 +181,8 @@ public class HiveDDLUtils {
 		SqlTypeNameSpec nameSpec = typeSpec.getTypeNameSpec();
 		SqlTypeNameSpec convertedNameSpec = convertDataTypes(nameSpec);
 		if (nameSpec != convertedNameSpec) {
-			typeSpec = new SqlDataTypeSpec(convertedNameSpec, typeSpec.getTimeZone(), typeSpec.getNullable(),
+			boolean nullable = typeSpec.getNullable() == null ? true : typeSpec.getNullable();
+			typeSpec = new SqlDataTypeSpec(convertedNameSpec, typeSpec.getTimeZone(), nullable,
 					typeSpec.getParserPosition());
 		}
 		return typeSpec;

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/type/ExtendedHiveStructTypeNameSpec.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/type/ExtendedHiveStructTypeNameSpec.java
@@ -55,7 +55,7 @@ public class ExtendedHiveStructTypeNameSpec extends ExtendedSqlRowTypeNameSpec {
 			writer.sep(",", false);
 			p.left.unparse(writer, 0, 0);
 			p.right.unparse(writer, leftPrec, rightPrec);
-			if (!p.right.getNullable()) {
+			if (p.right.getNullable() != null && !p.right.getNullable()) {
 				writer.keyword("NOT NULL");
 			}
 			if (getComments().get(i) != null) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
@@ -124,7 +124,7 @@ public abstract class SqlTableColumn extends SqlCall {
 		@Override
 		protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
 			type.unparse(writer, leftPrec, rightPrec);
-			if (!type.getNullable()) {
+			if (this.type.getNullable() != null && !this.type.getNullable()) {
 				// Default is nullable.
 				writer.keyword("NOT NULL");
 			}
@@ -179,7 +179,7 @@ public abstract class SqlTableColumn extends SqlCall {
 		@Override
 		protected void unparseColumn(SqlWriter writer, int leftPrec, int rightPrec) {
 			type.unparse(writer, leftPrec, rightPrec);
-			if (!type.getNullable()) {
+			if (this.type.getNullable() != null && !this.type.getNullable()) {
 				// Default is nullable.
 				writer.keyword("NOT NULL");
 			}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
@@ -111,7 +111,7 @@ public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
 				writer.sep(",", false);
 				p.left.unparse(writer, 0, 0);
 				p.right.unparse(writer, leftPrec, rightPrec);
-				if (!p.right.getNullable()) {
+				if (p.right.getNullable() != null && !p.right.getNullable()) {
 					writer.keyword("NOT NULL");
 				}
 				if (comments.get(i) != null) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlMapTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlMapTypeNameSpec.java
@@ -78,13 +78,13 @@ public class SqlMapTypeNameSpec extends SqlTypeNameSpec {
 		writer.sep(","); // configures the writer
 		keyType.unparse(writer, leftPrec, rightPrec);
 		// Default is nullable.
-		if (!keyType.getNullable()) {
+		if (keyType.getNullable() != null && !keyType.getNullable()) {
 			writer.keyword("NOT NULL");
 		}
 		writer.sep(",");
 		valType.unparse(writer, leftPrec, rightPrec);
 		// Default is nullable.
-		if (!valType.getNullable()) {
+		if (valType.getNullable() != null && !valType.getNullable()) {
 			writer.keyword("NOT NULL");
 		}
 		writer.endList(frame);

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -452,7 +452,7 @@ public class FlinkDDLDataTypeTest {
 			// SqlDataTypeSpec does not take care of the nullable attribute unparse,
 			// So we unparse nullable attribute specifically, this unparsing logic should
 			// keep sync with SqlTableColumn.
-			if (!dataTypeSpec.getNullable()) {
+			if (dataTypeSpec.getNullable() != null && !dataTypeSpec.getNullable()) {
 				sqlWriter.keyword("NOT NULL");
 			}
 			assertEquals(expectedUnparsed, sqlWriter.toSqlString().getSql());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.types.utils.TypeConversions;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -432,8 +433,9 @@ class MergeTableLikeUtil {
 						}
 					}
 
-					final RelDataType relType = metadataColumn.getType()
-						.deriveType(sqlValidator, metadataColumn.getType().getNullable());
+					SqlDataTypeSpec type = metadataColumn.getType();
+					boolean nullable = type.getNullable() == null ? true : type.getNullable();
+					RelDataType relType = type.deriveType(sqlValidator, nullable);
 					column = TableColumn.metadata(
 						name,
 						fromLogicalToDataType(toLogicalType(relType)),
@@ -457,8 +459,9 @@ class MergeTableLikeUtil {
 							"A column named '%s' already exists in the base table.",
 							name));
 					}
-					RelDataType relType = regularColumn.getType()
-						.deriveType(sqlValidator, regularColumn.getType().getNullable());
+					SqlDataTypeSpec type = regularColumn.getType();
+					boolean nullable = type.getNullable() == null ? true : type.getNullable();
+					RelDataType relType = type.deriveType(sqlValidator, nullable);
 					// add field name and field type to physical field list
 					physicalFieldNamesToTypes.put(name, relType);
 				}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/OperationConverterUtils.java
@@ -173,8 +173,9 @@ public class OperationConverterUtils {
 		SqlRegularColumn regularColumn = (SqlRegularColumn) tableColumn;
 		String name = regularColumn.getName().getSimple();
 		SqlDataTypeSpec typeSpec = regularColumn.getType();
+		boolean nullable = typeSpec.getNullable() == null ? true : typeSpec.getNullable();
 		LogicalType logicalType = FlinkTypeFactory.toLogicalType(
-				typeSpec.deriveType(sqlValidator, typeSpec.getNullable()));
+				typeSpec.deriveType(sqlValidator, nullable));
 		DataType dataType = TypeConversions.fromLogicalToDataType(logicalType);
 		return TableColumn.physical(name, dataType);
 	}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -97,6 +97,7 @@ import org.apache.flink.util.StringUtils;
 
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlExplainFormat;
@@ -621,10 +622,12 @@ public class SqlToOperationConverter {
 			.map(SqlRegularColumn.class::cast)
 			.collect(Collectors.toList());
 		for (SqlRegularColumn regularColumn : physicalColumns) {
+			SqlDataTypeSpec type = regularColumn.getType();
+			boolean nullable = type.getNullable() == null ? true : type.getNullable();
 			final RelDataType relType = regularColumn.getType()
 				.deriveType(
 					flinkPlanner.getOrCreateSqlValidator(),
-					regularColumn.getType().getNullable());
+						nullable);
 			builder.field(regularColumn.getName().getSimple(),
 				TypeConversions.fromLegacyInfoToDataType(FlinkTypeFactory.toTypeInfo(relType)));
 		}


### PR DESCRIPTION
## What is the purpose of the change

SqlDataTypeSpec#getNullable may return null(by Calcite design, it returns "Boolean" instead "boolean"), so the caller should handle null itself. In Calcite, every place calls this method adds the null judge.

Below is the code from Calcite.
**org.apache.calcite.sql.SqlDataTypeSpec**
```
  /** Whether data type allows nulls.
   *
   * <p>Nullable is nullable! Null means "not specified". E.g.
   * {@code CAST(x AS INTEGER)} preserves the same nullability as {@code x}.
   */
  private Boolean nullable;
```

## Brief change log

Handle "null" when calling SqlDataTypeSpec#getNullable.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
