### PR TITLE
[FLINK-19924][config] Disallow UC for iterative jobs

### DIFF
--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -68,5 +68,11 @@
             <td>Boolean</td>
             <td>Enables unaligned checkpoints, which greatly reduce checkpointing times under backpressure.<br /><br />Unaligned checkpoints contain data stored in buffers as part of the checkpoint state, which allows checkpoint barriers to overtake these buffers. Thus, the checkpoint duration becomes independent of the current throughput as checkpoint barriers are effectively not embedded into the stream of data anymore.<br /><br />Unaligned checkpoints can only be enabled if <span markdown="span">`execution.checkpointing.mode`</span> is <span markdown="span">`EXACTLY_ONCE`</span> and if <span markdown="span">`execution.checkpointing.max-concurrent-checkpoints`</span> is 1</td>
         </tr>
+        <tr>
+            <td><h5>execution.checkpointing.unaligned.forced</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Forces unaligned checkpoints, particularly allowing them for iterative jobs.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -763,3 +763,9 @@ class StreamExecutionEnvironment(object):
             j_stream_graph.setJobName(job_name)
 
         return j_stream_graph
+
+    def is_unaligned_checkpoints_enabled(self):
+        """
+        Returns whether Unaligned Checkpoints are enabled.
+        """
+        return self._j_stream_execution_environment.isUnalignedCheckpointsEnabled()

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -769,3 +769,9 @@ class StreamExecutionEnvironment(object):
         Returns whether Unaligned Checkpoints are enabled.
         """
         return self._j_stream_execution_environment.isUnalignedCheckpointsEnabled()
+
+    def is_force_unaligned_checkpoints(self):
+        """
+        Returns whether Unaligned Checkpoints are force-enabled.
+        """
+        return self._j_stream_execution_environment.isForceUnalignedCheckpoints()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -76,6 +76,9 @@ public class CheckpointConfig implements java.io.Serializable {
 	/** Flag to force checkpointing in iterative jobs. */
 	private boolean forceCheckpointing;
 
+	/** Flag to force checkpointing in iterative jobs. */
+	private boolean forceUnalignedCheckpoints;
+
 	/** Flag to enable unaligned checkpoints. */
 	private boolean unalignedCheckpointsEnabled;
 
@@ -121,6 +124,7 @@ public class CheckpointConfig implements java.io.Serializable {
 		this.alignmentTimeout = checkpointConfig.alignmentTimeout;
 		this.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
 		this.forceCheckpointing = checkpointConfig.forceCheckpointing;
+		this.forceUnalignedCheckpoints = checkpointConfig.forceUnalignedCheckpoints;
 		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
 	}
 
@@ -293,6 +297,26 @@ public class CheckpointConfig implements java.io.Serializable {
 	@PublicEvolving
 	public void setForceCheckpointing(boolean forceCheckpointing) {
 		this.forceCheckpointing = forceCheckpointing;
+	}
+
+	/**
+	 * Checks whether Unaligned Checkpoints are forced, despite iteration feedback.
+	 *
+	 * @return True, if Unaligned Checkpoints are forced, false otherwise.
+	 */
+	@PublicEvolving
+	public boolean isForceUnalignedCheckpoints() {
+		return forceUnalignedCheckpoints;
+	}
+
+	/**
+	 * Checks whether Unaligned Checkpoints are forced, despite currently non-checkpointable iteration feedback.
+	 *
+	 * @param forceUnalignedCheckpoints The flag to force checkpointing.
+	 */
+	@PublicEvolving
+	public void setForceUnalignedCheckpoints(boolean forceUnalignedCheckpoints) {
+		this.forceUnalignedCheckpoints = forceUnalignedCheckpoints;
 	}
 
 	/**
@@ -571,5 +595,7 @@ public class CheckpointConfig implements java.io.Serializable {
 			.ifPresent(this::enableUnalignedCheckpoints);
 		configuration.getOptional(ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT)
 			.ifPresent(timeout -> setAlignmentTimeout(timeout.toMillis()));
+		configuration.getOptional(ExecutionCheckpointingOptions.FORCE_UNALIGNED)
+			.ifPresent(this::setForceUnalignedCheckpoints);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -159,4 +159,12 @@ public class ExecutionCheckpointingOptions {
 					"If during checkpointing, checkpoint start delay exceeds this timeout, alignment " +
 					"will timeout and checkpoint barrier will start working as unaligned checkpoint.")
 				.build());
+
+	public static final ConfigOption<Boolean> FORCE_UNALIGNED =
+		ConfigOptions.key("execution.checkpointing.unaligned.forced")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription(Description.builder()
+				.text("Forces unaligned checkpoints, particularly allowing them for iterative jobs.")
+				.build());
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -533,6 +533,14 @@ public class StreamExecutionEnvironment {
 	}
 
 	/**
+	 * Returns whether Unaligned Checkpoints are force-enabled.
+	 */
+	@PublicEvolving
+	public boolean isForceUnalignedCheckpoints() {
+		return checkpointCfg.isForceUnalignedCheckpoints();
+	}
+
+	/**
 	 * Returns the checkpointing mode (exactly-once vs. at-least-once).
 	 *
 	 * <p>Shorthand for {@code getCheckpointConfig().getCheckpointingMode()}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -525,6 +525,14 @@ public class StreamExecutionEnvironment {
 	}
 
 	/**
+	 * Returns whether Unaligned Checkpoints are enabled.
+	 */
+	@PublicEvolving
+	public boolean isUnalignedCheckpointsEnabled() {
+		return checkpointCfg.isUnalignedCheckpointsEnabled();
+	}
+
+	/**
 	 * Returns the checkpointing mode (exactly-once vs. at-least-once).
 	 *
 	 * <p>Shorthand for {@code getCheckpointConfig().getCheckpointingMode()}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -90,6 +90,7 @@ public class StreamConfig implements Serializable {
 	private static final String OPERATOR_NAME = "operatorName";
 	private static final String OPERATOR_ID = "operatorID";
 	private static final String CHAIN_END = "chainEnd";
+	private static final String GRAPH_CONTAINING_LOOPS = "graphContainingLoops";
 
 	private static final String CHECKPOINTING_ENABLED = "checkpointing";
 	private static final String CHECKPOINT_MODE = "checkpointMode";
@@ -661,6 +662,14 @@ public class StreamConfig implements Serializable {
 
 	public boolean shouldSortInputs() {
 		return config.get(SORTED_INPUTS);
+	}
+
+	public void setGraphContainingLoops(boolean graphContainingLoops) {
+		config.setBoolean(GRAPH_CONTAINING_LOOPS, graphContainingLoops);
+	}
+
+	public boolean isGraphContainingLoops() {
+		return config.getBoolean(GRAPH_CONTAINING_LOOPS, false);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -614,6 +614,7 @@ public class StreamingJobGraphGenerator {
 		final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 
 		config.setStateBackend(streamGraph.getStateBackend());
+		config.setGraphContainingLoops(streamGraph.isIterative());
 		config.setTimerServiceProvider(streamGraph.getTimerServiceProvider());
 		config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
 		config.setCheckpointMode(getCheckpointingMode(checkpointCfg));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -216,6 +216,12 @@ public class StreamingJobGraphGenerator {
 						+ "State checkpoints happen normally, but records in-transit during the snapshot will be lost upon failure. "
 						+ "\nThe user can force enable state checkpoints with the reduced guarantees by calling: env.enableCheckpointing(interval,true)");
 			}
+			if (streamGraph.isIterative() && checkpointConfig.isUnalignedCheckpointsEnabled() && !checkpointConfig.isForceUnalignedCheckpoints()) {
+				throw new UnsupportedOperationException(
+					"Unaligned Checkpoints are currently not supported for iterative jobs, "
+						+ " as rescaling would require alignment (in addition to the reduced checkpointing guarantees)."
+						+ "\nThe user can force Unaligned Checkpoints by using 'execution.checkpointing.unaligned.forced'");
+			}
 
 			ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 			for (StreamNode node : streamGraph.getStreamNodes()) {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -886,6 +886,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * Returns whether Unaligned Checkpoints are enabled.
    */
   def isUnalignedCheckpointsEnabled: Boolean = javaEnv.isUnalignedCheckpointsEnabled
+
+  /**
+   * Returns whether Unaligned Checkpoints are force-enabled.
+   */
+  def isForceUnalignedCheckpoints: Boolean = javaEnv.isForceUnalignedCheckpoints
 }
 
 object StreamExecutionEnvironment {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -881,6 +881,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def registerCachedFile(filePath: String, name: String, executable: Boolean): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
   }
+
+  /**
+   * Returns whether Unaligned Checkpoints are enabled.
+   */
+  def isUnalignedCheckpointsEnabled: Boolean = javaEnv.isUnalignedCheckpointsEnabled
 }
 
 object StreamExecutionEnvironment {


### PR DESCRIPTION
## What is the purpose of the change

From 1.12, Unaligned checkpoints will support rescaling. 
But it will be limited to non-iterative jobs.
This PR adds:
 - validation: non-iterative or non-UC
 - a flag to skip validation
 - passing a flag to subtasks (whether the job is iterative)


## Brief change log

 - Disallow Unaligned Checkpoints for iterative jobs by default
 - Add an option to force Unaligned Checkpoints
 - Add StreamConfig.isGraphContainingLoops


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
