### PR TITLE
[FLINK-19235][python] Support mixed use with built-in aggs like count1, sum0 and first_value for Python UDAF.

### DIFF
--- a/flink-python/pyflink/fn_execution/aggregate.py
+++ b/flink-python/pyflink/fn_execution/aggregate.py
@@ -23,6 +23,7 @@ from apache_beam.coders import PickleCoder, Coder
 from pyflink.common import Row, RowKind
 from pyflink.common.state import ListState, MapState
 from pyflink.fn_execution.coders import from_proto
+from pyflink.fn_execution.operation_utils import is_built_in_function, load_aggregate_function
 from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend
 from pyflink.table import AggregateFunction, FunctionContext
 from pyflink.table.data_view import ListView, MapView
@@ -37,12 +38,37 @@ def join_row(left: Row, right: Row):
     return Row(*fields)
 
 
+def extract_data_view_specs_from_accumulator(current_index, accumulator):
+    # for built in functions we extract the data view specs from their accumulator
+    i = -1
+    extracted_specs = []
+    for field in accumulator:
+        i += 1
+        # TODO: infer the coder from the input types and output type of the built-in functions
+        if isinstance(field, MapView):
+            extracted_specs.append(MapViewSpec(
+                "builtInAgg%df%d" % (current_index, i), i, PickleCoder(), PickleCoder()))
+        elif isinstance(field, ListView):
+            extracted_specs.append(ListViewSpec(
+                "builtInAgg%df%d" % (current_index, i), i, PickleCoder()))
+    return extracted_specs
+
+
 def extract_data_view_specs(udfs):
     extracted_udf_data_view_specs = []
+    current_index = -1
     for udf in udfs:
+        current_index += 1
         udf_data_view_specs_proto = udf.specs
-        if udf_data_view_specs_proto is None:
-            extracted_udf_data_view_specs.append([])
+        if not udf_data_view_specs_proto:
+            if is_built_in_function(udf.payload):
+                bulit_in_function = load_aggregate_function(udf.payload)
+                accumulator = bulit_in_function.create_accumulator()
+                extracted_udf_data_view_specs.append(
+                    extract_data_view_specs_from_accumulator(current_index, accumulator))
+            else:
+                extracted_udf_data_view_specs.append([])
+            continue
         extracted_specs = []
         for spec_proto in udf_data_view_specs_proto:
             state_id = spec_proto.name
@@ -300,6 +326,7 @@ class SimpleAggsHandleFunction(AggsHandleFunction):
                  udfs: List[AggregateFunction],
                  input_extractors: List,
                  index_of_count_star: int,
+                 count_star_inserted: bool,
                  udf_data_view_specs: List[List[DataViewSpec]],
                  filter_args: List[int],
                  distinct_indexes: List[int],
@@ -308,7 +335,7 @@ class SimpleAggsHandleFunction(AggsHandleFunction):
         self._input_extractors = input_extractors
         self._accumulators = None  # type: Row
         self._get_value_indexes = [i for i in range(len(udfs))]
-        if index_of_count_star >= 0:
+        if index_of_count_star >= 0 and count_star_inserted:
             # The record count is used internally, should be ignored by the get_value method.
             self._get_value_indexes.remove(index_of_count_star)
         self._udf_data_view_specs = udf_data_view_specs

--- a/flink-python/pyflink/fn_execution/aggregate.py
+++ b/flink-python/pyflink/fn_execution/aggregate.py
@@ -62,27 +62,28 @@ def extract_data_view_specs(udfs):
         udf_data_view_specs_proto = udf.specs
         if not udf_data_view_specs_proto:
             if is_built_in_function(udf.payload):
-                bulit_in_function = load_aggregate_function(udf.payload)
-                accumulator = bulit_in_function.create_accumulator()
+                built_in_function = load_aggregate_function(udf.payload)
+                accumulator = built_in_function.create_accumulator()
                 extracted_udf_data_view_specs.append(
                     extract_data_view_specs_from_accumulator(current_index, accumulator))
             else:
                 extracted_udf_data_view_specs.append([])
-            continue
-        extracted_specs = []
-        for spec_proto in udf_data_view_specs_proto:
-            state_id = spec_proto.name
-            field_index = spec_proto.field_index
-            if spec_proto.HasField("list_view"):
-                element_coder = from_proto(spec_proto.list_view.element_type)
-                extracted_specs.append(ListViewSpec(state_id, field_index, element_coder))
-            elif spec_proto.HasField("map_view"):
-                key_coder = from_proto(spec_proto.map_view.key_type)
-                value_coder = from_proto(spec_proto.map_view.value_type)
-                extracted_specs.append(MapViewSpec(state_id, field_index, key_coder, value_coder))
-            else:
-                raise Exception("Unsupported data view spec type: " + spec_proto.type)
-        extracted_udf_data_view_specs.append(extracted_specs)
+        else:
+            extracted_specs = []
+            for spec_proto in udf_data_view_specs_proto:
+                state_id = spec_proto.name
+                field_index = spec_proto.field_index
+                if spec_proto.HasField("list_view"):
+                    element_coder = from_proto(spec_proto.list_view.element_type)
+                    extracted_specs.append(ListViewSpec(state_id, field_index, element_coder))
+                elif spec_proto.HasField("map_view"):
+                    key_coder = from_proto(spec_proto.map_view.key_type)
+                    value_coder = from_proto(spec_proto.map_view.value_type)
+                    extracted_specs.append(
+                        MapViewSpec(state_id, field_index, key_coder, value_coder))
+                else:
+                    raise Exception("Unsupported data view spec type: " + spec_proto.type)
+            extracted_udf_data_view_specs.append(extracted_specs)
     if all([len(i) == 0 for i in extracted_udf_data_view_specs]):
         return []
     return extracted_udf_data_view_specs

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc4\x05\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"N\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\x9b\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x88\x06\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\xc5\x02\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x82\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc4\x05\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"N\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xb8\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x88\x06\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\xc5\x02\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x82\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -214,8 +214,8 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=4470,
-  serialized_end=4759,
+  serialized_start=4499,
+  serialized_end=4788,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -304,8 +304,8 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5280,
-  serialized_end=5538,
+  serialized_start=5309,
+  serialized_end=5567,
 )
 _sym_db.RegisterEnumDescriptor(_TYPEINFO_TYPENAME)
 
@@ -913,6 +913,13 @@ _USERDEFINEDAGGREGATEFUNCTIONS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='count_star_inserted', full_name='org.apache.flink.fn_execution.v1.UserDefinedAggregateFunctions.count_star_inserted', index=10,
+      number=11, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -926,7 +933,7 @@ _USERDEFINEDAGGREGATEFUNCTIONS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=2317,
-  serialized_end=2728,
+  serialized_end=2757,
 )
 
 
@@ -963,8 +970,8 @@ _SCHEMA_MAPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2806,
-  serialized_end=2957,
+  serialized_start=2835,
+  serialized_end=2986,
 )
 
 _SCHEMA_TIMEINFO = _descriptor.Descriptor(
@@ -993,8 +1000,8 @@ _SCHEMA_TIMEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2959,
-  serialized_end=2988,
+  serialized_start=2988,
+  serialized_end=3017,
 )
 
 _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
@@ -1023,8 +1030,8 @@ _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2990,
-  serialized_end=3024,
+  serialized_start=3019,
+  serialized_end=3053,
 )
 
 _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1053,8 +1060,8 @@ _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3026,
-  serialized_end=3070,
+  serialized_start=3055,
+  serialized_end=3099,
 )
 
 _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1083,8 +1090,8 @@ _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3072,
-  serialized_end=3111,
+  serialized_start=3101,
+  serialized_end=3140,
 )
 
 _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
@@ -1120,8 +1127,8 @@ _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3113,
-  serialized_end=3160,
+  serialized_start=3142,
+  serialized_end=3189,
 )
 
 _SCHEMA_BINARYINFO = _descriptor.Descriptor(
@@ -1150,8 +1157,8 @@ _SCHEMA_BINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3162,
-  serialized_end=3190,
+  serialized_start=3191,
+  serialized_end=3219,
 )
 
 _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
@@ -1180,8 +1187,8 @@ _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3192,
-  serialized_end=3223,
+  serialized_start=3221,
+  serialized_end=3252,
 )
 
 _SCHEMA_CHARINFO = _descriptor.Descriptor(
@@ -1210,8 +1217,8 @@ _SCHEMA_CHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3225,
-  serialized_end=3251,
+  serialized_start=3254,
+  serialized_end=3280,
 )
 
 _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
@@ -1240,8 +1247,8 @@ _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3253,
-  serialized_end=3282,
+  serialized_start=3282,
+  serialized_end=3311,
 )
 
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
@@ -1364,8 +1371,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3285,
-  serialized_end=4357,
+  serialized_start=3314,
+  serialized_end=4386,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -1408,8 +1415,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4359,
-  serialized_end=4467,
+  serialized_start=4388,
+  serialized_end=4496,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -1439,8 +1446,8 @@ _SCHEMA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2731,
-  serialized_end=4759,
+  serialized_start=2760,
+  serialized_end=4788,
 )
 
 
