### PR TITLE
[FLINK-19762][Runtime / Web Frontend]Selecting Job-ID and TaskManager-ID in web UI covers more than the ID

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.html
@@ -26,25 +26,25 @@
   </div>
   <div class="status">
     <div class="field">
-      <span>ID:</span>
-      <span>{{ jobDetail.jid }}</span>
+      <div>ID:</div>
+      <div>{{ jobDetail.jid }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>Start Time:</span>
-      <span>{{ jobDetail['start-time'] | date:'yyyy-MM-dd HH:mm:ss' }}</span>
+      <div>Start Time:</div>
+      <div>{{ jobDetail['start-time'] | date:'yyyy-MM-dd HH:mm:ss' }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <ng-container *ngIf="jobDetail['end-time']>-1">
       <div class="field">
-        <span>End Time:</span>
-        <span>{{ jobDetail['end-time'] | date:'yyyy-MM-dd HH:mm:ss' }}</span>
+        <div>End Time:</div>
+        <div>{{ jobDetail['end-time'] | date:'yyyy-MM-dd HH:mm:ss' }}</div>
       </div>
       <nz-divider [nzType]="'vertical'"></nz-divider>
     </ng-container>
     <div class="field">
-      <span>Duration:</span>
-      <span>{{ jobDetail.duration | humanizeDuration}}</span>
+      <div>Duration:</div>
+      <div>{{ jobDetail.duration | humanizeDuration}}</div>
     </div>
   </div>
   <flink-navigation [listOfNavigation]="listOfNavigation"></flink-navigation>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.less
@@ -40,10 +40,10 @@
 }
 
 .field {
-  display: inline-block;
+  display: flex;
   font-size: 14px;
   line-height: 22px;
-  span {
+  div {
     line-height: 22px;
     &:last-child {
       margin-left: 8px;
@@ -55,6 +55,8 @@
 
 .status {
   margin-bottom: 12px;
+  display: flex;
+  align-items: center;
   nz-divider {
     margin: 0 24px;
   }

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.html
@@ -22,43 +22,43 @@
   </div>
   <div class="status">
     <div class="field">
-      <span>Last Heartbeat:</span>
-      <span>{{ taskManagerDetail.timeSinceLastHeartbeat | date:'yy-MM-dd HH:mm:ss' }}</span>
+      <div>Last Heartbeat:</div>
+      <div>{{ taskManagerDetail.timeSinceLastHeartbeat | date:'yy-MM-dd HH:mm:ss' }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>ID:</span>
-      <span>{{ taskManagerDetail.id }}</span>
+      <div>ID:</div>
+      <div>{{ taskManagerDetail.id }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>Data Port:</span>
-      <span>{{ taskManagerDetail.dataPort }}</span>
+      <div>Data Port:</div>
+      <div>{{ taskManagerDetail.dataPort }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>Free Slots / All Slots:</span>
-      <span>{{ taskManagerDetail.freeSlots }} / {{ taskManagerDetail.slotsNumber }}</span>
+      <div>Free Slots / All Slots:</div>
+      <div>{{ taskManagerDetail.freeSlots }} / {{ taskManagerDetail.slotsNumber }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>CPU Cores:</span>
-      <span>{{ taskManagerDetail.hardware.cpuCores }}</span>
+      <div>CPU Cores:</div>
+      <div>{{ taskManagerDetail.hardware.cpuCores }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>Physical Memory:</span>
-      <span>{{ taskManagerDetail.hardware.physicalMemory | humanizeBytes }}</span>
+      <div>Physical Memory:</div>
+      <div>{{ taskManagerDetail.hardware.physicalMemory | humanizeBytes }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>JVM Heap Size:</span>
-      <span>{{ taskManagerDetail.hardware.freeMemory | humanizeBytes }}</span>
+      <div>JVM Heap Size:</div>
+      <div>{{ taskManagerDetail.hardware.freeMemory | humanizeBytes }}</div>
     </div>
     <nz-divider [nzType]="'vertical'"></nz-divider>
     <div class="field">
-      <span>Flink Managed Memory:</span>
-      <span>{{ taskManagerDetail.hardware.managedMemory | humanizeBytes }}</span>
+      <div>Flink Managed Memory:</div>
+      <div>{{ taskManagerDetail.hardware.managedMemory | humanizeBytes }}</div>
     </div>
   </div>
   <flink-navigation [listOfNavigation]="listOfNavigation"></flink-navigation>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.less
@@ -40,12 +40,12 @@
 }
 
 .field {
-  display: inline-block;
+  display: flex;
   font-size: 14px;
   line-height: 22px;
   margin-bottom: 12px;
 
-  span {
+  div {
     line-height: 22px;
 
     &:last-child {
@@ -58,6 +58,9 @@
 
 .status {
   margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   padding: 12px 12px 0 12px;
   border: 1px solid @border-color-split;
   background: darken(@component-background, 1%);


### PR DESCRIPTION
## What is the purpose of the change

*Not only the ID is selected when trying to copy the Job ID from the web UI by double-clicking it*
The same thing happens for the TaskManager ID in the corresponding TaskManager Overview page.

## Brief change log
  - *fix double-click on Jod ID/Start Time/End Time/Duration*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
