### PR TITLE
[FLINK-19933][DataStream] Execute and collect with limit fails on bounded datastream jobs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/ClientAndIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/ClientAndIterator.java
@@ -43,6 +43,5 @@ public final class ClientAndIterator<E> implements AutoCloseable {
 	@Override
 	public void close() throws Exception {
 		iterator.close();
-		client.cancel();
 	}
 }


### PR DESCRIPTION
## Brief changelog

The underlying fetcher iterator already cancels the job on close, and properly handles the error case of the job already being completed, so we do not need to do it twice. 

I would actual drop `ClientWithIterator` entirly if I didn't need it for backwards compat with DataStreamUtils

## Verifying this change

Basic UT and also checked it manually. 