@@ -1494,8 +1501,8 @@ _TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=4840,
-  serialized_end=5165,
+  serialized_start=4869,
+  serialized_end=5194,
 )
 
 _TYPEINFO_FIELD = _descriptor.Descriptor(
@@ -1538,8 +1545,8 @@ _TYPEINFO_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5167,
-  serialized_end=5277,
+  serialized_start=5196,
+  serialized_end=5306,
 )
 
 _TYPEINFO = _descriptor.Descriptor(
@@ -1569,8 +1576,8 @@ _TYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4762,
-  serialized_end=5538,
+  serialized_start=4791,
+  serialized_end=5567,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -157,6 +157,8 @@ message UserDefinedAggregateFunctions {
   int32 map_state_read_cache_size = 9;
   // The map_state_write_cache_size.
   int32 map_state_write_cache_size = 10;
+  // True if the count(*) agg is inserted by the planner.
+  bool count_star_inserted = 11;
 }
 
 // A representation of the data schema.

--- a/flink-python/pyflink/table/functions.py
+++ b/flink-python/pyflink/table/functions.py
@@ -15,7 +15,15 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.table import AggregateFunction
+import sys
+import time
+from abc import abstractmethod
+from decimal import Decimal
+
+from pyflink.table import AggregateFunction, MapView
+
+MAX_LONG_VALUE = sys.maxsize
+MIN_LONG_VALUE = -MAX_LONG_VALUE - 1
 
 
 class Count1AggFunction(AggregateFunction):
@@ -35,3 +43,139 @@ class Count1AggFunction(AggregateFunction):
     def merge(self, accumulator, accumulators):
         for acc in accumulators:
             accumulator[0] += acc[0]
+
+
+class FirstValueWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [first_value, first_order, value_to_order_map, order_to_value_map]
+        return [None, None, MapView(), MapView()]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            prev_order = accumulator[1]
+            value_to_order_map = accumulator[2]
+            order_to_value_map = accumulator[3]
+
+            # get the order of current value if not given
+            if len(args) == 1:
+                order = int(time.time() * 1000)
+                if value in value_to_order_map:
+                    order_list = value_to_order_map[value]
+                else:
+                    order_list = []
+                order_list.append(order)
+                value_to_order_map[value] = order_list
+            else:
+                order = args[1]
+
+            if prev_order is None or prev_order > order:
+                accumulator[0] = value
+                accumulator[1] = order
+            if order in order_to_value_map:
+                value_list = order_to_value_map[order]
+            else:
+                value_list = []
+            value_list.append(value)
+            order_to_value_map[order] = value_list
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            prev_value = accumulator[0]
+            prev_order = accumulator[1]
+            value_to_order_map = accumulator[2]
+            order_to_value_map = accumulator[3]
+
+            # get the order of current value if not given
+            if len(args) == 1:
+                if value in value_to_order_map and len(value_to_order_map[value]) > 0:
+                    order_list = value_to_order_map[value]
+                else:
+                    # this data has not been accumulated
+                    return
+                # get and remove current order in value_to_order_map
+                order = order_list.pop(0)
+                if len(order_list) == 0:
+                    del value_to_order_map[value]
+                else:
+                    value_to_order_map[value] = order_list
+            else:
+                order = args[1]
+
+            # remove current value in order_to_value_map
+            if order in order_to_value_map:
+                value_list = order_to_value_map[order]
+            else:
+                # this data has not been accumulated
+                return
+            if value in value_list:
+                value_list.remove(value)
+                if len(value_list) == 0:
+                    del order_to_value_map[order]
+                else:
+                    order_to_value_map[order] = value_list
+
+            if value == prev_value:
+                start_key = prev_order
+                next_key = MAX_LONG_VALUE
+                for key in order_to_value_map:
+                    if start_key <= key < next_key:
+                        next_key = key
+
+                if next_key != MAX_LONG_VALUE:
+                    accumulator[0] = order_to_value_map[next_key][0]
+                    accumulator[1] = next_key
+                else:
+                    accumulator[0] = None
+                    accumulator[1] = None
+
+    def merge(self, accumulator, accumulators):
+        raise NotImplementedError("This function does not support merge.")
+
+
+class Sum0AggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    @abstractmethod
+    def create_accumulator(self):
+        pass
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0] += args[0]
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0] -= args[0]
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            accumulator[0] += acc[0]
+
+
+class IntSum0AggFunction(Sum0AggFunction):
+
+    def create_accumulator(self):
+        # [sum]
+        return [0]
+
+
+class FloatSum0AggFunction(Sum0AggFunction):
+
+    def create_accumulator(self):
+        # [sum]
+        return [0.0]
+
+
+class DecimalSum0AggFunction(Sum0AggFunction):
+
+    def create_accumulator(self):
+        # [sum]
+        return [Decimal('0')]

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -248,7 +248,7 @@ class CloseableIterator(object):
                 fields.append(None)
             else:
                 fields.append(java_to_python_converter(data, field_type))
