### PR TITLE
[FLINK-19894][python] Use iloc for positional slicing instead of direct slicing in from_pandas

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1526,7 +1526,7 @@ class TableEnvironment(object):
             result_type,
             pytz.timezone(self.get_config().get_local_timezone()))
         step = -(-len(pdf) // splits_num)
-        pdf_slices = [pdf[start:start + step] for start in range(0, len(pdf), step)]
+        pdf_slices = [pdf.iloc[start:start + step] for start in range(0, len(pdf), step)]
         data = [[c for (_, c) in pdf_slice.iteritems()] for pdf_slice in pdf_slices]
         try:
             with temp_file:

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -82,6 +82,7 @@ class PandasConversionTestBase(object):
         data_dict["f15"] = [row.as_dict() for row in data_dict["f15"]]
         import pandas as pd
         return pd.DataFrame(data=data_dict,
+                            index=[2., 3.],
                             columns=['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9',
                                      'f10', 'f11', 'f12', 'f13', 'f14', 'f15'])
 
@@ -132,15 +133,10 @@ class PandasConversionITTests(PandasConversionTestBase):
                             "1970-01-01 00:00:00.123,[hello, 中文],1,hello,"
                             "1970-01-01 00:00:00.123,[1, 2]"])
 
-    def test_from_pandas_with_float_index(self):
-        import pandas as pd
-        table = self.t_env.from_pandas(pd.DataFrame({'a': [1, 2, 3]}, index=[2., 3., 4.]))
-        result_pdf = table.to_pandas()
-        assert_frame_equal(result_pdf, pd.DataFrame(data={'a': [1, 2, 3]}))
-
     def test_to_pandas(self):
         table = self.t_env.from_pandas(self.pdf, self.data_type)
         result_pdf = table.to_pandas()
+        result_pdf.index = self.pdf.index
         self.assertEqual(2, len(result_pdf))
         assert_frame_equal(self.pdf, result_pdf)
 

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -132,6 +132,12 @@ class PandasConversionITTests(PandasConversionTestBase):
                             "1970-01-01 00:00:00.123,[hello, 中文],1,hello,"
                             "1970-01-01 00:00:00.123,[1, 2]"])
 
+    def test_from_pandas_with_float_index(self):
+        import pandas as pd
+        table = self.t_env.from_pandas(pd.DataFrame({'a': [1, 2, 3]}, index=[2., 3., 4.]))
+        result_pdf = table.to_pandas()
+        assert_frame_equal(result_pdf, pd.DataFrame(data={'a': [1, 2, 3]}))
+
     def test_to_pandas(self):
         table = self.t_env.from_pandas(self.pdf, self.data_type)
         result_pdf = table.to_pandas()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request use iloc for positional slicing instead of direct slicing in `from_pandas`*


## Brief change log

  - *use iloc for positional slicing instead of direct slicing in `from_pandas`*


## Verifying this change


This change added tests and can be verified as follows:

*`test_from_pandas_with_float_index` in `test_pandas_conversion.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
