### PR TITLE
[FLINK-19805] Revert "[FLINK-17295] Refactor the ExecutionAttemptID to consist of E…

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -49,7 +49,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
@@ -101,7 +100,7 @@ public class SavepointEnvironment implements Environment {
 	private SavepointEnvironment(RuntimeContext ctx, Configuration configuration, int maxParallelism, int indexOfSubtask, PrioritizedOperatorSubtaskState prioritizedOperatorSubtaskState) {
 		this.jobID = new JobID();
 		this.vertexID = new JobVertexID();
-		this.attemptID = new ExecutionAttemptID(jobID, new ExecutionVertexID(vertexID, 0), 0);
+		this.attemptID = new ExecutionAttemptID();
 		this.ctx = Preconditions.checkNotNull(ctx);
 		this.configuration = Preconditions.checkNotNull(configuration);
 

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -40,6 +39,7 @@ import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.util.AbstractID;
 
 import com.codahale.metrics.ScheduledReporter;
 import org.junit.Test;
@@ -96,7 +96,7 @@ public class ScheduledDropwizardReporterTest {
 
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(metricRegistry, hostname, taskManagerId);
 		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(metricRegistry, tmMetricGroup, new JobID(), jobName);
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new ExecutionAttemptID(), taskName, 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new AbstractID(), taskName, 0, 0);
 
 		SimpleCounter myCounter = new SimpleCounter();
 		com.codahale.metrics.Meter dropwizardMeter = new com.codahale.metrics.Meter();

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -26,13 +26,13 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.util.AbstractID;
 
 import com.mashape.unirest.http.exceptions.UnirestException;
 import io.prometheus.client.CollectorRegistry;
@@ -67,10 +67,10 @@ public class PrometheusReporterTaskScopeTest {
 
 	private final JobID jobId = new JobID();
 	private final JobVertexID taskId1 = new JobVertexID();
-	private final ExecutionAttemptID taskAttemptId1 = new ExecutionAttemptID();
+	private final AbstractID taskAttemptId1 = new AbstractID();
 	private final String[] labelValues1 = {jobId.toString(), taskId1.toString(), taskAttemptId1.toString(), TASK_MANAGER_HOST, TASK_NAME, "" + ATTEMPT_NUMBER, JOB_NAME, TASK_MANAGER_ID, "" + SUBTASK_INDEX_1};
 	private final JobVertexID taskId2 = new JobVertexID();
-	private final ExecutionAttemptID taskAttemptId2 = new ExecutionAttemptID();
+	private final AbstractID taskAttemptId2 = new AbstractID();
 	private final String[] labelValues2 = {jobId.toString(), taskId2.toString(), taskAttemptId2.toString(), TASK_MANAGER_HOST, TASK_NAME, "" + ATTEMPT_NUMBER, JOB_NAME, TASK_MANAGER_ID, "" + SUBTASK_INDEX_2};
 
 	private TaskMetricGroup taskMetricGroup1;

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.TestCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
@@ -41,6 +40,7 @@ import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -98,7 +98,7 @@ public class StatsDReporterTest extends TestLogger {
 
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(metricRegistry, hostname, taskManagerId);
 		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(metricRegistry, tmMetricGroup, new JobID(), jobName);
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new ExecutionAttemptID(), taskName, 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new AbstractID(), taskName, 0, 0);
 
 		SimpleCounter myCounter = new SimpleCounter();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -217,7 +217,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 		this.executor = checkNotNull(executor);
 		this.vertex = checkNotNull(vertex);
-		this.attemptId = new ExecutionAttemptID(vertex.getJobId(), vertex.getID(), attemptNumber);
+		this.attemptId = new ExecutionAttemptID();
 		this.rpcTimeout = checkNotNull(rpcTimeout);
 
 		this.globalModVersion = globalModVersion;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
@@ -18,102 +18,33 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.AbstractID;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.util.Preconditions;
-
-import java.util.Objects;
 
 /**
  * Unique identifier for the attempt to execute a tasks. Multiple attempts happen
  * in cases of failures and recovery.
  */
-public class ExecutionAttemptID implements java.io.Serializable {
+public class ExecutionAttemptID extends AbstractID {
 
 	private static final long serialVersionUID = -1169683445778281344L;
 
-	private final JobID jobId;
-	private final ExecutionVertexID executionVertexId;
-	private final int attemptNumber;
-
-	/**
-	 * Get a random execution attempt id.
-	 */
 	public ExecutionAttemptID() {
-		this(new JobID(), new ExecutionVertexID(new JobVertexID(), 0), 0);
 	}
 
-	public ExecutionAttemptID(JobID jobId, ExecutionVertexID executionVertexId, int attemptNumber) {
-		Preconditions.checkState(attemptNumber >= 0);
-		this.jobId = Preconditions.checkNotNull(jobId);
-		this.executionVertexId = Preconditions.checkNotNull(executionVertexId);
-		this.attemptNumber = attemptNumber;
+	public ExecutionAttemptID(long lowerPart, long upperPart) {
+		super(lowerPart, upperPart);
 	}
 
 	public void writeTo(ByteBuf buf) {
-		writeJobIdTo(buf);
-		executionVertexId.writeTo(buf);
-		buf.writeInt(this.attemptNumber);
+		buf.writeLong(this.lowerPart);
+		buf.writeLong(this.upperPart);
 	}
 
 	public static ExecutionAttemptID fromByteBuf(ByteBuf buf) {
-		final JobID jobId = jobIdFromByteBuf(buf);
-		final ExecutionVertexID executionVertexId = ExecutionVertexID.fromByteBuf(buf);
-		final int attemptNumber = buf.readInt();
-		return new ExecutionAttemptID(jobId, executionVertexId, attemptNumber);
-	}
-
-	private static JobID jobIdFromByteBuf(ByteBuf buf) {
-		final long lower = buf.readLong();
-		final long upper = buf.readLong();
-		return new JobID(lower, upper);
-	}
-
-	private void writeJobIdTo(ByteBuf buf) {
-		buf.writeLong(jobId.getLowerPart());
-		buf.writeLong(jobId.getUpperPart());
-	}
-
-	@VisibleForTesting
-	public int getAttemptNumber() {
-		return attemptNumber;
-	}
-
-	@VisibleForTesting
-	public ExecutionVertexID getExecutionVertexId() {
-		return executionVertexId;
-	}
-
-	@VisibleForTesting
-	public JobID getJobId() {
-		return jobId;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == this) {
-			return true;
-		} else if (obj != null && obj.getClass() == getClass()) {
-			ExecutionAttemptID that = (ExecutionAttemptID) obj;
-			return that.jobId.equals(this.jobId)
-				&& that.executionVertexId.equals(this.executionVertexId)
-				&& that.attemptNumber == this.attemptNumber;
-		} else {
-			return false;
-		}
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(jobId, executionVertexId, attemptNumber);
-	}
-
-	@Override
-	public String toString() {
-		return jobId.toString() + "_" + executionVertexId.toString() + "_" + attemptNumber;
+		long lower = buf.readLong();
+		long upper = buf.readLong();
+		return new ExecutionAttemptID(lower, upper);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -512,7 +512,7 @@ public abstract class NettyMessage {
 			ByteBuf result = null;
 
 			try {
-				result = allocateBuffer(allocator, ID, 20 + 40 + 4 + 16 + 4);
+				result = allocateBuffer(allocator, ID, 20 + 16 + 4 + 16 + 4);
 
 				partitionId.getPartitionId().writeTo(result);
 				partitionId.getProducerId().writeTo(result);
@@ -573,7 +573,7 @@ public abstract class NettyMessage {
 				// TODO Directly serialize to Netty's buffer
 				ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
-				result = allocateBuffer(allocator, ID, 4 + serializedEvent.remaining() + 20 + 40 + 16);
+				result = allocateBuffer(allocator, ID, 4 + serializedEvent.remaining() + 20 + 16 + 16);
 
 				result.writeInt(serializedEvent.remaining());
 				result.writeBytes(serializedEvent);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexID.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.topology.VertexID;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;
 
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-
 /**
  * A class for statistically unique job vertex IDs.
  */
@@ -45,16 +43,5 @@ public class JobVertexID extends AbstractID implements VertexID {
 
 	public static JobVertexID fromHexString(String hexString) {
 		return new JobVertexID(StringUtils.hexStringToByte(hexString));
-	}
-
-	public void writeTo(ByteBuf buf) {
-		buf.writeLong(lowerPart);
-		buf.writeLong(upperPart);
-	}
-
-	public static JobVertexID fromByteBuf(ByteBuf buf) {
-		final long lower = buf.readLong();
-		final long upper = buf.readLong();
-		return new JobVertexID(lower, upper);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
 
@@ -41,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricGroup> {
 
 	/** Map from execution attempt ID (task identifier) to task metrics. */
-	private final Map<ExecutionAttemptID, TaskMetricGroup> tasks = new HashMap<>();
+	private final Map<AbstractID, TaskMetricGroup> tasks = new HashMap<>();
 
 	// ------------------------------------------------------------------------
 
@@ -94,7 +95,7 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
 		}
 	}
 
-	public void removeTaskMetricGroup(ExecutionAttemptID executionId) {
+	public void removeTaskMetricGroup(AbstractID executionId) {
 		checkNotNull(executionId);
 
 		boolean removeFromParent = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.CharacterFilter;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -50,7 +49,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	private final TaskIOMetricGroup ioMetrics;
 
 	/** The execution Id uniquely identifying the executed task represented by this metrics group. */
-	private final ExecutionAttemptID executionId;
+	private final AbstractID executionId;
 
 	@Nullable
 	protected final JobVertexID vertexId;
@@ -68,7 +67,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 			MetricRegistry registry,
 			TaskManagerJobMetricGroup parent,
 			@Nullable JobVertexID vertexId,
-			ExecutionAttemptID executionId,
+			AbstractID executionId,
 			@Nullable String taskName,
 			int subtaskIndex,
 			int attemptNumber) {
@@ -92,7 +91,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 		return parent;
 	}
 
-	public ExecutionAttemptID executionId() {
+	public AbstractID executionId() {
 		return executionId;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
@@ -181,7 +181,7 @@ public class UnregisteredMetricGroups {
 	 */
 	public static class UnregisteredTaskMetricGroup extends TaskMetricGroup {
 		private static final JobVertexID DEFAULT_VERTEX_ID = new JobVertexID(0, 0);
-		private static final ExecutionAttemptID DEFAULT_ATTEMPT_ID = new ExecutionAttemptID();
+		private static final ExecutionAttemptID DEFAULT_ATTEMPT_ID = new ExecutionAttemptID(0, 0);
 		private static final String DEFAULT_TASK_NAME = "UnregisteredTask";
 
 		protected UnregisteredTaskMetricGroup() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/TaskScopeFormat.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.metrics.scope;
 
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.util.AbstractID;
 
@@ -43,7 +42,7 @@ public class TaskScopeFormat extends ScopeFormat {
 
 	public String[] formatScope(
 			TaskManagerJobMetricGroup parent,
-			AbstractID vertexId, ExecutionAttemptID attemptId,
+			AbstractID vertexId, AbstractID attemptId,
 			String taskName, int subtask, int attemptNumber) {
 
 		final String[] template = copyTemplate();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ExecutionVertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ExecutionVertexID.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.topology.VertexID;
 
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -48,17 +46,6 @@ public class ExecutionVertexID implements VertexID {
 
 	public int getSubtaskIndex() {
 		return subtaskIndex;
-	}
-
-	public void writeTo(ByteBuf buf) {
-		jobVertexId.writeTo(buf);
-		buf.writeInt(subtaskIndex);
-	}
-
-	public static ExecutionVertexID fromByteBuf(ByteBuf buf) {
-		final JobVertexID jobVertexID = JobVertexID.fromByteBuf(buf);
-		final int subtaskIndex = buf.readInt();
-		return new ExecutionVertexID(jobVertexID, subtaskIndex);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1065,7 +1065,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		final Task task = taskSlotTable.getTask(executionAttemptID);
 		if (task == null) {
 			return FutureUtils.completedExceptionally(new TaskNotRunningException(
-				"Task " + executionAttemptID + " not running on TaskManager"));
+				"Task " + executionAttemptID.toHexString() + " not running on TaskManager"));
 		}
 
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/VertexID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/VertexID.java
@@ -21,5 +21,5 @@ package org.apache.flink.runtime.topology;
 /**
  * ID of a {@link Vertex}.
  */
-public interface VertexID extends java.io.Serializable {
+public interface VertexID {
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -404,7 +404,7 @@ public class JobMasterTest extends TestLogger {
 			RpcCheckpointResponder rpcCheckpointResponder = new RpcCheckpointResponder(jobMasterGateway);
 			rpcCheckpointResponder.declineCheckpoint(
 				jobGraph.getJobID(),
-				new ExecutionAttemptID(),
+				new ExecutionAttemptID(1, 1),
 				1,
 				userException
 			);
@@ -1655,7 +1655,7 @@ public class JobMasterTest extends TestLogger {
 			final ResultPartitionDeploymentDescriptor partition = tdd.getProducedPartitions().iterator().next();
 
 			final ExecutionAttemptID executionAttemptId = tdd.getExecutionAttemptId();
-			final ExecutionAttemptID copiedExecutionAttemptId = new ExecutionAttemptID(executionAttemptId.getJobId(), executionAttemptId.getExecutionVertexId(), executionAttemptId.getAttemptNumber());
+			final ExecutionAttemptID copiedExecutionAttemptId = new ExecutionAttemptID(executionAttemptId.getLowerPart(), executionAttemptId.getUpperPart());
 
 			// finish the producer task
 			jobMasterGateway.updateTaskExecutionState(new TaskExecutionState(producerConsumerJobGraph.getJobID(), executionAttemptId, ExecutionState.FINISHED)).get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -35,6 +34,7 @@ import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.runtime.metrics.util.TestReporter;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -305,7 +305,7 @@ public class MetricGroupTest extends TestLogger {
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
 		JobVertexID vid = new JobVertexID();
-		ExecutionAttemptID eid = new ExecutionAttemptID();
+		AbstractID eid = new AbstractID();
 		MetricRegistryImpl registry = new MetricRegistryImpl(defaultMetricRegistryConfiguration);
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -65,7 +66,7 @@ public class OperatorGroupTest extends TestLogger {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
-				registry, jmGroup,  new JobVertexID(),  new ExecutionAttemptID(), "aTaskName", 11, 0);
+				registry, jmGroup,  new JobVertexID(),  new AbstractID(), "aTaskName", 11, 0);
 		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
 		assertArrayEquals(
@@ -111,7 +112,7 @@ public class OperatorGroupTest extends TestLogger {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
-			registry, jmGroup, new JobVertexID(), new ExecutionAttemptID(), "aTaskName", 11, 0);
+			registry, jmGroup, new JobVertexID(), new AbstractID(), "aTaskName", 11, 0);
 		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
 		assertNotNull(opGroup.getIOMetricGroup());
@@ -123,7 +124,7 @@ public class OperatorGroupTest extends TestLogger {
 	public void testVariables() {
 		JobID jid = new JobID();
 		JobVertexID tid = new JobVertexID();
-		ExecutionAttemptID eid = new ExecutionAttemptID();
+		AbstractID eid = new AbstractID();
 		OperatorID oid = new OperatorID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
@@ -157,7 +158,7 @@ public class OperatorGroupTest extends TestLogger {
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
 		JobVertexID vid = new JobVertexID();
-		ExecutionAttemptID eid = new ExecutionAttemptID();
+		AbstractID eid = new AbstractID();
 		OperatorID oid = new OperatorID();
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -22,13 +22,13 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
+import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -66,7 +66,7 @@ public class TaskMetricGroupTest extends TestLogger {
 	@Test
 	public void testGenerateScopeDefault() {
 		JobVertexID vertexId = new JobVertexID();
-		ExecutionAttemptID executionId = new ExecutionAttemptID();
+		AbstractID executionId = new AbstractID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
@@ -91,7 +91,7 @@ public class TaskMetricGroupTest extends TestLogger {
 
 		JobID jid = new JobID();
 		JobVertexID vertexId = new JobVertexID();
-		ExecutionAttemptID executionId = new ExecutionAttemptID();
+		AbstractID executionId = new AbstractID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
@@ -114,7 +114,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		cfg.setString(MetricOptions.SCOPE_NAMING_TASK, "*.<task_attempt_id>.<subtask_index>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
 
-		ExecutionAttemptID executionId = new ExecutionAttemptID();
+		AbstractID executionId = new AbstractID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
@@ -136,7 +136,7 @@ public class TaskMetricGroupTest extends TestLogger {
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
 		JobVertexID vid = new JobVertexID();
-		ExecutionAttemptID eid = new ExecutionAttemptID();
+		AbstractID eid = new AbstractID();
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
 		TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
@@ -153,7 +153,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		CountingMetricRegistry registry = new CountingMetricRegistry(new Configuration());
 		TaskManagerMetricGroup taskManagerMetricGroup = new TaskManagerMetricGroup(registry, "localhost", "0");
 		TaskManagerJobMetricGroup taskManagerJobMetricGroup = new TaskManagerJobMetricGroup(registry, taskManagerMetricGroup, new JobID(), "job");
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, taskManagerJobMetricGroup, new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, taskManagerJobMetricGroup, new JobVertexID(), new AbstractID(), "task", 0, 0);
 
 		// the io metric should have registered predefined metrics
 		assertTrue(registry.getNumberRegisteredMetrics() > 0);
@@ -173,7 +173,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, job, new JobVertexID(), new ExecutionAttemptID(), "task", 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, job, new JobVertexID(), new AbstractID(), "task", 0, 0);
 
 		String originalName = new String(new char[100]).replace("\0", "-");
 		OperatorMetricGroup operatorMetricGroup = taskMetricGroup.getOrAddOperator(originalName);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/chaining/ChainedOperatorsMetricTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.operators.util.UserCodeClassWrapper;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.OperatorIOMetricGroup;
@@ -80,7 +79,7 @@ public class ChainedOperatorsMetricTest extends TaskTestBase {
 				NoOpMetricRegistry.INSTANCE,
 				UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup(),
 				new JobVertexID(),
-				new ExecutionAttemptID(),
+				new AbstractID(),
 				"task",
 				0,
 				0))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -45,7 +45,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
@@ -97,8 +96,6 @@ public class MockEnvironment implements Environment, AutoCloseable {
 	private final JobID jobID;
 
 	private final JobVertexID jobVertexID;
-
-	private final ExecutionAttemptID executionAttemptID;
 
 	private final TaskManagerRuntimeInfo taskManagerRuntimeInfo;
 
@@ -156,7 +153,6 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		this.taskConfiguration = taskConfiguration;
 		this.inputs = new LinkedList<>();
 		this.outputs = new LinkedList<ResultPartitionWriter>();
-		this.executionAttemptID = new ExecutionAttemptID();
 
 		this.memManager = memManager;
 		this.ioManager = ioManager;
@@ -310,7 +306,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	@Override
 	public ExecutionAttemptID getExecutionId() {
-		return executionAttemptID;
+		return new ExecutionAttemptID(0L, 0L);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -177,7 +177,7 @@ public class TaskStateManagerImplTest extends TestLogger {
 		JobID jobID = new JobID(42L, 43L);
 		AllocationID allocationID = new AllocationID(4711L, 23L);
 		JobVertexID jobVertexID = new JobVertexID(12L, 34L);
-		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID(23L, 24L);
 		TestCheckpointResponder checkpointResponderMock = new TestCheckpointResponder();
 
 		Executor directExecutor = Executors.directExecutor();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -193,7 +193,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 		};
 
 		JobID jobID = new JobID();
-		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID(0L, 0L);
 		TestTaskStateManager taskStateManagerTestMock = new TestTaskStateManager(
 			jobID,
 			executionAttemptID,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -263,7 +263,7 @@ public class StreamTaskStateInitializerImplTest {
 		boolean createTimerServiceManager) {
 
 		JobID jobID = new JobID(42L, 43L);
-		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+		ExecutionAttemptID executionAttemptID = new ExecutionAttemptID(23L, 24L);
 		TestCheckpointResponder checkpointResponderMock = new TestCheckpointResponder();
 
 		TaskLocalStateStore taskLocalStateStore = new TestTaskLocalStateStore();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -135,7 +135,7 @@ public class StreamMockEnvironment implements Environment {
 		TaskStateManager taskStateManager) {
 		this(
 			new JobID(),
-			new ExecutionAttemptID(),
+			new ExecutionAttemptID(0L, 0L),
 			jobConfig,
 			taskConfig,
 			executionConfig,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -702,7 +702,7 @@ public class StreamTaskTest extends TestLogger {
 
 		TaskStateManager taskStateManager = new TaskStateManagerImpl(
 			new JobID(1L, 2L),
-			new ExecutionAttemptID(),
+			new ExecutionAttemptID(1L, 2L),
 			mock(TaskLocalStateStoreImpl.class),
 			null,
 			checkpointResponder);
@@ -876,7 +876,7 @@ public class StreamTaskTest extends TestLogger {
 
 		TaskStateManager taskStateManager = new TaskStateManagerImpl(
 			new JobID(1L, 2L),
-			new ExecutionAttemptID(),
+			new ExecutionAttemptID(1L, 2L),
 			mock(TaskLocalStateStoreImpl.class),
 			null,
 			checkpointResponder);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -488,7 +488,7 @@ public class StreamTaskTestHarness<OUT> {
 				new TestMetricRegistry(metrics),
 				new UnregisteredMetricGroups.UnregisteredTaskManagerJobMetricGroup(),
 				new JobVertexID(0, 0),
-				new ExecutionAttemptID(),
+				new ExecutionAttemptID(0, 0),
 				"test",
 				0,
 				0);


### PR DESCRIPTION

## What is the purpose of the change

This reverts commit b2e1c02db83e4eee6f561bb49feb9de70a445142 from FLINK-17295 (#11873)

While debugging FLINK-19805, we noticed that re-using the exact same `ExecutionAttemptID` across multiple leader sessions can lead to severe inconsistencies in the system. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)


