### PR TITLE
[FLINK-19907][network] Recover channel state before initializing operators chain

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -502,9 +502,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// both the following operations are protected by the lock
 			// so that we avoid race conditions in the case that initializeState()
 			// registers a timer, that fires before the open() is called.
-			operatorChain.initializeStateAndOpenOperators(createStreamTaskStateInitializer());
+			readRecoveredChannelState(); // WARN: should be done before operatorChain.initializeStateAndOpenOperators (see FLINK-19907)
 
-			readRecoveredChannelState();
+			operatorChain.initializeStateAndOpenOperators(createStreamTaskStateInitializer());
 		});
 
 		isRunning = true;


### PR DESCRIPTION
## What is the purpose of the change

Recover channel state bofer initializing operators chain.

Otherwise, operators in chain can emit watermarks or other data before
the old data is being sent to the downstream.

## Verifying this change

This is a trivial change.
`OverWindowITCase` in #13822 fails (non-deterministically) without this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
