### PR TITLE
[FLINK-19911] add read buffer for input stream

### DIFF
--- a/docs/_includes/generated/common_miscellaneous_section.html
+++ b/docs/_includes/generated/common_miscellaneous_section.html
@@ -20,6 +20,12 @@
             <td>String</td>
             <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of an HDFS NameNode.</td>
         </tr>
+		<tr>
+			<td><h5>fs.hdfs.read-buffer.size</h5></td>
+			<td style="word-wrap: break-word;">(none)</td>
+			<td>MemorySize</td>
+			<td>The default size of the read buffer for the hdfs input stream, default value of 4kb.</td>
+		</tr>
         <tr>
             <td><h5>io.tmp.dirs</h5></td>
             <td style="word-wrap: break-word;">'LOCAL_DIRS' on Yarn. '_FLINK_TMP_DIR' on Mesos. System.getProperty("java.io.tmpdir") in standalone.</td>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -52,6 +52,12 @@ This check should only be disabled if such a leak prevents further jobs from run
             <td>String</td>
             <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of an HDFS NameNode.</td>
         </tr>
+		<tr>
+			<td><h5>fs.hdfs.read-buffer.size</h5></td>
+			<td style="word-wrap: break-word;">(none)</td>
+			<td>MemorySize</td>
+			<td>The default size of the read buffer for the hdfs input stream, default value of 4kb.</td>
+		</tr>
         <tr>
             <td><h5>fs.output.always-create-directory</h5></td>
             <td style="word-wrap: break-word;">false</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -320,6 +320,13 @@ public class CoreOptions {
 			.withDescription("A (semicolon-separated) list of file schemes, for which Hadoop can be used instead " +
 				"of an appropriate Flink plugin. (example: s3;wasb)");
 
+	@Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
+	public static final ConfigOption<MemorySize> FILESYSTEM_READ_BUFFER_SIZE = ConfigOptions
+		.key("fs.hdfs.read-buffer.size")
+		.memoryType()
+		.defaultValue(MemorySize.parse("4kb"))
+		.withDescription("The default size of the read buffer for the hdfs input stream.");
+
 	/**
 	 * Specifies whether file output writers should overwrite existing files by default.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FSDataBufferedInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FSDataBufferedInputStream.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * FSDataInputStream with Buffer, only support single thread.
+ * <p>
+ * The design of FSDataBufferedInputStream refers to {@link java.io.BufferedInputStream}.
+ * Compared to {@link java.io.BufferedInputStream}, the seek and getPos interfaces are mainly added.
+ */
+public class FSDataBufferedInputStream extends FSDataInputStream {
+
+	private static final int DEFAULT_BUFFER_SIZE = 8192;
+
+	protected byte[] buf;
+
+	// read offset of buf
+	private int pos;
+
+	// availed count of buf
+	private int count;
+
+	private final FSDataInputStream inputStream;
+
+	private boolean closed;
+
+	public FSDataBufferedInputStream(FSDataInputStream inputStream) {
+		this(inputStream, DEFAULT_BUFFER_SIZE);
+	}
+
+	public FSDataBufferedInputStream(
+		FSDataInputStream inputStream,
+		int bufferSize) {
+		this.inputStream = inputStream;
+
+		Preconditions.checkState(bufferSize > 0, "bufferSize must > 0");
+		this.buf = new byte[bufferSize];
+
+		this.pos = 0;
+		this.count = 0;
+		this.closed = false;
+	}
+
+	@Override
+	public void seek(long desired) throws IOException {
+		long streamPos = inputStream.getPos();
+		long bufStartPos = streamPos - count;
+		if (bufStartPos <= desired && desired < streamPos) {
+			this.pos = (int) (desired - bufStartPos);
+			return;
+		}
+		inputStream.seek(desired);
+		this.pos = 0;
+		this.count = 0;
+	}
+
+	@Override
+	public long getPos() throws IOException {
+		int avail = count - pos;
+		return inputStream.getPos() - avail;
+	}
+
+	@Override
+	public int read() throws IOException {
+		if (pos >= count) {
+			fill();
+			if (pos >= count) {
+				return -1;
+			}
+		}
+		return buf[pos++] & 0xff;
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		if ((off | len | (off + len) | (b.length - (off + len))) < 0) {
+			throw new IndexOutOfBoundsException();
+		} else if (len == 0) {
+			return 0;
+		}
+
+		int n = 0;
+		for (; ; ) {
+			int nread = read1(b, off + n, len - n);
+			if (nread <= 0) {
+				return (n == 0) ? nread : n;
+			}
+			n += nread;
+			if (n >= len) {
+				return n;
+			}
+			// if not closed but no bytes available, return
+			InputStream input = inputStream;
+			if (input != null && input.available() <= 0) {
+				return n;
+			}
+		}
+	}
+
+	/**
+	 * Read characters into a portion of an array, reading from the underlying
+	 * stream at most once if necessary.
+	 */
+	private int read1(byte[] b, int off, int len) throws IOException {
+		int avail = count - pos;
+		if (avail <= 0) {
+            /* If the requested length is at least as large as the buffer,
+               do not bother to copy the bytes into the local buffer.
+               In this way buffered streams will cascade harmlessly. */
+			if (len >= buf.length) {
+				return inputStream.read(b, off, len);
+			}
+			fill();
+			avail = count - pos;
+			if (avail <= 0) {
+				return -1;
+			}
+		}
+		int cnt = Math.min(avail, len);
+		System.arraycopy(buf, pos, b, off, cnt);
+		pos += cnt;
+		return cnt;
+	}
+
+	@Override
+	public long skip(long n) throws IOException {
+		if (n <= 0) {
+			return 0;
+		}
+		long avail = count - pos;
+
+		if (avail <= 0) {
+			// Fill in buffer to save bytes for reset
+			fill();
+			avail = count - pos;
+			if (avail <= 0) {
+				return 0;
+			}
+		}
+
+		long skipped = Math.min(avail, n);
+		pos += skipped;
+		return skipped;
+	}
+
+	@Override
+	public int available() throws IOException {
+		int avail = count - pos;
+		return inputStream.available() + avail;
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		if (inputStream != null) {
+			inputStream.close();
+		}
+	}
+
+	@VisibleForTesting
+	public int getBufferSize() {
+		return buf.length;
+	}
+
+	private void fill() throws IOException {
+		Preconditions.checkState(pos >= count);
+		count = inputStream.read(buf);
+		pos = 0;
+	}
+
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/FSDataBufferedInputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FSDataBufferedInputStreamTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the {@link FSDataBufferedInputStream}.
+ */
+@RunWith(Parameterized.class)
+public class FSDataBufferedInputStreamTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Parameterized.Parameters
+	public static List<Integer> getDataSize() {
+		return Arrays.asList(10, 100, 1000, 10000, 50000);
+	}
+
+	@Parameterized.Parameter
+	public int dataSize;
+
+	LocalFileSystem lfs;
+	Path pathToTestFile;
+
+	@Before
+	public void before() throws IOException {
+		// prepare file
+		final File tempDir = new File(temporaryFolder.getRoot(), UUID.randomUUID().toString());
+
+		final File testFile = new File(tempDir, UUID.randomUUID().toString());
+		pathToTestFile = new Path(testFile.toURI().getPath());
+
+		lfs = new LocalFileSystem();
+		final FSDataOutputStream lfsOutput = lfs.create(
+			pathToTestFile,
+			FileSystem.WriteMode.NO_OVERWRITE);
+		DataOutputViewStreamWrapper outputView = new DataOutputViewStreamWrapper(
+			lfsOutput);
+
+		for (int i = 0; i < dataSize; i++) {
+			outputView.writeInt(i);
+		}
+		lfsOutput.close();
+
+		assertEquals(testFile.length(), Integer.BYTES * dataSize);
+
+	}
+
+	@Test
+	public void testOrderRead() throws Exception {
+		FSDataInputStream lfsInput = new FSDataBufferedInputStream(lfs.open(pathToTestFile));
+		DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(lfsInput);
+		for (int i = 0; i < dataSize; i++) {
+			int data = inputView.readInt();
+			assertEquals(i, data);
+		}
+		lfsInput.close();
+	}
+
+	@Test
+	public void testSeekRead() throws Exception {
+		FSDataInputStream lfsInput = new FSDataBufferedInputStream(lfs.open(pathToTestFile));
+		DataInputViewStreamWrapper inputView = new DataInputViewStreamWrapper(lfsInput);
+
+		// test for descending read
+		int expectedStateSize = dataSize * Integer.BYTES;
+		for (int i = dataSize - 1; i >= 0; i--) {
+			int offset = Integer.BYTES * i;
+			// test for pos and available
+			lfsInput.seek(offset);
+			Assert.assertEquals(offset, lfsInput.getPos());
+			int avail = expectedStateSize - offset;
+			Assert.assertEquals(avail, lfsInput.available());
+
+			// test for data
+			int read = inputView.readInt();
+			Assert.assertEquals(i, read);
+		}
+
+		// test for random read
+		Random random = new Random();
+		for (int j = 0; j < dataSize * 2; j++) {
+			int index = random.nextInt(dataSize);
+
+			int offset = Integer.BYTES * index;
+			// test for pos and available
+			lfsInput.seek(offset);
+			Assert.assertEquals(offset, lfsInput.getPos());
+			int avail = expectedStateSize - offset;
+			Assert.assertEquals(avail, lfsInput.available());
+
+			// test for data
+			int read = inputView.readInt();
+			Assert.assertEquals(index, read);
+		}
+
+		lfsInput.close();
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Read checkpoint stream with buffer to speedup restore.

There will be many small IOs in the restore process,  frequent small io is not friendly to disk. So add buffer to improve IO performance.

## Brief change log

  - add config `state.backend.fs.read-buffer-size`
  - Design FSDataBufferedInputStream, FSDataInputStream with buffer
  - Use FSDataBufferedInputStream to wrap fsDataInputStream in HeapRestoreOperation#restore.

tips: 
The design of FSDataBufferedInputStream refers to FsCheckpointStateOutputStream and Java's BufferedInputStream.
Compared to Java's BufferedInputStream, the seek and getPos interfaces are mainly added.

## Verifying this change

This change added tests and can be verified as follows:

  - Added order read for FSDataBufferedInputStream
  - Added seek and random read for FSDataBufferedInputStream

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs