### PR TITLE
[FLINK-19908][table-planner-blink] FlinkLogicalTableSourceScan and CommonPhysicalTableSourceScan should respect source reuse config option

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/reuse/SubplanReuser.scala
@@ -21,7 +21,8 @@ package org.apache.flink.table.planner.plan.reuse
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
-import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalLegacyTableSourceScan
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.planner.plan.nodes.common.CommonPhysicalTableSourceScan
 import org.apache.flink.table.planner.plan.nodes.physical.PhysicalLegacyTableSourceScan
 import org.apache.flink.table.planner.plan.utils.{DefaultRelShuttle, FlinkRelOptUtil}
 
@@ -152,7 +153,8 @@ object SubplanReuser {
     private def isNodeReusableDisabled(node: RelNode): Boolean = {
       node match {
         // TableSourceScan node can not be reused if reuse TableSource disabled
-        case _: FlinkLogicalLegacyTableSourceScan | _: PhysicalLegacyTableSourceScan =>
+        case _: FlinkLogicalLegacyTableSourceScan | _: PhysicalLegacyTableSourceScan |
+             _: FlinkLogicalTableSourceScan | _: CommonPhysicalTableSourceScan =>
           !tableSourceReuseEnabled
         // Exchange node can not be reused if its input is reusable disabled
         case e: Exchange => isNodeReusableDisabled(e.getInput)

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.xml
@@ -130,6 +130,53 @@ HashJoin(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, c, d, e, f, a0, b
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDisableReuseTableSourceOnNewSource">
+    <Resource name="sql">
+      <![CDATA[
+WITH t AS (
+  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+  FROM newX, newY
+  WHERE newX.a = newY.d)
+SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$2], e=[$3], a0=[$4], b0=[$5], d0=[$6], e0=[$7])
++- LogicalFilter(condition=[AND(=($1, $7), <($0, 10), >($4, 5))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+      :  +- LogicalFilter(condition=[=($0, $3)])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+      +- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+         +- LogicalFilter(condition=[=($0, $3)])
+            +- LogicalJoin(condition=[true], joinType=[inner])
+               :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0, e0], build=[right])
+:- Exchange(distribution=[hash[b]])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], build=[left])
+:     :- Exchange(distribution=[hash[a]])
+:     :  +- Calc(select=[a, b], where=[<(a, 10)])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b])
+:     +- Exchange(distribution=[hash[d]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
++- Exchange(distribution=[hash[e]])
+   +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], build=[left])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b], where=[>(a, 5)])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b])
+      +- Exchange(distribution=[hash[d]])
+         +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEnableReuseTableSource">
     <Resource name="sql">
       <![CDATA[
@@ -165,6 +212,52 @@ HashJoin(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0,
 :     +- Exchange(distribution=[hash[d]], reuse_id=[2])
 :        +- Calc(select=[d, e])
 :           +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
++- Exchange(distribution=[hash[e]])
+   +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], build=[left])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b], where=[>(a, 5)])
+      :     +- Reused(reference_id=[1])
+      +- Reused(reference_id=[2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEnableReuseTableSourceOnNewSource">
+    <Resource name="sql">
+      <![CDATA[
+WITH t AS (
+  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+  FROM newX, newY
+  WHERE newX.a = newY.d)
+SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$2], e=[$3], a0=[$4], b0=[$5], d0=[$6], e0=[$7])
++- LogicalFilter(condition=[AND(=($1, $7), <($0, 10), >($4, 5))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+      :  +- LogicalFilter(condition=[=($0, $3)])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+      +- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+         +- LogicalFilter(condition=[=($0, $3)])
+            +- LogicalJoin(condition=[true], joinType=[inner])
+               :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0, e0], build=[right])
+:- Exchange(distribution=[hash[b]], shuffle_mode=[BATCH])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], build=[left])
+:     :- Exchange(distribution=[hash[a]])
+:     :  +- Calc(select=[a, b], where=[<(a, 10)])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b], reuse_id=[1])
+:     +- Exchange(distribution=[hash[d]], reuse_id=[2])
+:        +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
 +- Exchange(distribution=[hash[e]])
    +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], build=[left])
       :- Exchange(distribution=[hash[a]])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.xml
