### PR TITLE
[FLINK-19850] Add e2e tests for the new File Sink in the streaming mode

### DIFF
--- a/flink-end-to-end-tests/flink-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-file-sink-test/pom.xml
@@ -27,8 +27,8 @@ under the License.
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-streaming-file-sink-test</artifactId>
-	<name>Flink : E2E Tests : Streaming file sink</name>
+	<artifactId>flink-file-sink-test</artifactId>
+	<name>Flink : E2E Tests : File sink</name>
 
 	<dependencies>
 		<dependency>
@@ -36,6 +36,12 @@ under the License.
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -46,16 +52,16 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>StreamingFileSinkSinkTestProgram</id>
+						<id>FileSinkTestProgram</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>StreamingFileSinkProgram</finalName>
+							<finalName>FileSinkProgram</finalName>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>StreamingFileSinkProgram</mainClass>
+									<mainClass>FileSinkProgram</mainClass>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/FileSinkProgram.java
@@ -24,11 +24,13 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
@@ -40,7 +42,7 @@ import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Test program for the {@link StreamingFileSink}.
+ * Test program for the {@link StreamingFileSink} and {@link FileSink}.
  *
  * <p>Uses a source that steadily emits a deterministic set of records over 60 seconds,
  * after which it idles and waits for job cancellation. Every record has a unique index that is
@@ -50,12 +52,13 @@ import java.util.concurrent.TimeUnit;
  * Adding all committed part files together, and numerically sorting the contents, should
  * result in a complete sequence from 0 (inclusive) to 60000 (exclusive).
  */
-public enum StreamingFileSinkProgram {
+public enum FileSinkProgram {
 	;
 
 	public static void main(final String[] args) throws Exception {
 		final ParameterTool params = ParameterTool.fromArgs(args);
 		final String outputPath = params.getRequired("outputPath");
+		final String sinkToTest = params.getRequired("sinkToTest");
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
@@ -63,23 +66,36 @@ public enum StreamingFileSinkProgram {
 		env.enableCheckpointing(5000L);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, Time.of(10L, TimeUnit.SECONDS)));
 
-		final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
-			.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
-				PrintStream out = new PrintStream(stream);
-				out.println(element.f1);
-			})
-			.withBucketAssigner(new KeyBucketAssigner())
-			.withRollingPolicy(OnCheckpointRollingPolicy.build())
-			.build();
-
 		// generate data, shuffle, sink
-		env.addSource(new Generator(10, 10, 60))
-			.keyBy(0)
-			.addSink(sink);
+		DataStream<Tuple2<Integer, Integer>> source =
+				env.addSource(new Generator(10, 10, 60));
+		if (sinkToTest.equalsIgnoreCase("StreamingFileSink")) {
+			final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
+					.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
+						PrintStream out = new PrintStream(stream);
+						out.println(element.f1);
+					})
+					.withBucketAssigner(new KeyBucketAssigner())
+					.withRollingPolicy(OnCheckpointRollingPolicy.build())
+					.build();
+
+			source.keyBy(0).addSink(sink);
+		} else if (sinkToTest.equalsIgnoreCase("FileSink")){
+			FileSink<Tuple2<Integer, Integer>> sink = FileSink
+					.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
+						PrintStream out = new PrintStream(stream);
+						out.println(element.f1);
+					})
+					.withBucketAssigner(new KeyBucketAssigner())
+					.withRollingPolicy(OnCheckpointRollingPolicy.build())
+					.build();
+			source.keyBy(0).sinkTo(sink);
+		} else {
+			throw new UnsupportedOperationException("Unsupported sink type: " + sinkToTest);
+		}
 
 		env.execute("StreamingFileSinkProgram");
 	}
-
 
 	/**
 	 * Use first field for buckets.

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<module>flink-confluent-schema-registry</module>
 		<module>flink-stream-state-ttl-test</module>
 		<module>flink-sql-client-test</module>
-		<module>flink-streaming-file-sink-test</module>
+		<module>flink-file-sink-test</module>
 		<module>flink-state-evolution-test</module>
 		<module>flink-rocksdb-state-memory-control-test</module>
 		<module>flink-end-to-end-tests-common</module>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -184,8 +184,11 @@ run_test "Batch SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_sq
 run_test "Streaming SQL end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh old" "skip_check_exceptions"
 run_test "Streaming SQL end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh blink" "skip_check_exceptions"
 
-run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh" "skip_check_exceptions"
-run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3" "skip_check_exceptions"
+run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh local StreamingFileSink" "skip_check_exceptions"
+run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3 StreamingFileSink" "skip_check_exceptions"
+run_test "New File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh local FileSink" "skip_check_exceptions"
+run_test "New File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3 FileSink" "skip_check_exceptions"
+
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 
 run_test "Netty shuffle direct memory consumption end-to-end test" "$END_TO_END_DIR/test-scripts/test_netty_shuffle_memory_control.sh"

--- a/flink-end-to-end-tests/test-scripts/test_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_file_sink.sh
@@ -18,8 +18,9 @@
 ################################################################################
 
 OUT_TYPE="${1:-local}" # other type: s3
+SINK_TO_TEST="${2:-"StreamingFileSink"}"
 
-S3_PREFIX=temp/test_streaming_file_sink-$(uuidgen)
+S3_PREFIX=temp/test_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
 S3_OUTPUT_PATH="s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
 source "$(dirname "$0")"/common.sh
@@ -60,7 +61,7 @@ if [ "${OUT_TYPE}" == "s3" ]; then
   on_exit out_cleanup
 fi
 
-TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-streaming-file-sink-test/target/StreamingFileSinkProgram.jar"
+TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-file-sink-test/target/FileSinkProgram.jar"
 
 ###################################
 # Get all lines in part files and sort them numerically.
@@ -135,7 +136,7 @@ function wait_for_complete_result {
     done
 }
 
-function run_streaming_file_sink_test {
+function run_file_sink_test {
   start_cluster
 
   "${FLINK_DIR}/bin/taskmanager.sh" start
@@ -143,7 +144,8 @@ function run_streaming_file_sink_test {
   "${FLINK_DIR}/bin/taskmanager.sh" start
 
   echo "Submitting job."
-  CLIENT_OUTPUT=$("$FLINK_DIR/bin/flink" run -d "${TEST_PROGRAM_JAR}" --outputPath "${JOB_OUTPUT_PATH}")
+  CLIENT_OUTPUT=$("$FLINK_DIR/bin/flink" run -d "${TEST_PROGRAM_JAR}" --outputPath "${JOB_OUTPUT_PATH}" \
+    --sinkToTest "${SINK_TO_TEST}")
   JOB_ID=$(echo "${CLIENT_OUTPUT}" | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
   if [[ -z $JOB_ID ]]; then
@@ -187,4 +189,4 @@ function run_streaming_file_sink_test {
 }
 
 # usual runtime is ~6 minutes
-run_test_with_timeout 900 run_streaming_file_sink_test
+run_test_with_timeout 900 run_file_sink_test


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the e2e tests for the new FileSink. In the e2e tests we mainly focus on cases of TaskMangers get killed, thus we only test the streaming mode since for batch mode, in this version the new file sink still not be able to achieve exactly-once if the ResultPartition gets lost. The stream & batch mode for cases of task failover is covered by `FileSinkITCase`. 

Therefore, the PR is roughly a copy of the E2E test of the `StreamingFileSink`.

## Brief change log

- 86e3c5950cf82baa0a5e3078b0c30050f262dcb0 adds the test program and the test scripts.

## Verifying this change

This change is a test for itself.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
