### PR TITLE
[FLINK-19865] Introduce default log rotation limit for non-standalone deployments

### DIFF
--- a/flink-dist/src/main/flink-bin/conf/log4j-console.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-console.properties
@@ -56,7 +56,7 @@ appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size=100MB
 appender.rolling.policies.startup.type = OnStartupTriggeringPolicy
 appender.rolling.strategy.type = DefaultRolloverStrategy
-appender.rolling.strategy.max = ${env:MAX_LOG_FILE_NUMBER}
+appender.rolling.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline

--- a/flink-dist/src/main/flink-bin/conf/log4j.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j.properties
@@ -49,7 +49,7 @@ appender.main.policies.size.type = SizeBasedTriggeringPolicy
 appender.main.policies.size.size = 100MB
 appender.main.policies.startup.type = OnStartupTriggeringPolicy
 appender.main.strategy.type = DefaultRolloverStrategy
-appender.main.strategy.max = ${env:MAX_LOG_FILE_NUMBER}
+appender.main.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline


### PR DESCRIPTION


## What is the purpose of the change

A failing Hadoop 3.1.3 YARN test on CI hinted at a problem with the recently introduced rolling of log files through log4j (https://github.com/apache/flink/pull/13457).
The number of rolled log files to keep is configured via an environment variable, which is set by the standalone scripts. In case of YARN (and also other resource managers), the environment variable is not available. Logs are managed by the resource managers, so it is save to just set a default value for the rotation.



## Verifying this change

This change fixes a failing nightly test. This is a green build with the Hadoop 3.1.3 profile: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8576&view=results

