### PR TITLE
[FLINK-19936] Make SinkITCase stable

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/FiniteTestSource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/FiniteTestSource.java
@@ -21,7 +21,13 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A stream source that:
@@ -46,12 +52,24 @@ public class FiniteTestSource<T> implements SourceFunction<T>, CheckpointListene
 
 	private transient int numCheckpointsComplete;
 
+	@Nullable
+	private final BooleanSupplier couldExit;
+
+	private final long waitTimeOut;
+
 	@SafeVarargs
 	public FiniteTestSource(T... elements) {
 		this(Arrays.asList(elements));
 	}
 
 	public FiniteTestSource(Iterable<T> elements) {
+		this(null, 0, elements);
+	}
+
+	public FiniteTestSource(@Nullable BooleanSupplier couldExit, long waitTimeOut, Iterable<T> elements) {
+		checkState(waitTimeOut >= 0);
+		this.couldExit = couldExit;
+		this.waitTimeOut = waitTimeOut;
 		this.elements = elements;
 	}
 
@@ -62,9 +80,25 @@ public class FiniteTestSource<T> implements SourceFunction<T>, CheckpointListene
 
 		// second round of the same
 		emitElementsAndWaitForCheckpoints(ctx, 2);
+
+		//verify the source could exit or not
+		if (couldExit != null) {
+			final long beginTime = System.currentTimeMillis();
+			synchronized (ctx.getCheckpointLock()) {
+				while (running && !couldExit.getAsBoolean()) {
+					ctx.getCheckpointLock().wait(10);
+					if ((System.currentTimeMillis() - beginTime) > waitTimeOut) {
+						throw new TimeoutException(
+								"Wait source exit time out " + waitTimeOut + "ms.");
+					}
+				}
+			}
+		}
 	}
 
-	private void emitElementsAndWaitForCheckpoints(SourceContext<T> ctx, int checkpointsToWaitFor) throws InterruptedException {
+	private void emitElementsAndWaitForCheckpoints(
+			SourceContext<T> ctx,
+			int checkpointsToWaitFor) throws InterruptedException {
 		final Object lock = ctx.getCheckpointLock();
 
 		final int checkpointToAwait;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the streaming execution mode there are two uncertain things:

1. The order of receiving the checkpoint complete.(`Committer` receive first or `GlobalCommitter` receive first)
1. Whether the operator can receive the last checkpoint
 This patch does following two things to resolve `SinkITCase`'s unstable owning to these two uncertainty 

This pr does two things
1. Changing how to verifying the output of `GlobalCommitter` for the case 1
2. Let the `FiniteTestSource` exit only when the Committer/GlobalCommitter received all the elements.


## Brief change log

  - *This patch changes how to verifying the output of `GlobalCommitter` to resolve `SinkITCase`'s unstable owning to this uncertainty.*
  - *FiniteTestSource exits only after user provide condition is satisfied or time out.*
  - *All streaming mode ITCases exit only when the Committer/GlobalCommitter receive all the data or time out*


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