-        result_row = Row(fields)
+        result_row = Row(*fields)
         result_row.set_row_kind(row_kind)
         return result_row
 

--- a/flink-python/pyflink/table/tests/test_aggregate.py
+++ b/flink-python/pyflink/table/tests/test_aggregate.py
@@ -21,7 +21,7 @@ import datetime
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
 
-from pyflink.common import Row
+from pyflink.common import Row, RowKind
 from pyflink.fn_execution.state_impl import RemovableConcatIterator
 from pyflink.table import DataTypes
 from pyflink.table.data_view import ListView, MapView
@@ -91,11 +91,13 @@ class ConcatAggregateFunction(AggregateFunction):
         return Row([], '')
 
     def accumulate(self, accumulator, *args):
-        accumulator[1] = args[1]
-        accumulator[0].append(args[0])
+        if args[0] is not None:
+            accumulator[1] = args[1]
+            accumulator[0].append(args[0])
 
     def retract(self, accumulator, *args):
-        accumulator[0].remove(args[0])
+        if args[0] is not None:
+            accumulator[0].remove(args[0])
 
     def get_accumulator_type(self):
         return DataTypes.ROW([
@@ -255,6 +257,59 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         result = t.group_by(t.c).select("my_count(a) as a, my_sum(a) as b, c") \
             .select("my_count(a) as a, my_sum(b) as b")
         assert_frame_equal(result.to_pandas(), pd.DataFrame([[3, 12]], columns=['a', 'b']))
+
+    def test_mixed_with_built_in_functions_with_retract(self):
+        self.env.set_parallelism(1)
+        self.t_env.create_temporary_system_function(
+            "concat",
+            ConcatAggregateFunction())
+        t = self.t_env.from_elements(
+            [(1, 'Hi_', 1),
+             (1, 'Hi', 2),
+             (2, 'Hi_', 3),
+             (2, 'Hi', 4),
+             (3, None, None),
+             (3, None, None),
+             (4, 'hello2_', 7),
+             (4, 'hello2', 8),
+             (5, 'hello_', 9),
+             (5, 'hello', 10)], ['a', 'b', 'c'])
+        self.t_env.create_temporary_view("source", t)
+        table_with_retract_message = self.t_env.sql_query(
+            "select a, LAST_VALUE(b) as b, LAST_VALUE(c) as c from source group by a")
+        self.t_env.create_temporary_view("retract_table", table_with_retract_message)
+        result_table = self.t_env.sql_query(
+            "select concat(b, ',') as a, "
+            "FIRST_VALUE(b) as b"
+            " from retract_table")
+        result = [i for i in result_table.execute().collect()]
+        expected = Row('Hi,Hi,hello,hello2', 'Hi')
+        expected.set_row_kind(RowKind.UPDATE_AFTER)
+        self.assertEqual(result[len(result) - 1], expected)
+
+    def test_mixed_with_built_in_sum0_with_retract(self):
+        self.t_env.create_temporary_system_function(
+            "concat",
+            ConcatAggregateFunction())
+        t = self.t_env.from_elements(
+            [(1, 'Hi_', 1),
+             (1, 'Hi', 2),
+             (2, 'Hi_', 3),
+             (2, 'Hi', 4),
+             (3, None, None),
+             (3, None, None),
+             (4, 'hello2_', 7),
+             (4, 'hello2', 8),
+             (5, 'hello_', 9),
+             (5, 'hello', 10)], ['a', 'b', 'c'])
+        self.t_env.create_temporary_view("source", t)
+        t = self.t_env.sql_query(
+            "select a, LAST_VALUE(b) as b, LAST_VALUE(c) as c from source group by a")
+        result_table = t.select("concat(b, ',') as a, sum0(c) as b, sum0(c.cast(float)) as c")
+        result = [i for i in result_table.execute().collect()]
+        expected = Row('Hi,Hi,hello,hello2', 24, 24.0)
+        expected.set_row_kind(RowKind.UPDATE_AFTER)
+        self.assertEqual(result[len(result) - 1], expected)
 
     def test_using_decorator(self):
         my_count = udaf(CountAggregateFunction(),

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -468,8 +468,8 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
                                                          DataTypes.FIELD('b', DataTypes.INT()),
                                                          DataTypes.FIELD('c', DataTypes.STRING())]))
         table_result = source.execute()
