### PR TITLE
[FLINK-19898][FLINK-19899][Kinesis][EFO] Optimise error handling and Retry Policy

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutShardSubscriberTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutShardSubscriberTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals.publisher.fanout;
+
+import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory;
+import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2;
+
+import io.netty.handler.timeout.ReadTimeoutException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.services.kinesis.model.StartingPosition;
+
+/**
+ * Tests for {@link FanOutShardSubscriber}.
+ */
+public class FanOutShardSubscriberTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testRecoverableErrorThrownToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RecoverableFanOutSubscriberException.class);
+		thrown.expectMessage("io.netty.handler.timeout.ReadTimeoutException");
+
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(ReadTimeoutException.INSTANCE);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
+			.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testRetryableErrorThrownToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.RetryableFanOutSubscriberException.class);
+		thrown.expectMessage("Error!");
+
+		RuntimeException error = new RuntimeException("Error!");
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		software.amazon.awssdk.services.kinesis.model.StartingPosition startingPosition = software.amazon.awssdk.services.kinesis.model.StartingPosition
+			.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+	@Test
+	public void testMultipleErrorsThrownPassesFirstErrorToConsumer() throws Exception {
+		thrown.expect(FanOutShardSubscriber.FanOutSubscriberException.class);
+		thrown.expectMessage("Error 1!");
+
+		RuntimeException error1 = new RuntimeException("Error 1!");
+		RuntimeException error2 = new RuntimeException("Error 2!");
+		SubscriptionErrorKinesisV2 errorKinesisV2 = FakeKinesisFanOutBehavioursFactory.errorDuringSubscription(error1, error2);
+
+		FanOutShardSubscriber subscriber = new FanOutShardSubscriber("consumerArn", "shardId", errorKinesisV2);
+
+		StartingPosition startingPosition = StartingPosition.builder().build();
+		subscriber.subscribeToShardAndConsumeRecords(startingPosition, event -> { });
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Test.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Test.java
@@ -22,10 +22,7 @@ import org.apache.flink.streaming.connectors.kinesis.internals.publisher.fanout.
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.DeregisterStreamConsumerRequest;
@@ -74,8 +71,6 @@ import static org.mockito.Mockito.when;
 /**
  * Test for methods in the {@link KinesisProxyV2} class.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(KinesisProxyV2.class)
 public class KinesisProxyV2Test {
 
 	private static final long EXPECTED_SUBSCRIBE_TO_SHARD_MAX = 1;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -86,8 +86,8 @@ public class FakeKinesisFanOutBehavioursFactory {
 		return new ExceptionalKinesisV2(ResourceNotFoundException.builder().build());
 	}
 
-	public static SubscriptionErrorKinesisV2 errorDuringSubscription(final Throwable throwable) {
-		return new SubscriptionErrorKinesisV2(throwable);
+	public static SubscriptionErrorKinesisV2 errorDuringSubscription(final Throwable...throwables) {
+		return new SubscriptionErrorKinesisV2(throwables);
 	}
 
 	public static SubscriptionErrorKinesisV2 alternatingSuccessErrorDuringSubscription() {
@@ -179,19 +179,21 @@ public class FakeKinesisFanOutBehavioursFactory {
 
 		public static final int NUMBER_OF_EVENTS_PER_SUBSCRIPTION = 5;
 
-		private final Throwable throwable;
+		private final Throwable[] throwables;
 
 		AtomicInteger sequenceNumber = new AtomicInteger();
 
-		private SubscriptionErrorKinesisV2(final Throwable throwable) {
+		private SubscriptionErrorKinesisV2(final Throwable...throwables) {
 			super(NUMBER_OF_SUBSCRIPTIONS);
-			this.throwable = throwable;
+			this.throwables = throwables;
 		}
 
 		@Override
 		void sendEvents(Subscriber<? super SubscribeToShardEventStream> subscriber) {
 			sendEventBatch(subscriber);
-			subscriber.onError(throwable);
+			for (Throwable throwable : throwables) {
+				subscriber.onError(throwable);
+			}
 		}
 
 		void sendEventBatch(Subscriber<? super SubscribeToShardEventStream> subscriber) {

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -43,7 +43,11 @@ under the License.
 		<suppress
 			files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java"
 			checks="IllegalImport"/>
-		<!-- Classes copied from Hadoop -->
+		<!-- Kinesis EFO consumer required to handle Netty ReadTimeoutException -->
+		<suppress 
+			files="FanOutRecordPublisherTest.java|FanOutShardSubscriber.java|FanOutShardSubscriberTest.java" 
+			checks="IllegalImport"/>
+	 	<!-- Classes copied from Hadoop -->
 		<suppress
 			files="org[\\/]apache[\\/]hadoop[\\/]conf[\\/]Configuration.java"
 			checks=".*"/>


### PR DESCRIPTION
## What is the purpose of the change

* The Flink Kinesis EFO consumer has a SubscribeToShard retry policy which will terminate the job after a given number of subsequent attempt failures. In high backpressure scenarios the Netty HTTP Client throws a ReadTimeoutException when the consumer takes longer than 30s to process a batch. If this happens (by default) 10 times in a row, the job will terminate. There is no need to terminate in this condition, and the restart results in the job falling further behind.
* There is a queue used to pass events between the network client and consumer application. When an error is thrown in the network thread, the queue is cleared to make space for the error event. This means that records will be thrown away to make space for errors (the records would be subsequently reloaded from the shard).

## Brief change log

* Excluded the ReadTimeoutException from the SubscribeToShard retry policy, such that that connector will gracefully reconnect once the consumer has processed the queued records.
* Added a new mechanism to pass exceptions between threads, meaning data does not need to be discarded. When an error is thrown, the error event will be processed by the consumer once all of the records have been processed.

## Verifying this change

* Existing unit tests continue to pass
* Added additional test coverage
* Deployed and tested on local Flink cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
