### PR TITLE
[FLINK-19294][connector-kafka] Support key/value formats in Kafka table source and sinks

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchema.java
@@ -28,7 +28,11 @@ import org.apache.flink.util.Collector;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A specific {@link KafkaSerializationSchema} for {@link KafkaDynamicSource}.
@@ -37,27 +41,44 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
 	private static final long serialVersionUID = 1L;
 
+	private final @Nullable DeserializationSchema<RowData> keyDeserialization;
+
 	private final DeserializationSchema<RowData> valueDeserialization;
 
 	private final boolean hasMetadata;
 
-	private final MetadataAppendingCollector metadataAppendingCollector;
+	private final BufferingCollector keyCollector;
+
+	private final OutputProjectionCollector outputCollector;
 
 	private final TypeInformation<RowData> producedTypeInfo;
 
 	DynamicKafkaDeserializationSchema(
+			int physicalArity,
+			@Nullable DeserializationSchema<RowData> keyDeserialization,
+			int[] keyProjection,
 			DeserializationSchema<RowData> valueDeserialization,
+			int[] valueProjection,
 			boolean hasMetadata,
 			MetadataConverter[] metadataConverters,
 			TypeInformation<RowData> producedTypeInfo) {
-		this.hasMetadata = hasMetadata;
+		this.keyDeserialization = keyDeserialization;
 		this.valueDeserialization = valueDeserialization;
-		this.metadataAppendingCollector = new MetadataAppendingCollector(metadataConverters);
+		this.hasMetadata = hasMetadata;
+		this.keyCollector = new BufferingCollector();
+		this.outputCollector = new OutputProjectionCollector(
+				physicalArity,
+				keyProjection,
+				valueProjection,
+				metadataConverters);
 		this.producedTypeInfo = producedTypeInfo;
 	}
 
 	@Override
 	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		if (keyDeserialization != null) {
+			keyDeserialization.open(context);
+		}
 		valueDeserialization.open(context);
 	}
 
