### PR TITLE
[FLINK-18117][e2e] Dynamically allocate port causing test instabilities

### DIFF
--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
@@ -128,7 +128,7 @@ RUN set -x \
     && echo "Port 2122" >> /etc/ssh/sshd_config
 
 # Hdfs ports
-EXPOSE 50470 9000 50010 50020 50070 50075 50090 50475 50091 8020
+EXPOSE 9000 50010 50020 50070 50075 50090 50475 50091 8020
 # Mapred ports
 EXPOSE 19888
 # Yarn ports

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/Dockerfile
@@ -128,7 +128,7 @@ RUN set -x \
     && echo "Port 2122" >> /etc/ssh/sshd_config
 
 # Hdfs ports
-EXPOSE 9000 50010 50020 50070 50075 50090 50475 50091 8020
+EXPOSE 9000 50010 50020 50075 50090 50475 50091 8020
 # Mapred ports
 EXPOSE 19888
 # Yarn ports

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/hdfs-site.xml
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/hdfs-site.xml
@@ -24,6 +24,13 @@ under the License.
         <name>dfs.namenode.rpc-address</name>
         <value>master.docker-hadoop-cluster-network:9000</value>
     </property>
+
+    <!-- Introduced to address instability described in FLINK-18117 -->
+    <property>
+        <name>dfs.namenode.http-address</name>
+        <value>0.0.0.0:0</value>
+    </property>
+
     <property>
          <name>dfs.permissions</name>
          <value>true</value>

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/hdfs-site.xml
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/hdfs-site.xml
@@ -30,6 +30,10 @@ under the License.
         <name>dfs.namenode.http-address</name>
         <value>0.0.0.0:0</value>
     </property>
+    <property>
+        <name>dfs.namenode.https-address</name>
+        <value>0.0.0.0:0</value>
+    </property>
 
     <property>
          <name>dfs.permissions</name>


### PR DESCRIPTION
The E2E test regularly fails because it can not allocate a port. This change allows Hadoop to pick any port.
