### PR TITLE
[FLINK-18363] Add user classloader to context in DeSerializationSchema

### DIFF
--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.gcp.pubsub;
 
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -97,7 +98,10 @@ public class PubSubSink<IN> extends RichSinkFunction<IN> implements Checkpointed
 
 	@Override
 	public void open(Configuration configuration) throws Exception {
-		serializationSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		serializationSchema.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 
 		Publisher.Builder builder = Publisher
 			.newBuilder(TopicName.of(projectName, topicName))

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.io.ratelimiting.FlinkConnectorRateLimiter;
 import org.apache.flink.api.common.io.ratelimiting.GuavaFlinkConnectorRateLimiter;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
@@ -97,7 +98,10 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 		//convert per-subtask-limit to global rate limit, as FlinkConnectorRateLimiter::setRate expects a global rate limit.
 		rateLimiter.setRate(messagePerSecondRateLimit * getRuntimeContext().getNumberOfParallelSubtasks());
 		rateLimiter.open(getRuntimeContext());
-		deserializationSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		deserializationSchema.open(RuntimeContextInitializationContextAdapters.deserializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 
 		createAndSetPubSubSubscriber();
 		this.isRunning = true;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -692,7 +693,12 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			}
 		}
 
-		this.deserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		this.deserializer.open(
+				RuntimeContextInitializationContextAdapters.deserializationAdapter(
+						getRuntimeContext(),
+						metricGroup -> metricGroup.addGroup("user")
+				)
+		);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -805,7 +806,10 @@ public class FlinkKafkaProducer<IN>
 		}
 
 		if (kafkaSchema != null) {
-			kafkaSchema.open(() -> ctx.getMetricGroup().addGroup("user"));
+			kafkaSchema.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+					getRuntimeContext(),
+					metricGroup -> metricGroup.addGroup("user")
+			));
 		}
 
 		super.open(configuration);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.java.ClosureCleaner;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
@@ -215,7 +216,10 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 	public void open(Configuration configuration) throws Exception {
 		if (schema instanceof KeyedSerializationSchemaWrapper) {
 			((KeyedSerializationSchemaWrapper<IN>) schema).getSerializationSchema()
-				.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+					.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+							getRuntimeContext(),
+							metricGroup -> metricGroup.addGroup("user")
+					));
 		}
 		producer = getKafkaProducer(this.producerConfig);
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kinesis;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
@@ -212,7 +213,10 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 
-		schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		schema.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 
 		// check and pass the configuration properties
 		KinesisProducerConfiguration producerConfig = KinesisConfigUtil.getValidatedProducerConfiguration(configProps);

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.rabbitmq;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -155,7 +156,10 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 
 	@Override
 	public void open(Configuration config) throws Exception {
-		schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		schema.open(RuntimeContextInitializationContextAdapters.serializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 
 		try {
 			connection = setupConnection();

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.rabbitmq;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
@@ -242,7 +243,10 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 			throw new RuntimeException("Cannot create RMQ connection with " + queueName + " at "
 					+ rmqConnectionConfig.getHost(), e);
 		}
-		this.deliveryDeserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		this.deliveryDeserializer.open(RuntimeContextInitializationContextAdapters.deserializationAdapter(
+				getRuntimeContext(),
+				metricGroup -> metricGroup.addGroup("user")
+		));
 		running = true;
 	}
 

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.MockSerializationSchema;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -111,6 +112,7 @@ public class RMQSinkTest {
 			}
 		};
 
+		rmqSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		rmqSink.open(new Configuration());
 
 		verify(mockConnection, times(1)).createChannel();
