### PR TITLE
[FLINK-19628][table-planner] Introduce multiple input operator for streaming

### DIFF
--- a/docs/_includes/generated/optimizer_config_configuration.html
+++ b/docs/_includes/generated/optimizer_config_configuration.html
@@ -42,7 +42,7 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when performing a join. By setting this value to -1 to disable broadcasting.</td>
         </tr>
         <tr>
-            <td><h5>table.optimizer.multiple-input-enabled</h5><br> <span class="label label-primary">Batch</span></td>
+            <td><h5>table.optimizer.multiple-input-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>When it is true, the optimizer will merge the operators with pipelined shuffling into a multiple input operator to reduce shuffling and improve performance. Default value is true.</td>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -260,7 +260,15 @@ public abstract class AbstractStreamOperator<OUT>
 				isUsingCustomRawKeyedState());
 
 		stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), streamTaskCloseableRegistry);
-		timeServiceManager = context.internalTimerServiceManager();
+		initializeState(stateHandler, context.internalTimerServiceManager());
+	}
+
+	@Internal
+	public final void initializeState(
+			StreamOperatorStateHandler stateHandler,
+			InternalTimeServiceManager<?> timeServiceManager) throws Exception {
+		this.stateHandler = stateHandler;
+		this.timeServiceManager = timeServiceManager;
 		stateHandler.initializeOperatorState(this);
 		runtimeContext.setKeyedStateStore(stateHandler.getKeyedStateStore().orElse(null));
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -531,7 +531,13 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 		throw new IllegalStateException("This method should never be called. Use Input class instead");
 	}
 