-        expected_result = [Row([1, None, 'a']), Row([3, 4, 'b']), Row([5, None, 'a']),
-                           Row([7, 8, 'b'])]
+        expected_result = [Row(1, None, 'a'), Row(3, 4, 'b'), Row(5, None, 'a'),
+                           Row(7, 8, 'b')]
         with table_result.collect() as results:
             collected_result = []
             for result in results:
@@ -617,14 +617,14 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         return [pathlib.Path(jar_path).as_uri() for jar_path in test_jars]
 
     def test_collect_for_all_data_types(self):
-        expected_result = [Row([1, None, 1, True, 32767, -2147483648, 1.23,
+        expected_result = [Row(1, None, 1, True, 32767, -2147483648, 1.23,
                            1.98932, bytearray(b'pyflink'), 'pyflink',
                            datetime.date(2014, 9, 13), datetime.time(12, 0),
                            datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
                            [Row(['[pyflink]']), Row(['[pyflink]']),
                             Row(['[pyflink]'])], {1: Row(['[flink]']), 2: Row(['[pyflink]'])},
                            decimal.Decimal('1000000000000000000.05'),
-                           decimal.Decimal('1000000000000000000.05999999999999999899999999999')])]
+                           decimal.Decimal('1000000000000000000.05999999999999999899999999999'))]
         source = self.t_env.from_elements([(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
                                             bytearray(b'pyflink'), 'pyflink',
                                             datetime.date(2014, 9, 13),
@@ -689,8 +689,8 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
 
             collected_result = [str(result) + ',' + str(result.get_row_kind())
                                 for result in collected_result]
-            expected_result = [Row([1, 'a']), Row([1, 'a']), Row([6, 'a']), Row([3, 'b']),
-                               Row([3, 'b']), Row([10, 'b'])]
+            expected_result = [Row(1, 'a'), Row(1, 'a'), Row(6, 'a'), Row(3, 'b'),
+                               Row(3, 'b'), Row(10, 'b')]
             for i in range(len(expected_result)):
                 expected_result[i] = str(expected_result[i]) + ',' + str(expected_row_kinds[i])
             expected_result.sort()
@@ -718,8 +718,8 @@ class BlinkStreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkBlinkStreamT
 
             collected_result = [str(result) + ',' + str(result.get_row_kind())
                                 for result in collected_result]
-            expected_result = [Row([1, 'a']), Row([1, 'a']), Row([6, 'a']), Row([3, 'b']),
-                               Row([3, 'b']), Row([10, 'b'])]
+            expected_result = [Row(1, 'a'), Row(1, 'a'), Row(6, 'a'), Row(3, 'b'),
+                               Row(3, 'b'), Row(10, 'b')]
             for i in range(len(expected_result)):
                 expected_result[i] = str(expected_result[i]) + ',' + str(expected_row_kinds[i])
             expected_result.sort()
@@ -727,14 +727,14 @@ class BlinkStreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkBlinkStreamT
             self.assertEqual(expected_result, collected_result)
 
     def test_collect_for_all_data_types(self):
-        expected_result = [Row([1, None, 1, True, 32767, -2147483648, 1.23,
+        expected_result = [Row(1, None, 1, True, 32767, -2147483648, 1.23,
                            1.98932, bytearray(b'pyflink'), 'pyflink',
                            datetime.date(2014, 9, 13), datetime.time(12, 0, 0, 123000),
                            datetime.datetime(2018, 3, 11, 3, 0, 0, 123000),
                            [Row(['[pyflink]']), Row(['[pyflink]']), Row(['[pyflink]'])],
                            {1: Row(['[flink]']), 2: Row(['[pyflink]'])},
                            decimal.Decimal('1000000000000000000.050000000000000000'),
-                           decimal.Decimal('1000000000000000000.059999999999999999')])]
+                           decimal.Decimal('1000000000000000000.059999999999999999'))]
         source = self.t_env.from_elements(
             [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932, bytearray(b'pyflink'), 'pyflink',
              datetime.date(2014, 9, 13), datetime.time(hour=12, minute=0, second=0,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
@@ -120,6 +120,11 @@ public class PythonStreamGroupAggregateOperator
 	private final int indexOfCountStar;
 
 	/**
+	 * True if the count(*) agg is inserted by the planner.
+	 */
+	private final boolean countStarInserted;
+
+	/**
 	 * Generate retract messages if true.
 	 */
 	private final boolean generateUpdateBefore;
@@ -209,6 +214,7 @@ public class PythonStreamGroupAggregateOperator
 			DataViewUtils.DataViewSpec[][] dataViewSpecs,
 			int[] grouping,
 			int indexOfCountStar,
+			boolean countStarInserted,
 			boolean generateUpdateBefore,
 			long minRetentionTime,
 			long maxRetentionTime) {
@@ -220,6 +226,7 @@ public class PythonStreamGroupAggregateOperator
 		this.jobOptions = buildJobOptions(config);
 		this.grouping = grouping;
 		this.indexOfCountStar = indexOfCountStar;
+		this.countStarInserted = countStarInserted;
 		this.generateUpdateBefore = generateUpdateBefore;
 		this.minRetentionTime = minRetentionTime;
 		this.maxRetentionTime = maxRetentionTime;
@@ -415,6 +422,7 @@ public class PythonStreamGroupAggregateOperator
 		builder.addAllGrouping(Arrays.stream(grouping).boxed().collect(Collectors.toList()));
 		builder.setGenerateUpdateBefore(generateUpdateBefore);
 		builder.setIndexOfCountStar(indexOfCountStar);
+		builder.setCountStarInserted(countStarInserted);
 		builder.setKeyType(toProtoType(getKeyType()));
 		builder.setStateCleaningEnabled(stateCleaningEnabled);
 		builder.setStateCacheSize(stateCacheSize);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -260,6 +260,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 			getGrouping(),
 			-1,
 			false,
+			false,
 			stateTtl,
 			stateTtl);
 	}
@@ -274,6 +275,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 			PythonAggregateFunctionInfo[] aggregateFunctions,
 			int[] grouping,
 			int indexOfCountStar,
+			boolean countStarInserted,
 			boolean generateUpdateBefore,
 			long minRetentionTime,
 			long maxRetentionTime) {
@@ -285,6 +287,7 @@ public class PythonStreamGroupAggregateOperatorTest {
 				new DataViewUtils.DataViewSpec[0][0],
 				grouping,
 				indexOfCountStar,
+				countStarInserted,
 				generateUpdateBefore,
 				minRetentionTime,
 				maxRetentionTime);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/BuiltInPythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/BuiltInPythonAggregateFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.python;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The list of the built-in aggregate functions which can be mixed with the Python UDAF.
+ */
+public enum BuiltInPythonAggregateFunction implements PythonFunction {
+
+	/*
+	The list of the Python built-in aggregate functions.
+	 */
+	COUNT1("Count1AggFunction"),
+	FIRST_VALUE_RETRACT("FirstValueWithRetractAggFunction"),
+	INT_SUM0("IntSum0AggFunction"),
+	FLOAT_SUM0("FloatSum0AggFunction"),
+	DECIMAL_SUM0("DecimalSum0AggFunction");
+
+	private final byte[] payload;
+
+	BuiltInPythonAggregateFunction(String pythonFunctionName) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		// the first byte '0' represents current payload contains a built-in function.
+		baos.write(0);
+		try {
+			baos.write(pythonFunctionName.getBytes(StandardCharsets.UTF_8));
+		} catch (IOException e) {
+			throw new RuntimeException(
+				"Exception thrown when creating the python built-in aggregate function enum.", e);
+		}
+		payload = baos.toByteArray();
+	}
+
+	@Override
+	public byte[] getSerializedPythonFunction() {
+		return payload;
+	}
+
+	@Override
+	public PythonEnv getPythonEnv() {
+		return new PythonEnv(PythonEnv.ExecType.PROCESS);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
@@ -47,17 +47,4 @@ public class PythonAggregateFunctionInfo extends PythonFunctionInfo {
 	public int getFilterArg() {
 		return filterArg;
 	}
-
-	public static final PythonAggregateFunctionInfo DUMMY_PLACEHOLDER = new PythonAggregateFunctionInfo(
-		new PythonFunction() {
-			@Override
-			public byte[] getSerializedPythonFunction() {
-				return new byte[0];
-			}
-
-			@Override
-			public PythonEnv getPythonEnv() {
-				return new PythonEnv(PythonEnv.ExecType.PROCESS);
-			}
-		}, new Object[0], -1, false);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupAggregateRule.java
@@ -67,13 +67,14 @@ public class StreamExecPythonGroupAggregateRule
 			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.GENERAL));
 		boolean existPandasFunction =
 			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.PANDAS));
-		boolean existJavaFunction =
-			aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null));
+		boolean existUserDefinedJavaFunction =
+			aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null) &&
+				!PythonUtil.isBuiltInAggregate(x));
 		if (existPandasFunction || existGeneralPythonFunction) {
 			if (existPandasFunction) {
 				throw new TableException("Pandas UDAFs are not supported in streaming mode currently.");
 			}
-			if (existJavaFunction) {
+			if (existUserDefinedJavaFunction) {
 				throw new TableException("Python UDAF and Java/Scala UDAF cannot be used together.");
 			}
 			return true;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupAggregateRule.java
@@ -67,14 +67,14 @@ public class StreamExecPythonGroupAggregateRule
 			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.GENERAL));
 		boolean existPandasFunction =
 			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.PANDAS));