@@ -141,6 +143,7 @@ public class RMQSinkTest {
 
 	private RMQSink<String> createRMQSink() throws Exception {
 		RMQSink<String> rmqSink = new RMQSink<>(rmqConnectionConfig, QUEUE_NAME, serializationSchema);
+		rmqSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		rmqSink.open(new Configuration());
 		return rmqSink;
 	}
@@ -148,6 +151,7 @@ public class RMQSinkTest {
 	private RMQSink<String> createRMQSinkWithOptions(boolean mandatory, boolean immediate) throws Exception {
 		publishOptions = new DummyPublishOptions(mandatory, immediate);
 		RMQSink<String> rmqSink = new RMQSink<>(rmqConnectionConfig, serializationSchema, publishOptions);
+		rmqSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		rmqSink.open(new Configuration());
 		return rmqSink;
 	}
@@ -156,6 +160,7 @@ public class RMQSinkTest {
 		publishOptions = new DummyPublishOptions(mandatory, immediate);
 		returnListener = new DummyReturnHandler();
 		RMQSink<String> rmqSink = new RMQSink<>(rmqConnectionConfig, serializationSchema, publishOptions, returnListener);
+		rmqSink.setRuntimeContext(new MockStreamingRuntimeContext(false, 1, 0));
 		rmqSink.open(new Configuration());
 		return rmqSink;
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -97,6 +98,7 @@ public interface DeserializationSchema<T> extends Serializable, ResultTypeQuerya
 	 * A contextual information provided for {@link #open(InitializationContext)} method. It can be used to:
 	 * <ul>
 	 *     <li>Register user metrics via {@link InitializationContext#getMetricGroup()}</li>
+	 *     <li>Access the user code class loader.</li>
 	 * </ul>
 	 */
 	@PublicEvolving
@@ -112,5 +114,13 @@ public interface DeserializationSchema<T> extends Serializable, ResultTypeQuerya
 		 * @see MetricGroup
 		 */
 		MetricGroup getMetricGroup();
+
+		/**
+		 * Gets the ClassLoader to load classes that are not in system's classpath, but are part of
+		 * the jar file of a user job.
+		 *
+		 * @see UserCodeClassLoader
+		 */
+		UserCodeClassLoader getUserCodeClassLoader();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/RuntimeContextInitializationContextAdapters.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/RuntimeContextInitializationContextAdapters.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.serialization;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import java.util.function.Function;
+
+/**
+ * A utility adapters between {@link RuntimeContext}
+ * and {@link DeserializationSchema.InitializationContext}
+ * or {@link SerializationSchema.InitializationContext}.
+ */
+@Internal
+public final class RuntimeContextInitializationContextAdapters {
+	public static DeserializationSchema.InitializationContext deserializationAdapter(
+			RuntimeContext runtimeContext) {
+		return deserializationAdapter(runtimeContext, Function.identity());
+	}
+
+	public static DeserializationSchema.InitializationContext deserializationAdapter(
+			RuntimeContext runtimeContext,
+			Function<MetricGroup, MetricGroup> mapMetricGroup) {
+		return new RuntimeContextDeserializationInitializationContextAdapter(
+				runtimeContext,
+				mapMetricGroup);
+	}
+
+	public static SerializationSchema.InitializationContext serializationAdapter(
+			RuntimeContext runtimeContext) {
+		return serializationAdapter(runtimeContext, Function.identity());
+	}
+
+	public static SerializationSchema.InitializationContext serializationAdapter(
+			RuntimeContext runtimeContext,
+			Function<MetricGroup, MetricGroup> mapMetricGroup) {
+		return new RuntimeContextSerializationInitializationContextAdapter(
+				runtimeContext,
+				mapMetricGroup);
+	}
+
+	private static final class RuntimeContextDeserializationInitializationContextAdapter
+			implements DeserializationSchema.InitializationContext {
+		private final RuntimeContext runtimeContext;
+		private final Function<MetricGroup, MetricGroup> mapMetricGroup;
+
+		private RuntimeContextDeserializationInitializationContextAdapter(
+				RuntimeContext runtimeContext,
+				Function<MetricGroup, MetricGroup> mapMetricGroup) {
+			this.runtimeContext = runtimeContext;
+			this.mapMetricGroup = mapMetricGroup;
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return mapMetricGroup.apply(runtimeContext.getMetricGroup());
+		}
+
+		@Override
+		public UserCodeClassLoader getUserCodeClassLoader() {
+			return new RuntimeContextUserCodeClassLoaderAdapter(runtimeContext);
+		}
+	}
+
+	private static final class RuntimeContextSerializationInitializationContextAdapter
+			implements SerializationSchema.InitializationContext {
+		private final RuntimeContext runtimeContext;
+		private final Function<MetricGroup, MetricGroup> mapMetricGroup;
+
+		private RuntimeContextSerializationInitializationContextAdapter(
+				RuntimeContext runtimeContext,
+				Function<MetricGroup, MetricGroup> mapMetricGroup) {
+			this.runtimeContext = runtimeContext;
+			this.mapMetricGroup = mapMetricGroup;
+		}
+
+		@Override
+		public MetricGroup getMetricGroup() {
+			return mapMetricGroup.apply(runtimeContext.getMetricGroup());
+		}
+
+		@Override
+		public UserCodeClassLoader getUserCodeClassLoader() {
+			return new RuntimeContextUserCodeClassLoaderAdapter(runtimeContext);
+		}
+	}
+
+	private static final class RuntimeContextUserCodeClassLoaderAdapter
+			implements UserCodeClassLoader {
+		private final RuntimeContext runtimeContext;
+
+		private RuntimeContextUserCodeClassLoaderAdapter(RuntimeContext runtimeContext) {
+			this.runtimeContext = runtimeContext;
+		}
+
+		@Override
+		public ClassLoader asClassLoader() {
+			return runtimeContext.getUserCodeClassLoader();
+		}
+
+		@Override
+		public void registerReleaseHookIfAbsent(String releaseHookName, Runnable releaseHook) {
+			runtimeContext.registerUserCodeClassLoaderReleaseHookIfAbsent(
+					releaseHookName,
+					releaseHook);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializationSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.serialization;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.Serializable;
 
@@ -58,6 +59,7 @@ public interface SerializationSchema<T> extends Serializable {
 	 * A contextual information provided for {@link #open(InitializationContext)} method. It can be used to:
 	 * <ul>
 	 *     <li>Register user metrics via {@link InitializationContext#getMetricGroup()}</li>
+	 *     <li>Access the user code class loader.</li>
 	 * </ul>
 	 */
 	@PublicEvolving
@@ -73,5 +75,13 @@ public interface SerializationSchema<T> extends Serializable {
 		 * @see MetricGroup
 		 */
 		MetricGroup getMetricGroup();
+
+		/**
+		 * Gets the ClassLoader to load classes that are not in system's classpath, but are part of
+		 * the jar file of a user job.
+		 *
+		 * @see UserCodeClassLoader
+		 */
+		UserCodeClassLoader getUserCodeClassLoader();
 	}
 }

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketSourceFunction.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketSourceFunction.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.examples.java.connectors;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.RuntimeContextInitializationContextAdapters;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
@@ -63,7 +64,9 @@ public final class SocketSourceFunction extends RichSourceFunction<RowData> impl
 
 	@Override
 	public void open(Configuration parameters) throws Exception {
-		deserializer.open(() -> getRuntimeContext().getMetricGroup());
+		deserializer.open(
+				RuntimeContextInitializationContextAdapters.deserializationAdapter(getRuntimeContext())
+		);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR exposes the user code classloader along with the possibility
to register release hooks in the DeserializationSchema and
SerializationSchema.

Additionally it introduces a helper classes for easier creating the
InitializationContexts from a RuntimeContext.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