@@ -73,14 +94,24 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
 	@Override
 	public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<RowData> collector) throws Exception {
-		// shortcut if no metadata is required
-		if (!hasMetadata) {
+		// shortcut in case no output projection is required,
+		// also not for a cartesian product with the keys
+		if (keyDeserialization == null && !hasMetadata) {
 			valueDeserialization.deserialize(record.value(), collector);
-		} else {
-			metadataAppendingCollector.inputRecord = record;
-			metadataAppendingCollector.outputCollector = collector;
-			valueDeserialization.deserialize(record.value(), metadataAppendingCollector);
+			return;
 		}
+
+		// buffer key(s)
+		if (keyDeserialization != null) {
+			keyDeserialization.deserialize(record.key(), keyCollector);
+		}
+
+		// project output while emitting values
+		outputCollector.inputRecord = record;
+		outputCollector.physicalKeyRows = keyCollector.buffer;
+		outputCollector.outputCollector = collector;
+		valueDeserialization.deserialize(record.value(), outputCollector);
+		keyCollector.buffer.clear();
 	}
 
 	@Override
@@ -96,44 +127,104 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
 	// --------------------------------------------------------------------------------------------
 
-	private static final class MetadataAppendingCollector implements Collector<RowData>, Serializable {
+	private static final class BufferingCollector implements Collector<RowData>, Serializable {
 
 		private static final long serialVersionUID = 1L;
 
-		private final MetadataConverter[] metadataConverters;
-
-		private transient ConsumerRecord<?, ?> inputRecord;
-
-		private transient Collector<RowData> outputCollector;
-
-		MetadataAppendingCollector(MetadataConverter[] metadataConverters) {
-			this.metadataConverters = metadataConverters;
-		}
+		private final List<RowData> buffer = new ArrayList<>();
 
 		@Override
-		public void collect(RowData physicalRow) {
-			final GenericRowData genericPhysicalRow = (GenericRowData) physicalRow;
-			final int physicalArity = physicalRow.getArity();
-			final int metadataArity = metadataConverters.length;
-
-			final GenericRowData producedRow = new GenericRowData(
-					physicalRow.getRowKind(),
-					physicalArity + metadataArity);
-
-			for (int i = 0; i < physicalArity; i++) {
-				producedRow.setField(i, genericPhysicalRow.getField(i));
-			}
-
-			for (int i = 0; i < metadataArity; i++) {
-				producedRow.setField(i + physicalArity, metadataConverters[i].read(inputRecord));
-			}
-
-			outputCollector.collect(producedRow);
+		public void collect(RowData record) {
+			buffer.add(record);
 		}
 
 		@Override
 		public void close() {
 			// nothing to do
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Emits a row with key, value, and metadata fields.
+	 *
+	 * <p>The collector is able to handle the following kinds of keys:
+	 * <ul>
+	 *     <li>No key is used.
+	 *     <li>A key is used.
+	 *     <li>The deserialization schema emits multiple keys.
+	 *     <li>Keys and values have overlapping fields.
+	 * </ul>
+	 */
+	private static final class OutputProjectionCollector implements Collector<RowData>, Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		private final int physicalArity;
+
+		private final int[] keyProjection;
+
+		private final int[] valueProjection;
+
+		private final MetadataConverter[] metadataConverters;
+
+		private transient ConsumerRecord<?, ?> inputRecord;
+
+		private transient List<RowData> physicalKeyRows;
+
+		private transient Collector<RowData> outputCollector;
+
+		OutputProjectionCollector(
+				int physicalArity,
+				int[] keyProjection,
+				int[] valueProjection,
+				MetadataConverter[] metadataConverters) {
+			this.physicalArity = physicalArity;
+			this.keyProjection = keyProjection;
+			this.valueProjection = valueProjection;
+			this.metadataConverters = metadataConverters;
+		}
+
+		@Override
+		public void collect(RowData physicalValueRow) {
+			// no key defined
+			if (keyProjection.length == 0) {
+				emitRow(null, (GenericRowData) physicalValueRow);
+				return;
+			}
+
+			// otherwise emit a value for each key
+			for (RowData physicalKeyRow : physicalKeyRows) {
+				emitRow((GenericRowData) physicalKeyRow, (GenericRowData) physicalValueRow);
+			}
+		}
+
+		@Override
+		public void close() {
+			// nothing to do
+		}
+
+		private void emitRow(GenericRowData physicalKeyRow, GenericRowData physicalValueRow) {
+			final int metadataArity = metadataConverters.length;
+
+			final GenericRowData producedRow = new GenericRowData(
+					physicalValueRow.getRowKind(),
+					physicalArity + metadataArity);
+
+			for (int keyPos = 0; keyPos < keyProjection.length; keyPos++) {
+				producedRow.setField(keyProjection[keyPos], physicalKeyRow.getField(keyPos));
+			}
+
+			for (int valuePos = 0; valuePos < valueProjection.length; valuePos++) {
+				producedRow.setField(valueProjection[valuePos], physicalValueRow.getField(valuePos));
+			}
+
+			for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
+				producedRow.setField(physicalArity + metadataPos, metadataConverters[metadataPos].read(inputRecord));
+			}
+
+			outputCollector.collect(producedRow);
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaSerializationSchema.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -43,7 +44,13 @@ class DynamicKafkaSerializationSchema
 
 	private final String topic;
 
+	private final @Nullable SerializationSchema<RowData> keySerialization;
+
 	private final SerializationSchema<RowData> valueSerialization;
+
+	private final RowData.FieldGetter[] keyFieldGetters;
+
+	private final RowData.FieldGetter[] valueFieldGetters;
 
 	private final boolean hasMetadata;
 
@@ -52,8 +59,6 @@ class DynamicKafkaSerializationSchema
 	 * -1 if this metadata key is not used.
 	 */
 	private final int[] metadataPositions;
-
-	private final RowData.FieldGetter[] physicalFieldGetters;
 
 	private int[] partitions;
 
@@ -64,20 +69,27 @@ class DynamicKafkaSerializationSchema
 	DynamicKafkaSerializationSchema(
 			String topic,
 			@Nullable FlinkKafkaPartitioner<RowData> partitioner,
+			@Nullable SerializationSchema<RowData> keySerialization,
 			SerializationSchema<RowData> valueSerialization,
+			RowData.FieldGetter[] keyFieldGetters,
+			RowData.FieldGetter[] valueFieldGetters,
 			boolean hasMetadata,
-			int[] metadataPositions,
-			RowData.FieldGetter[] physicalFieldGetters) {
+			int[] metadataPositions) {
 		this.topic = topic;
 		this.partitioner = partitioner;
+		this.keySerialization = keySerialization;
 		this.valueSerialization = valueSerialization;
+		this.keyFieldGetters = keyFieldGetters;
+		this.valueFieldGetters = valueFieldGetters;
 		this.hasMetadata = hasMetadata;
 		this.metadataPositions = metadataPositions;
-		this.physicalFieldGetters = physicalFieldGetters;
 	}
 
 	@Override
 	public void open(SerializationSchema.InitializationContext context) throws Exception {
+		if (keySerialization != null) {
+			keySerialization.open(context);
+		}
 		valueSerialization.open(context);
 		if (partitioner != null) {
 			partitioner.open(parallelInstanceId, numParallelInstances);
@@ -86,39 +98,32 @@ class DynamicKafkaSerializationSchema
 
 	@Override
 	public ProducerRecord<byte[], byte[]> serialize(RowData consumedRow, @Nullable Long timestamp) {
-		final RowData physicalRow;
-		// shortcut if no metadata is required
-		if (!hasMetadata) {
-			physicalRow = consumedRow;
+		// shortcut in case no input projection is required
+		if (keySerialization == null && !hasMetadata) {
+			final byte[] valueSerialized = valueSerialization.serialize(consumedRow);
+			return new ProducerRecord<>(
+					topic,
+					extractPartition(consumedRow, null, valueSerialized),
+					null,
+					valueSerialized);
+		}
+
+		final byte[] keySerialized;
+		if (keySerialization == null) {
+			keySerialized = null;
 		} else {
-			final int physicalArity = physicalFieldGetters.length;
-			final GenericRowData genericRowData = new GenericRowData(
-					consumedRow.getRowKind(),
-					physicalArity);
-			for (int i = 0; i < physicalArity; i++) {
-				genericRowData.setField(i, physicalFieldGetters[i].getFieldOrNull(consumedRow));
-			}
-			physicalRow = genericRowData;
+			final RowData keyRow = createProjectedRow(consumedRow, RowKind.INSERT, keyFieldGetters);
+			keySerialized = keySerialization.serialize(keyRow);
 		}
 
-		final byte[] valueSerialized = valueSerialization.serialize(physicalRow);
+		final RowData valueRow = createProjectedRow(consumedRow, consumedRow.getRowKind(), valueFieldGetters);
+		final byte[] valueSerialized = valueSerialization.serialize(valueRow);
 
-		final Integer partition;
-		if (partitioner != null) {
-			partition = partitioner.partition(physicalRow, null, valueSerialized, topic, partitions);
-		} else {
-			partition = null;
-		}
-
-		// shortcut if no metadata is required
-		if (!hasMetadata) {
-			return new ProducerRecord<>(topic, partition, null, null, valueSerialized);
-		}
 		return new ProducerRecord<>(
 				topic,
-				partition,
+				extractPartition(consumedRow, keySerialized, valueSerialized),
 				readMetadata(consumedRow, KafkaDynamicSink.WritableMetadata.TIMESTAMP),
-				null,
+				keySerialized,
 				valueSerialized,
 				readMetadata(consumedRow, KafkaDynamicSink.WritableMetadata.HEADERS));
 	}
@@ -150,6 +155,22 @@ class DynamicKafkaSerializationSchema
 			return null;
 		}
 		return (T) metadata.converter.read(consumedRow, pos);
+	}
+
+	private Integer extractPartition(RowData consumedRow, @Nullable byte[] keySerialized, byte[] valueSerialized) {
+		if (partitioner != null) {
+			return partitioner.partition(consumedRow, keySerialized, valueSerialized, topic, partitions);
+		}
+		return null;
+	}
+
+	private static RowData createProjectedRow(RowData consumedRow, RowKind kind, RowData.FieldGetter[] fieldGetters) {
+		final int arity = fieldGetters.length;
+		final GenericRowData genericRowData = new GenericRowData(kind, arity);
+		for (int fieldPos = 0; fieldPos < arity; fieldPos++) {
+			genericRowData.setField(fieldPos, fieldGetters[fieldPos].getFieldOrNull(consumedRow));
+		}
+		return genericRowData;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -140,7 +140,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 				createSerialization(context, keyEncodingFormat, keyProjection, keyPrefix);
 
 		final SerializationSchema<RowData> valueSerialization =
-				createSerialization(context, valueEncodingFormat, valueProjection, keyPrefix);
+				createSerialization(context, valueEncodingFormat, valueProjection, null);
 
 		final FlinkKafkaProducer<RowData> kafkaProducer =
 				createKafkaProducer(keySerialization, valueSerialization);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -34,19 +34,21 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.common.header.Header;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -66,11 +68,23 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	// Format attributes
 	// --------------------------------------------------------------------------------------------
 
-	/** Sink format for encoding records to Kafka. */
-	protected final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
-
-	/** Data type to configure the format. */
+	/** Data type to configure the formats. */
 	protected final DataType physicalDataType;
+
+	/** Optional format for encoding keys to Kafka. */
+	protected final @Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat;
+
+	/** Format for encoding values to Kafka. */
+	protected final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat;
+
+	/** Indices that determine the key fields and the source position in the consumed row. */
+	protected final int[] keyProjection;
+
+	/** Indices that determine the value fields and the source position in the consumed row. */
+	protected final int[] valueProjection;
+
+	/** Prefix that needs to be removed from fields when constructing the physical data type. */
+	protected final @Nullable String keyPrefix;
 
 	// --------------------------------------------------------------------------------------------
 	// Kafka-specific attributes
@@ -83,38 +97,53 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	protected final Properties properties;
 
 	/** Partitioner to select Kafka partition for each item. */
-	protected final Optional<FlinkKafkaPartitioner<RowData>> partitioner;
+	protected final @Nullable FlinkKafkaPartitioner<RowData> partitioner;
 
 	/** Sink commit semantic.*/
 	protected final KafkaSinkSemantic semantic;
 
 	public KafkaDynamicSink(
 			DataType physicalDataType,
+			@Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
+			EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			String topic,
 			Properties properties,
-			Optional<FlinkKafkaPartitioner<RowData>> partitioner,
-			EncodingFormat<SerializationSchema<RowData>> encodingFormat,
+			@Nullable FlinkKafkaPartitioner<RowData> partitioner,
 			KafkaSinkSemantic semantic) {
+		// Format attributes
 		this.physicalDataType = Preconditions.checkNotNull(physicalDataType, "Physical data type must not be null.");
+		this.keyEncodingFormat = keyEncodingFormat;
+		this.valueEncodingFormat = Preconditions.checkNotNull(valueEncodingFormat, "Value encoding format must not be null.");
+		this.keyProjection = Preconditions.checkNotNull(keyProjection, "Key projection must not be null.");
+		this.valueProjection = Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
+		this.keyPrefix = keyPrefix;
+		// Mutable attributes
 		this.metadataKeys = Collections.emptyList();
+		// Kafka-specific attributes
 		this.topic = Preconditions.checkNotNull(topic, "Topic must not be null.");
 		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
-		this.partitioner = Preconditions.checkNotNull(partitioner, "Partitioner must not be null.");
-		this.encodingFormat = Preconditions.checkNotNull(encodingFormat, "Encoding format must not be null.");
+		this.partitioner = partitioner;
 		this.semantic = Preconditions.checkNotNull(semantic, "Semantic must not be null.");
 	}
 
 	@Override
 	public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-		return this.encodingFormat.getChangelogMode();
+		return valueEncodingFormat.getChangelogMode();
 	}
 
 	@Override
 	public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
-		final SerializationSchema<RowData> valueSerialization =
-				this.encodingFormat.createRuntimeEncoder(context, this.physicalDataType);
+		final SerializationSchema<RowData> keySerialization =
+				createSerialization(context, keyEncodingFormat, keyProjection, keyPrefix);
 
-		final FlinkKafkaProducer<RowData> kafkaProducer = createKafkaProducer(valueSerialization);
+		final SerializationSchema<RowData> valueSerialization =
+				createSerialization(context, valueEncodingFormat, valueProjection, keyPrefix);
+
+		final FlinkKafkaProducer<RowData> kafkaProducer =
+				createKafkaProducer(keySerialization, valueSerialization);
 
 		return SinkFunctionProvider.of(kafkaProducer);
 	}
@@ -134,12 +163,16 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	@Override
 	public DynamicTableSink copy() {
 		final KafkaDynamicSink copy = new KafkaDynamicSink(
-				this.physicalDataType,
-				this.topic,
-				this.properties,
-				this.partitioner,
-				this.encodingFormat,
-				this.semantic);
+				physicalDataType,
+				keyEncodingFormat,
+				valueEncodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
+				topic,
+				properties,
+				partitioner,
+				semantic);
 		copy.metadataKeys = metadataKeys;
 		return copy;
 	}
@@ -160,9 +193,13 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 		final KafkaDynamicSink that = (KafkaDynamicSink) o;
 		return Objects.equals(metadataKeys, that.metadataKeys) &&
 			Objects.equals(physicalDataType, that.physicalDataType) &&
+			Objects.equals(keyEncodingFormat, that.keyEncodingFormat) &&
+			Objects.equals(valueEncodingFormat, that.valueEncodingFormat) &&
+			Arrays.equals(keyProjection, that.keyProjection) &&
+			Arrays.equals(valueProjection, that.valueProjection) &&
+			Objects.equals(keyPrefix, that.keyPrefix) &&
 			Objects.equals(topic, that.topic) &&
 			Objects.equals(properties, that.properties) &&
-			Objects.equals(encodingFormat, that.encodingFormat) &&
 			Objects.equals(partitioner, that.partitioner) &&
 			Objects.equals(semantic, that.semantic);
 	}
@@ -172,20 +209,30 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 		return Objects.hash(
 			metadataKeys,
 			physicalDataType,
+			keyEncodingFormat,
+			valueEncodingFormat,
+			keyProjection,
+			valueProjection,
+			keyPrefix,
 			topic,
 			properties,
-			encodingFormat,
 			partitioner,
 			semantic);
 	}
 
 	// --------------------------------------------------------------------------------------------
 
-	protected FlinkKafkaProducer<RowData> createKafkaProducer(SerializationSchema<RowData> valueSerialization) {
+	protected FlinkKafkaProducer<RowData> createKafkaProducer(
+			SerializationSchema<RowData> keySerialization,
+			SerializationSchema<RowData> valueSerialization) {
 		final List<LogicalType> physicalChildren = physicalDataType.getLogicalType().getChildren();
 
-		final RowData.FieldGetter[] physicalFieldGetters = IntStream.range(0, physicalChildren.size())
-				.mapToObj(pos -> RowData.createFieldGetter(physicalChildren.get(pos), pos))
+		final RowData.FieldGetter[] keyFieldGetters = Arrays.stream(keyProjection)
+				.mapToObj(targetField -> RowData.createFieldGetter(physicalChildren.get(targetField), targetField))
+				.toArray(RowData.FieldGetter[]::new);
+
+		final RowData.FieldGetter[] valueFieldGetters = Arrays.stream(valueProjection)
+				.mapToObj(targetField -> RowData.createFieldGetter(physicalChildren.get(targetField), targetField))
 				.toArray(RowData.FieldGetter[]::new);
 
 		// determine the positions of metadata in the consumed row
@@ -199,13 +246,18 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 				})
 				.toArray();
 
+		// check if metadata is used at all
+		final boolean hasMetadata = metadataKeys.size() > 0;
+
 		final DynamicKafkaSerializationSchema kafkaSerializer = new DynamicKafkaSerializationSchema(
 				topic,
-				partitioner.orElse(null),
+				partitioner,
+				keySerialization,
 				valueSerialization,
-				metadataKeys.size() > 0,
-				metadataPositions,
-				physicalFieldGetters);
+				keyFieldGetters,
+				valueFieldGetters,
+				hasMetadata,
+				metadataPositions);
 
 		return new FlinkKafkaProducer<>(
 			topic,
@@ -213,6 +265,21 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 			properties,
 			FlinkKafkaProducer.Semantic.valueOf(semantic.toString()),
 			FlinkKafkaProducer.DEFAULT_KAFKA_PRODUCERS_POOL_SIZE);
+	}
+
+	private @Nullable SerializationSchema<RowData> createSerialization(
+			DynamicTableSink.Context context,
+			@Nullable EncodingFormat<SerializationSchema<RowData>> format,
+			int[] projection,
+			@Nullable String prefix) {
+		if (format == null) {
+			return null;
+		}
+		DataType physicalFormatDataType = DataTypeUtils.projectRow(this.physicalDataType, projection);
+		if (prefix != null) {
+			physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+		}
+		return format.createRuntimeEncoder(context, physicalFormatDataType);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -165,7 +165,7 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 				createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
 
 		final DeserializationSchema<RowData> valueDeserialization =
-				createDeserialization(context, valueDecodingFormat, valueProjection, keyPrefix);
+				createDeserialization(context, valueDecodingFormat, valueProjection, null);
 
 		final TypeInformation<RowData> producedTypeInfo =
 				context.createTypeInformation(producedDataType);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -45,6 +46,7 @@ import org.apache.kafka.common.header.Header;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -75,11 +77,23 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 	// Format attributes
 	// --------------------------------------------------------------------------------------------
 
-	/** Scan format for decoding records from Kafka. */
-	protected final DecodingFormat<DeserializationSchema<RowData>> decodingFormat;
-
-	/** Data type to configure the format. */
+	/** Data type to configure the formats. */
 	protected final DataType physicalDataType;
+
+	/** Optional format for decoding keys from Kafka. */
+	protected final @Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat;
+
+	/** Format for decoding values from Kafka. */
+	protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
+
+	/** Indices that determine the key fields and the target position in the produced row. */
+	protected final int[] keyProjection;
+
+	/** Indices that determine the value fields and the target position in the produced row. */
+	protected final int[] valueProjection;
+
+	/** Prefix that needs to be removed from fields when constructing the physical data type. */
+	protected final @Nullable String keyPrefix;
 
 	// --------------------------------------------------------------------------------------------
 	// Kafka-specific attributes
@@ -105,24 +119,35 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 
 	public KafkaDynamicSource(
 			DataType physicalDataType,
+			@Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+			DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			@Nullable List<String> topics,
 			@Nullable Pattern topicPattern,
 			Properties properties,
-			DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets,
 			long startupTimestampMillis) {
+		// Format attributes
 		this.physicalDataType = Preconditions.checkNotNull(physicalDataType, "Physical data type must not be null.");
+		this.keyDecodingFormat = keyDecodingFormat;
+		this.valueDecodingFormat = Preconditions.checkNotNull(
+				valueDecodingFormat, "Value decoding format must not be null.");
+		this.keyProjection = Preconditions.checkNotNull(keyProjection, "Key projection must not be null.");
+		this.valueProjection = Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
+		this.keyPrefix = keyPrefix;
+		// Mutable attributes
 		this.producedDataType = physicalDataType;
 		this.metadataKeys = Collections.emptyList();
+		// Kafka-specific attributes
 		Preconditions.checkArgument((topics != null && topicPattern == null) ||
 				(topics == null && topicPattern != null),
 			"Either Topic or Topic Pattern must be set for source.");
 		this.topics = topics;
 		this.topicPattern = topicPattern;
 		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
-		this.decodingFormat = Preconditions.checkNotNull(
-			decodingFormat, "Decoding format must not be null.");
 		this.startupMode = Preconditions.checkNotNull(startupMode, "Startup mode must not be null.");
 		this.specificStartupOffsets = Preconditions.checkNotNull(
 			specificStartupOffsets, "Specific offsets must not be null.");
@@ -131,18 +156,22 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 
 	@Override
 	public ChangelogMode getChangelogMode() {
-		return this.decodingFormat.getChangelogMode();
+		return valueDecodingFormat.getChangelogMode();
 	}
 
 	@Override
-	public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+	public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
+		final DeserializationSchema<RowData> keyDeserialization =
+				createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+
 		final DeserializationSchema<RowData> valueDeserialization =
-				decodingFormat.createRuntimeDecoder(runtimeProviderContext, physicalDataType);
+				createDeserialization(context, valueDecodingFormat, valueProjection, keyPrefix);
 
 		final TypeInformation<RowData> producedTypeInfo =
-				runtimeProviderContext.createTypeInformation(producedDataType);
+				context.createTypeInformation(producedDataType);
 
-		final FlinkKafkaConsumer<RowData> kafkaConsumer = createKafkaConsumer(valueDeserialization, producedTypeInfo);
+		final FlinkKafkaConsumer<RowData> kafkaConsumer =
+				createKafkaConsumer(keyDeserialization, valueDeserialization, producedTypeInfo);
 
 		return SourceFunctionProvider.of(kafkaConsumer, false);
 	}
@@ -163,14 +192,18 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 	@Override
 	public DynamicTableSource copy() {
 		final KafkaDynamicSource copy = new KafkaDynamicSource(
-				this.physicalDataType,
-				this.topics,
-				this.topicPattern,
-				this.properties,
-				this.decodingFormat,
-				this.startupMode,
-				this.specificStartupOffsets,
-				this.startupTimestampMillis);
+				physicalDataType,
+				keyDecodingFormat,
+				valueDecodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
+				topics,
+				topicPattern,
+				properties,
+				startupMode,
+				specificStartupOffsets,
+				startupTimestampMillis);
 		copy.producedDataType = producedDataType;
 		copy.metadataKeys = metadataKeys;
 		return copy;
@@ -193,10 +226,14 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 		return Objects.equals(producedDataType, that.producedDataType) &&
 			Objects.equals(metadataKeys, that.metadataKeys) &&
 			Objects.equals(physicalDataType, that.physicalDataType) &&
+			Objects.equals(keyDecodingFormat, that.keyDecodingFormat) &&
+			Objects.equals(valueDecodingFormat, that.valueDecodingFormat) &&
+			Arrays.equals(keyProjection, that.keyProjection) &&
+			Arrays.equals(valueProjection, that.valueProjection) &&
+			Objects.equals(keyPrefix, that.keyPrefix) &&
 			Objects.equals(topics, that.topics) &&
 			Objects.equals(String.valueOf(topicPattern), String.valueOf(that.topicPattern)) &&
 			Objects.equals(properties, that.properties) &&
-			Objects.equals(decodingFormat, that.decodingFormat) &&
 			startupMode == that.startupMode &&
 			Objects.equals(specificStartupOffsets, that.specificStartupOffsets) &&
 			startupTimestampMillis == that.startupTimestampMillis;
@@ -208,10 +245,14 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 			producedDataType,
 			metadataKeys,
 			physicalDataType,
+			keyDecodingFormat,
+			valueDecodingFormat,
+			keyProjection,
+			valueProjection,
+			keyPrefix,
 			topics,
 			topicPattern,
 			properties,
-			decodingFormat,
 			startupMode,
 			specificStartupOffsets,
 			startupTimestampMillis);
