### PR TITLE
[FLINK-19949][csv] Unescape CSV format line delimiter character

### DIFF
--- a/docs/dev/table/connectors/formats/csv.md
+++ b/docs/dev/table/connectors/formats/csv.md
@@ -92,11 +92,8 @@ Format Options
       <td>optional</td>
       <td style="word-wrap: break-word;"><code>,</code></td>
       <td>String</td>
-      <td>Field delimiter character (<code>','</code> by default). Note the <code>\n</code> and <code>\r</code> are invisible special characters, you have to use unicode to specify them in plain SQL.
-          <ul>
-           <li>e.g. <code>'csv.field-delimiter' = U&'\000D'</code> specifies the to use carriage return <code>\r</code> as field delimiter.</li>
-           <li>e.g. <code>'csv.field-delimiter' = U&'\000A'</code> specifies the to use line feed <code>\n</code> as field delimiter.</li>
-          </ul>
+      <td>Field delimiter character (<code>','</code> by default), must be single character. You can use backslash to specify special characters, e.g. <code>'\t'</code> represents the tab character.
+       You can also use unicode to specify them in plain SQL, e.g. <code>'csv.field-delimiter' = U&'\0001'</code> represents the <code>0x01</code> character.
       </td>
     </tr>
     <tr>

--- a/docs/dev/table/connectors/formats/csv.zh.md
+++ b/docs/dev/table/connectors/formats/csv.zh.md
@@ -93,11 +93,8 @@ Format 参数
       <td>可选</td>
       <td style="word-wrap: break-word;"><code>,</code></td>
       <td>String</td>
