### PR TITLE
[FLINK-19235][python] Support more built-in aggs to be mixed use with Python UDAF

### DIFF
--- a/flink-python/pyflink/table/functions.py
+++ b/flink-python/pyflink/table/functions.py
@@ -20,10 +20,47 @@ import time
 from abc import abstractmethod
 from decimal import Decimal
 
-from pyflink.table import AggregateFunction, MapView
+from pyflink.table import AggregateFunction, MapView, ListView
 
 MAX_LONG_VALUE = sys.maxsize
 MIN_LONG_VALUE = -MAX_LONG_VALUE - 1
+
+
+class AvgAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        # sum / count
+        if accumulator[0] != 0:
+            return accumulator[1] / accumulator[0]
+        else:
+            return None
+
+    def create_accumulator(self):
+        # [count, sum]
+        return [0, None]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0] += 1
+            if accumulator[1] is None:
+                accumulator[1] = args[0]
+            else:
+                accumulator[1] += args[0]
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[1] is not None:
+                accumulator[0] -= 1
+                accumulator[1] -= args[0]
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            if acc[1] is not None:
+                accumulator[0] += acc[0]
+                if accumulator[1] is None:
+                    accumulator[1] = acc[1]
+                else:
+                    accumulator[1] += acc[1]
 
 
 class Count1AggFunction(AggregateFunction):
@@ -43,6 +80,53 @@ class Count1AggFunction(AggregateFunction):
     def merge(self, accumulator, accumulators):
         for acc in accumulators:
             accumulator[0] += acc[0]
+
+
+class CountAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        return [0]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0] += 1
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0] -= 1
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            accumulator[0] += acc[0]
+
+
+class FirstValueAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [first_value, first_order]
+        return [None, MAX_LONG_VALUE]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if len(args) > 1:
+                if accumulator[1] > args[1]:
+                    accumulator[0] = args[0]
+                    accumulator[1] = args[1]
+            else:
+                if accumulator[0] is None:
+                    accumulator[0] = args[0]
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+    def merge(self, accumulator, accumulators):
+        raise NotImplementedError("This function does not support merge.")
 
 
 class FirstValueWithRetractAggFunction(AggregateFunction):
@@ -138,6 +222,528 @@ class FirstValueWithRetractAggFunction(AggregateFunction):
         raise NotImplementedError("This function does not support merge.")
 
 