@@ -220,6 +261,7 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 	// --------------------------------------------------------------------------------------------
 
 	protected FlinkKafkaConsumer<RowData> createKafkaConsumer(
+			DeserializationSchema<RowData> keyDeserialization,
 			DeserializationSchema<RowData> valueDeserialization,
 			TypeInformation<RowData> producedTypeInfo) {
 
@@ -232,9 +274,16 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 				.map(m -> m.converter)
 				.toArray(MetadataConverter[]::new);
 
+		// check if metadata is used at all
+		final boolean hasMetadata = metadataKeys.size() > 0;
+
 		final KafkaDeserializationSchema<RowData> kafkaDeserializer = new DynamicKafkaDeserializationSchema(
+				physicalDataType.getChildren().size(),
+				keyDeserialization,
+				keyProjection,
 				valueDeserialization,
-				metadataKeys.size() > 0,
+				valueProjection,
+				hasMetadata,
 				metadataConverters,
 				producedTypeInfo);
 
@@ -266,6 +315,21 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 		kafkaConsumer.setCommitOffsetsOnCheckpoints(properties.getProperty("group.id") != null);
 
 		return kafkaConsumer;
+	}
+
+	private @Nullable DeserializationSchema<RowData> createDeserialization(
+			DynamicTableSource.Context context,
+			@Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+			int[] projection,
+			@Nullable String prefix) {
+		if (format == null) {
+			return null;
+		}
+		DataType physicalFormatDataType = DataTypeUtils.projectRow(this.physicalDataType, projection);
+		if (prefix != null) {
+			physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+		}
+		return format.createRuntimeDecoder(context, physicalFormatDataType);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumerBase;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -36,8 +37,10 @@ import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
 import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
 
 import javax.annotation.Nullable;
 
@@ -85,7 +88,6 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 	@Override
 	public Set<ConfigOption<?>> requiredOptions() {
 		final Set<ConfigOption<?>> options = new HashSet<>();
-		options.add(FactoryUtil.FORMAT);
 		options.add(PROPS_BOOTSTRAP_SERVERS);
 		return options;
 	}
@@ -93,6 +95,12 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 	@Override
 	public Set<ConfigOption<?>> optionalOptions() {
 		final Set<ConfigOption<?>> options = new HashSet<>();
+		options.add(FactoryUtil.FORMAT);
+		options.add(FactoryUtil.KEY_FORMAT);
+		options.add(FactoryUtil.KEY_FIELDS);
+		options.add(FactoryUtil.KEY_FIELDS_PREFIX);
+		options.add(FactoryUtil.VALUE_FORMAT);
+		options.add(FactoryUtil.VALUE_FIELDS_INCLUDE);
 		options.add(TOPIC);
 		options.add(TOPIC_PATTERN);
 		options.add(PROPS_GROUP_ID);
@@ -107,19 +115,24 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
 	@Override
 	public DynamicTableSource createDynamicTableSource(Context context) {
-		FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+		final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-		ReadableConfig tableOptions = helper.getOptions();
-		DecodingFormat<DeserializationSchema<RowData>> decodingFormat = helper.discoverDecodingFormat(
-				DeserializationFormatFactory.class,
-				FactoryUtil.FORMAT);
-		// Validate the option data type.
+		final ReadableConfig tableOptions = helper.getOptions();
+
+		final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+				getKeyDecodingFormat(helper);
+
+		final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+				getValueDecodingFormat(helper, keyDecodingFormat.isPresent());
+
 		helper.validateExcept(PROPERTIES_PREFIX);
-		// Validate the option values.
+
 		validateTableSourceOptions(tableOptions);
 
 		final StartupOptions startupOptions = getStartupOptions(tableOptions);
+
 		final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
+
 		// add topic-partition discovery
 		properties.setProperty(FlinkKafkaConsumerBase.KEY_PARTITION_DISCOVERY_INTERVAL_MILLIS,
 			String.valueOf(tableOptions
@@ -129,12 +142,22 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
 		final DataType physicalDataType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
 
+		final int[] keyProjection = FactoryUtil.createKeyFormatProjection(tableOptions, physicalDataType);
+
+		final int[] valueProjection = FactoryUtil.createValueFormatProjection(tableOptions, physicalDataType);
+
+		final String keyPrefix = tableOptions.getOptional(FactoryUtil.KEY_FIELDS_PREFIX).orElse(null);
+
 		return createKafkaTableSource(
 			physicalDataType,
+			keyDecodingFormat.orElse(null),
+			valueDecodingFormat,
+			keyProjection,
+			valueProjection,
+			keyPrefix,
 			KafkaOptions.getSourceTopics(tableOptions),
 			KafkaOptions.getSourceTopicPattern(tableOptions),
 			properties,
-			decodingFormat,
 			startupOptions.startupMode,
 			startupOptions.specificOffsets,
 			startupOptions.startupTimestampMillis);
@@ -142,47 +165,134 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
 	@Override
 	public DynamicTableSink createDynamicTableSink(Context context) {
-		FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+		final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
 
-		ReadableConfig tableOptions = helper.getOptions();
+		final ReadableConfig tableOptions = helper.getOptions();
 
-		EncodingFormat<SerializationSchema<RowData>> encodingFormat = helper.discoverEncodingFormat(
-				SerializationFormatFactory.class,
-				FactoryUtil.FORMAT);
+		final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+				getKeyEncodingFormat(helper);
 
-		// Validate the option values.
-		validateTableSinkOptions(tableOptions);
-		// Validate the option data type.
+		final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+				getValueEncodingFormat(helper, keyEncodingFormat.isPresent());
+
 		helper.validateExcept(PROPERTIES_PREFIX);
+
+		validateTableSinkOptions(tableOptions);
 
 		final DataType physicalDataType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
 
+		final int[] keyProjection = FactoryUtil.createKeyFormatProjection(tableOptions, physicalDataType);
+
+		final int[] valueProjection = FactoryUtil.createValueFormatProjection(tableOptions, physicalDataType);
+
+		final String keyPrefix = tableOptions.getOptional(FactoryUtil.KEY_FIELDS_PREFIX).orElse(null);
+
 		return createKafkaTableSink(
 				physicalDataType,
+				keyEncodingFormat.orElse(null),
+				valueEncodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
 				tableOptions.get(TOPIC).get(0),
 				getKafkaProperties(context.getCatalogTable().getOptions()),
-				getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()),
-				encodingFormat,
+				getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
 				getSinkSemantic(tableOptions));
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+			TableFactoryHelper helper) {
+		final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+				helper.discoverOptionalDecodingFormat(
+						DeserializationFormatFactory.class,
+						FactoryUtil.KEY_FORMAT);
+		keyDecodingFormat.ifPresent(format -> {
+			if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+				throw new ValidationException(
+						String.format(
+								"A key format should only deal with INSERT-only records. "
+										+ "But %s has a changelog mode of %s.",
+								helper.getOptions().get(FactoryUtil.KEY_FORMAT),
+								format.getChangelogMode()));
+			}
+		});
+		return keyDecodingFormat;
+	}
+
+	private static Optional<EncodingFormat<SerializationSchema<RowData>>> getKeyEncodingFormat(
+			TableFactoryHelper helper) {
+		final Optional<EncodingFormat<SerializationSchema<RowData>>> keyEncodingFormat =
+				helper.discoverOptionalEncodingFormat(
+						SerializationFormatFactory.class,
+						FactoryUtil.KEY_FORMAT);
+		keyEncodingFormat.ifPresent(format -> {
+			if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+				throw new ValidationException(
+						String.format(
+								"A key format should only deal with INSERT-only records. "
+										+ "But %s has a changelog mode of %s.",
+								helper.getOptions().get(FactoryUtil.KEY_FORMAT),
+								format.getChangelogMode()));
+			}
+		});
+		return keyEncodingFormat;
+	}
+
+	private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+			TableFactoryHelper helper,
+			boolean hasKeyFormat) {
+		final ConfigOption<String> valueFormatOption;
+		if (hasKeyFormat) {
+			valueFormatOption = FactoryUtil.VALUE_FORMAT;
+		} else {
+			valueFormatOption = FactoryUtil.FORMAT;
+		}
+		return helper.discoverDecodingFormat(
+				DeserializationFormatFactory.class,
+				valueFormatOption);
+	}
+
+	private static EncodingFormat<SerializationSchema<RowData>> getValueEncodingFormat(
+			TableFactoryHelper helper,
+			boolean hasKeyFormat) {
+		final ConfigOption<String> valueFormatOption;
+		if (hasKeyFormat) {
+			valueFormatOption = FactoryUtil.VALUE_FORMAT;
+		} else {
+			valueFormatOption = FactoryUtil.FORMAT;
+		}
+		return helper.discoverEncodingFormat(
+				SerializationFormatFactory.class,
+				valueFormatOption);
 	}
 
 	// --------------------------------------------------------------------------------------------
 
 	protected KafkaDynamicSource createKafkaTableSource(
 			DataType physicalDataType,
+			@Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+			DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			@Nullable List<String> topics,
 			@Nullable Pattern topicPattern,
 			Properties properties,
-			DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets,
 			long startupTimestampMillis) {
 		return new KafkaDynamicSource(
 				physicalDataType,
+				keyDecodingFormat,
+				valueDecodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
 				topics,
 				topicPattern,
 				properties,
-				decodingFormat,
 				startupMode,
 				specificStartupOffsets,
 				startupTimestampMillis);
@@ -190,17 +300,25 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
 	protected KafkaDynamicSink createKafkaTableSink(
 			DataType physicalDataType,
+			@Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
+			EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			String topic,
 			Properties properties,
-			Optional<FlinkKafkaPartitioner<RowData>> partitioner,
-			EncodingFormat<SerializationSchema<RowData>> encodingFormat,
+			FlinkKafkaPartitioner<RowData> partitioner,
 			KafkaSinkSemantic semantic) {
 		return new KafkaDynamicSink(
 				physicalDataType,
+				keyEncodingFormat,
+				valueEncodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
 				topic,
 				properties,
 				partitioner,
-				encodingFormat,
 				semantic);
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -28,8 +28,13 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartiti
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -41,14 +46,67 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaSinkSemantic.AT_LEAST_ONCE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaSinkSemantic.EXACTLY_ONCE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaSinkSemantic.NONE;
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT_SUFFIX;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /** Option utils for Kafka table source sink. */
 public class KafkaOptions {
 	private KafkaOptions() {}
+
+	// --------------------------------------------------------------------------------------------
+	// Format options
+	// --------------------------------------------------------------------------------------------
+
+	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
+			.key("key" + FORMAT_SUFFIX)
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Defines the format identifier for encoding key data. "
+				+ "The identifier is used to discover a suitable format factory.");
+
+	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
+			.key("value" + FORMAT_SUFFIX)
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Defines the format identifier for encoding value data. "
+				+ "The identifier is used to discover a suitable format factory.");
+
+	public static final ConfigOption<List<String>> KEY_FIELDS = ConfigOptions
+			.key("key.fields")
+			.stringType()
+			.asList()
+			.defaultValues()
+			.withDescription("Defines an explicit list of physical columns from the table schema "
+				+ "that configure the data type for the key format. By default, this list is "
+				+ "empty and thus a key is undefined.");
+
+	public static final ConfigOption<ValueFieldsStrategy> VALUE_FIELDS_INCLUDE = ConfigOptions
+			.key("value.fields-include")
+			.enumType(ValueFieldsStrategy.class)
+			.defaultValue(ValueFieldsStrategy.ALL)
+			.withDescription("Defines a strategy how to deal with key columns in the data type of "
+				+ "the value format. By default, '" + ValueFieldsStrategy.ALL + "' physical "
+				+ "columns of the table schema will be included in the value format which "
+				+ "means that key columns appear in the data type for both the key and value "
+				+ "format.");
+
+	public static final ConfigOption<String> KEY_FIELDS_PREFIX = ConfigOptions
+			.key("key.fields-prefix")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Defines a custom prefix for all fields of the key format to avoid "
+				+ "name clashes with fields of the value format. By default, the prefix is empty. "
+				+ "If a custom prefix is defined, both the table schema and "
+				+ "'" + KEY_FIELDS.key() + "' will work with prefixed names. When constructing "
+				+ "the data type of the key format, the prefix will be removed and the "
+				+ "non-prefixed names will be used within the key format. Please note that this "
+				+ "option requires that '" + VALUE_FIELDS_INCLUDE.key() + "' must be '"
+				+ ValueFieldsStrategy.EXCEPT_KEY + "'.");
 
 	// --------------------------------------------------------------------------------------------
 	// Kafka specific options
@@ -469,6 +527,124 @@ public class KafkaOptions {
 		}
 	}
 