-		boolean existUserDefinedJavaFunction =
+		boolean existJavaUserDefinedFunction =
 			aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null) &&
 				!PythonUtil.isBuiltInAggregate(x));
 		if (existPandasFunction || existGeneralPythonFunction) {
 			if (existPandasFunction) {
 				throw new TableException("Pandas UDAFs are not supported in streaming mode currently.");
 			}
-			if (existUserDefinedJavaFunction) {
+			if (existJavaUserDefinedFunction) {
 				throw new TableException("Python UDAF and Java/Scala UDAF cannot be used together.");
 			}
 			return true;

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
@@ -188,8 +188,8 @@ trait CommonPythonAggregate extends CommonPythonBase {
       case _: DecimalSum0AggFunction =>
         BuiltInPythonAggregateFunction.DECIMAL_SUM0
       case _ =>
-        throw new TableException("Aggregate function %s is still not supported to be mixed with " +
-          "Python UDAF: " + javaBuiltInAggregateFunction)
+        throw new TableException("Aggregate function " + javaBuiltInAggregateFunction +
+          " is still not supported to be mixed with Python UDAF.")
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
@@ -21,8 +21,10 @@ package org.apache.flink.table.planner.plan.nodes.common
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.dataview.{DataView, ListView, MapView}
-import org.apache.flink.table.functions.python.{PythonAggregateFunction, PythonAggregateFunctionInfo, PythonFunction, PythonFunctionInfo}
-import org.apache.flink.table.planner.functions.aggfunctions.Count1AggFunction
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.python._
+import org.apache.flink.table.planner.functions.aggfunctions.Sum0AggFunction._
+import org.apache.flink.table.planner.functions.aggfunctions._
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction
 import org.apache.flink.table.planner.functions.utils.AggSqlFunction
 import org.apache.flink.table.planner.plan.utils.AggregateInfoList
@@ -88,8 +90,20 @@ trait CommonPythonAggregate extends CommonPythonBase {
               i,
               function.asInstanceOf[PythonAggregateFunction].getTypeInference(null)
               .getAccumulatorTypeStrategy.get().inferType(null).get()))
-        case _: Count1AggFunction =>
-          pythonAggregateFunctionInfoList.add(PythonAggregateFunctionInfo.DUMMY_PLACEHOLDER)
+        case function: UserDefinedFunction =>
+          var filterArg = -1
+          var distinct = false
+          if (i < aggCalls.size) {
+            filterArg = aggCalls(i).filterArg
+            distinct = aggCalls(i).isDistinct
+          }
+          pythonAggregateFunctionInfoList.add(new PythonAggregateFunctionInfo(
+            getBuiltInPythonAggregateFunction(function),
+            pythonAggregateInfoList.aggInfos(i).argIndexes.map(_.asInstanceOf[AnyRef]),
+            filterArg,
+            distinct))
+          // The data views of the built in Python Aggregate Function are different from Java side,
+          // we will create the spec at Python side.
           dataViewSpecList.add(Array())
         case _ =>
           throw new TableException(
@@ -156,6 +170,26 @@ trait CommonPythonAggregate extends CommonPythonBase {
       }
     } else {
       Array()
+    }
+  }
+
+  private def getBuiltInPythonAggregateFunction(
+      javaBuiltInAggregateFunction: UserDefinedFunction): BuiltInPythonAggregateFunction = {
+    javaBuiltInAggregateFunction match {
+      case _: Count1AggFunction =>
+        BuiltInPythonAggregateFunction.COUNT1
+      case _: FirstValueWithRetractAggFunction[_] =>
+        BuiltInPythonAggregateFunction.FIRST_VALUE_RETRACT
+      case _: IntSum0AggFunction | _: ByteSum0AggFunction | _: ShortSum0AggFunction |
+           _: LongSum0AggFunction =>
+        BuiltInPythonAggregateFunction.INT_SUM0
+      case _: FloatSum0AggFunction | _: DoubleSum0AggFunction =>
+        BuiltInPythonAggregateFunction.FLOAT_SUM0
+      case _: DecimalSum0AggFunction =>
+        BuiltInPythonAggregateFunction.DECIMAL_SUM0
+      case _ =>
+        throw new TableException("This aggregate function can not be mixed with Python UDAF: " +
+          javaBuiltInAggregateFunction)
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
@@ -188,8 +188,8 @@ trait CommonPythonAggregate extends CommonPythonBase {
       case _: DecimalSum0AggFunction =>
         BuiltInPythonAggregateFunction.DECIMAL_SUM0
       case _ =>
-        throw new TableException("This aggregate function can not be mixed with Python UDAF: " +
-          javaBuiltInAggregateFunction)
+        throw new TableException("Aggregate function %s is still not supported to be mixed with " +
+          "Python UDAF: " + javaBuiltInAggregateFunction)
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
@@ -121,6 +121,8 @@ class StreamExecPythonGroupAggregate(
 
     val inputCountIndex = aggInfoList.getIndexOfCountStar
 
+    val countStarInserted = aggInfoList.countStarInserted
+
     var (pythonFunctionInfos, dataViewSpecs) =
       extractPythonAggregateFunctionInfos(aggInfoList, aggCalls)
 
@@ -138,7 +140,8 @@ class StreamExecPythonGroupAggregate(
       tableConfig.getMaxIdleStateRetentionTime,
       grouping,
       generateUpdateBefore,
-      inputCountIndex)
+      inputCountIndex,
+      countStarInserted)
 
     val selector = KeySelectorUtil.getRowDataSelector(
       grouping,
@@ -177,7 +180,8 @@ class StreamExecPythonGroupAggregate(
       maxIdleStateRetentionTime: Long,
       grouping: Array[Int],
       generateUpdateBefore: Boolean,
-      indexOfCountStar: Int): OneInputStreamOperator[RowData, RowData] = {
+      indexOfCountStar: Int,
+      countStarInserted: Boolean): OneInputStreamOperator[RowData, RowData] = {
 
     val clazz = loadClass(StreamExecPythonGroupAggregate.PYTHON_STREAM_AGGREAGTE_OPERATOR_NAME)
     val ctor = clazz.getConstructor(
@@ -189,6 +193,7 @@ class StreamExecPythonGroupAggregate(
       classOf[Array[Int]],
       classOf[Int],
       classOf[Boolean],
+      classOf[Boolean],
       classOf[Long],
       classOf[Long])
     ctor.newInstance(
@@ -199,6 +204,7 @@ class StreamExecPythonGroupAggregate(
       dataViewSpecs.asInstanceOf[AnyRef],
       grouping.asInstanceOf[AnyRef],
       indexOfCountStar.asInstanceOf[AnyRef],
+      countStarInserted.asInstanceOf[AnyRef],
       generateUpdateBefore.asInstanceOf[AnyRef],
       minIdleStateRetentionTime.asInstanceOf[AnyRef],
       maxIdleStateRetentionTime.asInstanceOf[AnyRef])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
@@ -22,6 +22,7 @@ import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.flink.table.functions.FunctionDefinition
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionKind}
+import org.apache.flink.table.planner.functions.aggfunctions.{DeclarativeAggregateFunction, InternalAggregateFunction}
 import org.apache.flink.table.planner.functions.bridging.{BridgingSqlAggFunction, BridgingSqlFunction}
 import org.apache.flink.table.planner.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 
@@ -87,6 +88,17 @@ object PythonUtil {
       case function: BridgingSqlAggFunction =>
         isPythonFunction(function.getDefinition, pythonFunctionKind)
       case _ => false
+    }
+  }
+
+  def isBuiltInAggregate(call: AggregateCall): Boolean = {
+    val aggregation = call.getAggregation
+    aggregation match {
+      case function: AggSqlFunction =>
+        function.aggregateFunction.isInstanceOf[InternalAggregateFunction[_, _]]
+      case function: BridgingSqlAggFunction =>
+        function.getDefinition.isInstanceOf[DeclarativeAggregateFunction]
+      case _ => true
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.xml
@@ -48,4 +48,20 @@ PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) A
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="testMixedUsePythonAggAndJavaAgg">
+        <Resource name="planBefore">
+            <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1], EXPR$1=[$2])
++- LogicalAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], EXPR$1=[COUNT($0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+        </Resource>
+        <Resource name="planAfter">
+            <![CDATA[
+PythonGroupAggregate(groupBy=[b], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0, COUNT(a) AS EXPR$1])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+        </Resource>
+    </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonAggregateTest.scala
@@ -55,7 +55,7 @@ class PythonAggregateTest extends TableTestBase {
     util.verifyPlan(resultTable)
   }
 
-  @Test(expected = classOf[TableException])
+  @Test
   def testMixedUsePythonAggAndJavaAgg(): Unit = {
     val util = streamTestUtil()
     val sourceTable = util.addTableSource[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports mixed use with built-in aggs like count1, sum0 and first_value for Python UDAF.*

## Brief change log

  - *Support mixed use with built-in aggs like count1, sum0 and first_value for Python UDAF.*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
