### PR TITLE
[FLINK-19799][connector files] FileSource supports extensions with subclasses of FileSourceSplit

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
+import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
+import org.apache.flink.connector.file.src.impl.ContinuousFileSplitEnumerator;
+import org.apache.flink.connector.file.src.impl.FileSourceReader;
+import org.apache.flink.connector.file.src.impl.StaticFileSplitEnumerator;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.reader.FileRecordFormat;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The base class for File Sources. The main implementation to use is the {@link FileSource},
+ * which also has the majority of the documentation.
+ *
+ * <p>To read new formats, one commonly does NOT need to extend this class, but should implement
+ * a new Format Reader (like {@link StreamFormat}, {@link BulkFormat}, {@link FileRecordFormat})
+ * and use it with the {@code FileSource}.
+ *
+ * <p>The only reason to extend this class is when a source needs a different type of
+ * <i>split</i>, meaning an extension of the {@link FileSourceSplit} to carry additional
+ * information.
+ *
+ * @param <T> The type of the events/records produced by this source.
+ * @param <SplitT> The subclass type of the FileSourceSplit used by the source implementation.
+ */
+@PublicEvolving
+public abstract class AbstractFileSource<T, SplitT extends FileSourceSplit>
+		implements Source<T, SplitT, PendingSplitsCheckpoint<SplitT>>, ResultTypeQueryable<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Path[] inputPaths;
+
+	private final FileEnumerator.Provider enumeratorFactory;
+
+	private final FileSplitAssigner.Provider assignerFactory;
+
+	private final BulkFormat<T, SplitT> readerFormat;
+
+	@Nullable
+	private final ContinuousEnumerationSettings continuousEnumerationSettings;
+
+	// ------------------------------------------------------------------------
+
+	protected AbstractFileSource(
+			final Path[] inputPaths,
+			final FileEnumerator.Provider fileEnumerator,
+			final FileSplitAssigner.Provider splitAssigner,
+			final BulkFormat<T, SplitT> readerFormat,
+			@Nullable final ContinuousEnumerationSettings continuousEnumerationSettings) {
+
+		checkArgument(inputPaths.length > 0);
+		this.inputPaths = inputPaths;
+		this.enumeratorFactory = checkNotNull(fileEnumerator);
+		this.assignerFactory = checkNotNull(splitAssigner);
+		this.readerFormat = checkNotNull(readerFormat);
+		this.continuousEnumerationSettings = continuousEnumerationSettings;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Source API Methods
+	// ------------------------------------------------------------------------
+
+	@Override
+	public Boundedness getBoundedness() {
+		return continuousEnumerationSettings == null ? Boundedness.BOUNDED : Boundedness.CONTINUOUS_UNBOUNDED;
+	}
+
+	@Override
+	public SourceReader<T, SplitT> createReader(SourceReaderContext readerContext) {
+		return new FileSourceReader<>(readerContext, readerFormat, readerContext.getConfiguration());
+	}
+
+	@Override
+	public SplitEnumerator<SplitT, PendingSplitsCheckpoint<SplitT>> createEnumerator(
+			SplitEnumeratorContext<SplitT> enumContext) {
+
+		final FileEnumerator enumerator = enumeratorFactory.create();
+
+		// read the initial set of splits (which is also the total set of splits for bounded sources)
+		final Collection<FileSourceSplit> splits;
+		try {
+			// TODO - in the next cleanup pass, we should try to remove the need to "wrap unchecked" here
+			splits = enumerator.enumerateSplits(inputPaths, enumContext.currentParallelism());
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Could not enumerate file splits", e);
+		}
+
+		return createSplitEnumerator(enumContext, enumerator, splits, null);
+	}
+
+	@Override
+	public SplitEnumerator<SplitT, PendingSplitsCheckpoint<SplitT>> restoreEnumerator(
+			SplitEnumeratorContext<SplitT> enumContext,
+			PendingSplitsCheckpoint<SplitT> checkpoint) {
+
+		final FileEnumerator enumerator = enumeratorFactory.create();
+
+		// cast this to a collection of FileSourceSplit because the enumerator code work
+		// non-generically just on that base split type
+		@SuppressWarnings("unchecked")
+		final Collection<FileSourceSplit> splits = (Collection<FileSourceSplit>) checkpoint.getSplits();
+
+		return createSplitEnumerator(enumContext, enumerator, splits, checkpoint.getAlreadyProcessedPaths());
+	}
+
+	@Override
+	public abstract SimpleVersionedSerializer<SplitT> getSplitSerializer();
+
+	@Override
+	public SimpleVersionedSerializer<PendingSplitsCheckpoint<SplitT>> getEnumeratorCheckpointSerializer() {
+		return new PendingSplitsCheckpointSerializer<>(getSplitSerializer());
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return readerFormat.getProducedType();
+	}
+
+	// ------------------------------------------------------------------------
+	//  helpers
+	// ------------------------------------------------------------------------
+
+	private SplitEnumerator<SplitT, PendingSplitsCheckpoint<SplitT>> createSplitEnumerator(
+			SplitEnumeratorContext<SplitT> context,
+			FileEnumerator enumerator,
+			Collection<FileSourceSplit> splits,
+			@Nullable Collection<Path> alreadyProcessedPaths) {
+
+		// cast this to a collection of FileSourceSplit because the enumerator code work
+		// non-generically just on that base split type
+		@SuppressWarnings("unchecked")
+		final SplitEnumeratorContext<FileSourceSplit> fileSplitContext = (SplitEnumeratorContext<FileSourceSplit>) context;
+
+		final FileSplitAssigner splitAssigner = assignerFactory.create(splits);
+
+		if (continuousEnumerationSettings == null) {
+			// bounded case
+			return castGeneric(new StaticFileSplitEnumerator(fileSplitContext, splitAssigner));
+		} else {
+			// unbounded case
+			if (alreadyProcessedPaths == null) {
+				alreadyProcessedPaths = splitsToPaths(splits);
+			}
+
+			return castGeneric(new ContinuousFileSplitEnumerator(
+					fileSplitContext,
+					enumerator,
+					splitAssigner,
+					inputPaths,
+					alreadyProcessedPaths,
+					continuousEnumerationSettings.getDiscoveryInterval().toMillis()));
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private SplitEnumerator<SplitT, PendingSplitsCheckpoint<SplitT>> castGeneric(
+			final SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> enumerator) {
+
+		// cast arguments away then cast them back. Java Generics Hell :-/
+		return (SplitEnumerator<SplitT, PendingSplitsCheckpoint<SplitT>>) (SplitEnumerator<?, ?>) enumerator;
+	}
+
+	private static Collection<Path> splitsToPaths(Collection<FileSourceSplit> splits) {
+		return splits.stream()
+			.map(FileSourceSplit::path)
+			.collect(Collectors.toCollection(HashSet::new));
+	}
+
+	// ------------------------------------------------------------------------
+	//  Builder
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The generic base builder. This builder carries a <i>SELF</i> type to make it convenient to
+	 * extend this for subclasses, using the following pattern.
+	 * <pre>{@code
+	 * public class SubBuilder<T> extends AbstractFileSourceBuilder<T, SubBuilder<T>> {
+	 *     ...
+	 * }
+	 * }</pre>
+	 * That way, all return values from builder method defined here are typed to the sub-class
+	 * type and support fluent chaining.
+	 *
+	 * <p>We don't make the publicly visible builder generic with a SELF type, because it leads to
+	 * generic signatures that can look complicated and confusing.
+	 */
+	protected abstract static class AbstractFileSourceBuilder<
+				T,
+				SplitT extends FileSourceSplit,
+				SELF extends AbstractFileSourceBuilder<T, SplitT, SELF>> {
+
+		// mandatory - have no defaults
+		protected final Path[] inputPaths;
+		protected final BulkFormat<T, SplitT> readerFormat;
+
+		// optional - have defaults
+		protected FileEnumerator.Provider fileEnumerator;
+		protected FileSplitAssigner.Provider splitAssigner;
+		@Nullable
+		protected ContinuousEnumerationSettings continuousSourceSettings;
+
+		protected AbstractFileSourceBuilder(
+				final Path[] inputPaths,
+				final BulkFormat<T, SplitT> readerFormat,
+				final FileEnumerator.Provider defaultFileEnumerator,
+				final FileSplitAssigner.Provider defaultSplitAssigner) {
+
+			this.inputPaths = checkNotNull(inputPaths);
+			this.readerFormat = checkNotNull(readerFormat);
+			this.fileEnumerator = defaultFileEnumerator;
+			this.splitAssigner = defaultSplitAssigner;
+		}
+
+		/**
+		 * Creates the file source with the settings applied to this builder.
+		 */
+		public abstract AbstractFileSource<T, SplitT> build();
+
+		/**
+		 * Sets this source to streaming ("continuous monitoring") mode.
+		 *
+		 * <p>This makes the source a "continuous streaming" source that keeps running, monitoring
+		 * for new files, and reads these files when they appear and are discovered by the monitoring.
+		 *
+		 * <p>The interval in which the source checks for new files is the {@code discoveryInterval}.
+		 * Shorter intervals mean that files are discovered more quickly, but also imply more frequent
+		 * listing or directory traversal of the file system / object store.
+		 */
+		public SELF monitorContinuously(Duration discoveryInterval) {
+			checkNotNull(discoveryInterval, "discoveryInterval");
+			checkArgument(!(discoveryInterval.isNegative() || discoveryInterval.isZero()), "discoveryInterval must be > 0");
+
+			this.continuousSourceSettings = new ContinuousEnumerationSettings(discoveryInterval);
+			return self();
+		}
+
+		/**
+		 * Sets this source to bounded (batch) mode.
+		 *
+		 * <p>In this mode, the source processes the files that are under the given paths when the
+		 * application is started. Once all files are processed, the source will finish.
+		 *
+		 * <p>This setting is also the default behavior. This method is mainly here to "switch back" to
+		 * bounded (batch) mode, or to make it explicit in the source construction.
+		 */
+		public SELF processStaticFileSet() {
+			this.continuousSourceSettings = null;
+			return self();
+		}
+
+		/**
+		 * Configures the {@link FileEnumerator} for the source.
+		 * The File Enumerator is responsible for selecting from the input path the set of files
+		 * that should be processed (and which to filter out). Furthermore, the File Enumerator
+		 * may split the files further into sub-regions, to enable parallelization beyond the number
+		 * of files.
+		 */
+		public SELF setFileEnumerator(FileEnumerator.Provider fileEnumerator) {
+			this.fileEnumerator = checkNotNull(fileEnumerator);
+			return self();
+		}
+
+		/**
+		 * Configures the {@link FileSplitAssigner} for the source.
+		 * The File Split Assigner determines which parallel reader instance gets which
+		 * {@link FileSourceSplit}, and in which order these splits are assigned.
+		 */
+		public SELF setSplitAssigner(FileSplitAssigner.Provider splitAssigner) {
+			this.splitAssigner = checkNotNull(splitAssigner);
+			return self();
+		}
+
+		@SuppressWarnings("unchecked")
+		private SELF self() {
+			return (SELF) this;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -140,7 +140,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 
 	private final FileSplitAssigner.Provider assignerFactory;
 
-	private final BulkFormat<T> readerFormat;
+	private final BulkFormat<T, FileSourceSplit> readerFormat;
 
 	@Nullable
 	private final ContinuousEnumerationSettings continuousEnumerationSettings;
@@ -151,7 +151,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 			final Path[] inputPaths,
 			final FileEnumerator.Provider fileEnumerator,
 			final FileSplitAssigner.Provider splitAssigner,
-			final BulkFormat<T> readerFormat,
+			final BulkFormat<T, FileSourceSplit> readerFormat,
 			@Nullable final ContinuousEnumerationSettings continuousEnumerationSettings) {
 
 		checkArgument(inputPaths.length > 0);
@@ -273,7 +273,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 		checkNotNull(paths, "paths");
 		checkArgument(paths.length > 0, "paths must not be empty");
 
-		final BulkFormat<T> bulkFormat = new StreamFormatAdapter<>(reader);
+		final BulkFormat<T, FileSourceSplit> bulkFormat = new StreamFormatAdapter<>(reader);
 		return new FileSourceBuilder<>(paths, bulkFormat);
 	}
 
@@ -283,7 +283,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	 *
 	 * <p>Examples for bulk readers are compressed and vectorized formats such as ORC or Parquet.
 	 */
-	public static <T> FileSourceBuilder<T> forBulkFileFormat(final BulkFormat<T> reader, final Path... paths) {
+	public static <T> FileSourceBuilder<T> forBulkFileFormat(final BulkFormat<T, FileSourceSplit> reader, final Path... paths) {
 		checkNotNull(reader, "reader");
 		checkNotNull(paths, "paths");
 		checkArgument(paths.length > 0, "paths must not be empty");
@@ -303,7 +303,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 		checkNotNull(paths, "paths");
 		checkArgument(paths.length > 0, "paths must not be empty");
 
-		final BulkFormat<T> bulkFormat = new FileRecordFormatAdapter<>(reader);
+		final BulkFormat<T, FileSourceSplit> bulkFormat = new FileRecordFormatAdapter<>(reader);
 		return new FileSourceBuilder<>(paths, bulkFormat);
 	}
 
@@ -322,7 +322,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	 * </ul>
 	 */
 	public static final class FileSourceBuilder<T> extends AbstractFileSourceBuilder<T, FileSourceBuilder<T>> {
-		public FileSourceBuilder(Path[] inputPaths, BulkFormat<T> readerFormat) {
+		public FileSourceBuilder(Path[] inputPaths, BulkFormat<T, FileSourceSplit> readerFormat) {
 			super(inputPaths, readerFormat);
 		}
 	}
@@ -345,7 +345,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 
 		// mandatory - have no defaults
 		private final Path[] inputPaths;
-		private final BulkFormat<T> readerFormat;
+		private final BulkFormat<T, FileSourceSplit> readerFormat;
 
 		// optional - have defaults
 		private FileEnumerator.Provider fileEnumerator;
@@ -353,7 +353,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 		@Nullable
 		private ContinuousEnumerationSettings continuousSourceSettings;
 
-		protected AbstractFileSourceBuilder(Path[] inputPaths, BulkFormat<T> readerFormat) {
+		protected AbstractFileSourceBuilder(Path[] inputPaths, BulkFormat<T, FileSourceSplit> readerFormat) {
 			this.inputPaths = checkNotNull(inputPaths);
 			this.readerFormat = checkNotNull(readerFormat);
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -107,7 +107,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of the events/records produced by this source.
  */
 @PublicEvolving
-public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSplitsCheckpoint>, ResultTypeQueryable<T> {
+public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>>, ResultTypeQueryable<T> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -177,7 +177,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	}
 
 	@Override
-	public SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint> createEnumerator(
+	public SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> createEnumerator(
 			SplitEnumeratorContext<FileSourceSplit> enumContext) {
 
 		final FileEnumerator enumerator = enumeratorFactory.create();
@@ -195,9 +195,9 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	}
 
 	@Override
-	public SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint> restoreEnumerator(
+	public SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> restoreEnumerator(
 			SplitEnumeratorContext<FileSourceSplit> enumContext,
-			PendingSplitsCheckpoint checkpoint) throws IOException {
+			PendingSplitsCheckpoint<FileSourceSplit> checkpoint) throws IOException {
 
 		final FileEnumerator enumerator = enumeratorFactory.create();
 
@@ -210,8 +210,8 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	}
 
 	@Override
-	public SimpleVersionedSerializer<PendingSplitsCheckpoint> getEnumeratorCheckpointSerializer() {
-		return PendingSplitsCheckpointSerializer.INSTANCE;
+	public SimpleVersionedSerializer<PendingSplitsCheckpoint<FileSourceSplit>> getEnumeratorCheckpointSerializer() {
+		return new PendingSplitsCheckpointSerializer<>(getSplitSerializer());
 	}
 
 	@Override
@@ -223,7 +223,7 @@ public final class FileSource<T> implements Source<T, FileSourceSplit, PendingSp
 	//  helpers
 	// ------------------------------------------------------------------------
 
-	private SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint> createSplitEnumerator(
+	private SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> createSplitEnumerator(
 			SplitEnumeratorContext<FileSourceSplit> context,
 			FileEnumerator enumerator,
 			Collection<FileSourceSplit> splits,

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
@@ -199,6 +199,14 @@ public class FileSourceSplit implements SourceSplit, Serializable {
 		return Optional.ofNullable(readerPosition);
 	}
 
+	/**
+	 * Creates a copy of this split where the checkpointed position is replaced by the
+	 * given new position.
+	 */
+	public FileSourceSplit updateWithCheckpointedPosition(@Nullable CheckpointedPosition position) {
+		return new FileSourceSplit(id, filePath, offset, length, hostnames, position);
+	}
+
 	// ------------------------------------------------------------------------
 	//  utils
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
@@ -202,6 +202,12 @@ public class FileSourceSplit implements SourceSplit, Serializable {
 	/**
 	 * Creates a copy of this split where the checkpointed position is replaced by the
 	 * given new position.
+	 *
+	 * <p><b>IMPORTANT:</b> Subclasses that add additional information to the split
+	 * must override this method to return that subclass type. This contract is enforced by
+	 * checks in the file source implementation.
+	 * We did not try to enforce this contract via generics in this split class, because
+	 * it leads to very ugly and verbose use of generics.
 	 */
 	public FileSourceSplit updateWithCheckpointedPosition(@Nullable CheckpointedPosition position) {
 		return new FileSourceSplit(id, filePath, offset, length, hostnames, position);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplitState.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplitState.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.file.src;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import java.util.Optional;
 
@@ -34,15 +35,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * need to always point to the record after the last emitted record.
  */
 @PublicEvolving
-public final class FileSourceSplitState {
+public final class FileSourceSplitState<SplitT extends FileSourceSplit> {
 
-	private final FileSourceSplit split;
+	private final SplitT split;
 
 	private long offset;
 
 	private long recordsToSkipAfterOffset;
 
-	public FileSourceSplitState(FileSourceSplit split) {
+	public FileSourceSplitState(SplitT split) {
 		this.split = checkNotNull(split);
 
 		final Optional<CheckpointedPosition> readerPosition = split.getReaderPosition();
@@ -90,11 +91,25 @@ public final class FileSourceSplitState {
 	/**
 	 * Use the current row count as the starting row count to create a new FileSourceSplit.
 	 */
-	public FileSourceSplit toFileSourceSplit() {
+	@SuppressWarnings("unchecked")
+	public SplitT toFileSourceSplit() {
 		final CheckpointedPosition position =
 				(offset == CheckpointedPosition.NO_OFFSET && recordsToSkipAfterOffset == 0) ?
 						null : new CheckpointedPosition(offset, recordsToSkipAfterOffset);
 
-		return split.updateWithCheckpointedPosition(position);
+		final FileSourceSplit updatedSplit = split.updateWithCheckpointedPosition(position);
+
+		// some sanity checks to avoid surprises and not accidentally lose split information
+		if (updatedSplit == null) {
+			throw new FlinkRuntimeException("Split returned 'null' in updateWithCheckpointedPosition(): " + split);
+		}
+		if (updatedSplit.getClass() != split.getClass()) {
+			throw new FlinkRuntimeException(String.format(
+					"Split returned different type in updateWithCheckpointedPosition(). " +
+					"Split type is %s, returned type is %s",
+					split.getClass().getName(), updatedSplit.getClass().getName()));
+		}
+
+		return (SplitT) updatedSplit;
 	}
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplitState.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplitState.java
@@ -95,12 +95,6 @@ public final class FileSourceSplitState {
 				(offset == CheckpointedPosition.NO_OFFSET && recordsToSkipAfterOffset == 0) ?
 						null : new CheckpointedPosition(offset, recordsToSkipAfterOffset);
 
-		return new FileSourceSplit(
-				split.splitId(),
-				split.path(),
-				split.offset(),
-				split.length(),
-				split.hostnames(),
-				position);
+		return split.updateWithCheckpointedPosition(position);
 	}
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
@@ -33,10 +33,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A checkpoint of the current state of the containing the currently pending splits that are not yet assigned.
  */
 @PublicEvolving
-public final class PendingSplitsCheckpoint {
+public final class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
 
 	/** The splits in the checkpoint. */
-	private final Collection<FileSourceSplit> splits;
+	private final Collection<SplitT> splits;
 
 	/** The paths that are no longer in the enumerator checkpoint, but have been processed
 	 * before and should this be ignored. Relevant only for sources in continuous monitoring mode. */
@@ -48,14 +48,14 @@ public final class PendingSplitsCheckpoint {
 	@Nullable
 	byte[] serializedFormCache;
 
-	private PendingSplitsCheckpoint(Collection<FileSourceSplit> splits, Collection<Path> alreadyProcessedPaths) {
+	private PendingSplitsCheckpoint(Collection<SplitT> splits, Collection<Path> alreadyProcessedPaths) {
 		this.splits = Collections.unmodifiableCollection(splits);
 		this.alreadyProcessedPaths = Collections.unmodifiableCollection(alreadyProcessedPaths);
 	}
 
 	// ------------------------------------------------------------------------
 
-	public Collection<FileSourceSplit> getSplits() {
+	public Collection<SplitT> getSplits() {
 		return splits;
 	}
 
@@ -67,27 +67,30 @@ public final class PendingSplitsCheckpoint {
 	//  factories
 	// ------------------------------------------------------------------------
 
-	public static PendingSplitsCheckpoint fromCollectionSnapshot(Collection<FileSourceSplit> splits) {
+	public static <T extends FileSourceSplit> PendingSplitsCheckpoint<T> fromCollectionSnapshot(
+			final Collection<T> splits) {
 		checkNotNull(splits);
 
 		// create a copy of the collection to make sure this checkpoint is immutable
-		final Collection<FileSourceSplit> copy = new ArrayList<>(splits);
-		return new PendingSplitsCheckpoint(copy, Collections.emptySet());
+		final Collection<T> copy = new ArrayList<>(splits);
+		return new PendingSplitsCheckpoint<>(copy, Collections.emptySet());
 	}
 
-	public static PendingSplitsCheckpoint fromCollectionSnapshot(
-			Collection<FileSourceSplit> splits,
-			Collection<Path> alreadyProcessedPaths) {
+	public static <T extends FileSourceSplit> PendingSplitsCheckpoint<T> fromCollectionSnapshot(
+			final Collection<T> splits,
+			final Collection<Path> alreadyProcessedPaths) {
 		checkNotNull(splits);
 
 		// create a copy of the collection to make sure this checkpoint is immutable
-		final Collection<FileSourceSplit> splitsCopy = new ArrayList<>(splits);
+		final Collection<T> splitsCopy = new ArrayList<>(splits);
 		final Collection<Path> pathsCopy = new ArrayList<>(alreadyProcessedPaths);
 
-		return new PendingSplitsCheckpoint(splitsCopy, pathsCopy);
+		return new PendingSplitsCheckpoint<>(splitsCopy, pathsCopy);
 	}
 
-	static PendingSplitsCheckpoint reusingCollection(Collection<FileSourceSplit> splits, Collection<Path> alreadyProcessedPaths) {
-		return new PendingSplitsCheckpoint(splits, alreadyProcessedPaths);
+	static <T extends FileSourceSplit> PendingSplitsCheckpoint<T> reusingCollection(
+			final Collection<T> splits,
+			final Collection<Path> alreadyProcessedPaths) {
+		return new PendingSplitsCheckpoint<>(splits, alreadyProcessedPaths);
 	}
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializer.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializer.java
@@ -30,18 +30,24 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A serializer for the {@link PendingSplitsCheckpoint}.
  */
 @PublicEvolving
-public final class PendingSplitsCheckpointSerializer implements SimpleVersionedSerializer<PendingSplitsCheckpoint> {
-
-	public static final PendingSplitsCheckpointSerializer INSTANCE = new PendingSplitsCheckpointSerializer();
+public final class PendingSplitsCheckpointSerializer<T extends FileSourceSplit>
+		implements SimpleVersionedSerializer<PendingSplitsCheckpoint<T>> {
 
 	private static final int VERSION = 1;
 
 	private static final int VERSION_1_MAGIC_NUMBER = 0xDEADBEEF;
+
+	private final SimpleVersionedSerializer<T> splitSerializer;
+
+	public PendingSplitsCheckpointSerializer(SimpleVersionedSerializer<T> splitSerializer) {
+		this.splitSerializer = checkNotNull(splitSerializer);
+	}
 
 	// ------------------------------------------------------------------------
 
@@ -51,7 +57,7 @@ public final class PendingSplitsCheckpointSerializer implements SimpleVersionedS
 	}
 
 	@Override
-	public byte[] serialize(PendingSplitsCheckpoint checkpoint) throws IOException {
+	public byte[] serialize(PendingSplitsCheckpoint<T> checkpoint) throws IOException {
 		checkArgument(checkpoint.getClass() == PendingSplitsCheckpoint.class,
 				"Cannot serialize subclasses of PendingSplitsCheckpoint");
 
@@ -60,17 +66,17 @@ public final class PendingSplitsCheckpointSerializer implements SimpleVersionedS
 			return checkpoint.serializedFormCache;
 		}
 
-		final FileSourceSplitSerializer serializer = FileSourceSplitSerializer.INSTANCE;
-		final Collection<FileSourceSplit> splits = checkpoint.getSplits();
+		final SimpleVersionedSerializer<T> splitSerializer = this.splitSerializer; // stack cache
+		final Collection<T> splits = checkpoint.getSplits();
 		final Collection<Path> processedPaths = checkpoint.getAlreadyProcessedPaths();
 
 		final ArrayList<byte[]> serializedSplits = new ArrayList<>(splits.size());
 		final ArrayList<byte[]> serializedPaths = new ArrayList<>(processedPaths.size());
 
-		int totalLen = 16; // four ints: magic, version, count splits, count paths
+		int totalLen = 16;	// four ints: magic, version of split serializer, count splits, count paths
 
-		for (FileSourceSplit split : splits) {
-			final byte[] serSplit = serializer.serialize(split);
+		for (T split : splits) {
+			final byte[] serSplit = splitSerializer.serialize(split);
 			serializedSplits.add(serSplit);
 			totalLen += serSplit.length + 4; // 4 bytes for the length field
 		}
@@ -84,7 +90,7 @@ public final class PendingSplitsCheckpointSerializer implements SimpleVersionedS
 		final byte[] result = new byte[totalLen];
 		final ByteBuffer byteBuffer = ByteBuffer.wrap(result).order(ByteOrder.LITTLE_ENDIAN);
 		byteBuffer.putInt(VERSION_1_MAGIC_NUMBER);
-		byteBuffer.putInt(serializer.getVersion());
+		byteBuffer.putInt(splitSerializer.getVersion());
 		byteBuffer.putInt(serializedSplits.size());
 		byteBuffer.putInt(serializedPaths.size());
 
@@ -107,14 +113,14 @@ public final class PendingSplitsCheckpointSerializer implements SimpleVersionedS
 	}
 
 	@Override
-	public PendingSplitsCheckpoint deserialize(int version, byte[] serialized) throws IOException {
+	public PendingSplitsCheckpoint<T> deserialize(int version, byte[] serialized) throws IOException {
 		if (version == 1) {
 			return deserializeV1(serialized);
 		}
 		throw new IOException("Unknown version: " + version);
 	}
 
-	private static PendingSplitsCheckpoint deserializeV1(byte[] serialized) throws IOException {
+	private PendingSplitsCheckpoint<T> deserializeV1(byte[] serialized) throws IOException {
 		final ByteBuffer bb = ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN);
 
 		final int magic = bb.getInt();
@@ -123,18 +129,18 @@ public final class PendingSplitsCheckpointSerializer implements SimpleVersionedS
 				"Expected: %X , found %X", VERSION_1_MAGIC_NUMBER, magic));
 		}
 
-		final int version = bb.getInt();
+		final int splitSerializerVersion = bb.getInt();
 		final int numSplits = bb.getInt();
 		final int numPaths = bb.getInt();
 
-		final FileSourceSplitSerializer serializer = FileSourceSplitSerializer.INSTANCE;
-		final ArrayList<FileSourceSplit> splits = new ArrayList<>(numSplits);
+		final SimpleVersionedSerializer<T> splitSerializer = this.splitSerializer; // stack cache
+		final ArrayList<T> splits = new ArrayList<>(numSplits);
 		final ArrayList<Path> paths = new ArrayList<>(numPaths);
 
 		for (int remaining = numSplits; remaining > 0; remaining--) {
 			final byte[] bytes = new byte[bb.getInt()];
 			bb.get(bytes);
-			final FileSourceSplit split = serializer.deserialize(version, bytes);
+			final T split = splitSerializer.deserialize(splitSerializerVersion, bytes);
 			splits.add(split);
 		}
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
@@ -49,7 +49,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A continuously monitoring enumerator.
  */
 @Internal
-public class ContinuousFileSplitEnumerator implements SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint> {
+public class ContinuousFileSplitEnumerator implements SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ContinuousFileSplitEnumerator.class);
 
@@ -123,7 +123,7 @@ public class ContinuousFileSplitEnumerator implements SplitEnumerator<FileSource
 	}
 
 	@Override
-	public PendingSplitsCheckpoint snapshotState() throws Exception {
+	public PendingSplitsCheckpoint<FileSourceSplit> snapshotState() throws Exception {
 		return PendingSplitsCheckpoint.fromCollectionSnapshot(splitAssigner.remainingSplits(), pathsAlreadyProcessed);
 	}
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -35,10 +35,10 @@ import java.util.Collection;
  * A {@link SourceReader} that read records from {@link FileSourceSplit}.
  */
 @Internal
-public final class FileSourceReader<T>
-		extends SingleThreadMultiplexSourceReaderBase<RecordAndPosition<T>, T, FileSourceSplit, FileSourceSplitState> {
+public final class FileSourceReader<T, SplitT extends FileSourceSplit>
+		extends SingleThreadMultiplexSourceReaderBase<RecordAndPosition<T>, T, SplitT, FileSourceSplitState<SplitT>> {
 
-	public FileSourceReader(SourceReaderContext readerContext, BulkFormat<T, FileSourceSplit> readerFormat, Configuration config) {
+	public FileSourceReader(SourceReaderContext readerContext, BulkFormat<T, SplitT> readerFormat, Configuration config) {
 		super(
 			() -> new FileSourceSplitReader<>(config, readerFormat),
 			new FileSourceRecordEmitter<>(),
@@ -57,12 +57,12 @@ public final class FileSourceReader<T>
 	}
 
 	@Override
-	protected FileSourceSplitState initializedState(FileSourceSplit split) {
-		return new FileSourceSplitState(split);
+	protected FileSourceSplitState<SplitT> initializedState(SplitT split) {
+		return new FileSourceSplitState<>(split);
 	}
 
 	@Override
-	protected FileSourceSplit toSplitType(String splitId, FileSourceSplitState splitState) {
+	protected SplitT toSplitType(String splitId, FileSourceSplitState<SplitT> splitState) {
 		return splitState.toFileSourceSplit();
 	}
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 public final class FileSourceReader<T>
 		extends SingleThreadMultiplexSourceReaderBase<RecordAndPosition<T>, T, FileSourceSplit, FileSourceSplitState> {
 
-	public FileSourceReader(SourceReaderContext readerContext, BulkFormat<T> readerFormat, Configuration config) {
+	public FileSourceReader(SourceReaderContext readerContext, BulkFormat<T, FileSourceSplit> readerFormat, Configuration config) {
 		super(
 			() -> new FileSourceSplitReader<>(config, readerFormat),
 			new FileSourceRecordEmitter<>(),

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceRecordEmitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceRecordEmitter.java
@@ -33,13 +33,14 @@ import org.apache.flink.connector.file.src.util.RecordAndPosition;
  * the current offset and records-to-skip need to always point to the record after the emitted record.
  */
 @Internal
-final class FileSourceRecordEmitter<T> implements RecordEmitter<RecordAndPosition<T>, T, FileSourceSplitState> {
+final class FileSourceRecordEmitter<T, SplitT extends FileSourceSplit>
+		implements RecordEmitter<RecordAndPosition<T>, T, FileSourceSplitState<SplitT>> {
 
 	@Override
 	public void emitRecord(
 			final RecordAndPosition<T> element,
 			final SourceOutput<T> output,
-			final FileSourceSplitState splitState) {
+			final FileSourceSplitState<SplitT> splitState) {
 
 		output.collect(element.getRecord());
 		splitState.setPosition(element.getOffset(), element.getRecordSkipCount());

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceSplitReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceSplitReader.java
@@ -43,21 +43,21 @@ import java.util.Queue;
  * The {@link SplitReader} implementation for the file source.
  */
 @Internal
-final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, FileSourceSplit> {
+final class FileSourceSplitReader<T, SplitT extends FileSourceSplit> implements SplitReader<RecordAndPosition<T>, SplitT> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FileSourceSplitReader.class);
 
 	private final Configuration config;
-	private final BulkFormat<T, FileSourceSplit> readerFactory;
+	private final BulkFormat<T, SplitT> readerFactory;
 
-	private final Queue<FileSourceSplit> splits;
+	private final Queue<SplitT> splits;
 
 	@Nullable
 	private BulkFormat.Reader<T> currentReader;
 	@Nullable
 	private String currentSplitId;
 
-	public FileSourceSplitReader(Configuration config, BulkFormat<T, FileSourceSplit> readerFactory) {
+	public FileSourceSplitReader(Configuration config, BulkFormat<T, SplitT> readerFactory) {
 		this.config = config;
 		this.readerFactory = readerFactory;
 		this.splits = new ArrayDeque<>();
@@ -72,7 +72,7 @@ final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>
 	}
 
 	@Override
-	public void handleSplitsChanges(final SplitsChange<FileSourceSplit> splitChange) {
+	public void handleSplitsChanges(final SplitsChange<SplitT> splitChange) {
 		if (!(splitChange instanceof SplitsAddition)) {
 			throw new UnsupportedOperationException(String.format(
 					"The SplitChange type of %s is not supported.", splitChange.getClass()));
@@ -90,7 +90,7 @@ final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>
 			return;
 		}
 
-		final FileSourceSplit nextSplit = splits.poll();
+		final SplitT nextSplit = splits.poll();
 		if (nextSplit == null) {
 			throw new IOException("Cannot fetch from another split - no split remaining");
 		}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceSplitReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceSplitReader.java
@@ -48,7 +48,7 @@ final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>
 	private static final Logger LOG = LoggerFactory.getLogger(FileSourceSplitReader.class);
 
 	private final Configuration config;
-	private final BulkFormat<T> readerFactory;
+	private final BulkFormat<T, FileSourceSplit> readerFactory;
 
 	private final Queue<FileSourceSplit> splits;
 
@@ -57,7 +57,7 @@ final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>
 	@Nullable
 	private String currentSplitId;
 
-	public FileSourceSplitReader(Configuration config, BulkFormat<T> readerFactory) {
+	public FileSourceSplitReader(Configuration config, BulkFormat<T, FileSourceSplit> readerFactory) {
 		this.config = config;
 		this.readerFactory = readerFactory;
 		this.splits = new ArrayDeque<>();
@@ -99,8 +99,8 @@ final class FileSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>
 
 		final Optional<CheckpointedPosition> position = nextSplit.getReaderPosition();
 		currentReader = position.isPresent()
-				? readerFactory.restoreReader(config, nextSplit.path(), nextSplit.offset(), nextSplit.length(), position.get())
-				: readerFactory.createReader(config, nextSplit.path(), nextSplit.offset(), nextSplit.length());
+				? readerFactory.restoreReader(config, nextSplit)
+				: readerFactory.createReader(config, nextSplit);
 	}
 
 	private FileRecords<T> finishSplit() throws IOException {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -52,7 +52,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link FileEnumerator} and in {@link FileSplitAssigner}, respectively.
  */
 @Internal
-public class StaticFileSplitEnumerator implements SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint> {
+public class StaticFileSplitEnumerator implements SplitEnumerator<FileSourceSplit, PendingSplitsCheckpoint<FileSourceSplit>> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StaticFileSplitEnumerator.class);
 
@@ -102,7 +102,7 @@ public class StaticFileSplitEnumerator implements SplitEnumerator<FileSourceSpli
 	}
 
 	@Override
-	public PendingSplitsCheckpoint snapshotState() {
+	public PendingSplitsCheckpoint<FileSourceSplit> snapshotState() {
 		return PendingSplitsCheckpoint.fromCollectionSnapshot(splitAssigner.remainingSplits());
 	}
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/FileRecordFormat.java
@@ -100,10 +100,6 @@ public interface FileRecordFormat<T> extends Serializable, ResultTypeQueryable<T
 	 * created for a split that was assigned from the enumerator. This method may also be called on
 	 * recovery from a checkpoint, if the reader never stored an offset in the checkpoint
 	 * (see {@link #restoreReader(Configuration, Path, long, long, long)} for details.
-	 *
-	 * <p>The {@code fileLen} is the length of the entire file, while {@code splitEnd} is the offset of
-	 * the first byte after the split end boundary (exclusive end boundary). For non-splittable formats,
-	 * both values are identical.
 	 */
 	FileRecordFormat.Reader<T> createReader(
 			Configuration config,
@@ -121,10 +117,6 @@ public interface FileRecordFormat<T> extends Serializable, ResultTypeQueryable<T
 	 * this method is not called, and the reader is created in the same way as a fresh reader via the method
 	 * {@link #createReader(Configuration, Path, long, long)} and the appropriate number of
 	 * records are read and discarded, to position to reader to the checkpointed position.
-	 *
-	 * <p>The {@code fileLen} is the length of the entire file, while {@code splitEnd} is the offset of
-	 * the first byte after the split end boundary (exclusive end boundary). For non-splittable formats,
-	 * both values are identical.
 	 */
 	FileRecordFormat.Reader<T> restoreReader(
 			Configuration config,

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/StreamFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/StreamFormat.java
@@ -139,7 +139,7 @@ public interface StreamFormat<T> extends Serializable, ResultTypeQueryable<T> {
 	 * <p>Having a different method for restoring readers to a checkpointed position allows readers to
 	 * seek to the start position differently in that case, compared to when the reader is created from
 	 * a split offset generated at the enumerator. In the latter case, the offsets are commonly "approximate",
-	 * because the enumerator typically generates splits based only on metadata. Reader then have to skip some
+	 * because the enumerator typically generates splits based only on metadata. Readers then have to skip some
 	 * bytes while searching for the next position to start from (based on a delimiter, sync marker, block
 	 * offset, etc.). In contrast, checkpointed offsets are often precise, because they were recorded as the
 	 * reader when through the data stream. Starting a reader from a checkpointed offset may hence not

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileRecordFormatAdapterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.file.src.impl;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.reader.FileRecordFormat;
 import org.apache.flink.core.fs.FSDataInputStream;
@@ -56,7 +57,7 @@ public class FileRecordFormatAdapterTest extends AdapterTestBase<FileRecordForma
 	}
 
 	@Override
-	protected BulkFormat<Integer> wrapWithAdapter(FileRecordFormat<Integer> format) {
+	protected BulkFormat<Integer, FileSourceSplit> wrapWithAdapter(FileRecordFormat<Integer> format) {
 		return new FileRecordFormatAdapter<>(format);
 	}
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
@@ -61,7 +62,7 @@ public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Intege
 	}
 
 	@Override
-	protected BulkFormat<Integer> wrapWithAdapter(StreamFormat<Integer> format) {
+	protected BulkFormat<Integer, FileSourceSplit> wrapWithAdapter(StreamFormat<Integer> format) {
 		return new StreamFormatAdapter<>(format);
 	}
 
@@ -88,7 +89,7 @@ public class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Intege
 		final Configuration config = new Configuration();
 		config.set(StreamFormat.FETCH_IO_SIZE, new MemorySize(batchSize));
 		final StreamFormatAdapter<Integer> format = new StreamFormatAdapter<>(new CheckpointedIntFormat());
-		final BulkFormat.Reader<Integer> reader = format.createReader(config, testPath, 0L, FILE_LEN);
+		final BulkFormat.Reader<Integer> reader = format.createReader(config, new FileSourceSplit("test-id", testPath, 0L, FILE_LEN));
 
 		final List<Integer> result = new ArrayList<>();
 		readNumbers(reader, result, NUM_NUMBERS);

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.parquet;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.connector.file.src.util.Pool;
@@ -68,7 +69,7 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
  * Parquet {@link BulkFormat} that reads data from the file to {@link VectorizedColumnBatch} in
  * vectorized mode.
  */
-public abstract class ParquetVectorizedInputFormat<T> implements BulkFormat<T> {
+public abstract class ParquetVectorizedInputFormat<T> implements BulkFormat<T, FileSourceSplit> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -105,10 +106,13 @@ public abstract class ParquetVectorizedInputFormat<T> implements BulkFormat<T> {
 
 	@Override
 	public ParquetReader createReader(
-			Configuration config,
-			Path filePath,
-			long splitOffset,
-			long splitLength) throws IOException {
+			final Configuration config,
+			final FileSourceSplit split) throws IOException {
+
+		final Path filePath = split.path();
+		final long splitOffset = split.offset();
+		final long splitLength = split.length();
+
 		org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(filePath.toUri());
 		ParquetMetadata footer = readFooter(
 				hadoopConfig.conf(), hadoopPath, range(splitOffset, splitOffset + splitLength));
@@ -140,15 +144,16 @@ public abstract class ParquetVectorizedInputFormat<T> implements BulkFormat<T> {
 
 	@Override
 	public ParquetReader restoreReader(
-			Configuration config,
-			Path filePath,
-			long splitOffset,
-			long splitLength,
-			CheckpointedPosition checkpointedPosition) throws IOException {
+			final Configuration config,
+			final FileSourceSplit split) throws IOException {
+
+		assert split.getReaderPosition().isPresent();
+		final CheckpointedPosition checkpointedPosition = split.getReaderPosition().get();
+
 		Preconditions.checkArgument(
 				checkpointedPosition.getOffset() == CheckpointedPosition.NO_OFFSET,
 				"The offset of CheckpointedPosition should always be NO_OFFSET");
-		ParquetReader reader = createReader(config, filePath, splitOffset, splitLength);
+		ParquetReader reader = createReader(config, split);
 		reader.seek(checkpointedPosition.getRecordsAfterOffset());
 		return reader;
 	}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormatTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.parquet;
 
+import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.core.fs.Path;
@@ -226,7 +227,7 @@ public class ParquetColumnarRowInputFormatTest {
 				true);
 
 		AtomicInteger cnt = new AtomicInteger(0);
-		forEachRemaining(format.createReader(EMPTY_CONF, testPath, 0, Long.MAX_VALUE), row -> {
+		forEachRemaining(format.createReader(EMPTY_CONF, new FileSourceSplit("id", testPath, 0, Long.MAX_VALUE)), row -> {
 			int i = cnt.get();
 			assertEquals(i, row.getDouble(0), 0);
 			assertEquals((byte) i, row.getByte(1));
@@ -354,10 +355,13 @@ public class ParquetColumnarRowInputFormatTest {
 
 		BulkFormat.Reader<RowData> reader = format.restoreReader(
 				EMPTY_CONF,
-				path,
-				splitStart,
-				splitLength,
-				new CheckpointedPosition(CheckpointedPosition.NO_OFFSET, seekToRow));
+				new FileSourceSplit(
+						"id",
+						path,
+						splitStart,
+						splitLength,
+						new String[0],
+						new CheckpointedPosition(CheckpointedPosition.NO_OFFSET, seekToRow)));
 
 		AtomicInteger cnt = new AtomicInteger(0);
 		forEachRemaining(reader, row -> {
@@ -479,7 +483,7 @@ public class ParquetColumnarRowInputFormatTest {
 				true);
 
 		AtomicInteger cnt = new AtomicInteger(0);
-		forEachRemaining(format.createReader(EMPTY_CONF, testPath, 0, Long.MAX_VALUE), row -> {
+		forEachRemaining(format.createReader(EMPTY_CONF, new FileSourceSplit("id", testPath, 0, Long.MAX_VALUE)), row -> {
 			int i = cnt.get();
 			// common values
 			assertEquals(i, row.getDouble(0), 0);


### PR DESCRIPTION
## What is the purpose of the change

This refactors several parts of the new File Source API for classes that need to subclass `FileSourceSplit` to add extra information to the splits.

Examples of that are the Hive Source and the Iceberg Source.

The changes here are purely in the yet unreleased File Source API and hence have no compatibility issues.

## Brief change log

  - [FLINK-19800] Make the interaction between `FileSourceSplit` and `FileSourceSplitState` extensible, to support different split types in the reader.
  - [FLINK-19803] Make `PendingSplitCheckpoint` and its Serializer generic to support sub-classes of `FileSourceSplit`
  - [FLINK-19802] Changes `BulkFormat.createReader(...)` and `BulkFormat.restoreReader(...)` to accept `FileSourceSplit` (or its subclasses) directly, to allow passing extra information via subclasses of `FileSourceSplit` 
  - [FINK-19804] Introduces an `AbstractFileSource` that is generic with respect to split types and changes `FileSource` to extend from that for the specific case of using `FileSourceSplit`. This makes the generics handling simpler for the common case (using `FileSource`).

## Verifying this change

This is a refactoring that does not change any functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (but unreleased)
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