+
+
+	/**
+	 * Creates an array of indices that determine which physical fields of the table schema to include
+	 * in the key format and the order that those fields have in the key format.
+	 *
+	 * <p>See {@link #KEY_FORMAT}, {@link #KEY_FIELDS}, and {@link #KEY_FIELDS_PREFIX} for more information.
+	 */
+	public static int[] createKeyFormatProjection(ReadableConfig options, DataType physicalDataType) {
+		final LogicalType physicalType = physicalDataType.getLogicalType();
+		Preconditions.checkArgument(
+			hasRoot(physicalType, LogicalTypeRoot.ROW),
+			"Row data type expected.");
+		final Optional<String> optionalKeyFormat = options.getOptional(KEY_FORMAT);
+		final Optional<List<String>> optionalKeyFields = options.getOptional(KEY_FIELDS);
+
+		if (!optionalKeyFormat.isPresent() && optionalKeyFields.isPresent()) {
+			throw new ValidationException(
+					String.format(
+							"The option '%s' can only be declared if a key format is defined using '%s'.",
+							KEY_FIELDS.key(),
+							KEY_FORMAT.key()
+					)
+			);
+		} else if (optionalKeyFormat.isPresent() &&
+				(!optionalKeyFields.isPresent() || optionalKeyFields.get().size() == 0)) {
+			throw new ValidationException(
+					String.format(
+							"A key format '%s' requires the declaration of one or more of key fields using '%s'.",
+							KEY_FORMAT.key(),
+							KEY_FIELDS.key()
+					)
+			);
+		}
+
+		if (!optionalKeyFormat.isPresent()) {
+			return new int[0];
+		}
+
+		final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+		final List<String> keyFields = optionalKeyFields.get();
+		final List<String> physicalFields = LogicalTypeChecks.getFieldNames(physicalType);
+		return keyFields.stream()
+				.mapToInt(keyField -> {
+					final int pos = physicalFields.indexOf(keyField);
+					// check that field name exists
+					if (pos < 0) {
+						throw new ValidationException(
+								String.format(
+										"Could not find the field '%s' in the table schema for usage in the key format. "
+												+ "A key field must be a regular, physical column. "
+												+ "The following columns can be selected in the '%s' option:\n"
+												+ "%s",
+										keyField,
+										KEY_FIELDS.key(),
+										physicalFields
+								)
+						);
+					}
+					// check that field name is prefixed correctly
+					if (!keyField.startsWith(keyPrefix)) {
+						throw new ValidationException(
+								String.format(
+										"All fields in '%s' must be prefixed with '%s' when option '%s' "
+											+ "is set but field '%s' is not prefixed.",
+										KEY_FIELDS.key(),
+										keyPrefix,
+										KEY_FIELDS_PREFIX.key(),
+										keyField
+								)
+						);
+					}
+					return pos;
+				})
+			.toArray();
+	}
+
+	/**
+	 * Creates an array of indices that determine which physical fields of the table schema to include
+	 * in the value format.
+	 *
+	 * <p>See {@link #VALUE_FORMAT}, {@link #VALUE_FIELDS_INCLUDE}, and {@link #KEY_FIELDS_PREFIX} for
+	 * more information.
+	 */
+	public static int[] createValueFormatProjection(ReadableConfig options, DataType physicalDataType) {
+		final LogicalType physicalType = physicalDataType.getLogicalType();
+		Preconditions.checkArgument(
+			hasRoot(physicalType, LogicalTypeRoot.ROW),
+			"Row data type expected.");
+		final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
+		final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
+
+		final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+		final ValueFieldsStrategy strategy = options.get(VALUE_FIELDS_INCLUDE);
+		if (strategy == ValueFieldsStrategy.ALL) {
+			if (keyPrefix.length() > 0) {
+				throw new ValidationException(
+						String.format(
+								"A key prefix is not allowed when option '%s' is set to '%s'. "
+									+ "Set it to '%s' instead to avoid field overlaps.",
+								VALUE_FIELDS_INCLUDE.key(),
+								ValueFieldsStrategy.ALL,
+								ValueFieldsStrategy.EXCEPT_KEY
+						)
+				);
+			}
+			return physicalFields.toArray();
+		} else if (strategy == ValueFieldsStrategy.EXCEPT_KEY) {
+			final int[] keyProjection = createKeyFormatProjection(options, physicalDataType);
+			return physicalFields
+					.filter(pos -> IntStream.of(keyProjection).noneMatch(k -> k == pos))
+					.toArray();
+		}
+		throw new TableException("Unknown value fields strategy:" + strategy);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Inner classes
 	// --------------------------------------------------------------------------------------------
@@ -478,5 +654,12 @@ public class KafkaOptions {
 		public StartupMode startupMode;
 		public Map<KafkaTopicPartition, Long> specificOffsets;
 		public long startupTimestampMillis;
+	}
+
+	/**
+	 * Strategies to derive the data type of a value format by considering a key format.
+	 */
+	public enum ValueFieldsStrategy {
+		ALL, EXCEPT_KEY
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -245,14 +245,14 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
 		final DecodingFormatMock keyDecodingFormat = new DecodingFormatMock("#", false);
 		keyDecodingFormat.producedDataType = DataTypes.ROW(
-				DataTypes.FIELD(NAME, DataTypes.STRING())
-		);
+				DataTypes.FIELD(NAME, DataTypes.STRING()))
+			.notNull();
 
 		final DecodingFormatMock valueDecodingFormat = new DecodingFormatMock("|", false);
 		valueDecodingFormat.producedDataType = DataTypes.ROW(
 				DataTypes.FIELD(COUNT, DataTypes.DECIMAL(38, 18)),
-				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3))
-		);
+				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3)))
+			.notNull();
 
 		final KafkaDynamicSource expectedKafkaSource = createExpectedScanSource(
 				SCHEMA_DATA_TYPE,
@@ -311,14 +311,14 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
 		final EncodingFormatMock keyEncodingFormat = new EncodingFormatMock("#");
 		keyEncodingFormat.consumedDataType = DataTypes.ROW(
-				DataTypes.FIELD(NAME, DataTypes.STRING())
-		);
+				DataTypes.FIELD(NAME, DataTypes.STRING()))
+			.notNull();
 
 		final EncodingFormatMock valueEncodingFormat = new EncodingFormatMock("|");
 		valueEncodingFormat.consumedDataType = DataTypes.ROW(
 				DataTypes.FIELD(COUNT, DataTypes.DECIMAL(38, 18)),
-				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3))
-		);
+				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3)))
+			.notNull();
 
 		final DynamicTableSink expectedSink = createExpectedSink(
 				SCHEMA_DATA_TYPE,
@@ -606,7 +606,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		tableOptions.put(
 				String.format("value.%s.%s", TestFormatFactory.IDENTIFIER, TestFormatFactory.DELIMITER.key()),
 				"|");
-		tableOptions.put("value.fields-include", FactoryUtil.ValueFieldsStrategy.EXCEPT_KEY.toString());
+		tableOptions.put("value.fields-include", KafkaOptions.ValueFieldsStrategy.EXCEPT_KEY.toString());
 		return tableOptions;
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -45,6 +45,8 @@ import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestFormatFactory;
+import org.apache.flink.table.factories.TestFormatFactory.DecodingFormatMock;
+import org.apache.flink.table.factories.TestFormatFactory.EncodingFormatMock;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
@@ -61,7 +63,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -100,7 +101,9 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 	private static final String DISCOVERY_INTERVAL = "1000 ms";
 
 	private static final Properties KAFKA_SOURCE_PROPERTIES = new Properties();
+	private static final Properties KAFKA_FINAL_SOURCE_PROPERTIES = new Properties();
 	private static final Properties KAFKA_SINK_PROPERTIES = new Properties();
+	private static final Properties KAFKA_FINAL_SINK_PROPERTIES = new Properties();
 	static {
 		KAFKA_SOURCE_PROPERTIES.setProperty("group.id", "dummy");
 		KAFKA_SOURCE_PROPERTIES.setProperty("bootstrap.servers", "dummy");
@@ -108,62 +111,57 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
 		KAFKA_SINK_PROPERTIES.setProperty("group.id", "dummy");
 		KAFKA_SINK_PROPERTIES.setProperty("bootstrap.servers", "dummy");
+
+		KAFKA_FINAL_SINK_PROPERTIES.putAll(KAFKA_SINK_PROPERTIES);
+		KAFKA_FINAL_SINK_PROPERTIES.setProperty("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+		KAFKA_FINAL_SINK_PROPERTIES.setProperty("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+		KAFKA_FINAL_SINK_PROPERTIES.put("transaction.timeout.ms", 3600000);
+
+		KAFKA_FINAL_SOURCE_PROPERTIES.putAll(KAFKA_SOURCE_PROPERTIES);
+		KAFKA_FINAL_SOURCE_PROPERTIES.setProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+		KAFKA_FINAL_SOURCE_PROPERTIES.setProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
 	}
 
 	private static final String PROPS_SCAN_OFFSETS =
 			String.format("partition:%d,offset:%d;partition:%d,offset:%d",
 					PARTITION_0, OFFSET_0, PARTITION_1, OFFSET_1);
 
-	private static final TableSchema SOURCE_SCHEMA = TableSchema.builder()
+	private static final TableSchema SCHEMA = TableSchema.builder()
 			.field(NAME, DataTypes.STRING())
 			.field(COUNT, DataTypes.DECIMAL(38, 18))
 			.field(TIME, DataTypes.TIMESTAMP(3))
 			.field(COMPUTED_COLUMN_NAME, COMPUTED_COLUMN_DATATYPE, COMPUTED_COLUMN_EXPRESSION)
-				.watermark(TIME, WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
-				.build();
-
-	private static final TableSchema SINK_SCHEMA = TableSchema.builder()
-			.field(NAME, DataTypes.STRING())
-			.field(COUNT, DataTypes.DECIMAL(38, 18))
-			.field(TIME, DataTypes.TIMESTAMP(3))
+			.watermark(TIME, WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
 			.build();
+
+	private static final DataType SCHEMA_DATA_TYPE = SCHEMA.toPhysicalRowDataType();
 
 	@Test
 	public void testTableSource() {
-		// prepare parameters for Kafka table source
-		final DataType producedDataType = SOURCE_SCHEMA.toPhysicalRowDataType();
+		final DynamicTableSource actualSource = createTableSource(getBasicSourceOptions());
+		final KafkaDynamicSource actualKafkaSource = (KafkaDynamicSource) actualSource;
 
 		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
 		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
 		specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_1), OFFSET_1);
 
-		DecodingFormat<DeserializationSchema<RowData>> decodingFormat =
-				new TestFormatFactory.DecodingFormatMock(",", true);
-
-		// Construct table source using options and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"scanTable");
-		CatalogTable catalogTable = createKafkaSourceCatalogTable();
-		final DynamicTableSource actualSource = FactoryUtil.createTableSource(null,
-				objectIdentifier,
-				catalogTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+		final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+				new DecodingFormatMock(",", true);
 
 		// Test scan source equals
 		final KafkaDynamicSource expectedKafkaSource = createExpectedScanSource(
-				producedDataType,
+				SCHEMA_DATA_TYPE,
+				null,
+				valueDecodingFormat,
+				new int[0],
+				new int[]{0, 1, 2},
+				null,
 				Collections.singletonList(TOPIC),
 				null,
 				KAFKA_SOURCE_PROPERTIES,
-				decodingFormat,
 				StartupMode.SPECIFIC_OFFSETS,
 				specificOffsets,
 				0);
-		final KafkaDynamicSource actualKafkaSource = (KafkaDynamicSource) actualSource;
 		assertEquals(actualKafkaSource, expectedKafkaSource);
 
 		// Test Kafka consumer
@@ -173,26 +171,17 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		final SourceFunctionProvider sourceFunctionProvider = (SourceFunctionProvider) provider;
 		final SourceFunction<RowData> sourceFunction = sourceFunctionProvider.createSourceFunction();
 		assertThat(sourceFunction, instanceOf(FlinkKafkaConsumer.class));
-		//  Test commitOnCheckpoints flag should be true when set consumer group
+
+		// Test commitOnCheckpoints flag should be true when set consumer group
 		assertTrue(((FlinkKafkaConsumer<?>) sourceFunction).getEnableCommitOnCheckpoints());
 	}
 
 	@Test
 	public void testTableSourceCommitOnCheckpointsDisabled() {
-		//Construct table source using options and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-			"default",
-			"default",
-			"scanTable");
-		Map<String, String> tableOptions = getFullSourceOptions();
-		tableOptions.remove("properties.group.id");
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(tableOptions);
-		final DynamicTableSource tableSource = FactoryUtil.createTableSource(null,
-			objectIdentifier,
-			catalogTable,
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader(),
-			false);
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+			getBasicSourceOptions(),
+			options -> options.remove("properties.group.id"));
+		final DynamicTableSource tableSource = createTableSource(modifiedOptions);
 
 		// Test commitOnCheckpoints flag should be false when do not set consumer group.
 		assertThat(tableSource, instanceOf(KafkaDynamicSource.class));
@@ -206,43 +195,32 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
 	@Test
 	public void testTableSourceWithPattern() {
-		// prepare parameters for Kafka table source
-		final DataType producedDataType = SOURCE_SCHEMA.toPhysicalRowDataType();
-
-		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
-
-		DecodingFormat<DeserializationSchema<RowData>> decodingFormat =
-			new TestFormatFactory.DecodingFormatMock(",", true);
-
-		// Construct table source using options and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-			"default",
-			"default",
-			"scanTable");
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-			getFullSourceOptions(),
+			getBasicSourceOptions(),
 			options -> {
 				options.remove("topic");
 				options.put("topic-pattern", TOPIC_REGEX);
 				options.put("scan.startup.mode", KafkaOptions.SCAN_STARTUP_MODE_VALUE_EARLIEST);
 				options.remove("scan.startup.specific-offsets");
 			});
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(modifiedOptions);
+		final DynamicTableSource actualSource = createTableSource(modifiedOptions);
 
-		final DynamicTableSource actualSource = FactoryUtil.createTableSource(null,
-			objectIdentifier,
-			catalogTable,
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader(),
-			false);
+		final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
+
+		DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+			new DecodingFormatMock(",", true);
 
 		// Test scan source equals
 		final KafkaDynamicSource expectedKafkaSource = createExpectedScanSource(
-			producedDataType,
+			SCHEMA_DATA_TYPE,
+			null,
+			valueDecodingFormat,
+			new int[0],
+			new int[]{0, 1, 2},
+			null,
 			null,
 			Pattern.compile(TOPIC_REGEX),
 			KAFKA_SOURCE_PROPERTIES,
-			decodingFormat,
 			StartupMode.EARLIEST,
 			specificOffsets,
 			0);
@@ -259,40 +237,63 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 	}
 
 	@Test
