### PR TITLE
[FLINK-19633][table-rumtime-blink] Fix ArrayIndexOutOfBoundsException in RetractableTopNFunction

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -380,13 +380,14 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 						curRank += 1;
 						RowData prevRow = inputIter.next();
 						if (!findsSortKey && equaliser.equals(prevRow, inputRow)) {
-							collectDelete(out, prevRow, curRank);
+							collectDelete(out, prevRow);
 							curRank -= 1;
 							findsSortKey = true;
 							inputIter.remove();
 						} else if (findsSortKey) {
 							if (curRank == rankEnd) {
-								collectInsert(out, prevRow, curRank);
+								collectInsert(out, prevRow);
+								curRank += 1;
 								break;
 							}
 						}


### PR DESCRIPTION
## What is the purpose of the change

*Fix ArrayIndexOutOfBoundsException in RetractableTopNFunction*


## Brief change log
  - *Fix ArrayIndexOutOfBoundsException in RetractableTopNFunction*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test testProcessRetractMessageWithGenerateUpdateBeforeWithoutRowNumber verify it*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