@@ -88,6 +88,53 @@ Join(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, c, d, e, f, a0, b0, c
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDisableReuseTableSourceOnNewSource">
+    <Resource name="sql">
+      <![CDATA[
+WITH t AS (
+  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+  FROM newX, newY
+  WHERE newX.a = newY.d)
+SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$2], e=[$3], a0=[$4], b0=[$5], d0=[$6], e0=[$7])
++- LogicalFilter(condition=[AND(=($1, $7), <($0, 10), >($4, 5))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+      :  +- LogicalFilter(condition=[=($0, $3)])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+      +- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+         +- LogicalFilter(condition=[=($0, $3)])
+            +- LogicalJoin(condition=[true], joinType=[inner])
+               :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0, e0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[b]])
+:  +- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:     :- Exchange(distribution=[hash[a]])
+:     :  +- Calc(select=[a, b], where=[<(a, 10)])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b])
+:     +- Exchange(distribution=[hash[d]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
++- Exchange(distribution=[hash[e]])
+   +- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b], where=[>(a, 5)])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b])
+      +- Exchange(distribution=[hash[d]])
+         +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testEnableReuseTableSource">
     <Resource name="sql">
       <![CDATA[
@@ -235,6 +282,52 @@ Union(all=[true], union=[a, EXPR$1])
 :- Calc(select=[a, random_udf() AS EXPR$1], where=[>(a, 10)], reuse_id=[1])
 :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEnableReuseTableSourceOnNewSource">
+    <Resource name="sql">
+      <![CDATA[
+WITH t AS (
+  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+  FROM newX, newY
+  WHERE newX.a = newY.d)
+SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$2], e=[$3], a0=[$4], b0=[$5], d0=[$6], e0=[$7])
++- LogicalFilter(condition=[AND(=($1, $7), <($0, 10), >($4, 5))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+      :  +- LogicalFilter(condition=[=($0, $3)])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+      +- LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
+         +- LogicalFilter(condition=[=($0, $3)])
+            +- LogicalJoin(condition=[true], joinType=[inner])
+               :- LogicalTableScan(table=[[default_catalog, default_database, newX]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, newY]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0, e0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[b]])
+:  +- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:     :- Exchange(distribution=[hash[a]])
+:     :  +- Calc(select=[a, b], where=[<(a, 10)])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, newX, filter=[], project=[a, b]]], fields=[a, b], reuse_id=[1])
+:     +- Exchange(distribution=[hash[d]], reuse_id=[2])
+:        +- TableSourceScan(table=[[default_catalog, default_database, newY, project=[d, e]]], fields=[d, e])
++- Exchange(distribution=[hash[e]])
+   +- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b], where=[>(a, 5)])
+      :     +- Reused(reference_id=[1])
+      +- Reused(reference_id=[2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
@@ -453,35 +453,17 @@ class SubplanReuseTest extends TableTestBase {
   def testEnableReuseTableSourceOnNewSource(): Unit = {
     util.tableEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true)
-    addNewSource()
-    val sqlQuery =
-      """
-        |WITH t AS (
-        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
-        |  FROM newX, newY
-        |  WHERE newX.a = newY.d)
-        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
-      """.stripMargin
-    util.verifyPlan(sqlQuery)
+    testReuseOnNewSource()
   }
 
   @Test
   def testDisableReuseTableSourceOnNewSource(): Unit = {
     util.tableEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, false)
-    addNewSource()
-    val sqlQuery =
-      """
-        |WITH t AS (
-        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
-        |  FROM newX, newY
-        |  WHERE newX.a = newY.d)
-        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
-      """.stripMargin
-    util.verifyPlan(sqlQuery)
+    testReuseOnNewSource()
   }
 
-  private def addNewSource(): Unit = {
+  private def testReuseOnNewSource(): Unit = {
     util.addTable(
       s"""
          |create table newX(
@@ -504,5 +486,14 @@ class SubplanReuseTest extends TableTestBase {
          |  'bounded' = 'true'
          |)
        """.stripMargin)
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
@@ -448,4 +448,61 @@ class SubplanReuseTest extends TableTestBase {
       """.stripMargin
     util.verifyPlan(sqlQuery)
   }
+
+  @Test
+  def testEnableReuseTableSourceOnNewSource(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true)
+    addNewSource()
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testDisableReuseTableSourceOnNewSource(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, false)
+    addNewSource()
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  private def addNewSource(): Unit = {
+    util.addTable(
+      s"""
+         |create table newX(
+         |  a int,
+         |  b bigint,
+         |  c varchar
+         |) with (
+         |  'connector' = 'values',
+         |  'bounded' = 'true'
+         |)
+       """.stripMargin)
+    util.addTable(
+      s"""
+         |create table newY(
+         |  d int,
+         |  e bigint,
+         |  f varchar
+         |) with (
+         |  'connector' = 'values',
+         |  'bounded' = 'true'
+         |)
+       """.stripMargin)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
@@ -301,4 +301,58 @@ class SubplanReuseTest extends TableTestBase {
     util.verifyPlan(sqlQuery)
   }
 
+  @Test
+  def testEnableReuseTableSourceOnNewSource(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true)
+    addNewSource()
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testDisableReuseTableSourceOnNewSource(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, false)
+    addNewSource()
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
+  }
+
+  private def addNewSource(): Unit = {
+    util.addTable(
+      s"""
+         |create table newX(
+         |  a int,
+         |  b bigint,
+         |  c varchar
+         |) with (
+         |  'connector' = 'values'
+         |)
+       """.stripMargin)
+    util.addTable(
+      s"""
+         |create table newY(
+         |  d int,
+         |  e bigint,
+         |  f varchar
+         |) with (
+         |  'connector' = 'values'
+         |)
+       """.stripMargin)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SubplanReuseTest.scala
@@ -305,35 +305,17 @@ class SubplanReuseTest extends TableTestBase {
   def testEnableReuseTableSourceOnNewSource(): Unit = {
     util.tableEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, true)
-    addNewSource()
-    val sqlQuery =
-      """
-        |WITH t AS (
-        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
-        |  FROM newX, newY
-        |  WHERE newX.a = newY.d)
-        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
-      """.stripMargin
-    util.verifyPlan(sqlQuery)
+    testReuseOnNewSource()
   }
 
   @Test
   def testDisableReuseTableSourceOnNewSource(): Unit = {
     util.tableEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SOURCE_ENABLED, false)
-    addNewSource()
-    val sqlQuery =
-      """
-        |WITH t AS (
-        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
-        |  FROM newX, newY
-        |  WHERE newX.a = newY.d)
-        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
-      """.stripMargin
-    util.verifyPlan(sqlQuery)
+    testReuseOnNewSource()
   }
 
-  private def addNewSource(): Unit = {
+  private def testReuseOnNewSource(): Unit = {
     util.addTable(
       s"""
          |create table newX(
@@ -354,5 +336,14 @@ class SubplanReuseTest extends TableTestBase {
          |  'connector' = 'values'
          |)
        """.stripMargin)
+    val sqlQuery =
+      """
+        |WITH t AS (
+        |  SELECT newX.a AS a, newX.b AS b, newY.d AS d, newY.e AS e
+        |  FROM newX, newY
+        |  WHERE newX.a = newY.d)
+        |SELECT t1.*, t2.* FROM t t1, t t2 WHERE t1.b = t2.e AND t1.a < 10 AND t2.a > 5
+      """.stripMargin
+    util.verifyPlan(sqlQuery)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently we have the `table.optimizer.reuse-sub-plan-enabled` config option to configure the reuse of sources. However `FlinkLogicalTableSourceScan` and `CommonPhysicalTableSourceScan` do not respect this option and are always reused.

This PR fixes the related code in `SubplanReuser` so that `FlinkLogicalTableSourceScan` and `CommonPhysicalTableSourceScan` now respect the config option,

## Brief change log

 - `FlinkLogicalTableSourceScan` and `CommonPhysicalTableSourceScan` now respect the config option

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