-	public void testTableSink() {
-		final DataType consumedDataType = SINK_SCHEMA.toPhysicalRowDataType();
-		EncodingFormat<SerializationSchema<RowData>> encodingFormat =
-				new TestFormatFactory.EncodingFormatMock(",");
+	public void testTableSourceWithKeyValue() {
+		final DynamicTableSource actualSource = createTableSource(getKeyValueOptions());
+		final KafkaDynamicSource actualKafkaSource = (KafkaDynamicSource) actualSource;
+		// initialize stateful testing formats
+		actualKafkaSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
 
-		// Construct table sink using options and table sink factory.
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"sinkTable");
-		final CatalogTable sinkTable = createKafkaSinkCatalogTable();
-		final DynamicTableSink actualSink = FactoryUtil.createTableSink(
+		final DecodingFormatMock keyDecodingFormat = new DecodingFormatMock("#", false);
+		keyDecodingFormat.producedDataType = DataTypes.ROW(
+				DataTypes.FIELD(NAME, DataTypes.STRING())
+		);
+
+		final DecodingFormatMock valueDecodingFormat = new DecodingFormatMock("|", false);
+		valueDecodingFormat.producedDataType = DataTypes.ROW(
+				DataTypes.FIELD(COUNT, DataTypes.DECIMAL(38, 18)),
+				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3))
+		);
+
+		final KafkaDynamicSource expectedKafkaSource = createExpectedScanSource(
+				SCHEMA_DATA_TYPE,
+				keyDecodingFormat,
+				valueDecodingFormat,
+				new int[]{0},
+				new int[]{1, 2},
 				null,
-				objectIdentifier,
-				sinkTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+				Collections.singletonList(TOPIC),
+				null,
+				KAFKA_FINAL_SOURCE_PROPERTIES,
+				StartupMode.GROUP_OFFSETS,
+				Collections.emptyMap(),
+				0);
+
+		assertEquals(actualSource, expectedKafkaSource);
+	}
+
+	@Test
+	public void testTableSink() {
+		final DynamicTableSink actualSink = createTableSink(getBasicSinkOptions());
+
+		final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
+				new EncodingFormatMock(",");
 
 		final DynamicTableSink expectedSink = createExpectedSink(
-				consumedDataType,
+				SCHEMA_DATA_TYPE,
+				null,
+				valueEncodingFormat,
+				new int[0],
+				new int[]{0, 1, 2},
+				null,
 				TOPIC,
 				KAFKA_SINK_PROPERTIES,
-				Optional.of(new FlinkFixedPartitioner<>()),
-				encodingFormat,
+				new FlinkFixedPartitioner<>(),
 				KafkaSinkSemantic.EXACTLY_ONCE
 			);
 		assertEquals(expectedSink, actualSink);
 
-		// Test sink format.
-		final KafkaDynamicSink actualKafkaSink = (KafkaDynamicSink) actualSink;
-		assertEquals(encodingFormat, actualKafkaSink.encodingFormat);
-
 		// Test kafka producer.
+		final KafkaDynamicSink actualKafkaSink = (KafkaDynamicSink) actualSink;
 		DynamicTableSink.SinkRuntimeProvider provider =
 				actualKafkaSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
 		assertThat(provider, instanceOf(SinkFunctionProvider.class));
@@ -301,193 +302,149 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		assertThat(sinkFunction, instanceOf(FlinkKafkaProducer.class));
 	}
 
+	@Test
+	public void testTableSinkWithKeyValue() {
+		final DynamicTableSink actualSink = createTableSink(getKeyValueOptions());
+		final KafkaDynamicSink actualKafkaSink = (KafkaDynamicSink) actualSink;
+		// initialize stateful testing formats
+		actualKafkaSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+
+		final EncodingFormatMock keyEncodingFormat = new EncodingFormatMock("#");
+		keyEncodingFormat.consumedDataType = DataTypes.ROW(
+				DataTypes.FIELD(NAME, DataTypes.STRING())
+		);
+
+		final EncodingFormatMock valueEncodingFormat = new EncodingFormatMock("|");
+		valueEncodingFormat.consumedDataType = DataTypes.ROW(
+				DataTypes.FIELD(COUNT, DataTypes.DECIMAL(38, 18)),
+				DataTypes.FIELD(TIME, DataTypes.TIMESTAMP(3))
+		);
+
+		final DynamicTableSink expectedSink = createExpectedSink(
+				SCHEMA_DATA_TYPE,
+				keyEncodingFormat,
+				valueEncodingFormat,
+				new int[]{0},
+				new int[]{1, 2},
+				null,
+				TOPIC,
+				KAFKA_FINAL_SINK_PROPERTIES,
+				new FlinkFixedPartitioner<>(),
+				KafkaSinkSemantic.EXACTLY_ONCE
+			);
+
+		assertEquals(expectedSink, actualSink);
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Negative tests
 	// --------------------------------------------------------------------------------------------
+
 	@Test
 	public void testInvalidScanStartupMode() {
-		// Construct table source using DDL and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"scanTable");
-		final Map<String, String> modifiedOptions = getModifiedOptions(
-				getFullSourceOptions(),
-				options -> options.put("scan.startup.mode", "abc"));
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(modifiedOptions);
-
 		thrown.expect(ValidationException.class);
 		thrown.expect(containsCause(new ValidationException("Invalid value for option 'scan.startup.mode'. "
 				+ "Supported values are [earliest-offset, latest-offset, group-offsets, specific-offsets, timestamp], "
 				+ "but was: abc")));
-		FactoryUtil.createTableSource(null,
-				objectIdentifier,
-				catalogTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+				getBasicSourceOptions(),
+				options -> options.put("scan.startup.mode", "abc"));
+
+		createTableSource(modifiedOptions);
 	}
 
 	@Test
 	public void testSourceTableWithTopicAndTopicPattern() {
-		// Construct table source using DDL and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-			"default",
-			"default",
-			"scanTable");
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException("Option 'topic' and 'topic-pattern' shouldn't be set together.")));
+
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-			getFullSourceOptions(),
+			getBasicSourceOptions(),
 			options -> {
 				options.put("topic", TOPICS);
 				options.put("topic-pattern", TOPIC_REGEX);
 			});
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(modifiedOptions);
 
-		thrown.expect(ValidationException.class);
-		thrown.expect(containsCause(new ValidationException("Option 'topic' and 'topic-pattern' shouldn't be set together.")));
-		FactoryUtil.createTableSource(null,
-			objectIdentifier,
-			catalogTable,
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader(),
-			false);
+		createTableSource(modifiedOptions);
 	}
 
 	@Test
 	public void testMissingStartupTimestamp() {
-		// Construct table source using DDL and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"scanTable");
-		final Map<String, String> modifiedOptions = getModifiedOptions(
-				getFullSourceOptions(),
-				options -> options.put("scan.startup.mode", "timestamp"));
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(modifiedOptions);
-
 		thrown.expect(ValidationException.class);
 		thrown.expect(containsCause(new ValidationException("'scan.startup.timestamp-millis' "
 				+ "is required in 'timestamp' startup mode but missing.")));
-		FactoryUtil.createTableSource(null,
-				objectIdentifier,
-				catalogTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+				getBasicSourceOptions(),
+				options -> options.put("scan.startup.mode", "timestamp"));
+
+		createTableSource(modifiedOptions);
 	}
 
 	@Test
 	public void testMissingSpecificOffsets() {
-		// Construct table source using DDL and table source factory
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"scanTable");
-		final Map<String, String> modifiedOptions = getModifiedOptions(
-				getFullSourceOptions(),
-				options -> options.remove("scan.startup.specific-offsets"));
-		CatalogTable catalogTable = createKafkaSourceCatalogTable(modifiedOptions);
-
 		thrown.expect(ValidationException.class);
 		thrown.expect(containsCause(new ValidationException("'scan.startup.specific-offsets' "
 				+ "is required in 'specific-offsets' startup mode but missing.")));
-		FactoryUtil.createTableSource(null,
-				objectIdentifier,
-				catalogTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+				getBasicSourceOptions(),
+				options -> options.remove("scan.startup.specific-offsets"));
+
+		createTableSource(modifiedOptions);
 	}
 
 	@Test
 	public void testInvalidSinkPartitioner() {
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-				"default",
-				"default",
-				"sinkTable");
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException("Could not find and instantiate partitioner "
+				+ "class 'abc'")));
 
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-				getFullSourceOptions(),
+				getBasicSourceOptions(),
 				options -> options.put("sink.partitioner", "abc"));
-		final CatalogTable sinkTable = createKafkaSinkCatalogTable(modifiedOptions);
 
-		thrown.expect(ValidationException.class);
-		thrown.expect(containsCause(new ValidationException("Could not find and instantiate partitioner class 'abc'")));
-		FactoryUtil.createTableSink(
-				null,
-				objectIdentifier,
-				sinkTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+		createTableSink(modifiedOptions);
 	}
 
 	@Test