+class LastValueAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [last_value, last_order]
+        return [None, -MAX_LONG_VALUE - 1]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if len(args) > 1:
+                if args[1] > accumulator[0]:
+                    accumulator[0] = args[0]
+                    accumulator[1] = args[1]
+            else:
+                accumulator[0] = args[0]
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+    def merge(self, accumulator, accumulators):
+        raise NotImplementedError("This function does not support merge.")
+
+
+class LastValueWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [last_value, last_order, value_to_order_map, order_to_value_mapl9]
+        return [None, None, MapView(), MapView()]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            prev_order = accumulator[1]
+            value_to_order_map = accumulator[2]
+            order_to_value_map = accumulator[3]
+
+            # get the order of current value if not given
+            if len(args) == 1:
+                order = int(time.time() * 1000)
+                if value in value_to_order_map:
+                    order_list = value_to_order_map[value]
+                else:
+                    order_list = []
+                order_list.append(order)
+                value_to_order_map[value] = order_list
+            else:
+                order = args[1]
+
+            if prev_order is None or prev_order <= order:
+                accumulator[0] = value
+                accumulator[1] = order
+
+            if order in order_to_value_map:
+                value_list = order_to_value_map[order]
+            else:
+                value_list = []
+            value_list.append(value)
+            order_to_value_map[order] = value_list
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            prev_value = accumulator[0]
+            prev_order = accumulator[1]
+            value_to_order_map = accumulator[2]
+            order_to_value_map = accumulator[3]
+
+            # get the order of current value if not given
+            if len(args) == 1:
+                if value in value_to_order_map and len(value_to_order_map[value]) > 0:
+                    order_list = value_to_order_map[value]
+                else:
+                    # this data has not been accumulated
+                    return
+                # get and remove current order in value_to_order_map
+                order = order_list.pop(0)
+                if len(order_list) == 0:
+                    del value_to_order_map[value]
+                else:
+                    value_to_order_map[value] = order_list
+            else:
+                order = args[1]
+
+            if order in order_to_value_map:
+                value_list = order_to_value_map[order]
+            else:
+                return
+
+            if value in value_list:
+                value_list.remove(value)
+                if len(value_list) == 0:
+                    del order_to_value_map[order]
+                else:
+                    order_to_value_map[order] = value_list
+
+            if value == prev_value:
+                start_key = prev_order
+                next_key = MIN_LONG_VALUE
+                for key in order_to_value_map:
+                    if start_key >= key > next_key:
+                        next_key = key
+
+                if next_key != MIN_LONG_VALUE:
+                    values = order_to_value_map[next_key]
+                    accumulator[0] = values[len(values) - 1]
+                    accumulator[1] = next_key
+                else:
+                    accumulator[0] = None
+                    accumulator[1] = None
+
+    def merge(self, accumulator, accumulators):
+        raise NotImplementedError("This function does not support merge.")
+
+
+class ListAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        if accumulator[1] is None:
+            return None
+        else:
+            return accumulator[0].join(accumulator[1])
+
+    def create_accumulator(self):
+        # delimiter, values
+        return [',', None]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if len(args) > 1:
+                accumulator[0] = args[1]
+            if accumulator[1] is None:
+                accumulator[1] = [args[0]]
+            else:
+                accumulator[1].append(args[0])
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+
+class ListAggWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        values = [i for i in accumulator[0]]
+        if len(values) > 0:
+            return ','.join(values)
+        else:
+            return None
+
+    def create_accumulator(self):
+        # [list, retract_list]
+        return [ListView(), ListView()]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[0].add(args[0])
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            values = [i for i in accumulator[0]]
+            if args[0] in values:
+                values.remove(args[0])
+                accumulator[0].clear()
+                accumulator[0].add_all(values)
+            else:
+                accumulator[1].add(args[0])
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            buffer = []
+            for e in acc[0]:
+                buffer.append(e)
+            retract_buffer = []
+            for e in acc[1]:
+                retract_buffer.append(e)
+
+            if len(buffer) == 0 and len(retract_buffer) == 0:
+                continue
+
+            for e in accumulator[0]:
+                buffer.append(e)
+            for e in accumulator[1]:
+                retract_buffer.append(e)
+
+            # merge list & retract list
+            new_retract_buffer = []
+            for e in retract_buffer:
+                if e in buffer:
+                    buffer.remove(e)
+                else:
+                    new_retract_buffer.append(e)
+
+            accumulator[0].clear()
+            accumulator[0].add_all(buffer)
+            accumulator[1].clear()
+            accumulator[1].add_all(retract_buffer)
+
+
+class ListAggWsWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        values = [i for i in accumulator[0]]
+        if len(values) > 0:
+            return accumulator[2].join(values)
+        else:
+            return None
+
+    def create_accumulator(self):
+        # [list, retract_list, delimiter]
+        return [ListView(), ListView(), ',']
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[2] = args[1]
+            accumulator[0].add(args[0])
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            accumulator[2] = args[1]
+            values = [i for i in accumulator[0]]
+            if args[0] in values:
+                values.remove(args[0])
+                accumulator[0].clear()
+                accumulator[0].add_all(values)
+            else:
+                accumulator[1].add(args[0])
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            buffer = []
+            for e in acc[0]:
+                buffer.append(e)
+            retract_buffer = []
+            for e in acc[1]:
+                retract_buffer.append(e)
+
+            if len(buffer) == 0 and len(retract_buffer) == 0:
+                continue
+
+            accumulator[2] = acc[2]
+            for e in accumulator[0]:
+                buffer.append(e)
+            for e in accumulator[1]:
+                retract_buffer.append(e)
+
+            # merge list & retract list
+            new_retract_buffer = []
+            for e in retract_buffer:
+                if e in buffer:
+                    buffer.remove(e)
+                else:
+                    new_retract_buffer.append(e)
+
+            accumulator[0].clear()
+            accumulator[0].add_all(buffer)
+            accumulator[1].clear()
+            accumulator[1].add_all(retract_buffer)
+
+
+class MaxAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        return [None]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[0] is None or args[0] > accumulator[0]:
+                accumulator[0] = args[0]
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            if acc[0] is not None:
+                if accumulator[0] is None or acc[0] > accumulator[0]:
+                    accumulator[0] = acc[0]
+
+
+class MaxWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        if accumulator[1] > 0:
+            return accumulator[0]
+        else:
+            return None
+
+    def create_accumulator(self):
+        # [max, map_size, value_to_count_map]
+        return [None, 0, MapView()]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            if accumulator[1] == 0 or accumulator[0] < value:
+                accumulator[0] = value
+
+            if value in accumulator[2]:
+                count = accumulator[2][value]
+            else:
+                count = 0
+
+            count += 1
+            if count == 0:
+                del accumulator[2][value]
+            else:
+                accumulator[2][value] = count
+            if count == 1:
+                accumulator[1] += 1
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            if value in accumulator[2]:
+                count = accumulator[2][value]
+            else:
+                count = 0
+
+            count -= 1
+            if count == 0:
+                del accumulator[2][value]
+                accumulator[1] -= 1
+
+                if accumulator[1] == 0:
+                    accumulator[0] = None
+                    return
+
+                if value == accumulator[0]:
+                    self.update_max(accumulator)
+
+    @staticmethod
+    def update_max(acc):
+        has_max = False
+        for value in acc[2]:
+            if not has_max or acc[0] < value:
+                acc[0] = value
+                has_max = True
+
+        # The behavior of deleting expired data in the state backend is uncertain.
+        # so `mapSize` data may exist, while `map` data may have been deleted
+        # when both of them are expired.
+        if not has_max:
+            acc[0] = None
+            # we should also override max value, because it may have an old value.
+            acc[1] = 0
+
+    def merge(self, acc, accumulators):
+        need_update_max = False
+        for a in accumulators:
+            # set max element
+            if acc[1] == 0 or (a[1] > 0 and a[0] is not None and acc[0] < a[0]):
+                acc[0] = a[0]
+
+            # merge the count for each key
+            for value, count in a[2].items():
+                if value in acc[2]:
+                    this_count = acc[2][value]
+                else:
+                    this_count = 0
+                merged_count = count + this_count
+                if merged_count == 0:
+                    # remove it when count is increased from -1 to 0
+                    del acc[2][value]
+                    # origin is > 0, and retract to 0
+                    if this_count > 0:
+                        acc[1] -= 1
+                        if value == acc[0]:
+                            need_update_max = True
+                elif merged_count < 0:
+                    acc[2][value] = merged_count
+                    if this_count > 0:
+                        # origin is > 0, and retract to < 0
+                        acc[1] -= 1
+                        if value == acc[0]:
+                            need_update_max = True
+                else:  # merged_count > 0
+                    acc[2][value] = merged_count
+                    if this_count <= 0:
+                        # origin is <= 0, and accumulate to > 0
+                        acc[1] += 1
+
+        if need_update_max:
+            self.update_max(acc)
+
+
+class MinAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [min]
+        return [None]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[0] is None or accumulator[0] > args[0]:
+                accumulator[0] = args[0]
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            if acc[0] is not None:
+                if accumulator[0] is None or accumulator[0] > acc[0]:
+                    accumulator[0] = acc[0]
+
+
+class MinWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        if accumulator[1] > 0:
+            return accumulator[0]
+        else:
+            return None
+
+    def create_accumulator(self):
+        # [min, map_size, value_to_count_map]
+        return [None, 0, MapView()]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            if accumulator[1] == 0 or accumulator[0] > value:
+                accumulator[0] = value
+
+            if value in accumulator[2]:
+                count = accumulator[2][value]
+            else:
+                count = 0
+
+            count += 1
+            if count == 0:
+                del accumulator[2][value]
+            else:
+                accumulator[2][value] = count
+            if count == 1:
+                accumulator[1] += 1
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            value = args[0]
+            if value in accumulator[2]:
+                count = accumulator[2][value]
+            else:
+                count = 0
+
+            count -= 1
+            if count == 0:
+                del accumulator[2][value]
+                accumulator[1] -= 1
+
+                if accumulator[1] == 0:
+                    accumulator[0] = None
+                    return
+
+                if value == accumulator[0]:
+                    self.update_min(accumulator)
+
+    @staticmethod
+    def update_min(acc):
+        has_max = False
+        for value in acc[2]:
+            if not has_max or acc[0] > value:
+                acc[0] = value
+                has_max = True
+
+        # The behavior of deleting expired data in the state backend is uncertain.
+        # so `mapSize` data may exist, while `map` data may have been deleted
+        # when both of them are expired.
+        if not has_max:
+            acc[0] = None
+            # we should also override min value, because it may have an old value.
+            acc[1] = 0
+
+    def merge(self, acc, accumulators):
+        need_update_min = False
+        for a in accumulators:
+            # set min element
+            if acc[1] == 0 or (a[1] > 0 and a[0] is not None and acc[0] > a[0]):
+                acc[0] = a[0]
+
+            # merge the count for each key
+            for value, count in a[2].items():
+                if value in acc[2]:
+                    this_count = acc[2][value]
+                else:
+                    this_count = 0
+                merged_count = count + this_count
+                if merged_count == 0:
+                    # remove it when count is increased from -1 to 0
+                    del acc[2][value]
+                    # origin is > 0, and retract to 0
+                    if this_count > 0:
+                        acc[1] -= 1
+                        if value == acc[0]:
+                            need_update_min = True
+                elif merged_count < 0:
+                    acc[2][value] = merged_count
+                    if this_count > 0:
+                        # origin is > 0, and retract to < 0
+                        acc[1] -= 1
+                        if value == acc[0]:
+                            need_update_min = True
+                else:  # merged_count > 0
+                    acc[2][value] = merged_count
+                    if this_count <= 0:
+                        # origin is <= 0, and accumulate to > 0
+                        acc[1] += 1
+
+        if need_update_min:
+            self.update_min(acc)
+
+
 class Sum0AggFunction(AggregateFunction):
 
     def get_value(self, accumulator):
