### PR TITLE
[FLINK-19693][runtime] Downstream Failover for Approximate Local Recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -70,7 +70,10 @@ public final class PipelinedRegionComputeUtil {
 			vertexToRegion.put(vertex, currentRegion);
 
 			for (R consumedResult : vertex.getConsumedResults()) {
-				if (consumedResult.getResultType().isPipelined()) {
+				// Similar to the BLOCKING ResultPartitionType, each vertex connected through PIPELINED_APPROXIMATE
+				// is also considered as a single region. This attribute is called "reconnectable".
+				// reconnectable will be removed after FLINK-19895, see also {@link ResultPartitionType#isReconnectable}
+				if (!consumedResult.getResultType().isReconnectable()) {
 					final V producerVertex = consumedResult.getProducer();
 					final Set<V> producerRegion = vertexToRegion.get(producerVertex);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
@@ -62,8 +62,9 @@ public class JobMasterPartitionTrackerImpl
 		Preconditions.checkNotNull(producingTaskExecutorId);
 		Preconditions.checkNotNull(resultPartitionDeploymentDescriptor);
 
-		// only blocking partitions require explicit release call
-		if (!resultPartitionDeploymentDescriptor.getPartitionType().isBlocking()) {
+		// blocking and PIPELINED_APPROXIMATE partitions require explicit partition release calls
+		// reconnectable will be removed after FLINK-19895, see also {@link ResultPartitionType#isReconnectable}.
+		if (!resultPartitionDeploymentDescriptor.getPartitionType().isReconnectable()) {
 			return;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -34,7 +34,7 @@ public enum ResultPartitionType {
 	 * {@link #PIPELINED} partitions), but only released through the scheduler, when it determines
 	 * that the partition is no longer needed.
 	 */
-	BLOCKING(false, false, false, false),
+	BLOCKING(false, false, false, false, true),
 
 	/**
 	 * BLOCKING_PERSISTENT partitions are similar to {@link #BLOCKING} partitions, but have
@@ -47,7 +47,7 @@ public enum ResultPartitionType {
 	 * scenarios, like when the TaskManager exits or when the TaskManager looses connection
 	 * to JobManager / ResourceManager for too long.
 	 */
-	BLOCKING_PERSISTENT(false, false, false, true),
+	BLOCKING_PERSISTENT(false, false, false, true, true),
 
 	/**
 	 * A pipelined streaming data exchange. This is applicable to both bounded and unbounded streams.
@@ -58,7 +58,7 @@ public enum ResultPartitionType {
 	 * <p>This result partition type may keep an arbitrary amount of data in-flight, in contrast to
 	 * the {@link #PIPELINED_BOUNDED} variant.
 	 */
-	PIPELINED(true, true, false, false),
+	PIPELINED(true, true, false, false, false),
 
 	/**
 	 * Pipelined partitions with a bounded (local) buffer pool.
@@ -71,17 +71,17 @@ public enum ResultPartitionType {
 	 * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there are
 	 * no checkpoint barriers.
 	 */
-	PIPELINED_BOUNDED(true, true, true, false),
+	PIPELINED_BOUNDED(true, true, true, false, false),
 
 	/**
 	 * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
 	 * continue consuming data after reconnection in Approximate Local-Recovery.
 	 *
 	 * <p>Pipelined results can be consumed only once by a single consumer at one time.
-	 * {@link #PIPELINED_APPROXIMATE} is different from {@link #PIPELINED_BOUNDED} in that
-	 * {@link #PIPELINED_APPROXIMATE} is not decomposed automatically after consumption.
+	 * {@link #PIPELINED_APPROXIMATE} is different from {@link #PIPELINED} and {@link #PIPELINED_BOUNDED} in that
+	 * {@link #PIPELINED_APPROXIMATE} partition can be reconnected after down stream task fails.
 	 */
-	PIPELINED_APPROXIMATE(true, true, true, true);
+	PIPELINED_APPROXIMATE(true, true, true, false, true);
 
 	/** Can the partition be consumed while being produced? */
 	private final boolean isPipelined;
@@ -96,13 +96,31 @@ public enum ResultPartitionType {
 	private final boolean isPersistent;
 
 	/**
+	 * Can the partition be reconnected.
+	 *
+	 * <p>Attention: this attribute is introduced temporally for ResultPartitionType.PIPELINED_APPROXIMATE
+	 * It will be removed afterwards:
+	 * TODO:
+	 * 1. Approximate local recovery has its won failover strategy to restart the failed set of tasks instead of
+	 *     restarting downstream of failed tasks depending on {@code RestartPipelinedRegionFailoverStrategy}
+	 * 2. FLINK-19895: Unify the life cycle of ResultPartitionType Pipelined Family
+	 */
+	private final boolean isReconnectable;
+
+	/**
 	 * Specifies the behaviour of an intermediate result partition at runtime.
 	 */
-	ResultPartitionType(boolean isPipelined, boolean hasBackPressure, boolean isBounded, boolean isPersistent) {
+	ResultPartitionType(
+			boolean isPipelined,
+			boolean hasBackPressure,
+			boolean isBounded,
+			boolean isPersistent,
+			boolean isReconnectable) {
 		this.isPipelined = isPipelined;
 		this.hasBackPressure = hasBackPressure;
 		this.isBounded = isBounded;
 		this.isPersistent = isPersistent;
+		this.isReconnectable = isReconnectable;
 	}
 
 	public boolean hasBackPressure() {
@@ -115,6 +133,10 @@ public enum ResultPartitionType {
 
 	public boolean isPipelined() {
 		return isPipelined;
+	}
+
+	public boolean isReconnectable() {
+		return isReconnectable;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -82,6 +82,9 @@ public class JobGraph implements Serializable {
 	/** The mode in which the job is scheduled. */
 	private ScheduleMode scheduleMode = ScheduleMode.LAZY_FROM_SOURCES;
 
+	/** Whether approximate local recovery is enabled. This flag will be removed together with legacy scheduling strategies. */
+	private boolean approximateLocalRecovery = false;
+
 	// --- checkpointing ---
 
 	/** Job specific execution config. */
@@ -229,6 +232,14 @@ public class JobGraph implements Serializable {
 
 	public ScheduleMode getScheduleMode() {
 		return scheduleMode;
+	}
+
+	public void enableApproximateLocalRecovery(boolean enabled) {
+		this.approximateLocalRecovery = enabled;
+	}
+
+	public boolean isApproximateLocalRecoveryEnabled() {
+		return approximateLocalRecovery;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponents.java
@@ -45,6 +45,8 @@ import org.apache.flink.util.clock.SystemClock;
 
 import java.util.function.Consumer;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * Components to create a {@link DefaultScheduler} which depends on the
  * configured {@link JobManagerOptions#SCHEDULING_STRATEGY}.
@@ -82,6 +84,7 @@ public class DefaultSchedulerComponents {
 
 	static DefaultSchedulerComponents createSchedulerComponents(
 			final ScheduleMode scheduleMode,
+			final boolean isApproximateLocalRecoveryEnabled,
 			final Configuration jobMasterConfiguration,
 			final SlotPool slotPool,
 			final Time slotRequestTimeout) {
@@ -89,12 +92,18 @@ public class DefaultSchedulerComponents {
 		final String schedulingStrategy = jobMasterConfiguration.getString(JobManagerOptions.SCHEDULING_STRATEGY);
 		switch (schedulingStrategy) {
 			case PIPELINED_REGION_SCHEDULING:
+				checkArgument(
+					!isApproximateLocalRecoveryEnabled,
+					"Approximate local recovery can not be used together with PipelinedRegionScheduler for now! " +
+						"Please set JobManagerOptions.SCHEDULING_STRATEGY to legacy.");
 				return createPipelinedRegionSchedulerComponents(
 					scheduleMode,
 					jobMasterConfiguration,
 					slotPool,
 					slotRequestTimeout);
 			case LEGACY_SCHEDULING:
+				checkArgument(!isApproximateLocalRecoveryEnabled || !scheduleMode.allowLazyDeployment(),
+					"Approximate local recovery can only be used together with EAGER schedule mode!");
 				return createLegacySchedulerComponents(
 					scheduleMode,
 					jobMasterConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -69,6 +69,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 
 		final DefaultSchedulerComponents schedulerComponents = createSchedulerComponents(
 			jobGraph.getScheduleMode(),
+			jobGraph.isApproximateLocalRecoveryEnabled(),
 			jobMasterConfiguration,
 			slotPool,
 			slotRequestTimeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtilTest.java
@@ -546,6 +546,31 @@ public class PipelinedRegionComputeUtilTest extends TestLogger {
 		assertSameRegion(r1, r2, r3, r4);
 	}
 
+	@Test
+	public void testPipelinedApproximateDifferentRegions() {
+		TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+		TestingSchedulingExecutionVertex v1 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v2 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v3 = topology.newExecutionVertex();
+		TestingSchedulingExecutionVertex v4 = topology.newExecutionVertex();
+
+		topology
+			.connect(v1, v2, ResultPartitionType.PIPELINED_APPROXIMATE)
+			.connect(v1, v3, ResultPartitionType.PIPELINED_APPROXIMATE)
+			.connect(v2, v4, ResultPartitionType.PIPELINED_APPROXIMATE)
+			.connect(v3, v4, ResultPartitionType.PIPELINED_APPROXIMATE);
+
+		Map<ExecutionVertexID, Set<SchedulingExecutionVertex>> pipelinedRegionByVertex = computePipelinedRegionByVertex(topology);
+
+		Set<SchedulingExecutionVertex> r1 = pipelinedRegionByVertex.get(v1.getId());
+		Set<SchedulingExecutionVertex> r2 = pipelinedRegionByVertex.get(v2.getId());
+		Set<SchedulingExecutionVertex> r3 = pipelinedRegionByVertex.get(v3.getId());
+		Set<SchedulingExecutionVertex> r4 = pipelinedRegionByVertex.get(v4.getId());
+
+		assertDistinctRegions(r1, r2, r3, r4);
+	}
+
 	// ------------------------------------------------------------------------
 	//  utilities
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
@@ -60,6 +60,11 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
 		testReleaseOnConsumptionHandling(ResultPartitionType.BLOCKING);
 	}
 
+	@Test
+	public void testPipelinedApproximatePartitionIsTracked() {
+		testReleaseOnConsumptionHandling(ResultPartitionType.PIPELINED_APPROXIMATE);
+	}
+
 	private static void testReleaseOnConsumptionHandling(ResultPartitionType resultPartitionType) {
 		final JobMasterPartitionTracker partitionTracker = new JobMasterPartitionTrackerImpl(
 			new JobID(),
@@ -76,7 +81,7 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
 				resultPartitionType,
 				false));
 
-		assertThat(partitionTracker.isTrackingPartitionsFor(resourceId), is(resultPartitionType.isBlocking()));
+		assertThat(partitionTracker.isTrackingPartitionsFor(resourceId), is(resultPartitionType.isReconnectable()));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
@@ -26,14 +26,19 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.TestingSlotPoolImpl;
+import org.apache.flink.runtime.scheduler.strategy.EagerSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import static org.apache.flink.runtime.jobgraph.ScheduleMode.EAGER;
+import static org.apache.flink.runtime.jobgraph.ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the factory method {@link DefaultSchedulerComponents#createSchedulerComponents(
@@ -67,9 +72,56 @@ public class DefaultSchedulerComponentsFactoryTest extends TestLogger {
 		assertThat(components.getSchedulingStrategyFactory(), instanceOf(PipelinedRegionSchedulingStrategy.Factory.class));
 	}
 
+	@Test
+	public void testCreatingPipelinedRegionSchedulingStrategyFactoryWithApproximateLocalRecovery() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(JobManagerOptions.SCHEDULING_STRATEGY, "region");
+
+		try {
+			createSchedulerComponents(configuration, true, EAGER);
+			fail("expected failure");
+		} catch (IllegalArgumentException e) {
+			assertTrue(
+				e.getMessage()
+					.contains("Approximate local recovery can not be used together with PipelinedRegionScheduler for now"));
+		}
+	}
+
+	@Test
+	public void testCreatingLegacySchedulingStrategyFactoryWithApproximateLocalRecoveryInLazyMode() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(JobManagerOptions.SCHEDULING_STRATEGY, "legacy");
+
+		try {
+			createSchedulerComponents(configuration, true, LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
+			fail("expected failure");
+		} catch (IllegalArgumentException e) {
+			assertTrue(
+				e.getMessage()
+					.contains("Approximate local recovery can only be used together with EAGER schedule mode"));
+		}
+	}
+
+	@Test
+	public void testCreatingLegacySchedulingStrategyFactoryWithApproximateLocalRecoveryInEagerMode() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(JobManagerOptions.SCHEDULING_STRATEGY, "legacy");
+
+		final DefaultSchedulerComponents components = createSchedulerComponents(configuration, true, EAGER);
+		assertThat(components.getSchedulingStrategyFactory(), instanceOf(EagerSchedulingStrategy.Factory.class));
+	}
+
 	private static DefaultSchedulerComponents createSchedulerComponents(final Configuration configuration) {
+		return createSchedulerComponents(configuration, false, LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
+	}
+
+	private static DefaultSchedulerComponents createSchedulerComponents(
+			final Configuration configuration,
+			boolean iApproximateLocalRecoveryEnabled,
+			ScheduleMode scheduleMode) {
 		return DefaultSchedulerComponents.createSchedulerComponents(
-			ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
+			scheduleMode,
+			iApproximateLocalRecoveryEnabled,
 			configuration,
 			new TestingSlotPoolImpl(new JobID()),
 			Time.milliseconds(10L));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.environment;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobStatus;
@@ -84,6 +85,9 @@ public class CheckpointConfig implements java.io.Serializable {
 
 	private long alignmentTimeout = ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT.defaultValue().toMillis();
 
+	/** Flag to enable approximate local recovery. */
+	private boolean approximateLocalRecovery;
+
 	/** Cleanup behaviour for persistent checkpoints. */
 	private ExternalizedCheckpointCleanup externalizedCheckpointCleanup;
 
@@ -122,6 +126,7 @@ public class CheckpointConfig implements java.io.Serializable {
 		this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
 		this.unalignedCheckpointsEnabled = checkpointConfig.isUnalignedCheckpointsEnabled();
 		this.alignmentTimeout = checkpointConfig.alignmentTimeout;
+		this.approximateLocalRecovery = checkpointConfig.isApproximateLocalRecoveryEnabled();
 		this.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
 		this.forceCheckpointing = checkpointConfig.forceCheckpointing;
 		this.forceUnalignedCheckpoints = checkpointConfig.forceUnalignedCheckpoints;
@@ -502,6 +507,35 @@ public class CheckpointConfig implements java.io.Serializable {
 	@PublicEvolving
 	public long getAlignmentTimeout() {
 		return alignmentTimeout;
+	}
+
+	/**
+	 * Returns whether approximate local recovery is enabled.
+	 *
+	 * @return <code>true</code> if approximate local recovery is enabled.
+	 */
+	@Experimental
+	public boolean isApproximateLocalRecoveryEnabled() {
+		return approximateLocalRecovery;
+	}
+
+	/**
+	 * Enables the approximate local recovery mode.
+	 *
+	 * <p>In this recovery mode, when a task fails, the entire downstream of the tasks (including the failed task) restart.
+	 *
+	 * <p>Notice that
+	 * 1. Approximate recovery may lead to data loss. The amount of data which leads the failed task
+	 * from the state of the last completed checkpoint to the state when the task fails is lost.
+	 * 2. In the next version, we will support restarting the set of failed set of tasks only.
+	 * In this version, we only support downstream restarts when a task fails.
+	 * 3. It is only an internal feature for now.
+	 *
+	 * @param enabled Flag to indicate whether approximate local recovery is enabled .
+	 */
+	@Experimental
+	public void enableApproximateLocalRecovery(boolean enabled) {
+		approximateLocalRecovery = enabled;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
@@ -44,5 +44,8 @@ public enum GlobalDataExchangeMode {
 	POINTWISE_EDGES_PIPELINED,
 
 	/** Set all job edges {@link ResultPartitionType#PIPELINED_BOUNDED}. */
-	ALL_EDGES_PIPELINED
+	ALL_EDGES_PIPELINED,
+
+	/** Set all job edges {@link ResultPartitionType#PIPELINED_APPROXIMATE}. */
+	ALL_EDGES_PIPELINED_APPROXIMATE
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -287,9 +287,21 @@ public class StreamGraphGenerator {
 			setBatchStateBackendAndTimerService(graph);
 		} else {
 			graph.setStateBackend(stateBackend);
-			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED);
 			graph.setScheduleMode(ScheduleMode.EAGER);
+
+			if (checkpointConfig.isApproximateLocalRecoveryEnabled()) {
+				checkApproximateLocalRecoveryCompatibility();
+				graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED_APPROXIMATE);
+			} else {
+				graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED);
+			}
 		}
+	}
+
+	private void checkApproximateLocalRecoveryCompatibility() {
+		checkState(
+			!checkpointConfig.isUnalignedCheckpointsEnabled(),
+			"Approximate Local Recovery and Unaligned Checkpoint can not be used together yet");
 	}
 
 	private void setBatchStateBackendAndTimerService(StreamGraph graph) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -162,6 +162,7 @@ public class StreamingJobGraphGenerator {
 
 		// make sure that all vertices start immediately
 		jobGraph.setScheduleMode(streamGraph.getScheduleMode());
+		jobGraph.enableApproximateLocalRecovery(streamGraph.getCheckpointConfig().isApproximateLocalRecoveryEnabled());
 
 		// Generate deterministic hashes for the nodes in order to identify them across
 		// submission iff they didn't change.
@@ -743,6 +744,8 @@ public class StreamingJobGraphGenerator {
 				}
 			case ALL_EDGES_PIPELINED:
 				return ResultPartitionType.PIPELINED_BOUNDED;
+			case ALL_EDGES_PIPELINED_APPROXIMATE:
+				return ResultPartitionType.PIPELINED_APPROXIMATE;
 			default:
 				throw new RuntimeException("Unrecognized global data exchange mode " + streamGraph.getGlobalDataExchangeMode());
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryDownstreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ApproximateLocalRecoveryDownstreamITCase.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.SuccessException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.flink.test.util.TestUtils.tryExecute;
+
+/**
+ * To test approximate downstream failover.
+ *
+ * <p>If a task fails, all its downstream tasks restart, including itself.
+ * - Test the failed task can reconnect successfully.
+ * - Test partial records are cleaned up correctly.
+ * - Test only downstream are tasks restart.
+ */
+
+public class ApproximateLocalRecoveryDownstreamITCase extends TestLogger {
+	private static final int BUFFER_SIZE = 4096;
+
+	@Rule
+	public MiniClusterWithClientResource cluster = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setConfiguration(createConfig())
+			.setNumberTaskManagers(4)
+			.setNumberSlotsPerTaskManager(1)
+			.build());
+
+	@Rule
+	public final Timeout timeout = Timeout.millis(300000L);
+
+	/**
+	 * Test the following topology.
+	 * <pre>
+	 *     (source1/1) -----> (map1/1) -----> (sink1/1)
+	 * </pre>
+	 * (map1/1) fails, (map1/1) and (sink1/1) restart
+	 */
+	@Test
+	public void localTaskFailureRecoveryThreeTasks() throws Exception {
+		final int failAfterElements = 150;
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env
+			.setParallelism(1)
+			.setBufferTimeout(0)
+			.setMaxParallelism(128)
+			.disableOperatorChaining()
+			.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.getCheckpointConfig().enableApproximateLocalRecovery(true);
+
+		env.addSource(new AppSourceFunction())
+			.slotSharingGroup("source")
+			.map(new FailingMapper<>(failAfterElements))
+			.slotSharingGroup("map")
+			.addSink(new ValidatingAtMostOnceSink(300))
+			.slotSharingGroup("sink");
+
+		FailingMapper.failedBefore = false;
+		tryExecute(env, "testThreeTasks");
+	}
+
+	/**
+	 * Test the following topology.
+	 * <pre>
+	 *     (source1/1) -----> (map1/2) -----> (sink1/1)
+	 *         |                                ^
+	 *         -------------> (map2/2) ---------|
+	 * </pre>
+	 * (map1/2) fails, (map1/2) and (sink1/1) restart
+	 */
+	@Test
+	public void localTaskFailureRecoveryTwoMapTasks() throws Exception {
+		final int failAfterElements = 20;
+		final int keyByChannelNumber = 2;
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env
+			.setParallelism(1)
+			.setBufferTimeout(0)
+			.disableOperatorChaining()
+			.setMaxParallelism(128)
+			.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.getCheckpointConfig().enableApproximateLocalRecovery(true);
+
+		env.addSource(new AppSourceFunction(BUFFER_SIZE, env.getMaxParallelism(), keyByChannelNumber))
+			.slotSharingGroup("source")
+			.keyBy(InvertedKeyTuple::key)
+			.map(new FailingMapper<>(failAfterElements))
+			.setParallelism(keyByChannelNumber)
+			.slotSharingGroup("map")
+			.addSink(new ValidatingAtMostOnceSink(200, keyByChannelNumber))
+			.slotSharingGroup("sink");
+
+		FailingMapper.failedBefore = false;
+		tryExecute(env, "testTwoMapTasks");
+	}
+
+	/**
+	 * source function used to generate InvertedKeyTuple.
+	 *
+	 * <p>InvertedKeyTuple includes four fields:
+	 * - index: increased upon each tuple is generated.
+	 * - key: based on which the tuple to be partitioned for downstream consumption (a map, as shown in the testcase for example).
+	 * - selectedChannel: the selected channel (the selected instance of the downstream operator) the tuple to be sent to.
+	 *                    Usually, selectedChannel is decided by the hash-partition function applied on the key.
+	 *                    However in this case, we invert the process by selecting the channel to be sent first, and then
+	 *                    decide a possible key the tuple may contain. In this way, we can control exactly how many
+	 *                    tuples are sent to each instance of the downstream operator.
+	 * - longOrShortString: either long or short string used to test network transition upon reconnection.
+	 *
+	 * <p>AppSourceFunction makes sure tuples generated are evenly distributed amongst downstream operator instances.
+	 */
+	private static class AppSourceFunction extends RichParallelSourceFunction<InvertedKeyTuple> {
+		private final String shortString = "I am a very long string to test partial records hohoho hahaha ";
+		private final String longOrShortString;
+		private final int maxParallelism;
+		private final int numberOfChannels;
+		private final int[] keys;
+		private int index = 0;
+		private volatile boolean running = true;
+
+		// short-length string
+		AppSourceFunction() {
+			this.longOrShortString = shortString;
+			this.maxParallelism = 128;
+			this.numberOfChannels = 1;
+			this.keys = initKeys(numberOfChannels);
+		}
+
+		// long-length string
+		AppSourceFunction(int bufferSize, int maxParallelism, int numberOfChannels) {
+			this.maxParallelism = maxParallelism;
+			this.numberOfChannels = numberOfChannels;
+			this.keys = initKeys(numberOfChannels);
+
+			StringBuilder builder = new StringBuilder(shortString);
+			for (int i = 0; i <= 2 * bufferSize / shortString.length() + 1; i++) {
+				builder.append(shortString);
+			}
+			this.longOrShortString = builder.toString();
+		}
+
+		@Override
+		public void run(SourceContext<InvertedKeyTuple> ctx) throws Exception{
+			while (running) {
+				synchronized (ctx.getCheckpointLock()) {
+					if (index % 100 == 0) {
+						Thread.sleep(50);
+					}
+					int selectedChannel = index % numberOfChannels;
+					int key = keys[selectedChannel];
+					ctx.collect(new InvertedKeyTuple(index, key, selectedChannel, longOrShortString));
+				}
+				index++;
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		// Find the first key which falls into the key group of each downstream channel
+		private int[] initKeys(int numberOfChannels) {
+			int[] keys = new int[numberOfChannels];
+
+			for (int i = 0; i < numberOfChannels; i++) {
+				int key = 0;
+				while (key < 1000 && selectedChannel(key) != i) {
+					key++;
+				}
+				assert key < 1000 : "Can not find a key within number 1000";
+				keys[i] = key;
+			}
+
+			return keys;
+		}
+
+		private int selectedChannel(int key) {
+			return KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, numberOfChannels);
+		}
+	}
+
+	/** Fails once the first map instance reaches failCount. */
+	private static class FailingMapper<T> extends RichMapFunction<T, T>  {
+		private static final long serialVersionUID = 6334389850158703L;
+
+		private static volatile boolean failedBefore;
+
+		private final int failCount;
+		private int numElementsTotal;
+
+		private boolean failer;
+
+		FailingMapper(int failCount) {
+			this.failCount = failCount;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
+		}
+
+		@Override
+		public T map(T value) throws Exception {
+			numElementsTotal++;
+
+			if (!failedBefore) {
+				Thread.sleep(10);
+
+				if (failer && numElementsTotal >= failCount) {
+					failedBefore = true;
+					throw new Exception("Artificial Test Failure");
+				}
+			}
+
+			return value;
+		}
+	}
+
+	/**
+	 * Validating sink to make sure each selectedChannel (of map) gets at least numElementsTotal elements.
+	 *
+	 * <p>Notice that the source generates tuples evenly distributed amongst downstream operator (map) instances.
+	 * Besides, the index generated is continuous and monotonic increasing as long as the source is not restarted.
+	 * Hence,
+	 * - In the case of approximate local recovery is NOT enabled, where the entire job, including source, is restarted
+	 *   after map fails, source regenerates tuples indexed from 0. Upon reach numElementsTotal,
+	 *   the maximal possible index is numElementsTotal * numberOfInputChannels - 1
+	 * - In the case of approximate local recovery is enabled, where only the downstream of the failed task restart,
+	 *   source does not regenerating tuples, the maximal possible index > numElementsTotal * numberOfInputChannels - 1
+	 */
+	private static class ValidatingAtMostOnceSink extends RichSinkFunction<InvertedKeyTuple> {
+		private static final long serialVersionUID = 1748426382527469932L;
+		private final int numElementsTotal;
+		private final int[] numElements;
+		private final Integer[] indexReachingNumElements;
+		private final int numberOfInputChannels;
+
+		ValidatingAtMostOnceSink(int numElementsTotal, int numberOfInputChannels) {
+			this.numElementsTotal = numElementsTotal;
+			this.numberOfInputChannels = numberOfInputChannels;
+			this.numElements = new int[numberOfInputChannels];
+			this.indexReachingNumElements = new Integer[numberOfInputChannels];
+		}
+
+		ValidatingAtMostOnceSink(int numElementsTotal) {
+			this.numElementsTotal = numElementsTotal;
+			this.numberOfInputChannels = 1;
+			this.numElements = new int[numberOfInputChannels];
+			this.indexReachingNumElements = new Integer[numberOfInputChannels];
+		}
+
+		@Override
+		public void invoke(InvertedKeyTuple tuple, Context ctx) throws Exception {
+			assert tuple.selectedChannel < numberOfInputChannels;
+			numElements[tuple.selectedChannel]++;
+
+			boolean allReachNumElementsTotal = true;
+			for (int i = 0; i < numberOfInputChannels; i++) {
+				if (numElements[i] == numElementsTotal) {
+					indexReachingNumElements[i] = tuple.index;
+				} else if (numElements[i] < numElementsTotal) {
+					allReachNumElementsTotal = false;
+				}
+			}
+			if (allReachNumElementsTotal) {
+				assert Collections.max(Arrays.asList(indexReachingNumElements)) >= numElementsTotal * numberOfInputChannels;
+				throw new SuccessException();
+			}
+		}
+	}
+
+	private static Configuration createConfig() {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.SCHEDULING_STRATEGY, "legacy");
+		config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse(Integer.toString(BUFFER_SIZE)));
+
+		return config;
+	}
+
+	private static class InvertedKeyTuple {
+		int index;
+		/** Key based on which the tuple is partitioned. */
+		int key;
+		/** The selected channel of this tuple after key-partitioned. */
+		int selectedChannel;
+		String longOrShortString;
+
+		InvertedKeyTuple(int index, int key, int selectedChannel, String longOrShortString) {
+			this.index = index;
+			this.key = key;
+			this.selectedChannel = selectedChannel;
+			this.longOrShortString = longOrShortString;
+		}
+
+		int key() {
+			return key;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR includes three changes:
- Enables downstream failover for approximate local recovery. That says if a task fails, all its downstream tasks restart, including itself. This is achieved by reusing the existing `RestartPipelinedRegionFailoverStrategy` --- treat each individual task connected by ResultPartition.Pipelined_Approximate as a separate region. 
- Expose Approximate downstream failover flag as an internal feature flag in CheckpointConfig: `approximateLocalRecovery`
- ITcases downstream failover


## Brief change log

- introduce an attribute "reconnectable" in ResultPartitionType to indicate whether the partition is reconnectable. Notice that this is only a temporary solution for now. It will be removed after:
	 1. Approximate local recovery has its won failover strategy to restart the failed set of tasks instead of
	      restarting downstream of failed tasks depending on {@code RestartPipelinedRegionFailoverStrategy}
	 2. FLINK-19895: Unify the life cycle of ResultPartitionType Pipelined Family. There is also a good discussion on this in FLINK-19632.
- PipelinedRegionComputeUtil#buildRawRegions to build each task connected by PIPELINED_APPROXIMATE as a region.
- JobMasterPartitionTrackerImpl#startTrackingPartition to track the pipelined_approximate partition
- Introduce an internal flag `approximateLocalRecovery` in CheckpointConfig to enable the feature.
- ITCase (examples) how to use Approximate downstream failover.

## Verifying this change

Unittests + ITCases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
     An internal feature only, not ready for public usage.