-	public void testInvalidSinkSemantic(){
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-			"default",
-			"default",
-			"sinkTable");
+	public void testInvalidSinkSemantic() {
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException("Unsupported value 'xyz' for 'sink.semantic'. "
+				+ "Supported values are ['at-least-once', 'exactly-once', 'none'].")));
 
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-			getFullSourceOptions(),
+			getBasicSourceOptions(),
 			options -> options.put("sink.semantic", "xyz"));
-		final CatalogTable sinkTable = createKafkaSinkCatalogTable(modifiedOptions);
 
-		thrown.expect(ValidationException.class);
-		thrown.expect(containsCause(new ValidationException("Unsupported value 'xyz' for 'sink.semantic'. Supported values are ['at-least-once', 'exactly-once', 'none'].")));
-		FactoryUtil.createTableSink(
-			null,
-			objectIdentifier,
-			sinkTable,
-			new Configuration(),
-			Thread.currentThread().getContextClassLoader(),
-			false);
+		createTableSink(modifiedOptions);
 	}
 
 	@Test
 	public void testSinkWithTopicListOrTopicPattern(){
-		ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
-			"default",
-			"default",
-			"sinkTable");
-
 		Map<String, String> modifiedOptions = getModifiedOptions(
-			getFullSourceOptions(),
+			getBasicSourceOptions(),
 			options -> {
 				options.put("topic", TOPICS);
 				options.put("scan.startup.mode", "earliest-offset");
 				options.remove("specific-offsets");
 			});
-		CatalogTable sinkTable = createKafkaSinkCatalogTable(modifiedOptions);
-		String errorMessageTemp = "Flink Kafka sink currently only supports single topic, but got %s: %s.";
+		final String errorMessageTemp = "Flink Kafka sink currently only supports single topic, but got %s: %s.";
 
 		try {
-			FactoryUtil.createTableSink(
-				null,
-				objectIdentifier,
-				sinkTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+			createTableSink(modifiedOptions);
 		} catch (Throwable t) {
 			assertEquals(String.format(errorMessageTemp, "'topic'", String.format("[%s]", String.join(", ", TOPIC_LIST))),
 				t.getCause().getMessage());
 		}
 
 		modifiedOptions = getModifiedOptions(
-			getFullSourceOptions(),
+			getBasicSourceOptions(),
 			options -> options.put("topic-pattern", TOPIC_REGEX));
-		sinkTable = createKafkaSinkCatalogTable(modifiedOptions);
 
 		try {
-			FactoryUtil.createTableSink(
-				null,
-				objectIdentifier,
-				sinkTable,
-				new Configuration(),
-				Thread.currentThread().getContextClassLoader(),
-				false);
+			createTableSink(modifiedOptions);
 		} catch (Throwable t) {
 			assertEquals(String.format(errorMessageTemp, "'topic-pattern'", TOPIC_REGEX), t.getCause().getMessage());
 		}
@@ -498,55 +455,85 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 	// --------------------------------------------------------------------------------------------
 
 	private static KafkaDynamicSource createExpectedScanSource(
-			DataType producedDataType,
+			DataType physicalDataType,
+			@Nullable DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat,
+			DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			@Nullable List<String> topics,
 			@Nullable Pattern topicPattern,
 			Properties properties,
-			DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
 			StartupMode startupMode,
 			Map<KafkaTopicPartition, Long> specificStartupOffsets,
-			long startupTimestamp) {
+			long startupTimestampMillis) {
 		return new KafkaDynamicSource(
-				producedDataType,
+				physicalDataType,
+				keyDecodingFormat,
+				valueDecodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
 				topics,
 				topicPattern,
 				properties,
-				decodingFormat,
 				startupMode,
 				specificStartupOffsets,
-				startupTimestamp);
+				startupTimestampMillis);
 	}
 
 	private static KafkaDynamicSink createExpectedSink(
-			DataType consumedDataType,
+			DataType physicalDataType,
+			@Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
+			EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat,
+			int[] keyProjection,
+			int[] valueProjection,
+			@Nullable String keyPrefix,
 			String topic,
 			Properties properties,
-			Optional<FlinkKafkaPartitioner<RowData>> partitioner,
-			EncodingFormat<SerializationSchema<RowData>> encodingFormat,
+			@Nullable FlinkKafkaPartitioner<RowData> partitioner,
 			KafkaSinkSemantic semantic) {
 		return new KafkaDynamicSink(
-				consumedDataType,
+				physicalDataType,
+				keyEncodingFormat,
+				valueEncodingFormat,
+				keyProjection,
+				valueProjection,
+				keyPrefix,
 				topic,
 				properties,
 				partitioner,
-				encodingFormat,
 				semantic);
 	}
 
-	private static CatalogTable createKafkaSourceCatalogTable() {
-		return createKafkaSourceCatalogTable(getFullSourceOptions());
+	private static DynamicTableSource createTableSource(Map<String, String> options) {
+		final ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
+				"default",
+				"default",
+				"scanTable");
+		final CatalogTable catalogTable = new CatalogTableImpl(SCHEMA, options, "scanTable");
+		return FactoryUtil.createTableSource(
+			null,
+			objectIdentifier,
+			catalogTable,
+			new Configuration(),
+			Thread.currentThread().getContextClassLoader(),
+			false);
 	}
 
-	private static CatalogTable createKafkaSinkCatalogTable() {
-		return createKafkaSinkCatalogTable(getFullSinkOptions());
-	}
-
-	private static CatalogTable createKafkaSourceCatalogTable(Map<String, String> options) {
-		return new CatalogTableImpl(SOURCE_SCHEMA, options, "scanTable");
-	}
-
-	private static CatalogTable createKafkaSinkCatalogTable(Map<String, String> options) {
-		return new CatalogTableImpl(SINK_SCHEMA, options, "sinkTable");
+	private static DynamicTableSink createTableSink(Map<String, String> options) {
+		final ObjectIdentifier objectIdentifier = ObjectIdentifier.of(
+				"default",
+				"default",
+				"sinkTable");
+		final CatalogTable catalogTable = new CatalogTableImpl(SCHEMA, options, "sinkTable");
+		return FactoryUtil.createTableSink(
+			null,
+			objectIdentifier,
+			catalogTable,
+			new Configuration(),
+			Thread.currentThread().getContextClassLoader(),
+			false);
 	}
 
 	/**
@@ -561,7 +548,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		return options;
 	}
 
-	private static Map<String, String> getFullSourceOptions() {
+	private static Map<String, String> getBasicSourceOptions() {
 		Map<String, String> tableOptions = new HashMap<>();
 		// Kafka specific options.
 		tableOptions.put("connector", KafkaDynamicTableFactory.IDENTIFIER);
@@ -582,7 +569,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		return tableOptions;
 	}
 
-	private static Map<String, String> getFullSinkOptions() {
+	private static Map<String, String> getBasicSinkOptions() {
 		Map<String, String> tableOptions = new HashMap<>();
 		// Kafka specific options.
 		tableOptions.put("connector", KafkaDynamicTableFactory.IDENTIFIER);
@@ -596,6 +583,30 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		final String formatDelimiterKey = String.format("%s.%s",
 				TestFormatFactory.IDENTIFIER, TestFormatFactory.DELIMITER.key());
 		tableOptions.put(formatDelimiterKey, ",");
+		return tableOptions;
+	}
+
+	private static Map<String, String> getKeyValueOptions() {
+		Map<String, String> tableOptions = new HashMap<>();
+		// Kafka specific options.
+		tableOptions.put("connector", KafkaDynamicTableFactory.IDENTIFIER);
+		tableOptions.put("topic", TOPIC);
+		tableOptions.put("properties.group.id", "dummy");
+		tableOptions.put("properties.bootstrap.servers", "dummy");
+		tableOptions.put("scan.topic-partition-discovery.interval", DISCOVERY_INTERVAL);
+		tableOptions.put("sink.partitioner", KafkaOptions.SINK_PARTITIONER_VALUE_FIXED);
+		tableOptions.put("sink.semantic", KafkaOptions.SINK_SEMANTIC_VALUE_EXACTLY_ONCE);
+		// Format options.
+		tableOptions.put("key.format", TestFormatFactory.IDENTIFIER);
+		tableOptions.put(
+				String.format("key.%s.%s", TestFormatFactory.IDENTIFIER, TestFormatFactory.DELIMITER.key()),
+				"#");
+		tableOptions.put("key.fields", NAME);
+		tableOptions.put("value.format", TestFormatFactory.IDENTIFIER);
+		tableOptions.put(
+				String.format("value.%s.%s", TestFormatFactory.IDENTIFIER, TestFormatFactory.DELIMITER.key()),
+				"|");
+		tableOptions.put("value.fields-include", FactoryUtil.ValueFieldsStrategy.EXCEPT_KEY.toString());
 		return tableOptions;
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptionsTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptionsTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+/**
+ * Test for {@link KafkaOptions}.
+ */
+public class KafkaOptionsTest {
+
+	@Test
+	public void testFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.add(TableColumn.metadata("timestamp", DataTypes.TIMESTAMP(3)))
+				.add(TableColumn.computed("timestamp_converted", DataTypes.STRING(), "CAST(`timestamp` AS STRING)"))
+				.add(TableColumn.physical("name", DataTypes.STRING()))
+				.add(TableColumn.physical("age", DataTypes.INT()))
+				.add(TableColumn.physical("address", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createTestOptions();
+		options.put("key.fields", "address; name");
+		options.put("value.fields-include", "EXCEPT_KEY");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		assertArrayEquals(new int[]{3, 1}, createKeyFormatProjection(config, dataType));
+		assertArrayEquals(new int[]{0, 2}, createValueFormatProjection(config, dataType));
+	}
+
+	@Test
+	public void testMissingKeyFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.build();
+		final Map<String, String> options = createTestOptions();
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			createKeyFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+								"A key format 'key.format' requires the declaration of one or more "
+										+ "of key fields using 'key.fields'.")));
+		}
+	}
+
+	@Test
+	public void testInvalidKeyFormatFieldProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.add(TableColumn.physical("name", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createTestOptions();
+		options.put("key.fields", "non_existing");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			createKeyFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+									"Could not find the field 'non_existing' in the table schema for "
+											+ "usage in the key format. A key field must be a regular, "
+											+ "physical column. The following columns can be selected "
+											+ "in the 'key.fields' option:\n"
+											+ "[id, name]")));
+		}
+	}
+
+	@Test
+	public void testInvalidKeyFormatPrefixProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("k_part_1", DataTypes.INT()))
+				.add(TableColumn.physical("part_2", DataTypes.STRING()))
+				.add(TableColumn.physical("name", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createTestOptions();
+		options.put("key.fields", "k_part_1;part_2");
+		options.put("key.fields-prefix", "k_");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			createKeyFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+									"All fields in 'key.fields' must be prefixed with 'k_' when option "
+										+ "'key.fields-prefix' is set but field 'part_2' is not prefixed.")));
+		}
+	}
+
+	@Test
+	public void testInvalidValueFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("k_id", DataTypes.INT()))
+				.add(TableColumn.physical("id", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createTestOptions();
+		options.put("key.fields", "k_id");
+		options.put("key.fields-prefix", "k_");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			createValueFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+									"A key prefix is not allowed when option 'value.fields-include' "
+										+ "is set to 'ALL'. Set it to 'EXCEPT_KEY' instead to avoid field overlaps.")));
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static Map<String, String> createTestOptions() {
+		final Map<String, String> options = new HashMap<>();
+		options.put("key.format", "test-format");
+		options.put("key.test-format.delimiter", ",");
+		options.put("value.format", "test-format");
+		options.put("value.test-format.delimiter", "|");
+		options.put("value.test-format.fail-on-missing", "true");
+		return options;
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -383,6 +383,147 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 		deleteTestTopic(topic);
 	}
 
