### PR TITLE
[FLINK-19874][table-planner-blink] Apply JoinDeriveNullFilterRule after join reorder

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkBatchProgram.scala
@@ -158,10 +158,17 @@ object FlinkBatchProgram {
     // join rewrite
     chainedProgram.addLast(
       JOIN_REWRITE,
-      FlinkHepRuleSetProgramBuilder.newBuilder
-        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
-        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-        .add(FlinkBatchRuleSets.JOIN_COND_EQUAL_TRANSFER_RULES)
+      FlinkGroupProgramBuilder.newBuilder[BatchOptimizeContext]
+        .addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
+          .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+          .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+          .add(FlinkBatchRuleSets.JOIN_COND_EQUAL_TRANSFER_RULES)
+          .build(), "simplify and push down join predicates")
+        .addProgram(FlinkHepRuleSetProgramBuilder.newBuilder
+          .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+          .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+          .add(FlinkBatchRuleSets.JOIN_NULL_FILTER_RULES)
+          .build(), "deal with possible null join keys")
         .build())
 
     // window rewrite

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -222,9 +222,12 @@ object FlinkBatchRuleSets {
   val JOIN_COND_EQUAL_TRANSFER_RULES: RuleSet = RuleSets.ofList((
     RuleSets.ofList(JoinConditionEqualityTransferRule.INSTANCE).asScala ++
       PREDICATE_SIMPLIFY_EXPRESSION_RULES.asScala ++
-      FILTER_RULES.asScala ++
-      RuleSets.ofList(JoinDeriveNullFilterRule.INSTANCE).asScala
+      FILTER_RULES.asScala
     ).asJava)
+
+  val JOIN_NULL_FILTER_RULES: RuleSet = RuleSets.ofList(
+    JoinDeriveNullFilterRule.INSTANCE
+  )
 
   val JOIN_REORDER_PREPARE_RULES: RuleSet = RuleSets.ofList(
     // merge join to MultiJoin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -222,7 +222,8 @@ object FlinkBatchRuleSets {
   val JOIN_COND_EQUAL_TRANSFER_RULES: RuleSet = RuleSets.ofList((
     RuleSets.ofList(JoinConditionEqualityTransferRule.INSTANCE).asScala ++
       PREDICATE_SIMPLIFY_EXPRESSION_RULES.asScala ++
-      FILTER_RULES.asScala
+      FILTER_RULES.asScala ++
+      RuleSets.ofList(JoinDeriveNullFilterRule.INSTANCE).asScala
     ).asJava)
 
   val JOIN_REORDER_PREPARE_RULES: RuleSet = RuleSets.ofList(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -144,10 +144,14 @@ object FlinkBatchRuleSets {
     CoreRules.FILTER_MERGE
   )
 
-  val JOIN_PREDICATE_REWRITE_RULES: RuleSet = RuleSets.ofList(
-    JoinDependentConditionDerivationRule.INSTANCE,
+  val JOIN_NULL_FILTER_RULES: RuleSet = RuleSets.ofList(
     JoinDeriveNullFilterRule.INSTANCE
   )
+
+  val JOIN_PREDICATE_REWRITE_RULES: RuleSet = RuleSets.ofList((
+    RuleSets.ofList(JoinDependentConditionDerivationRule.INSTANCE).asScala ++
+    JOIN_NULL_FILTER_RULES.asScala
+  ).asJava)
 
   /**
     * RuleSet to do predicate pushdown
@@ -224,10 +228,6 @@ object FlinkBatchRuleSets {
       PREDICATE_SIMPLIFY_EXPRESSION_RULES.asScala ++
       FILTER_RULES.asScala
     ).asJava)
-
-  val JOIN_NULL_FILTER_RULES: RuleSet = RuleSets.ofList(
-    JoinDeriveNullFilterRule.INSTANCE
-  )
 
   val JOIN_REORDER_PREPARE_RULES: RuleSet = RuleSets.ofList(
     // merge join to MultiJoin

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/JoinReorderTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/JoinReorderTest.xml
@@ -241,28 +241,28 @@ SELECT * FROM T6
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a6=[$0], b6=[$1], c6=[$2], a7=[$3], b7=[$4], c7=[$5], a8=[$6], b8=[$7], c8=[$8])
-+- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
-   :- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
-   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]])
+LogicalProject(a6=[$0], b6=[$1], a7=[$2], b7=[$3], a8=[$4], b8=[$5])
++- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :- LogicalJoin(condition=[=($1, $3)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a6, b6, c6, a7, b7, c7, a8, b8, c8])
-+- HashJoin(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, c6, a8, b8, c8, a7, b7, c7], build=[right])
+Calc(select=[a6, b6, a7, b7, a8, b8])
++- HashJoin(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, a8, b8, a7, b7], build=[right])
    :- Exchange(distribution=[hash[b6]])
-   :  +- HashJoin(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, c6, a8, b8, c8], build=[right])
+   :  +- HashJoin(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, a8, b8], build=[right])
    :     :- Exchange(distribution=[hash[a6]])
-   :     :  +- Calc(select=[a6, b6, c6], where=[IS NOT NULL(a6)])
-   :     :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]], fields=[a6, b6, c6])
+   :     :  +- Calc(select=[a6, b6], where=[IS NOT NULL(a6)])
+   :     :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6)]]], fields=[a6, b6])
    :     +- Exchange(distribution=[hash[a8]])
-   :        +- Calc(select=[a8, b8, c8], where=[IS NOT NULL(a8)])
-   :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]], fields=[a8, b8, c8])
+   :        +- Calc(select=[a8, b8], where=[IS NOT NULL(a8)])
+   :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8)]]], fields=[a8, b8])
    +- Exchange(distribution=[hash[b7]])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]], fields=[a7, b7, c7])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7)]]], fields=[a7, b7])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/JoinReorderTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/JoinReorderTest.xml
@@ -231,6 +231,41 @@ Calc(select=[a1, b1, c1, a2, b2, c2, a3, b3, c3, a4, b4, c4, a5, b5, c5])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDeriveNullFilterAfterJoinReorder">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T6
+   INNER JOIN T7 ON b6 = b7
+   INNER JOIN T8 ON a6 = a8
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a6=[$0], b6=[$1], c6=[$2], a7=[$3], b7=[$4], c7=[$5], a8=[$6], b8=[$7], c8=[$8])
++- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
+   :- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a6, b6, c6, a7, b7, c7, a8, b8, c8])
++- HashJoin(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, c6, a8, b8, c8, a7, b7, c7], build=[right])
+   :- Exchange(distribution=[hash[b6]])
+   :  +- HashJoin(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, c6, a8, b8, c8], build=[right])
+   :     :- Exchange(distribution=[hash[a6]])
+   :     :  +- Calc(select=[a6, b6, c6], where=[IS NOT NULL(a6)])
+   :     :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]], fields=[a6, b6, c6])
+   :     +- Exchange(distribution=[hash[a8]])
+   :        +- Calc(select=[a8, b8, c8], where=[IS NOT NULL(a8)])
+   :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]], fields=[a8, b8, c8])
+   +- Exchange(distribution=[hash[b7]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]], fields=[a7, b7, c7])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInnerAndFullOuterJoin">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinReorderTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinReorderTest.xml
@@ -245,6 +245,39 @@ Calc(select=[a1, b1, c1, a2, b2, c2, a3, b3, c3, a4, b4, c4, a5, b5, c5])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDeriveNullFilterAfterJoinReorder">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM T6
+   INNER JOIN T7 ON b6 = b7
+   INNER JOIN T8 ON a6 = a8
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a6=[$0], b6=[$1], c6=[$2], a7=[$3], b7=[$4], c7=[$5], a8=[$6], b8=[$7], c8=[$8])
++- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
+   :- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a6, b6, c6, a7, b7, c7, a8, b8, c8])
++- Join(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, c6, a8, b8, c8, a7, b7, c7], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b6]])
+   :  +- Join(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, c6, a8, b8, c8], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :     :- Exchange(distribution=[hash[a6]])
+   :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]], fields=[a6, b6, c6])
+   :     +- Exchange(distribution=[hash[a8]])
+   :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]], fields=[a8, b8, c8])
+   +- Exchange(distribution=[hash[b7]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]], fields=[a7, b7, c7])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInnerAndFullOuterJoin">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinReorderTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinReorderTest.xml
@@ -255,26 +255,26 @@ SELECT * FROM T6
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a6=[$0], b6=[$1], c6=[$2], a7=[$3], b7=[$4], c7=[$5], a8=[$6], b8=[$7], c8=[$8])
-+- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
-   :- LogicalJoin(condition=[=($1, $4)], joinType=[inner])
-   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]])
+LogicalProject(a6=[$0], b6=[$1], a7=[$2], b7=[$3], a8=[$4], b8=[$5])
++- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :- LogicalJoin(condition=[=($1, $3)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a6, b6, c6, a7, b7, c7, a8, b8, c8])
-+- Join(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, c6, a8, b8, c8, a7, b7, c7], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+Calc(select=[a6, b6, a7, b7, a8, b8])
++- Join(joinType=[InnerJoin], where=[=(b6, b7)], select=[a6, b6, a8, b8, a7, b7], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :- Exchange(distribution=[hash[b6]])
-   :  +- Join(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, c6, a8, b8, c8], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :  +- Join(joinType=[InnerJoin], where=[=(a6, a8)], select=[a6, b6, a8, b8], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
    :     :- Exchange(distribution=[hash[a6]])
-   :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6, c6)]]], fields=[a6, b6, c6])
+   :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T6, source: [TestTableSource(a6, b6)]]], fields=[a6, b6])
    :     +- Exchange(distribution=[hash[a8]])
-   :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8, c8)]]], fields=[a8, b8, c8])
+   :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, T8, source: [TestTableSource(a8, b8)]]], fields=[a8, b8])
    +- Exchange(distribution=[hash[b7]])
-      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7, c7)]]], fields=[a7, b7, c7])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T7, source: [TestTableSource(a7, b7)]]], fields=[a7, b7])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/JoinReorderTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/JoinReorderTestBase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
+import org.apache.flink.table.planner.plan.rules.logical.JoinDeriveNullFilterRule
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.utils.{TableTestBase, TableTestUtil}
 
@@ -67,6 +68,27 @@ abstract class JoinReorderTestBase extends TableTestBase {
       .tableStats(new TableStats(500000L, Map(
         "a5" -> new ColumnStats(200000L, 0L, 4.0, 4, null, null),
         "b5" -> new ColumnStats(200L, 0L, 8.0, 8, null, null)
+      ))).build())
+
+    util.addTableSource("T6", types, Array("a6", "b6", "c6"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a6" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
+        "b6" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
+        "c6" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
+      ))).build())
+
+    util.addTableSource("T7", types, Array("a7", "b7", "c7"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a7" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
+        "b7" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
+        "c7" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
+      ))).build())
+
+    util.addTableSource("T8", types, Array("a8", "b8", "c8"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a8" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
+        "b8" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
+        "c8" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
       ))).build())
 
     util.getTableEnv.getConfig.getConfiguration.setBoolean(
@@ -230,6 +252,19 @@ abstract class JoinReorderTestBase extends TableTestBase {
          |   FULL OUTER JOIN T5 ON a4 = a5
          """.stripMargin
     // can not reorder
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testDeriveNullFilterAfterJoinReorder(): Unit = {
+    util.getTableEnv.getConfig.getConfiguration.setLong(
+      JoinDeriveNullFilterRule.TABLE_OPTIMIZER_JOIN_NULL_FILTER_THRESHOLD, 10000L)
+    val sql =
+      s"""
+         |SELECT * FROM T6
+         |   INNER JOIN T7 ON b6 = b7
+         |   INNER JOIN T8 ON a6 = a8
+         |""".stripMargin
     util.verifyPlan(sql)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/JoinReorderTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/JoinReorderTestBase.scala
@@ -70,27 +70,6 @@ abstract class JoinReorderTestBase extends TableTestBase {
         "b5" -> new ColumnStats(200L, 0L, 8.0, 8, null, null)
       ))).build())
 
-    util.addTableSource("T6", types, Array("a6", "b6", "c6"), FlinkStatistic.builder()
-      .tableStats(new TableStats(500000L, Map(
-        "a6" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
-        "b6" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
-        "c6" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
-      ))).build())
-
-    util.addTableSource("T7", types, Array("a7", "b7", "c7"), FlinkStatistic.builder()
-      .tableStats(new TableStats(500000L, Map(
-        "a7" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
-        "b7" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
-        "c7" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
-      ))).build())
-
-    util.addTableSource("T8", types, Array("a8", "b8", "c8"), FlinkStatistic.builder()
-      .tableStats(new TableStats(500000L, Map(
-        "a8" -> new ColumnStats(200000L, 50000L, 4.0, 4, null, null),
-        "b8" -> new ColumnStats(100000L, 0L, 8.0, 8, null, null),
-        "c8" -> new ColumnStats(50000L, 20000L, 8.0, 8, null, null)
-      ))).build())
-
     util.getTableEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED, true)
   }
@@ -257,6 +236,36 @@ abstract class JoinReorderTestBase extends TableTestBase {
 
   @Test
   def testDeriveNullFilterAfterJoinReorder(): Unit = {
+    val types = Array[TypeInformation[_]](Types.INT, Types.LONG)
+    val builderA = ColumnStats.Builder.builder()
+      .setNdv(200000L)
+      .setNullCount(50000L)
+      .setAvgLen(4.0)
+      .setMaxLen(4)
+    val builderB = ColumnStats.Builder.builder()
+      .setNdv(100000L)
+      .setNullCount(0L)
+      .setAvgLen(8.0)
+      .setMaxLen(8)
+
+    util.addTableSource("T6", types, Array("a6", "b6"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a6" -> builderA.build(),
+        "b6" -> builderB.build()
+      ))).build())
+
+    util.addTableSource("T7", types, Array("a7", "b7"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a7" -> builderA.build(),
+        "b7" -> builderB.build()
+      ))).build())
+
+    util.addTableSource("T8", types, Array("a8", "b8"), FlinkStatistic.builder()
+      .tableStats(new TableStats(500000L, Map(
+        "a8" -> builderA.build(),
+        "b8" -> builderB.build()
+      ))).build())
+
     util.getTableEnv.getConfig.getConfiguration.setLong(
       JoinDeriveNullFilterRule.TABLE_OPTIMIZER_JOIN_NULL_FILTER_THRESHOLD, 10000L)
     val sql =


### PR DESCRIPTION
## What is the purpose of the change

`JoinDeriveNullFilterRule` will filter out null join keys to prevent data skew for joins. Currently this rule is only applied before join reorder. After join reorder the join keys for some inputs might change and we need to apply this rule again.

This PR applies the rule again after join reorder.

## Brief change log

 - Apply `JoinDeriveNullFilterRule` after join reorder

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