@@ -179,3 +785,69 @@ class DecimalSum0AggFunction(Sum0AggFunction):
     def create_accumulator(self):
         # [sum]
         return [Decimal('0')]
+
+
+class SumAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        return accumulator[0]
+
+    def create_accumulator(self):
+        # [sum]
+        return [None]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[0] is None:
+                accumulator[0] = args[0]
+            else:
+                accumulator[0] += args[0]
+
+    def retract(self, accumulator, *args):
+        raise NotImplementedError("This function does not support retraction.")
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            if acc[0] is not None:
+                if accumulator[0] is None:
+                    accumulator[0] = acc[0]
+                else:
+                    accumulator[0] += acc[0]
+
+
+class SumWithRetractAggFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        if accumulator[1] == 0:
+            return None
+        else:
+            return accumulator[0]
+
+    def create_accumulator(self):
+        # [sum, count]
+        return [None, 0]
+
+    def accumulate(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[0] is None:
+                accumulator[0] = args[0]
+            else:
+                accumulator[0] += args[0]
+            accumulator[1] += 1
+
+    def retract(self, accumulator, *args):
+        if args[0] is not None:
+            if accumulator[0] is None:
+                accumulator[0] = -args[0]
+            else:
+                accumulator[0] -= args[0]
+            accumulator[1] -= 1
+
+    def merge(self, accumulator, accumulators):
+        for acc in accumulators:
+            if acc[0] is not None:
+                if accumulator[0] is None:
+                    accumulator[0] = acc[0]
+                else:
+                    accumulator[0] += acc[0]
+                accumulator[1] += acc[1]

--- a/flink-python/pyflink/table/functions.py
+++ b/flink-python/pyflink/table/functions.py
@@ -780,29 +780,20 @@ class SumWithRetractAggFunction(AggregateFunction):
 
     def create_accumulator(self):
         # [sum, count]
-        return [None, 0]
+        return [0, 0]
 
     def accumulate(self, accumulator, *args):
         if args[0] is not None:
-            if accumulator[0] is None:
-                accumulator[0] = args[0]
-            else:
-                accumulator[0] += args[0]
+            accumulator[0] += args[0]
             accumulator[1] += 1
 
     def retract(self, accumulator, *args):
         if args[0] is not None:
-            if accumulator[0] is None:
-                accumulator[0] = -args[0]
-            else:
-                accumulator[0] -= args[0]
+            accumulator[0] -= args[0]
             accumulator[1] -= 1
 
     def merge(self, accumulator, accumulators):
         for acc in accumulators:
             if acc[0] is not None:
-                if accumulator[0] is None:
-                    accumulator[0] = acc[0]
-                else:
-                    accumulator[0] += acc[0]
+                accumulator[0] += acc[0]
                 accumulator[1] += acc[1]

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/BuiltInPythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/BuiltInPythonAggregateFunction.java
@@ -30,11 +30,25 @@ public enum BuiltInPythonAggregateFunction implements PythonFunction {
 	/*
 	The list of the Python built-in aggregate functions.
 	 */
+	AVG("AvgAggFunction"),
 	COUNT1("Count1AggFunction"),
+	COUNT("CountAggFunction"),
+	FIRST_VALUE("FirstValueAggFunction"),
 	FIRST_VALUE_RETRACT("FirstValueWithRetractAggFunction"),
+	LAST_VALUE("LastValueAggFunction"),
+	LAST_VALUE_RETRACT("LastValueWithRetractAggFunction"),
+	LIST_AGG("ListAggFunction"),
+	LIST_AGG_RETRACT("ListAggWithRetractAggFunction"),
+	LIST_AGG_WS_RETRACT("ListAggWsWithRetractAggFunction"),
+	MAX("MaxAggFunction"),
+	MAX_RETRACT("MaxWithRetractAggFunction"),
+	MIN("MinAggFunction"),
+	MIN_RETRACT("MinWithRetractAggFunction"),
 	INT_SUM0("IntSum0AggFunction"),
 	FLOAT_SUM0("FloatSum0AggFunction"),
-	DECIMAL_SUM0("DecimalSum0AggFunction");
+	DECIMAL_SUM0("DecimalSum0AggFunction"),
+	SUM("SumAggFunction"),
+	SUM_RETRACT("SumWithRetractAggFunction");
 
 	private final byte[] payload;
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonAggregate.scala
@@ -176,10 +176,36 @@ trait CommonPythonAggregate extends CommonPythonBase {
   private def getBuiltInPythonAggregateFunction(
       javaBuiltInAggregateFunction: UserDefinedFunction): BuiltInPythonAggregateFunction = {
     javaBuiltInAggregateFunction match {
+      case _: AvgAggFunction =>
+        BuiltInPythonAggregateFunction.AVG
       case _: Count1AggFunction =>
         BuiltInPythonAggregateFunction.COUNT1
+      case _: CountAggFunction =>
+        BuiltInPythonAggregateFunction.COUNT
+      case _: FirstValueAggFunction[_] =>
+        BuiltInPythonAggregateFunction.FIRST_VALUE
       case _: FirstValueWithRetractAggFunction[_] =>
         BuiltInPythonAggregateFunction.FIRST_VALUE_RETRACT
+      case _: LastValueAggFunction[_] =>
+        BuiltInPythonAggregateFunction.LAST_VALUE
+      case _: LastValueWithRetractAggFunction[_] =>
+        BuiltInPythonAggregateFunction.LAST_VALUE_RETRACT
+      case _: ListAggFunction =>
+        BuiltInPythonAggregateFunction.LIST_AGG
+      case _: ListAggWithRetractAggFunction =>
+        BuiltInPythonAggregateFunction.LIST_AGG_RETRACT
+      case _: ListAggWsWithRetractAggFunction =>
+        BuiltInPythonAggregateFunction.LIST_AGG_WS_RETRACT
+      case _: MaxAggFunction =>
+        BuiltInPythonAggregateFunction.MAX
+      case _: MaxWithRetractAggFunction[_] =>
+        BuiltInPythonAggregateFunction.MAX_RETRACT
+      case _: MinAggFunction =>
+        BuiltInPythonAggregateFunction.MIN
+      case _: MinWithRetractAggFunction[_] =>
+        BuiltInPythonAggregateFunction.MIN_RETRACT
+      case _: SumAggFunction =>
+        BuiltInPythonAggregateFunction.SUM
       case _: IntSum0AggFunction | _: ByteSum0AggFunction | _: ShortSum0AggFunction |
            _: LongSum0AggFunction =>
         BuiltInPythonAggregateFunction.INT_SUM0
@@ -187,6 +213,8 @@ trait CommonPythonAggregate extends CommonPythonBase {
         BuiltInPythonAggregateFunction.FLOAT_SUM0
       case _: DecimalSum0AggFunction =>
         BuiltInPythonAggregateFunction.DECIMAL_SUM0
+      case _: SumWithRetractAggFunction =>
+        BuiltInPythonAggregateFunction.SUM_RETRACT
       case _ =>
         throw new TableException("Aggregate function " + javaBuiltInAggregateFunction +
           " is still not supported to be mixed with Python UDAF.")


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports mixed use with most built-in aggs (min, max, sum, last_value and so on) for Python UDAF.*


## Brief change log

  - *Support mixed use with most built-in aggs (min, max, sum, last_value and so on) for Python UDAF.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