+	@Internal
 	protected Optional<InternalTimeServiceManager<?>> getTimeServiceManager() {
 		return Optional.ofNullable(timeServiceManager);
+	}
+
+	@Internal
+	protected Optional<StreamOperatorStateHandler> getStateHandler() {
+		return Optional.ofNullable(stateHandler);
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -100,7 +100,7 @@ public class OptimizerConfigOptions {
 			.defaultValue(false)
 			.withDescription("Enables join reorder in optimizer. Default is disabled.");
 
-	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
 	public static final ConfigOption<Boolean> TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED =
 		key("table.optimizer.multiple-input-enabled")
 			.defaultValue(true)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInput.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInput.scala
@@ -78,18 +78,18 @@ class BatchExecMultipleInput(
     val generator = new TableOperatorWrapperGenerator(inputTransforms, tailTransform, readOrders)
     generator.generate()
 
-    val inputTransformAndInputSpecPairs = generator.getInputTransformAndInputSpecPairs
+    val inputInfoList = generator.getInputInfoList
     val multipleInputTransform = new MultipleInputTransformation[RowData](
       getRelDetailedDescription,
       new BatchMultipleInputStreamOperatorFactory(
-        inputTransformAndInputSpecPairs.map(_.getValue),
+        inputInfoList.map(_.getInputSpec),
         generator.getHeadWrappers,
         generator.getTailWrapper),
       outputType,
       generator.getParallelism)
 
     // add inputs as the order of input specs
-    inputTransformAndInputSpecPairs.foreach(input => multipleInputTransform.addInput(input.getKey))
+    inputInfoList.foreach(input => multipleInputTransform.addInput(input.getInputTransform))
 
     if (generator.getMaxParallelism > 0) {
       multipleInputTransform.setMaxParallelism(generator.getMaxParallelism)

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainMultipleInput.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainMultipleInput.out
@@ -1,0 +1,34 @@
+MultipleInput(members=[\nJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, EXPR$1, d, EXPR$10], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])\n:- GroupAggregate(groupBy=[a], select=[a, SUM(b) AS EXPR$1])\n:  +- [#1] Exchange(distribution=[hash[a]])\n+- GroupAggregate(groupBy=[d], select=[d, SUM(e) AS EXPR$1])\n   +- [#2] Exchange(distribution=[hash[d]])\n])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a, b])
+:     +- DataStreamScan(table=[[default_catalog, default_database, MyTable1]], fields=[a, b, c])
++- Exchange(distribution=[hash[d]])
+   +- Calc(select=[d, e])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e, f])
+
+ : Data Source
+	content : Source: Collection Source
+
+ : Data Source
+	content : Source: Collection Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable1], fields=[a, b, c])
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : Calc(select=[a, b])
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : SourceConversion(table=[default_catalog.default_database.MyTable2], fields=[d, e, f])
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Calc(select=[d, e])
+					ship_strategy : FORWARD
+
+					 : Operator
+						content : MultipleInput(members=[\nJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, EXPR$1, d, EXPR$10], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])\n:- GroupAggregate(groupBy=[a], select=[a, SUM(b) AS EXPR$1])\n:  +- [#1] Exchange(distribution=[hash[a]])\n+- GroupAggregate(groupBy=[d], select=[d, SUM(e) AS EXPR$1])\n   +- [#2] Exchange(distribution=[hash[d]])\n])
+						ship_strategy : HASH
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api.batch
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
-import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.planner.utils.TableTestBase
 import org.apache.flink.table.types.logical.{BigIntType, IntType, VarCharType}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/KeyedProcessFunctionWithCleanupState.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/KeyedProcessFunctionWithCleanupState.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.streaming.api.TimeDomain;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.table.runtime.operators.StateNameAwareKeyedProcessFunction;
 
 import java.io.IOException;
 
@@ -34,7 +34,7 @@ import java.io.IOException;
  * @param <OUT> Type of the output elements.
  */
 public abstract class KeyedProcessFunctionWithCleanupState<K, IN, OUT>
-	extends KeyedProcessFunction<K, IN, OUT> implements CleanupState {
+	extends StateNameAwareKeyedProcessFunction<K, IN, OUT> implements CleanupState {
 
 	private static final long serialVersionUID = 2084560869233898457L;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAware.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAware.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.operators.multipleinput.StreamMultipleInputStreamOperator;
+
+/**
+ * All sub-classes of this interface will share a same {@link StateNameContext} instance,
+ * that could make sure the state name in those class are unique.
+ *
+ * <p><strong>A operator or function which can be merged into {@link StreamMultipleInputStreamOperator}
+ * must implement this interface.</strong>
+ */
+@Internal
+public interface StateNameAware {
+
+	/**
+	 * Return a {@link StateNameContext} to get a unique state name.
+	 */
+	StateNameContext getStateNameContext();
+
+	/**
+	 * Set a shared {@link StateNameContext} to current instance.
+	 */
+	void setStateNameContext(StateNameContext context);
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAwareKeyedProcessFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAwareKeyedProcessFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators;
+
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.table.runtime.operators.multipleinput.StreamMultipleInputStreamOperator;
+
+/**
+ * Base class for all keyed process functions which operator can be merge into {@link StreamMultipleInputStreamOperator}.
+ * The sub-classes can get unique state name through getStateNameContext().getUniqueStateName(name);
+ */
+public abstract class StateNameAwareKeyedProcessFunction<K, IN, OUT>
+		extends KeyedProcessFunction<K, IN, OUT>
+		implements StateNameAware {
+	private static final long serialVersionUID = 1;
+
+	// this instance should never be null,
+	// because this operator may not be merged into multiple input operator.
+	private StateNameContext stateNameContext = new StateNameContext();
+
+	@Override
+	public StateNameContext getStateNameContext() {
+		return stateNameContext;
+	}
+
+	@Override
+	public void setStateNameContext(StateNameContext context) {
+		this.stateNameContext = context;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAwareStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameAwareStreamOperator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.table.runtime.operators.multipleinput.StreamMultipleInputStreamOperator;
+
+/**
+ * Base class for all stream operators which can be merge into {@link StreamMultipleInputStreamOperator}.
+ * The sub-classes can get unique state name through getStateNameContext().getUniqueStateName(name);
+ */
+public abstract class StateNameAwareStreamOperator<OUT>
+		extends AbstractStreamOperator<OUT>
+		implements StateNameAware {
+	private static final long serialVersionUID = 1;
+
+	// this instance should never be null,
+	// because this operator may not be merged into multiple input operator.
+	private StateNameContext stateNameContext = new StateNameContext();
+
+	@Override
+	public StateNameContext getStateNameContext() {
+		return stateNameContext;
+	}
+
+	@Override
+	public void setStateNameContext(StateNameContext context) {
+		this.stateNameContext = context;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/StateNameContext.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A StateNameContext stores all state names and the number of visits.
+ * This context can return a unique state name by adding access number as suffix.
+ */
+@Internal
+public class StateNameContext implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final Map<String, Integer> nameToCountMap;
+
+	public StateNameContext() {
+		nameToCountMap = new HashMap<>();
+	}
+
+	/**
+	 * Returns unique state name by adding access number as suffix to the given name.
+	 */
+	public String getUniqueStateName(String name) {
+		int count = nameToCountMap.getOrDefault(name, 0);
+		nameToCountMap.put(name, count + 1);
+		if (count == 0) {
+			return name;
+		} else {
+			return name + count;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupAggFunction.java
@@ -128,7 +128,8 @@ public class GroupAggFunction extends KeyedProcessFunction<RowData, RowData, Row
 		equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
 
 		InternalTypeInfo<RowData> accTypeInfo = InternalTypeInfo.ofFields(accTypes);
-		ValueStateDescriptor<RowData> accDesc = new ValueStateDescriptor<>("accState", accTypeInfo);
+		ValueStateDescriptor<RowData> accDesc = new ValueStateDescriptor<>(
+				getStateNameContext().getUniqueStateName("accState"), accTypeInfo);
 		if (ttlConfig.isEnabled()){
 			accDesc.enableTimeToLive(ttlConfig);
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -21,13 +21,13 @@ package org.apache.flink.table.runtime.operators.join.stream;
 import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
+import org.apache.flink.table.runtime.operators.StateNameAwareStreamOperator;
 import org.apache.flink.table.runtime.operators.join.NullAwareJoinHelper;
 import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
 import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Abstract implementation for streaming unbounded Join operator which defines some member fields
  * can be shared between different implementations.
  */
-public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperator<RowData>
+public abstract class AbstractStreamingJoinOperator extends StateNameAwareStreamOperator<RowData>
 	implements TwoInputStreamOperator<RowData, RowData, RowData> {
 
 	private static final long serialVersionUID = -376944622236540545L;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -80,14 +80,14 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
 		if (leftIsOuter) {
 			this.leftRecordStateView = OuterJoinRecordStateViews.create(
 				getRuntimeContext(),
-				"left-records",
+				getStateNameContext().getUniqueStateName("left-records"),
 				leftInputSideSpec,
 				leftType,
 				stateRetentionTime);
 		} else {
 			this.leftRecordStateView = JoinRecordStateViews.create(
 				getRuntimeContext(),
-				"left-records",
+				getStateNameContext().getUniqueStateName("left-records"),
 				leftInputSideSpec,
 				leftType,
 				stateRetentionTime);
@@ -96,14 +96,14 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
 		if (rightIsOuter) {
 			this.rightRecordStateView = OuterJoinRecordStateViews.create(
 				getRuntimeContext(),
-				"right-records",
+				getStateNameContext().getUniqueStateName("right-records"),
 				rightInputSideSpec,
 				rightType,
 				stateRetentionTime);
 		} else {
 			this.rightRecordStateView = JoinRecordStateViews.create(
 				getRuntimeContext(),
-				"right-records",
+				getStateNameContext().getUniqueStateName("right-records"),
 				rightInputSideSpec,
 				rightType,
 				stateRetentionTime);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.multipleinput;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
@@ -43,6 +44,8 @@ import org.apache.flink.table.runtime.operators.multipleinput.output.CopyingSeco
 import org.apache.flink.table.runtime.operators.multipleinput.output.FirstInputOfTwoInputStreamOperatorOutput;
 import org.apache.flink.table.runtime.operators.multipleinput.output.OneInputStreamOperatorOutput;
 import org.apache.flink.table.runtime.operators.multipleinput.output.SecondInputOfTwoInputStreamOperatorOutput;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -107,14 +110,17 @@ public abstract class MultipleInputStreamOperatorBase
 	private Input createInput(InputSpec inputSpec) {
 		StreamOperator<RowData> operator = inputSpec.getOutput().getStreamOperator();
 		if (operator instanceof OneInputStreamOperator) {
-			return new OneInput((OneInputStreamOperator<RowData, RowData>) operator);
+			return new OneInput(
+					this,
+					inputSpec.getMultipleInputId(),
+					(OneInputStreamOperator<RowData, RowData>) operator);
 		} else if (operator instanceof TwoInputStreamOperator) {
 			TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
 					(TwoInputStreamOperator<RowData, RowData, RowData>) operator;
 			if (inputSpec.getOutputOpInputId() == 1) {
-				return new FirstInputOfTwoInput(twoInputOp);
+				return new FirstInputOfTwoInput(this, inputSpec.getMultipleInputId(), twoInputOp);
 			} else {
-				return new SecondInputOfTwoInput(twoInputOp);
+				return new SecondInputOfTwoInput(this, inputSpec.getMultipleInputId(), twoInputOp);
 			}
 		} else {
 			throw new RuntimeException("Unsupported StreamOperator: " + operator);
@@ -231,12 +237,12 @@ public abstract class MultipleInputStreamOperatorBase
 					int inputId = edge.getInputId();
 					StreamOperator<RowData> outputOperator = edge.getTarget().getStreamOperator();
 					if (isObjectReuseEnabled) {
-						outputs[i] = createOutput(outputOperator, inputId);
+						outputs[i] = createOutput(outputOperator, inputId, edge.getKeySelector());
 					} else {
 						// the source's output type info is equal to the target's type info for the corresponding index
 						TypeSerializer<RowData> serializer =
 								(TypeSerializer<RowData>) edge.getSource().getOutputType().createSerializer(executionConfig);
-						outputs[i] = createCopyingOutput(serializer, outputOperator, inputId);
+						outputs[i] = createCopyingOutput(serializer, outputOperator, inputId, edge.getKeySelector());
 					}
 				}
 				if (outputs.length == 1) {
@@ -288,18 +294,19 @@ public abstract class MultipleInputStreamOperatorBase
 
 	private Output<StreamRecord<RowData>> createOutput(
 			StreamOperator<RowData> outputOperator,
-			int inputId) {
+			int inputId,
+			@Nullable KeySelector<RowData, ?> keySelector) {
 		if (outputOperator instanceof OneInputStreamOperator) {
 			OneInputStreamOperator<RowData, RowData> oneInputOp =
 					(OneInputStreamOperator<RowData, RowData>) outputOperator;
-			return new OneInputStreamOperatorOutput(oneInputOp);
+			return new OneInputStreamOperatorOutput(oneInputOp, keySelector);
 		} else if (outputOperator instanceof TwoInputStreamOperator) {
 			TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
 					(TwoInputStreamOperator<RowData, RowData, RowData>) outputOperator;
 			if (inputId == 1) {
-				return new FirstInputOfTwoInputStreamOperatorOutput(twoInputOp);
+				return new FirstInputOfTwoInputStreamOperatorOutput(twoInputOp, keySelector);
 			} else {
-				return new SecondInputOfTwoInputStreamOperatorOutput(twoInputOp);
+				return new SecondInputOfTwoInputStreamOperatorOutput(twoInputOp, keySelector);
 			}
 		} else {
 			throw new RuntimeException("Unsupported StreamOperator: " + outputOperator);
@@ -309,18 +316,19 @@ public abstract class MultipleInputStreamOperatorBase
 	private Output<StreamRecord<RowData>> createCopyingOutput(
 			TypeSerializer<RowData> serializer,
 			StreamOperator<RowData> outputOperator,
-			int inputId) {
+			int inputId,
+			@Nullable KeySelector<RowData, ?> keySelector) {
 		if (outputOperator instanceof OneInputStreamOperator) {
 			final OneInputStreamOperator<RowData, RowData> oneInputOp =
 					(OneInputStreamOperator<RowData, RowData>) outputOperator;
-			return new CopyingOneInputStreamOperatorOutput(oneInputOp, serializer);
+			return new CopyingOneInputStreamOperatorOutput(oneInputOp, serializer, keySelector);
 		} else if (outputOperator instanceof TwoInputStreamOperator) {
 			final TwoInputStreamOperator<RowData, RowData, RowData> twoInputOp =
 					(TwoInputStreamOperator<RowData, RowData, RowData>) outputOperator;
 			if (inputId == 1) {
-				return new CopyingFirstInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer);
+				return new CopyingFirstInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer, keySelector);
 			} else {
-				return new CopyingSecondInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer);
+				return new CopyingSecondInputOfTwoInputStreamOperatorOutput(twoInputOp, serializer, keySelector);
 			}
 		} else {
 			throw new RuntimeException("Unsupported StreamOperator: " + outputOperator);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperator.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.StateNameAware;
+import org.apache.flink.table.runtime.operators.StateNameAwareStreamOperator;
+import org.apache.flink.table.runtime.operators.StateNameContext;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@link MultipleInputStreamOperatorBase} to handle streaming operators.
+ */
+public class StreamMultipleInputStreamOperator extends MultipleInputStreamOperatorBase {
+
+	private static final long serialVersionUID = 1L;
+
+	public StreamMultipleInputStreamOperator(
+			StreamOperatorParameters<RowData> parameters,
+			List<InputSpec> inputSpecs,
+			List<TableOperatorWrapper<?>> headWrappers,
+			TableOperatorWrapper<?> tailWrapper) {
+		super(parameters, inputSpecs, headWrappers, tailWrapper);
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public void open() throws Exception {
+		// initializeState for each operator first
+		StateNameContext stateNameContext = new StateNameContext();
+		final Iterator<TableOperatorWrapper<?>> it = topologicalOrderingOperators.descendingIterator();
+		while (it.hasNext()) {
+			StreamOperator<?> operator = it.next().getStreamOperator();
+			if (operator instanceof AbstractUdfStreamOperator) {
+				Function function = ((AbstractUdfStreamOperator) operator).getUserFunction();
+				if (function instanceof StateNameAware) {
+					((StateNameAware) function).setStateNameContext(stateNameContext);
+				} else {
+					throw new RuntimeException(
+							function.getClass().getName() + " must extend from StateNameAware to make sure " +
+									"all state names in a multiple input operator are unique " +
+									"(via getStateNameContext().getUniqueStateName(\"your_state_name\")).\n" +
+									"The example is StateNameAwareKeyedProcessFunction.");
+				}
+			} else if (operator instanceof StateNameAwareStreamOperator) {
+				((StateNameAware) operator).setStateNameContext(stateNameContext);
+			} else {
+				throw new RuntimeException(
+						operator.getClass().getName() + " must extend from StateNameAware to make sure " +
+								"all state names in a multiple input operator are unique " +
+								"(via getStateNameContext().getUniqueStateName(\"your_state_name\")).\n" +
+								"The example is StateNameAwareStreamOperator.");
+			}
+
+			// initialize state
+			((AbstractStreamOperator<?>) operator).initializeState(
+					getStateHandler().orElseThrow(() -> new RuntimeException("This should not happen.")),
+					getTimeServiceManager().orElse(null));
+		}
+		super.open();
+	}
+
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		super.prepareSnapshotPreBarrier(checkpointId);
+		// go forward through the operator chain and tell each operator
+		// to prepare the checkpoint
+		for (TableOperatorWrapper<?> wrapper : topologicalOrderingOperators) {
+			if (!wrapper.isClosed()) {
+				wrapper.getStreamOperator().prepareSnapshotPreBarrier(checkpointId);
+			}
+		}
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+		// go forward through the operator chain and tell each operator
+		// to do snapshot
+		for (TableOperatorWrapper<?> wrapper : topologicalOrderingOperators) {
+			if (!wrapper.isClosed()) {
+				StreamOperator<?> operator = wrapper.getStreamOperator();
+				if (operator instanceof AbstractStreamOperator) {
+					((AbstractStreamOperator<?>) operator).snapshotState(context);
+				} else if (operator instanceof AbstractStreamOperatorV2) {
+					((AbstractStreamOperatorV2<?>) operator).snapshotState(context);
+				} else {
+					throw new RuntimeException("Unsupported StreamOperator: " + operator);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		super.notifyCheckpointComplete(checkpointId);
+		// go forward through the operator chain and tell each operator
+		// to notify checkpoint complete
+		for (TableOperatorWrapper<?> wrapper : topologicalOrderingOperators) {
+			if (!wrapper.isClosed()) {
+				wrapper.getStreamOperator().notifyCheckpointComplete(checkpointId);
+			}
+		}
+	}
+
+	@Override
+	public void notifyCheckpointAborted(long checkpointId) throws Exception {
+		super.notifyCheckpointAborted(checkpointId);
+		// go back through the operator chain and tell each operator
+		// to notify checkpoint aborted
+		Iterator<TableOperatorWrapper<?>> it = topologicalOrderingOperators.descendingIterator();
+		while (it.hasNext()) {
+			TableOperatorWrapper<?> wrapper = it.next();
+			if (!wrapper.isClosed()) {
+				wrapper.getStreamOperator().notifyCheckpointAborted(checkpointId);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+
+import java.util.List;
+
+/**
+ * The factory to create stream {@link MultipleInputStreamOperator}.
+ */
+public class StreamMultipleInputStreamOperatorFactory extends AbstractStreamOperatorFactory<RowData> {
+	private static final long serialVersionUID = 1L;
+
+	private final List<InputSpec> inputSpecs;
+	private final List<TableOperatorWrapper<?>> headWrappers;
+	private final TableOperatorWrapper<?> tailWrapper;
+
+	public StreamMultipleInputStreamOperatorFactory(
+			List<InputSpec> inputSpecs,
+			List<TableOperatorWrapper<?>> headWrappers,
+			TableOperatorWrapper<?> tailWrapper) {
+		this.inputSpecs = inputSpecs;
+		this.headWrappers = headWrappers;
+		this.tailWrapper = tailWrapper;
+	}
+
+	@Override
+	public <T extends StreamOperator<RowData>> T createStreamOperator(StreamOperatorParameters<RowData> parameters) {
+		throw new UnsupportedOperationException("Unsupported now.");
+	}
+
+	@Override
+	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+		throw new UnsupportedOperationException("Unsupported now.");
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorFactory.java
@@ -46,13 +46,18 @@ public class StreamMultipleInputStreamOperatorFactory extends AbstractStreamOper
 		this.tailWrapper = tailWrapper;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public <T extends StreamOperator<RowData>> T createStreamOperator(StreamOperatorParameters<RowData> parameters) {
-		throw new UnsupportedOperationException("Unsupported now.");
+		return (T) new StreamMultipleInputStreamOperator(
+				parameters,
+				inputSpecs,
+				headWrappers,
+				tailWrapper);
 	}
 
 	@Override
 	public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
-		throw new UnsupportedOperationException("Unsupported now.");
+		return StreamMultipleInputStreamOperator.class;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -32,7 +33,11 @@ public class FirstInputOfTwoInput extends InputBase {
 
 	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
 
-	public FirstInputOfTwoInput(TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+	public FirstInputOfTwoInput(
+			AbstractStreamOperatorV2<RowData> owner,
+			int inputId,
+			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		super(owner, inputId, operator);
 		this.operator = operator;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -32,7 +33,11 @@ public class OneInput extends InputBase {
 
 	private final OneInputStreamOperator<RowData, RowData> operator;
 
-	public OneInput(OneInputStreamOperator<RowData, RowData> operator) {
+	public OneInput(
+			AbstractStreamOperatorV2<RowData> owner,
+			int inputId,
+			OneInputStreamOperator<RowData, RowData> operator) {
+		super(owner, inputId, operator);
 		this.operator = operator;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -32,7 +33,11 @@ public class SecondInputOfTwoInput extends InputBase {
 
 	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
 
-	public SecondInputOfTwoInput(TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+	public SecondInputOfTwoInput(
+			AbstractStreamOperatorV2<RowData> owner,
+			int inputId,
+			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+		super(owner, inputId, operator);
 		this.operator = operator;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingOneInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingOneInputStreamOperatorOutput.java
@@ -19,10 +19,13 @@
 package org.apache.flink.table.runtime.operators.multipleinput.output;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
 
 /**
  * An {@link Output} that can be used to emit copying elements and other messages for {@link OneInputStreamOperator}.
@@ -31,13 +34,17 @@ public class CopyingOneInputStreamOperatorOutput extends OneInputStreamOperatorO
 
 	private final OneInputStreamOperator<RowData, RowData> operator;
 	private final TypeSerializer<RowData> serializer;
+	@Nullable
+	private final KeySelector<RowData, ?> keySelector;
 
 	public CopyingOneInputStreamOperatorOutput(
 			OneInputStreamOperator<RowData, RowData> operator,
-			TypeSerializer<RowData> serializer) {
-		super(operator);
+			TypeSerializer<RowData> serializer,
+			@Nullable KeySelector<RowData, ?> keySelector) {
+		super(operator, keySelector);
 		this.operator = operator;
 		this.serializer = serializer;
+		this.keySelector = keySelector;
 	}
 
 	protected <X> void pushToOperator(StreamRecord<X> record) {
@@ -48,6 +55,10 @@ public class CopyingOneInputStreamOperatorOutput extends OneInputStreamOperatorO
 			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
 			StreamRecord<RowData> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
 
+			if (keySelector != null) {
+				Object key = keySelector.getKey(copy.getValue());
+				operator.setCurrentKey(key);
+			}
 			operator.processElement(copy);
 		} catch (Exception e) {
 			throw new ExceptionInMultipleInputOperatorException(e);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.output;
 
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -26,6 +27,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.OutputTag;
 
+import javax.annotation.Nullable;
+
 /**
  * An {@link Output} that can be used to emit elements and other messages
  * for the first input of {@link TwoInputStreamOperator}.
@@ -33,11 +36,15 @@ import org.apache.flink.util.OutputTag;
 public class FirstInputOfTwoInputStreamOperatorOutput extends OutputBase {
 
 	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+	@Nullable
+	private final KeySelector<RowData, ?> keySelector;
 
 	public FirstInputOfTwoInputStreamOperatorOutput(
-			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+			TwoInputStreamOperator<RowData, RowData, RowData> operator,
+			@Nullable KeySelector<RowData, ?> keySelector) {
 		super(operator);
 		this.operator = operator;
+		this.keySelector = keySelector;
 	}
 
 	@Override
@@ -75,6 +82,10 @@ public class FirstInputOfTwoInputStreamOperatorOutput extends OutputBase {
 			@SuppressWarnings("unchecked")
 			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
 
+			if (keySelector != null) {
+				Object key = keySelector.getKey(castRecord.getValue());
+				operator.setCurrentKey(key);
+			}
 			operator.processElement1(castRecord);
 		} catch (Exception e) {
 			throw new ExceptionInMultipleInputOperatorException(e);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.output;
 
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -26,6 +27,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.OutputTag;
 
+import javax.annotation.Nullable;
+
 /**
  * An {@link Output} that can be used to emit elements and other messages
  * for the second input of {@link TwoInputStreamOperator}.
@@ -33,11 +36,15 @@ import org.apache.flink.util.OutputTag;
 public class SecondInputOfTwoInputStreamOperatorOutput extends OutputBase {
 
 	private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
+	@Nullable
+	private final KeySelector<RowData, ?> keySelector;
 
 	public SecondInputOfTwoInputStreamOperatorOutput(
-			TwoInputStreamOperator<RowData, RowData, RowData> operator) {
+			TwoInputStreamOperator<RowData, RowData, RowData> operator,
+			@Nullable KeySelector<RowData, ?> keySelector) {
 		super(operator);
 		this.operator = operator;
+		this.keySelector = keySelector;
 	}
 
 	@Override
@@ -75,6 +82,10 @@ public class SecondInputOfTwoInputStreamOperatorOutput extends OutputBase {
 			@SuppressWarnings("unchecked")
 			StreamRecord<RowData> castRecord = (StreamRecord<RowData>) record;
 
+			if (keySelector != null) {
+				Object key = keySelector.getKey(castRecord.getValue());
+				operator.setCurrentKey(key);
+			}
 			operator.processElement2(castRecord);
 		} catch (Exception e) {
 			throw new ExceptionInMultipleInputOperatorException(e);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
@@ -32,13 +32,13 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapperGenerator.InputInfo;
 import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
 import org.apache.flink.table.runtime.operators.multipleinput.input.OneInput;
 import org.apache.flink.table.runtime.operators.multipleinput.input.SecondInputOfTwoInput;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -319,13 +319,12 @@ public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase 
 				new int[] { 1, 2, 0 });
 		generator.generate();
 
-		List<Pair<Transformation<?>, InputSpec>> inputTransformAndInputSpecPairs =
-				generator.getInputTransformAndInputSpecPairs();
+		List<InputInfo> inputInfoList = generator.getInputInfoList();
 
 		List<StreamElement> outputData = new ArrayList<>();
 		return new TestingBatchMultipleInputStreamOperator(
 				createStreamOperatorParameters(new TestingOutput(outputData)),
-				inputTransformAndInputSpecPairs.stream().map(Pair::getValue).collect(Collectors.toList()),
+				inputInfoList.stream().map(InputInfo::getInputSpec).collect(Collectors.toList()),
 				generator.getHeadWrappers(),
 				generator.getTailWrapper(),
 				outputData);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperatorTest.java
@@ -74,7 +74,7 @@ public class BatchMultipleInputStreamOperatorTest extends MultipleInputTestBase 
 
 		assertFalse(aggOp1.isOpened());
 		assertFalse(aggOp2.isOpened());
-		assertFalse(aggOp1.isOpened());
+		assertFalse(joinOp1.isOpened());
 		assertFalse(joinOp2.isOpened());
 
 		op.open();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/StreamMultipleInputStreamOperatorTest.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapperGenerator.InputInfo;
+import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link StreamMultipleInputStreamOperator}.
+ */
+public class StreamMultipleInputStreamOperatorTest extends MultipleInputTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testOpen() throws Exception {
+		TestingStreamMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = op.getTailWrapper().getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		op.initializeState(new StreamTaskStateInitializerImpl(new MockEnvironmentBuilder().build(), new MemoryStateBackend()));
+
+		assertFalse(aggOp1.isOpened());
+		checkBeforeInitializeState(aggOp1);
+		assertFalse(aggOp2.isOpened());
+		checkBeforeInitializeState(aggOp2);
+		assertFalse(joinOp.isOpened());
+		checkBeforeInitializeState(joinOp);
+
+		op.open();
+
+		assertTrue(aggOp1.isOpened());
+		assertNotNull(aggOp1.getOperatorStateBackend());
+
+		assertTrue(aggOp2.isOpened());
+		assertNotNull(aggOp2.getOperatorStateBackend());
+
+		assertTrue(joinOp.isOpened());
+		assertNotNull(joinOp.getOperatorStateBackend());
+	}
+
+	@Test
+	public void testOperatorDoesNotImplementStateNameAware() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		Transformation<RowData> source1 = createSource(env, "source1");
+		Transformation<RowData> source2 = createSource(env, "source2");
+		Transformation<RowData> source3 = createSource(env, "source3");
+
+		TwoInputTransformation<RowData, RowData, RowData> join1 = new TwoInputTransformation<>(
+				source1,
+				source2,
+				"join1",
+				new TestingOperatorWithoutStateNameAware(),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())),
+				10);
+		TwoInputTransformation<RowData, RowData, RowData> join2 = new TwoInputTransformation<>(
+				join1,
+				source3,
+				"join2",
+				new TestingOperatorWithoutStateNameAware(),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())),
+				10);
+
+		TableOperatorWrapperGenerator generator = new TableOperatorWrapperGenerator(
+				Arrays.asList(source1, source2, source3),
+				join2);
+		generator.generate();
+
+		TestingStreamMultipleInputStreamOperator op = new TestingStreamMultipleInputStreamOperator(
+				createStreamOperatorParameters(),
+				generator.getInputInfoList().stream().map(InputInfo::getInputSpec).collect(Collectors.toList()),
+				generator.getHeadWrappers(),
+				generator.getTailWrapper());
+
+		thrown.expect(RuntimeException.class);
+		thrown.expectMessage("TestingOperatorWithoutStateNameAware must extend from StateNameAware");
+		op.open();
+	}
+
+	@Test
+	public void testFunctionDoesNotImplementStateNameAware() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		Transformation<RowData> source1 = createSource(env, "source1");
+		Transformation<RowData> source2 = createSource(env, "source2");
+		Transformation<RowData> source3 = createSource(env, "source3");
+
+		TwoInputTransformation<RowData, RowData, RowData> join1 = new TwoInputTransformation<>(
+				source1,
+				source2,
+				"join1",
+				new TestingAbstractUdfStreamOperator(),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())),
+				10);
+		TwoInputTransformation<RowData, RowData, RowData> join2 = new TwoInputTransformation<>(
+				join1,
+				source3,
+				"join2",
+				new TestingAbstractUdfStreamOperator(),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())),
+				10);
+
+		TableOperatorWrapperGenerator generator = new TableOperatorWrapperGenerator(
+				Arrays.asList(source1, source2, source3),
+				join2);
+		generator.generate();
+
+		TestingStreamMultipleInputStreamOperator op = new TestingStreamMultipleInputStreamOperator(
+				createStreamOperatorParameters(),
+				generator.getInputInfoList().stream().map(InputInfo::getInputSpec).collect(Collectors.toList()),
+				generator.getHeadWrappers(),
+				generator.getTailWrapper());
+
+		thrown.expect(RuntimeException.class);
+		thrown.expectMessage("TestingFunctionWithoutStateNameAware must extend from StateNameAware");
+		op.open();
+	}
+
+	@Test
+	public void testPrepareSnapshotPreBarrier() throws Exception {
+		TestingStreamMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = op.getTailWrapper().getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertEquals(-1, joinOp.getCheckpointIdOfPrepareSnapshotPreBarrier());
+		assertEquals(-1, aggOp1.getCheckpointIdOfPrepareSnapshotPreBarrier());
+		assertEquals(-1, aggOp2.getCheckpointIdOfPrepareSnapshotPreBarrier());
+
+		op.prepareSnapshotPreBarrier(100);
+
+		assertEquals(100, joinOp.getCheckpointIdOfPrepareSnapshotPreBarrier());
+		assertEquals(100, aggOp1.getCheckpointIdOfPrepareSnapshotPreBarrier());
+		assertEquals(100, aggOp2.getCheckpointIdOfPrepareSnapshotPreBarrier());
+	}
+
+	@Test
+	public void testSnapshotState() throws Exception {
+		TestingStreamMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = op.getTailWrapper().getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertFalse(joinOp.isSnapshotStateExecuted());
+		assertFalse(aggOp1.isSnapshotStateExecuted());
+		assertFalse(aggOp2.isSnapshotStateExecuted());
+
+		op.snapshotState(new StateSnapshotContextSynchronousImpl(100, 200));
+
+		assertTrue(joinOp.isSnapshotStateExecuted());
+		assertTrue(aggOp1.isSnapshotStateExecuted());
+		assertTrue(aggOp2.isSnapshotStateExecuted());
+	}
+
+	@Test
+	public void testNotifyCheckpointComplete() throws Exception {
+		TestingStreamMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = op.getTailWrapper().getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertEquals(-1, joinOp.getCheckpointIdOfNotifyCheckpointComplete());
+		assertEquals(-1, aggOp1.getCheckpointIdOfNotifyCheckpointComplete());
+		assertEquals(-1, aggOp2.getCheckpointIdOfNotifyCheckpointComplete());
+
+		op.notifyCheckpointComplete(100);
+
+		assertEquals(100, joinOp.getCheckpointIdOfNotifyCheckpointComplete());
+		assertEquals(100, aggOp1.getCheckpointIdOfNotifyCheckpointComplete());
+		assertEquals(100, aggOp2.getCheckpointIdOfNotifyCheckpointComplete());
+	}
+
+	@Test
+	public void testNotifyCheckpointAborted() throws Exception {
+		TestingStreamMultipleInputStreamOperator op = createMultipleInputStreamOperator();
+		TestingTwoInputStreamOperator joinOp =
+				(TestingTwoInputStreamOperator) op.getTailWrapper().getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper1 = op.getTailWrapper().getInputWrappers().get(0);
+		TestingOneInputStreamOperator aggOp1 = (TestingOneInputStreamOperator) aggWrapper1.getStreamOperator();
+
+		TableOperatorWrapper<?> aggWrapper2 = op.getTailWrapper().getInputWrappers().get(1);
+		TestingOneInputStreamOperator aggOp2 = (TestingOneInputStreamOperator) aggWrapper2.getStreamOperator();
+
+		assertEquals(-1, joinOp.getCheckpointIdOfNotifyCheckpointAborted());
+		assertEquals(-1, aggOp1.getCheckpointIdOfNotifyCheckpointAborted());
+		assertEquals(-1, aggOp2.getCheckpointIdOfNotifyCheckpointAborted());
+
+		op.notifyCheckpointAborted(100);
+
+		assertEquals(100, joinOp.getCheckpointIdOfNotifyCheckpointAborted());
+		assertEquals(100, aggOp1.getCheckpointIdOfNotifyCheckpointAborted());
+		assertEquals(100, aggOp2.getCheckpointIdOfNotifyCheckpointAborted());
+	}
+
+	private void checkBeforeInitializeState(AbstractStreamOperator<?> operator) {
+		try {
+			operator.getOperatorStateBackend();
+			fail("This should not happen.");
+		} catch (NullPointerException e) {
+			// do nothing
+		}
+	}
+
+	/**
+	 * Create a StreamMultipleInputStreamOperator which contains the following sub-graph.
+	 * <pre>
+	 *
+	 * source1  source2
+	 *   |        |
+	 *  agg1     agg2
+	 *     \     /
+	 *      join
+	 *
+	 * </pre>
+	 */
+	private TestingStreamMultipleInputStreamOperator createMultipleInputStreamOperator() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		Transformation<RowData> source1 = createSource(env, "source1");
+		Transformation<RowData> source2 = createSource(env, "source2");
+		OneInputTransformation<RowData, RowData> agg1 = createOneInputTransform(
+				source1,
+				"agg1",
+				new TestingOneInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+		agg1.setStateKeySelector(new TestingKeySelector());
+		agg1.setStateKeyType(InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+
+		OneInputTransformation<RowData, RowData> agg2 = createOneInputTransform(
+				source2,
+				"agg2",
+				new TestingOneInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+		agg2.setStateKeySelector(new TestingKeySelector());
+		agg2.setStateKeyType(InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+
+		TwoInputTransformation<RowData, RowData, RowData> join = createTwoInputTransform(
+				agg1,
+				agg2,
+				"join",
+				new TestingTwoInputStreamOperator(true),
+				InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+		join.setStateKeySelectors(new TestingKeySelector(), new TestingKeySelector());
+		join.setStateKeyType(InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
+
+		TableOperatorWrapperGenerator generator = new TableOperatorWrapperGenerator(
+				Arrays.asList(source1, source2),
+				join);
+		generator.generate();
+
+		List<InputInfo> inputInfoList = generator.getInputInfoList();
+
+		return new TestingStreamMultipleInputStreamOperator(
+				createStreamOperatorParameters(),
+				inputInfoList.stream().map(InputInfo::getInputSpec).collect(Collectors.toList()),
+				generator.getHeadWrappers(),
+				generator.getTailWrapper());
+	}
+
+	/**
+	 * A sub class of {@link StreamMultipleInputStreamOperator} for testing.
+	 */
+	private static class TestingStreamMultipleInputStreamOperator extends StreamMultipleInputStreamOperator {
+		private static final long serialVersionUID = 1L;
+		private final TableOperatorWrapper<?> tailWrapper;
+
+		public TestingStreamMultipleInputStreamOperator(
+				StreamOperatorParameters<RowData> parameters,
+				List<InputSpec> inputSpecs,
+				List<TableOperatorWrapper<?>> headWrapper,
+				TableOperatorWrapper<?> tailWrapper) {
+			super(parameters, inputSpecs, headWrapper, tailWrapper);
+			this.tailWrapper = tailWrapper;
+		}
+
+		public TableOperatorWrapper<?> getTailWrapper() {
+			return tailWrapper;
+		}
+	}
+
+	/**
+	 * A sub class of {@link AbstractStreamOperator} for testing which does not implement StateNameAware.
+	 */
+	private static class TestingOperatorWithoutStateNameAware
+			extends AbstractStreamOperator<RowData>
+			implements TwoInputStreamOperator<RowData, RowData, RowData> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void processElement1(StreamRecord<RowData> element) throws Exception {
+
+		}
+
+		@Override
+		public void processElement2(StreamRecord<RowData> element) throws Exception {
+
+		}
+	}
+
+	/**
+	 * A sub class of {@link AbstractUdfStreamOperator} for testing.
+	 */
+	private static class TestingAbstractUdfStreamOperator
+			extends AbstractUdfStreamOperator<RowData, TestingFunctionWithoutStateNameAware>
+			implements TwoInputStreamOperator<RowData, RowData, RowData> {
+		private static final long serialVersionUID = 1L;
+
+		public TestingAbstractUdfStreamOperator() {
+			super(new TestingFunctionWithoutStateNameAware());
+		}
+
+		@Override
+		public void processElement1(StreamRecord<RowData> element) throws Exception {
+
+		}
+
+		@Override
+		public void processElement2(StreamRecord<RowData> element) throws Exception {
+
+		}
+	}
+
+	/**
+	 * A sub class of {@link Function} for testing.
+	 */
+	private static class TestingFunctionWithoutStateNameAware implements Function {
+		private static final long serialVersionUID = 1L;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput;
 
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapper.Edge;
@@ -48,31 +49,33 @@ public class TableOperatorWrapperTest extends MultipleInputTestBase {
 		TableOperatorWrapper<TestingOneInputStreamOperator> wrapper2 =
 				createOneInputOperatorWrapper(inOperator2, "test2");
 
+		KeySelector<RowData, RowData> keySelector1 = new TestingKeySelector();
+		KeySelector<RowData, RowData> keySelector2 = new TestingKeySelector();
 		TableOperatorWrapper<TestingTwoInputStreamOperator> wrapper3 =
 				createTwoInputOperatorWrapper(outOperator, "test3");
-		wrapper3.addInput(wrapper1, 1);
-		wrapper3.addInput(wrapper2, 2);
+		wrapper3.addInput(wrapper1, 1, keySelector1);
+		wrapper3.addInput(wrapper2, 2, keySelector2);
 
 		assertTrue(wrapper1.getInputEdges().isEmpty());
 		assertTrue(wrapper1.getInputWrappers().isEmpty());
 		assertEquals(Collections.singletonList(wrapper3), wrapper1.getOutputWrappers());
 		assertEquals(
-				Collections.singletonList(new Edge(wrapper1, wrapper3, 1)),
+				Collections.singletonList(new Edge(wrapper1, wrapper3, 1, keySelector1)),
 				wrapper1.getOutputEdges());
 
 		assertTrue(wrapper2.getInputEdges().isEmpty());
 		assertTrue(wrapper2.getInputWrappers().isEmpty());
 		assertEquals(Collections.singletonList(wrapper3), wrapper2.getOutputWrappers());
 		assertEquals(Collections.singletonList(
-				new Edge(wrapper2, wrapper3, 2)),
+				new Edge(wrapper2, wrapper3, 2, keySelector2)),
 				wrapper2.getOutputEdges());
 
 		assertTrue(wrapper3.getOutputEdges().isEmpty());
 		assertTrue(wrapper3.getOutputWrappers().isEmpty());
 		assertEquals(Arrays.asList(wrapper1, wrapper2), wrapper3.getInputWrappers());
 		assertEquals(Arrays.asList(
-				new Edge(wrapper1, wrapper3, 1),
-				new Edge(wrapper2, wrapper3, 2)),
+				new Edge(wrapper1, wrapper3, 1, keySelector1),
+				new Edge(wrapper2, wrapper3, 2, keySelector2)),
 				wrapper3.getInputEdges());
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingKeySelector.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TestingKeySelector.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.multipleinput;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * A test implementation of {@link KeySelector}.
+ */
+public class TestingKeySelector implements KeySelector<RowData, RowData> {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public RowData getKey(RowData value) throws Exception {
+		return value;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/output/OutputTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.runtime.operators.multipleinput.MultipleInputTestBase;
+import org.apache.flink.table.runtime.operators.multipleinput.TestingKeySelector;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingOneInputStreamOperator;
 import org.apache.flink.table.runtime.operators.multipleinput.TestingTwoInputStreamOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -65,7 +66,7 @@ public class OutputTest extends MultipleInputTestBase {
 	@Test
 	public void testOneInput() throws Exception {
 		TestingOneInputStreamOperator op = createOneInputStreamOperator();
-		OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op);
+		OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op, null);
 
 		output.collect(element);
 		assertEquals(element, op.getCurrentElement());
@@ -78,9 +79,20 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testOneInputWithKeySelector() throws Exception {
+		TestingOneInputStreamOperator op = createOneInputStreamOperator();
+		OneInputStreamOperatorOutput output = new OneInputStreamOperatorOutput(op, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testCopyingOneInput() throws Exception {
 		TestingOneInputStreamOperator op = createOneInputStreamOperator();
-		CopyingOneInputStreamOperatorOutput output = new CopyingOneInputStreamOperatorOutput(op, serializer);
+		CopyingOneInputStreamOperatorOutput output = new CopyingOneInputStreamOperatorOutput(op, serializer, null);
 
 		output.collect(element);
 		assertNotSame(element, op.getCurrentElement());
@@ -94,9 +106,22 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testCopyingOneInputWithKeySelector() throws Exception {
+		TestingOneInputStreamOperator op = createOneInputStreamOperator();
+		CopyingOneInputStreamOperatorOutput output = new CopyingOneInputStreamOperatorOutput(
+				op, serializer, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement());
+		assertEquals(element, op.getCurrentElement());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testFirstInputOfTwoInput() throws Exception {
 		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
-		FirstInputOfTwoInputStreamOperatorOutput output = new FirstInputOfTwoInputStreamOperatorOutput(op);
+		FirstInputOfTwoInputStreamOperatorOutput output = new FirstInputOfTwoInputStreamOperatorOutput(op, null);
 
 		output.collect(element);
 		assertEquals(element, op.getCurrentElement1());
@@ -112,10 +137,22 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testFirstInputOfTwoInputWithKeySelector() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		FirstInputOfTwoInputStreamOperatorOutput output = new FirstInputOfTwoInputStreamOperatorOutput(
+				op, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement1());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testCopyingFirstInputOfTwoInput() throws Exception {
 		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
-		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(op,
-				serializer);
+		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(
+				op, serializer, null);
 
 		output.collect(element);
 		assertNotSame(element, op.getCurrentElement1());
@@ -132,9 +169,22 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testCopyingFirstInputOfTwoInputWithKeySelector() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		CopyingFirstInputOfTwoInputStreamOperatorOutput output = new CopyingFirstInputOfTwoInputStreamOperatorOutput(
+				op, serializer, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement1());
+		assertEquals(element, op.getCurrentElement1());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testSecondInputOfTwoInput() throws Exception {
 		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
-		SecondInputOfTwoInputStreamOperatorOutput output = new SecondInputOfTwoInputStreamOperatorOutput(op);
+		SecondInputOfTwoInputStreamOperatorOutput output = new SecondInputOfTwoInputStreamOperatorOutput(op, null);
 
 		output.collect(element);
 		assertEquals(element, op.getCurrentElement2());
@@ -150,10 +200,22 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testSecondInputOfTwoInputWithKeySelector() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		SecondInputOfTwoInputStreamOperatorOutput output = new SecondInputOfTwoInputStreamOperatorOutput(
+				op, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertEquals(element, op.getCurrentElement2());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testCopyingSecondInputOfTwoInput() throws Exception {
 		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
 		CopyingSecondInputOfTwoInputStreamOperatorOutput output =
-				new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer);
+				new CopyingSecondInputOfTwoInputStreamOperatorOutput(op, serializer, null);
 
 		output.collect(element);
 		assertNotSame(element, op.getCurrentElement2());
@@ -170,12 +232,25 @@ public class OutputTest extends MultipleInputTestBase {
 	}
 
 	@Test
+	public void testCopyingSecondInputOfTwoInputWithKeySelector() throws Exception {
+		TestingTwoInputStreamOperator op = createTwoInputStreamOperator();
+		CopyingSecondInputOfTwoInputStreamOperatorOutput output = new CopyingSecondInputOfTwoInputStreamOperatorOutput(
+				op, serializer, new TestingKeySelector());
+
+		assertNull(op.getCurrentStateKey());
+		output.collect(element);
+		assertNotSame(element, op.getCurrentElement2());
+		assertEquals(element, op.getCurrentElement2());
+		assertEquals(element.getValue(), op.getCurrentStateKey());
+	}
+
+	@Test
 	public void testBroadcasting() throws Exception {
 		TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
 		TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
 		BroadcastingOutput output = new BroadcastingOutput(new Output[] {
-				new OneInputStreamOperatorOutput(op1),
-				new OneInputStreamOperatorOutput(op2) });
+				new OneInputStreamOperatorOutput(op1, null),
+				new OneInputStreamOperatorOutput(op2, null) });
 
 		output.collect(element);
 		assertEquals(element, op1.getCurrentElement());
@@ -200,8 +275,8 @@ public class OutputTest extends MultipleInputTestBase {
 		TestingOneInputStreamOperator op1 = createOneInputStreamOperator();
 		TestingOneInputStreamOperator op2 = createOneInputStreamOperator();
 		CopyingBroadcastingOutput output = new CopyingBroadcastingOutput(new Output[] {
-				new OneInputStreamOperatorOutput(op1),
-				new OneInputStreamOperatorOutput(op2) });
+				new OneInputStreamOperatorOutput(op1, null),
+				new OneInputStreamOperatorOutput(op2, null) });
 
 		output.collect(element);
 		assertNotSame(element, op1.getCurrentElement());


### PR DESCRIPTION

## What is the purpose of the change

*Multiple input operator for batch is implemented in [FLINK-19627](https://issues.apache.org/jira/browse/FLINK-19627). This pr aims to introduce multiple input operator for streaming. Different from batch multiple input operator, the stream multiple input operator should handle key selector, state/checkpoint/barrier operations. If each sub-operator in a multiple input operator has a state handler, it involves many change in runtime. So all sub-operators share a same state handler. There are three main problems we need to solve:
1. stateHandler in AbstractStreamOperatorV2 is private, we need to change it to protected so that StreamMultipleInputStreamOperator can access it*
2. stateHandler in AbstractStreamOperator is created when calling initializeState method. We need to add a new method and pass the StreamMultipleInputStreamOperator's stateHandler to AbstractStreamOperator so that the sub-operators could share same stateHandler instance.
3. StreamMultipleInputStreamOperator may contain operators with same type (e.g. two aggregate operators), they have same state name. This can lead to the wrong state values. We introduce StateNameAware and StateNameContext to make sure all state names in a multiple input operator are unique.


## Brief change log

  - *Rename BatchExecMultipleInputNode/StreamExecMultipleInputNode to BatchExecMultipleInput/StreamExecMultipleInput*
  - *Stream planner support multiple input node*
  - *Introduce AbstractStreamOperator#initializeState(StreamOperatorStateHandler, InternalTimeServiceManager<?>) method so that AbstractStreamOperator can use existing state handler*
  - *Change access modifier priority of `stateHandler` and `timeServiceManager` from `private` to `protected` in AbstractStreamOperatorV2 so that the sub-class of AbstractStreamOperatorV2 can access stateHandler*
  - *Introduce multiple input operator for streaming*


## Verifying this change

This change added tests and can be verified as follows:

  - *The first, third and fourth commit is a trivial rework and is already covered by existing tests*
  - *The second commit is verified by TableOperatorWrapperGeneratorTest, TableOperatorWrapperTest and ExplainTest*
  - *The last commit is verified by InputTest, OutputTest, StreamMultipleInputStreamOperatorTest*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
