### PR TITLE
[FLINK-19740][python] Fix to_pandas to Support EventTime in Blink Planner

### DIFF
--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -159,4 +159,51 @@ class BlinkBatchPandasConversionTests(PandasConversionTests,
 
 class BlinkStreamPandasConversionTests(PandasConversionITTests,
                                        PyFlinkBlinkStreamTableTestCase):
-    pass
+    def test_to_pandas_with_event_time(self):
+        self.env.set_parallelism(1)
+        # create source file path
+        import tempfile
+        from pyflink.datastream.time_characteristic import TimeCharacteristic
+        import os
+        tmp_dir = tempfile.gettempdir()
+        data = [
+            '2018-03-11 03:10:00',
+            '2018-03-11 03:10:00',
+            '2018-03-11 03:10:00',
+            '2018-03-11 03:40:00',
+            '2018-03-11 04:20:00',
+            '2018-03-11 03:30:00'
+        ]
+        source_path = tmp_dir + '/test_to_pandas_with_event_time.csv'
+        with open(source_path, 'w') as fd:
+            for ele in data:
+                fd.write(ele + '\n')
+
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+
+        source_table = """
+            create table source_table(
+                rowtime TIMESTAMP(3),
+                WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
+            ) with(
+                'connector.type' = 'filesystem',
+                'format.type' = 'csv',
+                'connector.path' = '%s',
+                'format.ignore-first-line' = 'false',
+                'format.field-delimiter' = ','
+            )
+        """ % source_path
+        self.t_env.execute_sql(source_table)
+        t = self.t_env.from_path("source_table")
+        result_pdf = t.to_pandas()
+        import pandas as pd
+        os.remove(source_path)
+        assert_frame_equal(result_pdf, pd.DataFrame(
+            data={"rowtime": [
+                datetime.datetime(2018, 3, 11, 3, 10),
+                datetime.datetime(2018, 3, 11, 3, 10),
+                datetime.datetime(2018, 3, 11, 3, 10),
+                datetime.datetime(2018, 3, 11, 3, 40),
+                datetime.datetime(2018, 3, 11, 4, 20),
+                datetime.datetime(2018, 3, 11, 3, 30),
+            ]}))

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -633,8 +633,8 @@ public final class ArrowUtils {
 				public RowData next() {
 					// The SelectTableSink of blink planner will convert the table schema and we
 					// need to keep the table schema used here be consistent with the converted table schema
-					TableSchema convertedTableSchema =
-						SelectTableSinkSchemaConverter.changeDefaultConversionClass(table.getSchema());
+					TableSchema convertedTableSchema = SelectTableSinkSchemaConverter.convertTimeAttributeToRegularTimestamp(
+						SelectTableSinkSchemaConverter.changeDefaultConversionClass(table.getSchema()));
 					DataFormatConverters.DataFormatConverter converter =
 						DataFormatConverters.getConverterForDataType(convertedTableSchema.toRowDataType());
 					return (RowData) converter.toInternal(results.next());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkSchemaConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/SelectTableSinkSchemaConverter.java
@@ -50,7 +50,7 @@ public class SelectTableSinkSchemaConverter {
 	 * Convert time attributes (proc time / event time) to regular timestamp
 	 * and build a new {@link TableSchema}.
 	 */
-	static TableSchema convertTimeAttributeToRegularTimestamp(TableSchema tableSchema) {
+	public static TableSchema convertTimeAttributeToRegularTimestamp(TableSchema tableSchema) {
 		DataType[] dataTypes = tableSchema.getFieldDataTypes();
 		String[] oldNames = tableSchema.getFieldNames();
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix `to_pandas` to support EventTime in Blink Planner*


## Brief change log

  - *convertTimeAttributeToRegularTimestamp in to_pandas in blink planner*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add it test `test_to_pandas_with_event_time` in `test_pandas_conversion.py`*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