-      <td>字段分隔符 (默认<code>','</code>)。注意 <code>\n</code> 和 <code>\r</code> 是不可见的特殊符号, 在显式的 SQL 语句中必须使用 unicode 编码。
-          <ul>
-           <li>例如 <code>'csv.field-delimiter' = U&'\000D'</code> 使用回车符号 <code>\r</code> 作为字段分隔符。</li>
-           <li>例如 <code>'csv.field-delimiter' = U&'\000A'</code> 使用换行符号 <code>\n</code> 作为字段分隔符。</li>
-          </ul>
+      <td>字段分隔符 (默认<code>','</code>)，必须为单字符。你可以使用反斜杠字符指定一些特殊字符，例如 <code>'\t'</code> 代表制表符。
+      你也可以通过 unicode 编码在纯 SQL 文本中指定一些特殊字符，例如 <code>'csv.field-delimiter' = U&'\0001'</code> 代表 <code>0x01</code> 字符。
       </td>
     </tr>
     <tr>

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileSystemFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileSystemFormatFactory.java
@@ -35,6 +35,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.MappingIt
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -131,7 +133,8 @@ public class CsvFileSystemFormatFactory implements FileSystemFormatFactory {
 		CsvSchema csvSchema = CsvRowSchemaConverter.convert(rowType);
 		CsvSchema.Builder csvBuilder = csvSchema.rebuild();
 		//format properties
-		options.getOptional(FIELD_DELIMITER).map(s -> s.charAt(0))
+		options.getOptional(FIELD_DELIMITER)
+			.map(s -> StringEscapeUtils.unescapeJava(s).charAt(0))
 			.ifPresent(csvBuilder::setColumnSeparator);
 
 		options.getOptional(QUOTE_CHARACTER).map(s -> s.charAt(0))

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -77,19 +77,8 @@ public class CsvFormatFactoryTest extends TestLogger {
 						.setEscapeCharacter('\\')
 						.setNullLiteral("n/a")
 						.build();
-
 		final Map<String, String> options = getAllOptions();
-
-		final DynamicTableSource actualSource = createTableSource(options);
-		assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
-		TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
-				(TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
-
-		DeserializationSchema<RowData> actualDeser = scanSourceMock.valueFormat
-				.createRuntimeDecoder(
-						ScanRuntimeProviderContext.INSTANCE,
-						SCHEMA.toRowDataType());
-
+		DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
 		assertEquals(expectedDeser, actualDeser);
 
 		final CsvRowDataSerializationSchema expectedSer = new CsvRowDataSerializationSchema.Builder(ROW_TYPE)
@@ -99,17 +88,7 @@ public class CsvFormatFactoryTest extends TestLogger {
 			.setEscapeCharacter('\\')
 			.setNullLiteral("n/a")
 			.build();
-
-		final DynamicTableSink actualSink = createTableSink(options);
-		assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
-		TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
-				(TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
-
-		SerializationSchema<RowData> actualSer = sinkMock.valueFormat
-				.createRuntimeEncoder(
-						null,
-						SCHEMA.toRowDataType());
-
+		SerializationSchema<RowData> actualSer = createSerializationSchema(options);
 		assertEquals(expectedSer, actualSer);
 	}
 
@@ -127,16 +106,7 @@ public class CsvFormatFactoryTest extends TestLogger {
 			.setNullLiteral("n/a")
 			.disableQuoteCharacter()
 			.build();
-
-		final DynamicTableSink actualSink = createTableSink(options);
-		assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
-		TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
-				(TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
-
-		SerializationSchema<RowData> actualSer = sinkMock.valueFormat
-				.createRuntimeEncoder(
-						null,
-						SCHEMA.toRowDataType());
+		SerializationSchema<RowData> actualSer = createSerializationSchema(options);
 
 		assertEquals(expectedSer, actualSer);
 	}
@@ -144,10 +114,12 @@ public class CsvFormatFactoryTest extends TestLogger {
 	@Test
 	public void testDisableQuoteCharacterException() {
 		thrown.expect(ValidationException.class);
-		thrown.expect(containsCause(new ValidationException("Format cannot define a quote character and disabled quote character at the same time.")));
+		thrown.expect(containsCause(new ValidationException(
+			"Format cannot define a quote character and disabled quote character at the same time.")));
 
-		final Map<String, String> options =
-				getModifiedOptions(opts -> opts.put("csv.disable-quote-character", "true"));
+		final Map<String, String> options = getModifiedOptions(opts ->
+			opts.put("csv.disable-quote-character", "true")
+		);
 
 		createTableSink(options);
 	}
@@ -155,8 +127,8 @@ public class CsvFormatFactoryTest extends TestLogger {
 	@Test
 	public void testInvalidCharacterOption() {
 		thrown.expect(ValidationException.class);
-		thrown.expect(containsCause(new ValidationException("Option 'csv.quote-character' must be "
-				+ "a string with single character, but was: abc")));
+		thrown.expect(containsCause(new ValidationException(
+			"Option 'csv.quote-character' must be a string with single character, but was: abc")));
 
 		final Map<String, String> options =
 				getModifiedOptions(opts -> opts.put("csv.quote-character", "abc"));
@@ -165,29 +137,53 @@ public class CsvFormatFactoryTest extends TestLogger {
 	}
 
 	@Test
-	public void testSerializeWithEscapedFieldDelimiter() {
-		// test serialization schema
-		final Map<String, String> options =
+	public void testEscapedFieldDelimiter() throws IOException {
+		final CsvRowDataSerializationSchema expectedSer = new CsvRowDataSerializationSchema.Builder(ROW_TYPE)
+			.setFieldDelimiter('\t')
+			.setQuoteCharacter('\'')
+			.setArrayElementDelimiter("|")
+			.setEscapeCharacter('\\')
+			.setNullLiteral("n/a")
+			.build();
+		final CsvRowDataDeserializationSchema expectedDeser =
+			new CsvRowDataDeserializationSchema.Builder(ROW_TYPE, InternalTypeInfo.of(ROW_TYPE))
+				.setFieldDelimiter('\t')
+				.setQuoteCharacter('\'')
+				.setAllowComments(true)
+				.setIgnoreParseErrors(true)
+				.setArrayElementDelimiter("|")
+				.setEscapeCharacter('\\')
+				.setNullLiteral("n/a")
+				.build();
+
+		// test schema
+		final Map<String, String> options1 =
+			getModifiedOptions(opts -> opts.put("csv.field-delimiter", "\t"));
+		SerializationSchema<RowData> serializationSchema1 = createSerializationSchema(options1);
+		DeserializationSchema<RowData> deserializationSchema1 = createDeserializationSchema(options1);
+		assertEquals(expectedSer, serializationSchema1);
+		assertEquals(expectedDeser, deserializationSchema1);
+
+		final Map<String, String> options2 =
 			getModifiedOptions(opts -> opts.put("csv.field-delimiter", "\\t"));
+		SerializationSchema<RowData> serializationSchema2 = createSerializationSchema(options2);
+		DeserializationSchema<RowData> deserializationSchema2 = createDeserializationSchema(options2);
+		assertEquals(expectedSer, serializationSchema2);
+		assertEquals(expectedDeser, deserializationSchema2);
 
-		final DynamicTableSink actualSink = createTableSink(options);
-		assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
-		TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
-			(TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
-
-		SerializationSchema<RowData> serializationSchema =
-			sinkMock.valueFormat.createRuntimeEncoder(null, SCHEMA.toRowDataType());
+		// test (de)serialization
 		RowData rowData = GenericRowData.of(fromString("abc"), 123, false);
-		byte[] bytes = serializationSchema.serialize(rowData);
-		String actual = new String(bytes);
-		assertEquals("abc\t123\tfalse", actual);
+		byte[] bytes = serializationSchema2.serialize(rowData);
+		assertEquals("abc\t123\tfalse", new String(bytes));
+		RowData actual = deserializationSchema2.deserialize("abc\t123\tfalse".getBytes());
+		assertEquals(rowData, actual);
 	}
 
 	@Test
 	public void testDeserializeWithEscapedFieldDelimiter() throws IOException {
 		// test deserialization schema
 		final Map<String, String> options =
-			getModifiedOptions(opts -> opts.put("csv.field-delimiter", "\\t"));
+			getModifiedOptions(opts -> opts.put("csv.field-delimiter", "\t"));
 
 		final DynamicTableSource actualSource = createTableSource(options);
 		assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
@@ -223,13 +219,13 @@ public class CsvFormatFactoryTest extends TestLogger {
 	 *
 	 * @param optionModifier Consumer to modify the options
 	 */
-	private Map<String, String> getModifiedOptions(Consumer<Map<String, String>> optionModifier) {
+	private static Map<String, String> getModifiedOptions(Consumer<Map<String, String>> optionModifier) {
 		Map<String, String> options = getAllOptions();
 		optionModifier.accept(options);
 		return options;
 	}
 
-	private Map<String, String> getAllOptions() {
+	private static Map<String, String> getAllOptions() {
 		final Map<String, String> options = new HashMap<>();
 		options.put("connector", TestDynamicTableFactory.IDENTIFIER);
 		options.put("target", "MyTarget");
@@ -244,6 +240,25 @@ public class CsvFormatFactoryTest extends TestLogger {
 		options.put("csv.escape-character", "\\");
 		options.put("csv.null-literal", "n/a");
 		return options;
+	}
+
+	private static DeserializationSchema<RowData> createDeserializationSchema(Map<String, String> options) {
+		final DynamicTableSource actualSource = createTableSource(options);
+		assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
+		TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
+			(TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+
+		return sourceMock.valueFormat
+			.createRuntimeDecoder(ScanRuntimeProviderContext.INSTANCE, SCHEMA.toRowDataType());
+	}
+
+	private static SerializationSchema<RowData> createSerializationSchema(Map<String, String> options) {
+		final DynamicTableSink actualSink = createTableSink(options);
+		assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
+		TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
+			(TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
+
+		return sinkMock.valueFormat.createRuntimeEncoder(null, SCHEMA.toRowDataType());
 	}
 
 	private static DynamicTableSource createTableSource(Map<String, String> options) {


### PR DESCRIPTION
## What is the purpose of the change

We should unescape the line delimiter characters first because the DDL can be read from a file. So that the new line "\n" in the DDL options was recognized as 2 characters.

While what user want is actually the invisible new line character.

```sql
create table t1(
  ...
) with (
  'format' = 'csv',
  'csv.line-delimiter' = '\n'
  ...
)
```

## Brief change log

*(for example:)*
  - unescape the line delimiter string first before setting
  - add test case


## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
