### PR TITLE
[FLINK-19897][web] Improve UI related to FLIP-102

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.html
@@ -36,6 +36,7 @@
         <td rowspan="2">
           <nz-progress nzSize="small" nzStrokeLinecap="square" [nzPercent]="+(metrics['Status.JVM.Memory.Heap.Used'] / metrics['Status.JVM.Memory.Heap.Max']  * 100 | number:'1.0-2')" nzStatus="normal"></nz-progress>
           {{metrics['Status.JVM.Memory.Heap.Used'] | humanizeBytes}} / {{metrics['Status.JVM.Memory.Heap.Max'] | humanizeBytes }}
+          <i nz-icon nz-tooltip nzTitle="The maximum heap displayed might differ from the configured values depending on the used GC algorithm for this process." nzType="info-circle"></i>
         </td>
       </tr>
       <tr>
@@ -154,7 +155,7 @@
     </div>
     <div nz-row [nzGutter]="16">
       <div nz-col [nzSpan]="12">
-        <nz-card nzType="inner" [nzBodyStyle]="{ padding:'0px' }" nzTitle="Network Memory Segments">
+        <nz-card nzType="inner" [nzBodyStyle]="{ padding:'0px' }" nzTitle="Netty Shuffle Buffers">
           <nz-table
               [nzTemplateMode]="true"
               [nzShowPagination]="false"
@@ -180,7 +181,7 @@
         </nz-card>
       </div>
       <div nz-col [nzSpan]="12">
-        <nz-card nzType="inner" [nzBodyStyle]="{ padding:'0px' }" nzTitle="Network Garbage Collection">
+        <nz-card nzType="inner" [nzBodyStyle]="{ padding:'0px' }" nzTitle="Garbage Collection">
           <nz-table
               [nzTemplateMode]="true"
               [nzShowPagination]="false"

--- a/flink-runtime-web/web-dashboard/src/styles/rewrite.less
+++ b/flink-runtime-web/web-dashboard/src/styles/rewrite.less
@@ -72,7 +72,7 @@ nz-table {
 }
 
 .ant-tooltip-inner {
-  word-break: break-all;
+  word-break: break-word;
   font-size: 12px;
 }
 


### PR DESCRIPTION
## What is the purpose of the change

ref https://issues.apache.org/jira/browse/FLINK-19897

## Brief change log

Improve UI related to FLIP-102


## Verifying this change

- Add Tooltip to Heap metrics cell pointing out that the max metrics might differ from the configured maximum value. This tooltip could be made optional and only appears if heap max is different from the configured value. Here's a proposal for the tooltip text: The maximum heap displayed might differ from the configured values depending on the used GC algorithm for this process.
- Rename "Network Memory Segments" into "Netty Shuffle Buffers"
- Rename "Network Garbage Collection" into "Garbage Collection"

before:

![image](https://user-images.githubusercontent.com/1506722/97827334-f0134e00-1cfe-11eb-843d-594641e2d83b.png)

after:

![image](https://user-images.githubusercontent.com/1506722/97827315-deca4180-1cfe-11eb-98a3-e00d58b9a9aa.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no needed)
