### PR TITLE
[FLINK-19931] Do not emit intermediate results for reduce operation BATCH execution mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -48,7 +48,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator;
-import org.apache.flink.streaming.api.operators.StreamGroupedReduce;
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
@@ -734,7 +734,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 * @return The transformed DataStream.
 	 */
 	public SingleOutputStreamOperator<T> reduce(ReduceFunction<T> reducer) {
-		return transform("Keyed Reduce", getType(), new StreamGroupedReduce<>(
+		return transform("Keyed Reduce", getType(), new StreamGroupedReduceOperator<>(
 				clean(reducer), getType().createSerializer(getExecutionConfig())));
 	}
 
@@ -1011,7 +1011,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	}
 
 	protected SingleOutputStreamOperator<T> aggregate(AggregationFunction<T> aggregate) {
-		StreamGroupedReduce<T> operator = new StreamGroupedReduce<>(
+		StreamGroupedReduceOperator<T> operator = new StreamGroupedReduceOperator<>(
 				clean(aggregate), getType().createSerializer(getExecutionConfig()));
 		return transform("Keyed Aggregation", getType(), operator);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -48,11 +48,11 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator;
-import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.api.transformations.ReduceTransformation;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
@@ -734,8 +734,18 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	 * @return The transformed DataStream.
 	 */
 	public SingleOutputStreamOperator<T> reduce(ReduceFunction<T> reducer) {
-		return transform("Keyed Reduce", getType(), new StreamGroupedReduceOperator<>(
-				clean(reducer), getType().createSerializer(getExecutionConfig())));
+		ReduceTransformation<T, KEY> reduce = new ReduceTransformation<>(
+			"Keyed Reduce",
+			environment.getParallelism(),
+			transformation,
+			clean(reducer),
+			keySelector,
+			getKeyType()
+		);
+
+		getExecutionEnvironment().addOperator(reduce);
+
+		return new SingleOutputStreamOperator<>(getExecutionEnvironment(), reduce);
 	}
 
 	/**
@@ -1011,9 +1021,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 	}
 
 	protected SingleOutputStreamOperator<T> aggregate(AggregationFunction<T> aggregate) {
-		StreamGroupedReduceOperator<T> operator = new StreamGroupedReduceOperator<>(
-				clean(aggregate), getType().createSerializer(getExecutionConfig()));
-		return transform("Keyed Aggregation", getType(), operator);
+		return reduce(aggregate).name("Keyed Aggregation");
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.api.transformations.MultipleInputTransformatio
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.PhysicalTransformation;
+import org.apache.flink.streaming.api.transformations.ReduceTransformation;
 import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
@@ -56,6 +57,7 @@ import org.apache.flink.streaming.runtime.translators.LegacySourceTransformation
 import org.apache.flink.streaming.runtime.translators.MultiInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.OneInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.PartitionTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.ReduceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SideOutputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SinkTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.SourceTransformationTranslator;
@@ -161,6 +163,7 @@ public class StreamGraphGenerator {
 		tmp.put(UnionTransformation.class, new UnionTransformationTranslator<>());
 		tmp.put(PartitionTransformation.class, new PartitionTransformationTranslator<>());
 		tmp.put(SideOutputTransformation.class, new SideOutputTransformationTranslator<>());
+		tmp.put(ReduceTransformation.class, new ReduceTransformationTranslator<>());
 		translatorMap = Collections.unmodifiableMap(tmp);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BatchGroupedReduceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BatchGroupedReduceOperator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A {@link StreamOperator} for executing a {@link ReduceFunction} on a
+ * {@link org.apache.flink.streaming.api.datastream.KeyedStream} in a
+ * {@link RuntimeExecutionMode#BATCH} mode.
+ */
+@Internal
+public class BatchGroupedReduceOperator<IN, KEY>
+		extends AbstractUdfStreamOperator<IN, ReduceFunction<IN>>
+		implements OneInputStreamOperator<IN, IN>, Triggerable<KEY, VoidNamespace> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String STATE_NAME = "_op_state";
+
+	private transient ValueState<IN> values;
+
+	private final TypeSerializer<IN> serializer;
+
+	private InternalTimerService<VoidNamespace> timerService;
+
+	public BatchGroupedReduceOperator(ReduceFunction<IN> reducer, TypeSerializer<IN> serializer) {
+		super(reducer);
+		this.serializer = serializer;
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+		ValueStateDescriptor<IN> stateId = new ValueStateDescriptor<>(STATE_NAME, serializer);
+		values = getPartitionedState(stateId);
+		timerService = getInternalTimerService(
+			"end-key-timers",
+			new VoidNamespaceSerializer(),
+			this
+		);
+	}
+
+	@Override
+	public void processElement(StreamRecord<IN> element) throws Exception {
+		IN value = element.getValue();
+		IN currentValue = values.value();
+
+		if (currentValue != null) {
+			value = userFunction.reduce(currentValue, value);
+			timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, Long.MAX_VALUE);
+		}
+		values.update(value);
+	}
+
+	@Override
+	public void onEventTime(InternalTimer<KEY, VoidNamespace> timer) throws Exception {
+		IN currentValue = values.value();
+		if (currentValue != null) {
+			output.collect(new StreamRecord<>(currentValue, Long.MAX_VALUE));
+		}
+	}
+
+	@Override
+	public void onProcessingTime(InternalTimer<KEY, VoidNamespace> timer) throws Exception {
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceOperator.java
@@ -30,7 +30,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  */
 
 @Internal
-public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, ReduceFunction<IN>>
+public class StreamGroupedReduceOperator<IN>
+		extends AbstractUdfStreamOperator<IN, ReduceFunction<IN>>
 		implements OneInputStreamOperator<IN, IN> {
 
 	private static final long serialVersionUID = 1L;
@@ -39,9 +40,9 @@ public class StreamGroupedReduce<IN> extends AbstractUdfStreamOperator<IN, Reduc
 
 	private transient ValueState<IN> values;
 
-	private TypeSerializer<IN> serializer;
+	private final TypeSerializer<IN> serializer;
 
-	public StreamGroupedReduce(ReduceFunction<IN> reducer, TypeSerializer<IN> serializer) {
+	public StreamGroupedReduceOperator(ReduceFunction<IN> reducer, TypeSerializer<IN> serializer) {
 		super(reducer);
 		this.serializer = serializer;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link Transformation} that describes a reduce operation on a {@link KeyedStream}.
+ * @param <IN> The input and output type of the transformation.
+ * @param <K> The type of the key of the stream.
+ */
+@Internal
+public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN> {
+	private final Transformation<IN> input;
+	private final ReduceFunction<IN> reducer;
+	private final KeySelector<IN, K> keySelector;
+	private final TypeInformation<K> keyTypeInfo;
+	private ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
+
+	public ReduceTransformation(
+			String name,
+			int parallelism,
+			Transformation<IN> input,
+			ReduceFunction<IN> reducer,
+			KeySelector<IN, K> keySelector,
+			TypeInformation<K> keyTypeInfo) {
+		super(name, input.getOutputType(), parallelism);
+		this.input = input;
+		this.reducer = reducer;
+		this.keySelector = keySelector;
+		this.keyTypeInfo = keyTypeInfo;
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.chainingStrategy = strategy;
+	}
+
+	public ChainingStrategy getChainingStrategy() {
+		return chainingStrategy;
+	}
+
+	public KeySelector<IN, K> getKeySelector() {
+		return keySelector;
+	}
+
+	public TypeInformation<K> getKeyTypeInfo() {
+		return keyTypeInfo;
+	}
+
+	public ReduceFunction<IN> getReducer() {
+		return reducer;
+	}
+
+	/**
+	 * Returns the {@code TypeInformation} for the elements of the input.
+	 */
+	public TypeInformation<IN> getInputType() {
+		return input.getOutputType();
+	}
+
+	@Override
+	public List<Transformation<?>> getTransitivePredecessors() {
+		List<Transformation<?>> result = Lists.newArrayList();
+		result.add(this);
+		result.addAll(input.getTransitivePredecessors());
+		return result;
+	}
+
+	@Override
+	public List<Transformation<?>> getInputs() {
+		return Collections.singletonList(input);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A utility base class for one input {@link Transformation transformations} that provides a
+ * function for configuring common graph properties.
+ */
+abstract class AbstractOneInputTransformationTranslator<IN, OUT, OP extends Transformation<OUT>>
+		extends SimpleTransformationTranslator<OUT, OP> {
+	protected Collection<Integer> translateInternal(
+			final Transformation<OUT> transformation,
+			final StreamOperatorFactory<OUT> operatorFactory,
+			final TypeInformation<IN> inputType,
+			@Nullable final KeySelector<IN, ?> stateKeySelector,
+			@Nullable final TypeInformation<?> stateKeyType,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(operatorFactory);
+		checkNotNull(inputType);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addOperator(
+			transformationId,
+			slotSharingGroup,
+			transformation.getCoLocationGroupKey(),
+			operatorFactory,
+			inputType,
+			transformation.getOutputType(),
+			transformation.getName());
+
+		if (stateKeySelector != null) {
+			TypeSerializer<?> keySerializer = stateKeyType.createSerializer(executionConfig);
+			streamGraph.setOneInputStateKey(transformationId, stateKeySelector, keySerializer);
+		}
+
+		int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+			? transformation.getParallelism()
+			: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		final List<Transformation<?>> parentTransformations = transformation.getInputs();
+		checkState(
+			parentTransformations.size() == 1,
+			"Expected exactly one input transformation but found " + parentTransformations.size());
+
+		for (Integer inputId: context.getStreamNodeIds(parentTransformations.get(0))) {
+			streamGraph.addEdge(inputId, transformationId, 0);
+		}
+
+		return Collections.singleton(transformationId);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/ReduceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/ReduceTransformationTranslator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.operators.BatchGroupedReduceOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
+import org.apache.flink.streaming.api.transformations.ReduceTransformation;
+
+import java.util.Collection;
+
+/**
+ * A {@link TransformationTranslator} for the {@link ReduceTransformation}.
+ *
+ * @param <IN> The type of the elements in the input {@code Transformation} of the transformation to translate.
+ */
+public class ReduceTransformationTranslator<IN, KEY>
+		extends AbstractOneInputTransformationTranslator<IN, IN, ReduceTransformation<IN, KEY>> {
+	@Override
+	public Collection<Integer> translateForBatchInternal(
+			final ReduceTransformation<IN, KEY> transformation,
+			final Context context) {
+		BatchGroupedReduceOperator<IN, KEY> groupedReduce = new BatchGroupedReduceOperator<>(
+			transformation.getReducer(),
+			transformation
+				.getInputType()
+				.createSerializer(context.getStreamGraph().getExecutionConfig())
+		);
+		SimpleOperatorFactory<IN> operatorFactory = SimpleOperatorFactory.of(groupedReduce);
+		operatorFactory.setChainingStrategy(transformation.getChainingStrategy());
+		Collection<Integer> ids = translateInternal(
+			transformation,
+			operatorFactory,
+			transformation.getInputType(),
+			transformation.getKeySelector(),
+			transformation.getKeyTypeInfo(),
+			context);
+		BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+
+		return ids;
+	}
+
+	@Override
+	public Collection<Integer> translateForStreamingInternal(
+			final ReduceTransformation<IN, KEY> transformation,
+			final Context context) {
+		StreamGroupedReduceOperator<IN> groupedReduce = new StreamGroupedReduceOperator<>(
+			transformation.getReducer(),
+			transformation
+				.getInputType()
+				.createSerializer(context.getStreamGraph().getExecutionConfig())
+		);
+
+		SimpleOperatorFactory<IN> operatorFactory = SimpleOperatorFactory.of(groupedReduce);
+		operatorFactory.setChainingStrategy(transformation.getChainingStrategy());
+		return translateInternal(
+			transformation,
+			operatorFactory,
+			transformation.getInputType(),
+			transformation.getKeySelector(),
+			transformation.getKeyTypeInfo(),
+			context);
+	}
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/AggregationFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/AggregationFunctionTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction.AggregationType;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
-import org.apache.flink.streaming.api.operators.StreamGroupedReduce;
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
 import org.apache.flink.streaming.util.MockContext;
 import org.apache.flink.streaming.util.keys.KeySelectorUtil;
 
@@ -99,17 +99,17 @@ public class AggregationFunctionTest {
 				1, typeInfo, AggregationType.MAX, config);
 
 		List<Tuple2<Integer, Integer>> groupedSumList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(sumFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(sumFunction, typeInfo.createSerializer(config)),
 				getInputList(),
 				keySelector, keyType);
 
 		List<Tuple2<Integer, Integer>> groupedMinList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minFunction, typeInfo.createSerializer(config)),
 				getInputList(),
 				keySelector, keyType);
 
 		List<Tuple2<Integer, Integer>> groupedMaxList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(maxFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(maxFunction, typeInfo.createSerializer(config)),
 				getInputList(),
 				keySelector, keyType);
 
@@ -167,17 +167,17 @@ public class AggregationFunctionTest {
 				false, config);
 
 		List<MyPojo> groupedSumList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(sumFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(sumFunction, typeInfo.createSerializer(config)),
 				getInputPojoList(),
 				keySelector, keyType);
 
 		List<MyPojo> groupedMinList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minFunction, typeInfo.createSerializer(config)),
 				getInputPojoList(),
 				keySelector, keyType);
 
 		List<MyPojo> groupedMaxList = MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(maxFunction, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(maxFunction, typeInfo.createSerializer(config)),
 				getInputPojoList(),
 				keySelector, keyType);
 
@@ -233,22 +233,22 @@ public class AggregationFunctionTest {
 				new ComparableAggregator<>(1, typeInfo, AggregationType.MINBY, false, config);
 
 		assertEquals(maxByFirstExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(maxByFunctionFirst, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(maxByFunctionFirst, typeInfo.createSerializer(config)),
 				getInputByList(),
 				keySelector, keyType));
 
 		assertEquals(maxByLastExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(maxByFunctionLast, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(maxByFunctionLast, typeInfo.createSerializer(config)),
 				getInputByList(),
 				keySelector, keyType));
 
 		assertEquals(minByLastExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minByFunctionLast, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minByFunctionLast, typeInfo.createSerializer(config)),
 				getInputByList(),
 				keySelector, keyType));
 
 		assertEquals(minByFirstExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minByFunctionFirst, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minByFunctionFirst, typeInfo.createSerializer(config)),
 				getInputByList(),
 				keySelector, keyType));
 	}
@@ -299,22 +299,22 @@ public class AggregationFunctionTest {
 				new ComparableAggregator<>("f1", typeInfo, AggregationType.MINBY, false, config);
 
 		assertEquals(maxByFirstExpected, MockContext.createAndExecuteForKeyedStream(
-						new StreamGroupedReduce<>(maxByFunctionFirst, typeInfo.createSerializer(config)),
+						new StreamGroupedReduceOperator<>(maxByFunctionFirst, typeInfo.createSerializer(config)),
 						getInputByPojoList(),
 						keySelector, keyType));
 
 		assertEquals(maxByLastExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(maxByFunctionLast, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(maxByFunctionLast, typeInfo.createSerializer(config)),
 				getInputByPojoList(),
 				keySelector, keyType));
 
 		assertEquals(minByLastExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minByFunctionLast, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minByFunctionLast, typeInfo.createSerializer(config)),
 				getInputByPojoList(),
 				keySelector, keyType));
 
 		assertEquals(minByFirstExpected, MockContext.createAndExecuteForKeyedStream(
-				new StreamGroupedReduce<>(minByFunctionFirst, typeInfo.createSerializer(config)),
+				new StreamGroupedReduceOperator<>(minByFunctionFirst, typeInfo.createSerializer(config)),
 				getInputByPojoList(),
 				keySelector, keyType));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceOperatorTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * Tests for {@link StreamGroupedReduce}. These test that:
+ * Tests for {@link StreamGroupedReduceOperator}. These test that:
  *
  * <ul>
  *     <li>RichFunction methods are called correctly</li>
@@ -45,14 +45,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * </ul>
  */
 
-public class StreamGroupedReduceTest {
+public class StreamGroupedReduceOperatorTest {
 
 	@Test
 	public void testGroupedReduce() throws Exception {
 
 		KeySelector<Integer, Integer> keySelector = new IntegerKeySelector();
 
-		StreamGroupedReduce<Integer> operator = new StreamGroupedReduce<>(new MyReducer(), IntSerializer.INSTANCE);
+		StreamGroupedReduceOperator<Integer> operator = new StreamGroupedReduceOperator<>(new MyReducer(), IntSerializer.INSTANCE);
 
 		OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, BasicTypeInfo.INT_TYPE_INFO);
@@ -84,8 +84,8 @@ public class StreamGroupedReduceTest {
 
 		KeySelector<Integer, Integer> keySelector = new IntegerKeySelector();
 
-		StreamGroupedReduce<Integer> operator =
-				new StreamGroupedReduce<>(new TestOpenCloseReduceFunction(), IntSerializer.INSTANCE);
+		StreamGroupedReduceOperator<Integer> operator =
+				new StreamGroupedReduceOperator<>(new TestOpenCloseReduceFunction(), IntSerializer.INSTANCE);
 		OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
 				new KeyedOneInputStreamOperatorTestHarness<>(operator, keySelector, BasicTypeInfo.INT_TYPE_INFO);
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.functions.aggregation.{AggregationFunction
 import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
 import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
-import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
@@ -486,11 +485,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
   }
 
   private def aggregate(aggregationFunc: AggregationFunction[T]): DataStream[T] = {
-    val invokable =
-      new StreamGroupedReduceOperator[T](aggregationFunc, dataType.createSerializer(executionConfig))
-
-    new DataStream[T](javaStream.transform("aggregation", javaStream.getType(), invokable))
-      .asInstanceOf[DataStream[T]]
+    reduce(aggregationFunc).name("Keyed Aggregation")
   }
 
   // ------------------------------------------------------------------------

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.functions.aggregation.{AggregationFunction
 import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
 import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
-import org.apache.flink.streaming.api.operators.StreamGroupedReduce
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.time.Time
@@ -487,7 +487,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
 
   private def aggregate(aggregationFunc: AggregationFunction[T]): DataStream[T] = {
     val invokable =
-      new StreamGroupedReduce[T](aggregationFunc, dataType.createSerializer(executionConfig))
+      new StreamGroupedReduceOperator[T](aggregationFunc, dataType.createSerializer(executionConfig))
 
     new DataStream[T](javaStream.transform("aggregation", javaStream.getType(), invokable))
       .asInstanceOf[DataStream[T]]

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
-import org.apache.flink.streaming.api.operators.StreamGroupedReduce;
+import org.apache.flink.streaming.api.operators.StreamGroupedReduceOperator;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.EvictingQueue;
 
@@ -45,7 +45,7 @@ import java.util.Random;
  * of {@link AbstractUdfStreamOperator} is correctly restored in case of recovery from
  * a failure.
  *
- * <p>The topology currently tests the proper behaviour of the {@link StreamGroupedReduce} operator.
+ * <p>The topology currently tests the proper behaviour of the {@link StreamGroupedReduceOperator} operator.
  */
 @SuppressWarnings("serial")
 public class UdfStreamOperatorCheckpointingITCase extends StreamFaultToleranceTestBase {


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces ReduceTransformation and a corresponding translator
that produces runtime execution mode dependent operator.

The operator for the BATCH execution instead of emitting intermediate results after each incoming event it registers a callback for max watermark and then emits the result for a given key when the timer fires.


## Verifying this change

* Added tests in `org.apache.flink.test.streaming.runtime.ReduceITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