+	@Test
+	public void testKafkaSourceSinkWithKeyAndPartialValue() throws Exception {
+		if (isLegacyConnector) {
+			return;
+		}
+		// we always use a different topic name for each parameterized topic,
+		// in order to make sure the topic can be created.
+		final String topic = "key_partial_value_topic_" + format;
+		createTestTopic(topic, 1, 1);
+
+		// ---------- Produce an event time stream into Kafka -------------------
+		String groupId = standardProps.getProperty("group.id");
+		String bootstraps = standardProps.getProperty("bootstrap.servers");
+
+		// k_user_id and user_id have different data types to verify the correct mapping,
+		// fields are reordered on purpose
+		final String createTable = String.format(
+				"CREATE TABLE kafka (\n"
+						+ "  `k_user_id` BIGINT,\n"
+						+ "  `name` STRING,\n"
+						+ "  `timestamp` TIMESTAMP(3) METADATA,\n"
+						+ "  `k_event_id` BIGINT,\n"
+						+ "  `user_id` INT,\n"
+						+ "  `payload` STRING\n"
+						+ ") WITH (\n"
+						+ "  'connector' = 'kafka',\n"
+						+ "  'topic' = '%s',\n"
+						+ "  'properties.bootstrap.servers' = '%s',\n"
+						+ "  'properties.group.id' = '%s',\n"
+						+ "  'scan.startup.mode' = 'earliest-offset',\n"
+						+ "  'key.format' = '%s',\n"
+						+ "  'key.fields' = 'k_event_id; k_user_id',\n"
+						+ "  'key.fields-prefix' = 'k_',\n"
+						+ "  'value.format' = '%s',\n"
+						+ "  'value.fields-include' = 'EXCEPT_KEY'\n"
+						+ ")",
+				topic,
+				bootstraps,
+				groupId,
+				format,
+				format);
+
+		tEnv.executeSql(createTable);
+
+		String initialValues = "INSERT INTO kafka\n"
+				+ "VALUES\n"
+				+ " (1, 'name 1', TIMESTAMP '2020-03-08 13:12:11.123', 100, 1, 'payload 1'),\n"
+				+ " (2, 'name 2', TIMESTAMP '2020-03-09 13:12:11.123', 101, 2, 'payload 2'),\n"
+				+ " (3, 'name 3', TIMESTAMP '2020-03-10 13:12:11.123', 102, 3, 'payload 3')";
+		tEnv.executeSql(initialValues).await();
+
+		// ---------- Consume stream from Kafka -------------------
+
+		final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM kafka"), 3);
+
+		final List<Row> expected = Arrays.asList(
+				Row.of(1L, "name 1", LocalDateTime.parse("2020-03-08T13:12:11.123"), 100L, 1, "payload 1"),
+				Row.of(2L, "name 2", LocalDateTime.parse("2020-03-09T13:12:11.123"), 101L, 2, "payload 2"),
+				Row.of(3L, "name 3", LocalDateTime.parse("2020-03-10T13:12:11.123"), 102L, 3, "payload 3")
+		);
+
+		assertThat(result, deepEqualTo(expected, true));
+
+		// ------------- cleanup -------------------
+
+		deleteTestTopic(topic);
+	}
+
+	@Test
+	public void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
+		if (isLegacyConnector) {
+			return;
+		}
+		// we always use a different topic name for each parameterized topic,
+		// in order to make sure the topic can be created.
+		final String topic = "key_full_value_topic_" + format;
+		createTestTopic(topic, 1, 1);
+
+		// ---------- Produce an event time stream into Kafka -------------------
+		String groupId = standardProps.getProperty("group.id");
+		String bootstraps = standardProps.getProperty("bootstrap.servers");
+
+		// compared to the partial value test we cannot support both k_user_id and user_id in a full
+		// value due to duplicate names after key prefix stripping,
+		// fields are reordered on purpose,
+		// fields for keys and values are overlapping
+		final String createTable = String.format(
+				"CREATE TABLE kafka (\n"
+						+ "  `k_user_id` BIGINT,\n"
+						+ "  `name` STRING,\n"
+						+ "  `timestamp` TIMESTAMP(3) METADATA,\n"
+						+ "  `k_event_id` BIGINT,\n"
+						+ "  `payload` STRING\n"
+						+ ") WITH (\n"
+						+ "  'connector' = 'kafka',\n"
+						+ "  'topic' = '%s',\n"
+						+ "  'properties.bootstrap.servers' = '%s',\n"
+						+ "  'properties.group.id' = '%s',\n"
+						+ "  'scan.startup.mode' = 'earliest-offset',\n"
+						+ "  'key.format' = '%s',\n"
+						+ "  'key.fields' = 'k_event_id; k_user_id',\n"
+						+ "  'key.fields-prefix' = 'k_',\n"
+						+ "  'value.format' = '%s',\n"
+						+ "  'value.fields-include' = 'ALL'\n"
+						+ ")",
+				topic,
+				bootstraps,
+				groupId,
+				format,
+				format);
+
+		tEnv.executeSql(createTable);
+
+		String initialValues = "INSERT INTO kafka\n"
+				+ "VALUES\n"
+				+ " (1, 'name 1', TIMESTAMP '2020-03-08 13:12:11.123', 100, 'payload 1'),\n"
+				+ " (2, 'name 2', TIMESTAMP '2020-03-09 13:12:11.123', 101, 'payload 2'),\n"
+				+ " (3, 'name 3', TIMESTAMP '2020-03-10 13:12:11.123', 102, 'payload 3')";
+		tEnv.executeSql(initialValues).await();
+
+		// ---------- Consume stream from Kafka -------------------
+
+		final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM kafka"), 3);
+
+		final List<Row> expected = Arrays.asList(
+				Row.of(1L, "name 1", LocalDateTime.parse("2020-03-08T13:12:11.123"), 100L, "payload 1"),
+				Row.of(2L, "name 2", LocalDateTime.parse("2020-03-09T13:12:11.123"), 101L, "payload 2"),
+				Row.of(3L, "name 3", LocalDateTime.parse("2020-03-10T13:12:11.123"), 102L, "payload 3")
+		);
+
+		assertThat(result, deepEqualTo(expected, true));
+
+		// ------------- cleanup -------------------
+
+		deleteTestTopic(topic);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Utilities
+	// --------------------------------------------------------------------------------------------
+
 	private String formatOptions() {
 		if (!isLegacyConnector) {
 			return String.format("'format' = '%s'", format);

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -429,9 +429,9 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 
 		String initialValues = "INSERT INTO kafka\n"
 				+ "VALUES\n"
-				+ " (1, 'name 1', TIMESTAMP '2020-03-08 13:12:11.123', 100, 1, 'payload 1'),\n"
-				+ " (2, 'name 2', TIMESTAMP '2020-03-09 13:12:11.123', 101, 2, 'payload 2'),\n"
-				+ " (3, 'name 3', TIMESTAMP '2020-03-10 13:12:11.123', 102, 3, 'payload 3')";
+				+ " (1, 'name 1', TIMESTAMP '2020-03-08 13:12:11.123', 100, 41, 'payload 1'),\n"
+				+ " (2, 'name 2', TIMESTAMP '2020-03-09 13:12:11.123', 101, 42, 'payload 2'),\n"
+				+ " (3, 'name 3', TIMESTAMP '2020-03-10 13:12:11.123', 102, 43, 'payload 3')";
 		tEnv.executeSql(initialValues).await();
 
 		// ---------- Consume stream from Kafka -------------------
@@ -439,9 +439,9 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 		final List<Row> result = collectRows(tEnv.sqlQuery("SELECT * FROM kafka"), 3);
 
 		final List<Row> expected = Arrays.asList(
-				Row.of(1L, "name 1", LocalDateTime.parse("2020-03-08T13:12:11.123"), 100L, 1, "payload 1"),
-				Row.of(2L, "name 2", LocalDateTime.parse("2020-03-09T13:12:11.123"), 101L, 2, "payload 2"),
-				Row.of(3L, "name 3", LocalDateTime.parse("2020-03-10T13:12:11.123"), 102L, 3, "payload 3")
+				Row.of(1L, "name 1", LocalDateTime.parse("2020-03-08T13:12:11.123"), 100L, 41, "payload 1"),
+				Row.of(2L, "name 2", LocalDateTime.parse("2020-03-09T13:12:11.123"), 101L, 42, "payload 2"),
+				Row.of(3L, "name 3", LocalDateTime.parse("2020-03-10T13:12:11.123"), 102L, 43, "payload 3")
 		);
 
 		assertThat(result, deepEqualTo(expected, true));
@@ -471,10 +471,10 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 		// fields for keys and values are overlapping
 		final String createTable = String.format(
 				"CREATE TABLE kafka (\n"
-						+ "  `k_user_id` BIGINT,\n"
+						+ "  `user_id` BIGINT,\n"
 						+ "  `name` STRING,\n"
 						+ "  `timestamp` TIMESTAMP(3) METADATA,\n"
-						+ "  `k_event_id` BIGINT,\n"
+						+ "  `event_id` BIGINT,\n"
 						+ "  `payload` STRING\n"
 						+ ") WITH (\n"
 						+ "  'connector' = 'kafka',\n"
@@ -483,8 +483,7 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
 						+ "  'properties.group.id' = '%s',\n"
 						+ "  'scan.startup.mode' = 'earliest-offset',\n"
 						+ "  'key.format' = '%s',\n"
-						+ "  'key.fields' = 'k_event_id; k_user_id',\n"
-						+ "  'key.fields-prefix' = 'k_',\n"
+						+ "  'key.fields' = 'event_id; user_id',\n"
 						+ "  'value.format' = '%s',\n"
 						+ "  'value.fields-include' = 'ALL'\n"
 						+ ")",

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -85,6 +85,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	// --------------------------------------------------------------------------------------------
 
 	/**
+	 * Creates a new configuration that is initialized with the options of the given map.
+	 */
+	public static Configuration fromMap(Map<String, String> map) {
+		final Configuration configuration = new Configuration();
+		map.forEach(configuration::setString);
+		return configuration;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
 	 * Returns the class associated with the given key as a string.
 	 *
 	 * @param <T> The type of the class to return.

--- a/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.configuration;
 
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
@@ -36,14 +35,15 @@ import static org.junit.Assert.assertTrue;
 public class DelegatingConfigurationTest {
 
 	@Test
-	public void testIfDelegatesImplementAllMethods() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+	public void testIfDelegatesImplementAllMethods() throws IllegalArgumentException {
 
 		// For each method in the Configuration class...
 		Method[] confMethods = Configuration.class.getDeclaredMethods();
 		Method[] delegateMethods = DelegatingConfiguration.class.getDeclaredMethods();
 
 		for (Method configurationMethod : confMethods) {
-			if (!Modifier.isPublic(configurationMethod.getModifiers())) {
+			final int mod = configurationMethod.getModifiers();
+			if (!Modifier.isPublic(mod) || Modifier.isStatic(mod)) {
 				continue;
 			}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
@@ -91,6 +91,11 @@ public final class ChangelogMode {
 		return Objects.hash(kinds);
 	}
 
+	@Override
+	public String toString() {
+		return kinds.toString();
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -404,12 +403,6 @@ public final class FactoryUtil {
 			EncodingUtils.escapeSingleQuotes(value));
 	}
 
-	private static Configuration asConfiguration(Map<String, String> options) {
-		final Configuration configuration = new Configuration();
-		options.forEach(configuration::setString);
-		return configuration;
-	}
-
 	private static <T> T readOption(ReadableConfig options, ConfigOption<T> option) {
 		try {
 			return options.get(option);
@@ -440,7 +433,7 @@ public final class FactoryUtil {
 		private TableFactoryHelper(DynamicTableFactory tableFactory, DynamicTableFactory.Context context) {
 			this.tableFactory = tableFactory;
 			this.context = context;
-			this.allOptions = asConfiguration(context.getCatalogTable().getOptions());
+			this.allOptions = Configuration.fromMap(context.getCatalogTable().getOptions());
 			this.consumedOptionKeys = new HashSet<>();
 			this.consumedOptionKeys.add(PROPERTY_VERSION.key());
 			this.consumedOptionKeys.add(CONNECTOR.key());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -33,6 +33,10 @@ import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -50,6 +54,9 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 
 /**
  * Utility for working with {@link Factory}s.
@@ -100,6 +107,36 @@ public final class FactoryUtil {
 		.noDefaultValue()
 		.withDescription("Defines the format identifier for encoding data. " +
 			"The identifier is used to discover a suitable format factory.");
+
+	public static final ConfigOption<List<String>> KEY_FIELDS = ConfigOptions
+			.key("key.fields")
+			.stringType()
+			.asList()
+			.defaultValues()
+			.withDescription("Defines an explicit list of physical columns from the table schema "
+					+ "that configure the data type for the key format. By default, this list is "
+					+ "empty and thus a key is undefined.");
+
+	public static final ConfigOption<String> KEY_FIELDS_PREFIX = ConfigOptions
+			.key("key.fields-prefix")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("Defines a custom prefix for all fields of the key format to avoid "
+					+ "name clashes with fields of the value format. By default, the prefix is empty. "
+					+ "If a custom prefix is defined, both the table schema and "
+					+ "'" + KEY_FIELDS.key() + "' will work with prefixed names. When constructing "
+					+ "the data type of the key format, the prefix will be removed and the "
+					+ "non-prefixed names will be used within the key format.");
+
+	public static final ConfigOption<ValueFieldsStrategy> VALUE_FIELDS_INCLUDE = ConfigOptions
+			.key("value.fields-include")
+			.enumType(ValueFieldsStrategy.class)
+			.defaultValue(ValueFieldsStrategy.ALL)
+			.withDescription("Defines a strategy how to deal with key columns in the data type of "
+					+ "the value format. By default, '" + ValueFieldsStrategy.ALL + "' physical "
+					+ "columns of the table schema will be included in the value format which "
+					+ "means that key columns appear in the data type for both the key and value "
+					+ "format.");
 
 	private static final String FORMAT_KEY = "format";
 
@@ -340,6 +377,92 @@ public final class FactoryUtil {
 									.sorted()
 									.collect(Collectors.joining("\n"))));
 		}
+	}
+
+	/**
+	 * Creates an array of indices that determine which physical fields of the table schema to include
+	 * in the key format and the order that those fields have in the key format.
+	 *
+	 * <p>See {@link #KEY_FORMAT} and {@link #KEY_FIELDS} for more information.
+	 */
+	public static int[] createKeyFormatProjection(ReadableConfig options, DataType physicalDataType) {
+		final LogicalType physicalType = physicalDataType.getLogicalType();
+		Preconditions.checkArgument(
+			hasRoot(physicalType, LogicalTypeRoot.ROW),
+			"Row data type expected.");
+		final Optional<String> optionalKeyFormat = options.getOptional(KEY_FORMAT);
+		final Optional<List<String>> optionalKeyFields = options.getOptional(KEY_FIELDS);
+
+		if (!optionalKeyFormat.isPresent() && optionalKeyFields.isPresent()) {
+			throw new ValidationException(
+					String.format(
+							"The option '%s' can only be declared if a key format is defined using '%s'.",
+							KEY_FIELDS.key(),
+							KEY_FORMAT.key()
+					)
+			);
+		} else if (optionalKeyFormat.isPresent() &&
+				(!optionalKeyFields.isPresent() || optionalKeyFields.get().size() == 0)) {
+			throw new ValidationException(
+					String.format(
+							"A key format '%s' requires the declaration of one or more of key fields using '%s'.",
+							KEY_FORMAT.key(),
+							KEY_FIELDS.key()
+					)
+			);
+		}
+
+		if (!optionalKeyFormat.isPresent()) {
+			return new int[0];
+		}
+
+		final List<String> keyFields = optionalKeyFields.get();
+		final List<String> physicalFields = LogicalTypeChecks.getFieldNames(physicalType);
+		return keyFields.stream()
+				.mapToInt(keyField -> {
+					final int pos = physicalFields.indexOf(keyField);
+					if (pos < 0) {
+						throw new ValidationException(
+								String.format(
+										"Could not find the field '%s' in the table schema for usage in the key format. "
+												+ "A key field must be a regular, physical column. "
+												+ "The following columns can be selected in the '%s' option:\n"
+												+ "%s",
+										keyField,
+										KEY_FIELDS.key(),
+										physicalFields
+								)
+						);
+					}
+					return pos;
+				})
+			.toArray();
+	}
+
+	/**
+	 * Creates an array of indices that determine which physical fields of the table schema to include
+	 * in the value format.
+	 *
+	 * <p>See {@link #VALUE_FORMAT} and {@link #VALUE_FIELDS_INCLUDE} for more information.
+	 */
+	public static int[] createValueFormatProjection(ReadableConfig options, DataType physicalDataType) {
+		final LogicalType physicalType = physicalDataType.getLogicalType();
+		Preconditions.checkArgument(
+			hasRoot(physicalType, LogicalTypeRoot.ROW),
+			"Row data type expected.");
+		final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
+		final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
+
+		final ValueFieldsStrategy strategy = options.get(VALUE_FIELDS_INCLUDE);
+		if (strategy == ValueFieldsStrategy.ALL) {
+			return physicalFields.toArray();
+		} else if (strategy == ValueFieldsStrategy.EXCEPT_KEY) {
+			final int[] keyProjection = createKeyFormatProjection(options, physicalDataType);
+			return physicalFields
+					.filter(pos -> IntStream.of(keyProjection).noneMatch(k -> k == pos))
+					.toArray();
+		}
+		throw new TableException("Unknown value fields strategy:" + strategy);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -647,6 +770,13 @@ public final class FactoryUtil {
 		public boolean isTemporary() {
 			return isTemporary;
 		}
+	}
+
+	/**
+	 * Strategies to derive the data type of a value format by considering a key format.
+	 */
+	public enum ValueFieldsStrategy {
+		ALL, EXCEPT_KEY
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeUtils.java
@@ -34,9 +34,11 @@ import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.util.Preconditions;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Utilities for handling {@link LogicalType}s.
@@ -149,6 +151,25 @@ public final class LogicalTypeUtils {
 			fieldName = ATOMIC_FIELD_NAME + "_" + i++;
 		}
 		return fieldName;
+	}
+
+	/**
+	 * Renames the fields of the given {@link RowType}.
+	 */
+	public static RowType renameRowFields(RowType rowType, List<String> newFieldNames) {
+		Preconditions.checkArgument(
+				rowType.getFieldCount() == newFieldNames.size(),
+				"Row length and new names must match.");
+		final List<RowField> newFields = IntStream.range(0, rowType.getFieldCount())
+				.mapToObj(pos -> {
+					final RowField oldField = rowType.getFields().get(pos);
+					return new RowField(
+							newFieldNames.get(pos),
+							oldField.getType(),
+							oldField.getDescription().orElse(null));
+				})
+				.collect(Collectors.toList());
+		return new RowType(rowType.isNullable(), newFields);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -30,6 +32,7 @@ import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSink
 import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSourceMock;
 import org.apache.flink.table.factories.TestFormatFactory.DecodingFormatMock;
 import org.apache.flink.table.factories.TestFormatFactory.EncodingFormatMock;
+import org.apache.flink.table.types.DataType;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +45,12 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 /**
  * Tests for {@link FactoryUtil}.
@@ -201,6 +209,78 @@ public class FactoryUtilTest {
 			new EncodingFormatMock(","),
 			new EncodingFormatMock(";"));
 		assertEquals(expectedSink, actualSink);
+	}
+
+	@Test
+	public void testFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.add(TableColumn.metadata("timestamp", DataTypes.TIMESTAMP(3)))
+				.add(TableColumn.computed("timestamp_converted", DataTypes.STRING(), "CAST(`timestamp` AS STRING)"))
+				.add(TableColumn.physical("name", DataTypes.STRING()))
+				.add(TableColumn.physical("age", DataTypes.INT()))
+				.add(TableColumn.physical("address", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createAllOptions();
+		options.put("key.fields", "address; name");
+		options.put("value.fields-include", "EXCEPT_KEY");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		assertArrayEquals(new int[]{3, 1}, FactoryUtil.createKeyFormatProjection(config, dataType));
+		assertArrayEquals(new int[]{0, 2}, FactoryUtil.createValueFormatProjection(config, dataType));
+	}
+
+	@Test
+	public void testMissingKeyFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.build();
+		final Map<String, String> options = createAllOptions();
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			FactoryUtil.createKeyFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+								"A key format 'key.format' requires the declaration of one or more "
+										+ "of key fields using 'key.fields'.")));
+		}
+	}
+
+	@Test
+	public void testInvalidKeyFormatProjection() {
+		final TableSchema schema = TableSchema.builder()
+				.add(TableColumn.physical("id", DataTypes.INT()))
+				.add(TableColumn.physical("name", DataTypes.STRING()))
+				.build();
+		final Map<String, String> options = createAllOptions();
+		options.put("key.fields", "non_existing");
+
+		final Configuration config = Configuration.fromMap(options);
+		final DataType dataType = schema.toPhysicalRowDataType();
+
+		try {
+			FactoryUtil.createKeyFormatProjection(config, dataType);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+					e,
+					hasMessage(
+							equalTo(
+									"Could not find the field 'non_existing' in the table schema for "
+											+ "usage in the key format. A key field must be a regular, "
+											+ "physical column. The following columns can be selected "
+											+ "in the 'key.fields' option:\n"
+											+ "[id, name]")));
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -39,8 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
-import static org.apache.flink.table.factories.FactoryUtil.KEY_FORMAT;
-import static org.apache.flink.table.factories.FactoryUtil.VALUE_FORMAT;
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT_SUFFIX;
 
 /**
  * Test implementations for {@link DynamicTableSourceFactory} and {@link DynamicTableSinkFactory}.
@@ -58,6 +57,16 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 		.key("buffer-size")
 		.longType()
 		.defaultValue(100L);
+
+	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
+		.key("key" + FORMAT_SUFFIX)
+		.stringType()
+		.noDefaultValue();
+
+	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
+		.key("value" + FORMAT_SUFFIX)
+		.stringType()
+		.noDefaultValue();
 
 	@Override
 	public DynamicTableSource createDynamicTableSource(Context context) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
@@ -99,6 +99,9 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 		public final String delimiter;
 		public final Boolean failOnMissing;
 
+		// we make the format stateful for capturing parameterization during testing
+		public DataType producedDataType;
+
 		public DecodingFormatMock(String delimiter, Boolean failOnMissing) {
 			this.delimiter = delimiter;
 			this.failOnMissing = failOnMissing;
@@ -108,12 +111,13 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 		public DeserializationSchema<RowData> createRuntimeDecoder(
 				DynamicTableSource.Context context,
 				DataType producedDataType) {
+			this.producedDataType = producedDataType;
 			return null;
 		}
 
 		@Override
 		public ChangelogMode getChangelogMode() {
-			return null;
+			return ChangelogMode.insertOnly();
 		}
 
 		@Override
@@ -125,12 +129,14 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 				return false;
 			}
 			DecodingFormatMock that = (DecodingFormatMock) o;
-			return delimiter.equals(that.delimiter) && failOnMissing.equals(that.failOnMissing);
+			return delimiter.equals(that.delimiter)
+					&& failOnMissing.equals(that.failOnMissing)
+					&& Objects.equals(producedDataType, that.producedDataType);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(delimiter, failOnMissing);
+			return Objects.hash(delimiter, failOnMissing, producedDataType);
 		}
 	}
 
@@ -145,6 +151,9 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 
 		public final String delimiter;
 
+		// we make the format stateful for capturing parameterization during testing
+		public DataType consumedDataType;
+
 		public EncodingFormatMock(String delimiter) {
 			this.delimiter = delimiter;
 		}
@@ -152,13 +161,14 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 		@Override
 		public SerializationSchema<RowData> createRuntimeEncoder(
 				DynamicTableSink.Context context,
-				DataType consumeDataType) {
+				DataType consumedDataType) {
+			this.consumedDataType = consumedDataType;
 			return null;
 		}
 
 		@Override
 		public ChangelogMode getChangelogMode() {
-			return null;
+			return ChangelogMode.insertOnly();
 		}
 
 		@Override
@@ -170,12 +180,13 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 				return false;
 			}
 			EncodingFormatMock that = (EncodingFormatMock) o;
-			return delimiter.equals(that.delimiter);
+			return delimiter.equals(that.delimiter)
+					&& Objects.equals(consumedDataType, that.consumedDataType);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(delimiter);
+			return Objects.hash(delimiter, consumedDataType);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Adds support for the following 3 options in Kafka:

```
public static final ConfigOption<List<String>> KEY_FIELDS = ConfigOptions
		.key("key.fields")
		.stringType()
		.asList()
		.defaultValues()
		.withDescription("Defines an explicit list of physical columns from the table schema "
				+ "that configure the data type for the key format. By default, this list is "
				+ "empty and thus a key is undefined.");

public static final ConfigOption<String> KEY_FIELDS_PREFIX = ConfigOptions
		.key("key.fields-prefix")
		.stringType()
		.noDefaultValue()
		.withDescription("Defines a custom prefix for all fields of the key format to avoid "
				+ "name clashes with fields of the value format. By default, the prefix is empty. "
				+ "If a custom prefix is defined, both the table schema and "
				+ "'" + KEY_FIELDS.key() + "' will work with prefixed names. When constructing "
				+ "the data type of the key format, the prefix will be removed and the "
				+ "non-prefixed names will be used within the key format.");

public static final ConfigOption<ValueFieldsStrategy> VALUE_FIELDS_INCLUDE = ConfigOptions
		.key("value.fields-include")
		.enumType(ValueFieldsStrategy.class)
		.defaultValue(ValueFieldsStrategy.ALL)
		.withDescription("Defines a strategy how to deal with key columns in the data type of "
				+ "the value format. By default, '" + ValueFieldsStrategy.ALL + "' physical "
				+ "columns of the table schema will be included in the value format which "
				+ "means that key columns appear in the data type for both the key and value "
				+ "format.");
```

Documentation will follow in a separate PR, once we have implemented all changes to the Kafka table connectors.

## Brief change log

- Update Kafka factory and tests to accept the mentioned options
- Update the Kafka source and sink to split the physical data into 2 data structures for key and value

## Verifying this change

This change added tests and can be verified as follows: `KafkaTableITCase`, `KafkaDynamicTableFactoryTest`, `FactoryUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
