### PR TITLE
[FLINK-19904][docs] Added information about differences between the configured heap size and the maximum heap size returned by the metric system.

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -874,7 +874,10 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
     </tr>
     <tr>
       <td>Heap.Max</td>
-      <td>The maximum amount of heap memory that can be used for memory management (in bytes).</td>
+      <td>The maximum amount of heap memory that can be used for memory management (in bytes). <br/>
+      This value might not be necessarily equal to the maximum value specified through -Xmx or 
+      the equivalent Flink configuration parameter. Some GC algorithms allocate heap memory that won't 
+      be available to the user code and, therefore, not being exposed through the heap metrics.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -873,7 +873,10 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
     </tr>
     <tr>
       <td>Heap.Max</td>
-      <td>The maximum amount of heap memory that can be used for memory management (in bytes).</td>
+      <td>The maximum amount of heap memory that can be used for memory management (in bytes). <br/>
+      This value might not be necessarily equal to the maximum value specified through -Xmx or 
+      the equivalent Flink configuration parameter. Some GC algorithms allocate heap memory that won't 
+      be available to the user code and, therefore, not being exposed through the heap metrics.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/ops/memory/mem_setup.md
+++ b/docs/ops/memory/mem_setup.md
@@ -96,14 +96,17 @@ or derived memory component sizes:
 
 | &nbsp;&nbsp;**JVM Arguments**&nbsp;&nbsp;                                              | &nbsp;&nbsp;**Value for TaskManager**&nbsp;&nbsp;  | &nbsp;&nbsp;**Value for JobManager**&nbsp;&nbsp;  |
 | :------------------------------------------------------------------------------------- | :------------------------------------------------- | :------------------------------------------------ |
-| *-Xmx* and *-Xms*                                                                      | Framework + Task Heap Memory                       | JVM Heap Memory                                   |
-| *-XX:MaxDirectMemorySize*<br/>(always added only for TaskManager, see note for JobManager) | Framework + Task Off-heap (\*) + Network Memory     | Off-heap Memory (\*),(\*\*)                          |
+| *-Xmx* and *-Xms*                                                                      | Framework + Task Heap Memory                       | JVM Heap Memory (\*)                              |
+| *-XX:MaxDirectMemorySize*<br/>(always added only for TaskManager, see note for JobManager) | Framework + Task Off-heap (\*\*) + Network Memory     | Off-heap Memory (\*\*),(\*\*\*)            |
 | *-XX:MaxMetaspaceSize*                                                                 | JVM Metaspace                                      | JVM Metaspace                                     |
 {:.table-bordered}
-(\*) Notice, that the native non-direct usage of memory in user code can be also accounted for as a part of the off-heap memory.
+(\*) Keep in mind that you might not be able to use the full amount of heap memory depending on the GC algorithm used. Some GC algorithms allocate a certain amount of heap memory for themselves. 
+This will lead to a different maximum being returned by the [Heap metrics](../../monitoring/metrics.html#memory).
 <br/>
-(\*\*) The *JVM Direct memory limit* is added for JobManager process only if the corresponding option
-[`jobmanager.memory.enable-jvm-direct-memory-limit`](../config.html#jobmanager-memory-enable-jvm-direct-memory-limit) is set.
+(\*\*) Notice, that the native non-direct usage of memory in user code can be also accounted for as a part of the off-heap memory.
+<br/>
+(\*\*\*) The *JVM Direct memory limit* is added for JobManager process only if the corresponding option
+[`jobmanager.memory.enable-jvm-direct-memory-limit`](../config.html#jobmanager-memory-enable-jvm-direct-memory-limit) is set. 
 <br/><br/>
 
 Check also the detailed memory model for [TaskManager](mem_setup_tm.html#detailed-memory-model) and

--- a/docs/ops/memory/mem_setup.zh.md
+++ b/docs/ops/memory/mem_setup.zh.md
@@ -96,13 +96,16 @@ Flink 进程启动时，会根据配置的和自动推导出的各内存部分�
 
 | &nbsp;&nbsp;**JVM 参数**&nbsp;&nbsp; | &nbsp;&nbsp;**TaskManager 取值**&nbsp;&nbsp; | &nbsp;&nbsp;**JobManager 取值**&nbsp;&nbsp; |
 | :---------------------------------------- | :------------------------------------------------- | :------------------------------------------------ |
-| *-Xmx* 和 *-Xms*                         | 框架堆内存 + 任务堆内存                       | JVM 堆内存                                   |
-| *-XX:MaxDirectMemorySize*<br/>（TaskManager 始终设置，JobManager 见注释）                 | 框架堆外内存 + 任务堆外内存(\*) + 网络内存     | 堆外内存 (\*) (\*\*)                               |
+| *-Xmx* 和 *-Xms*                         | 框架堆内存 + 任务堆内存                       | JVM 堆内存 (\*)                                  |
+| *-XX:MaxDirectMemorySize*<br/>（TaskManager 始终设置，JobManager 见注释）                 | 框架堆外内存 + 任务堆外内存(\*\*) + 网络内存     | 堆外内存 (\*\*) (\*\*\*)                               |
 | *-XX:MaxMetaspaceSize*                    | JVM Metaspace                                      | JVM Metaspace                                     |
 {:.table-bordered}
-(\*) 请注意，堆外内存也包括了用户代码使用的本地内存（非直接内存）。
+(\*) Keep in mind that you might not be able to use the full amount of heap memory depending on the GC algorithm used. Some GC algorithms allocate a certain amount of heap memory for themselves. 
+This will lead to a different maximum being returned by the [Heap metrics](../../monitoring/metrics.html#memory).
 <br/>
-(\*\*) 只有在 [`jobmanager.memory.enable-jvm-direct-memory-limit`](../config.html#jobmanager-memory-enable-jvm-direct-memory-limit) 设置为 `true` 时，JobManager 才会设置 *JVM 直接内存限制*。
+(\*\*) 请注意，堆外内存也包括了用户代码使用的本地内存（非直接内存）。
+<br/>
+(\*\*\*) 只有在 [`jobmanager.memory.enable-jvm-direct-memory-limit`](../config.html#jobmanager-memory-enable-jvm-direct-memory-limit) 设置为 `true` 时，JobManager 才会设置 *JVM 直接内存限制*。
 <br/><br/>
 
 相关内存部分的配置方法，请同时参考 [TaskManager](mem_setup_tm.html#detailed-memory-model) 和 [JobManager](mem_setup_jobmanager.html#detailed-configuration) 的详细内存模型。


### PR DESCRIPTION
## What is the purpose of the change

We want to clarify why the maximum heap size returned by the metric system might differ from the heap size specified by the user. See https://plumbr.io/blog/memory-leaks/less-memory-than-xmx for further details.

## Brief change log

The memory configuration docs and the metrics docs were updated accordingly.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
