### PR TITLE
[FLINK-19948][table-planner-blink] Fix calling NOW() function throws compile exception

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -242,9 +242,6 @@ object BuiltInMethods {
     "strToDate",
     classOf[String], classOf[String])
 
-  val NOW = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "now")
-
   val DATE_FORMAT_STRING_STRING_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String],
     classOf[String], classOf[String], classOf[TimeZone])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -491,6 +491,11 @@ object FunctionGenerator {
     new CurrentTimePointCallGen(false))
 
   addSqlFunction(
+    NOW,
+    Seq(),
+    new CurrentTimePointCallGen(false))
+
+  addSqlFunction(
     CURRENT_TIMESTAMP,
     Seq(),
     new CurrentTimePointCallGen(false))
@@ -544,11 +549,6 @@ object FunctionGenerator {
     TANH,
     Seq(DECIMAL),
     BuiltInMethods.TANH_DEC)
-
-  addSqlFunctionMethod(
-    NOW,
-    Seq(),
-    BuiltInMethods.NOW)
 
   addSqlFunctionMethod(
     UNIX_TIMESTAMP,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
@@ -58,6 +58,13 @@ class NonDeterministicTests extends ExpressionTestBase {
   }
 
   @Test
+  def testNow(): Unit = {
+    testSqlApi(
+      "NOW() > TIMESTAMP '1970-01-01 00:00:00'",
+      "true")
+  }
+
+  @Test
   def testLocalTimestamp(): Unit = {
     testAllApis(
       localTimestamp().isGreater("1970-01-01 00:00:00".toTimestamp),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3057,6 +3057,10 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "CHAR_LENGTH(CAST(LOCALTIME AS VARCHAR)) >= 5",
       "true")
 
+    testSqlApi(
+      "CHAR_LENGTH(CAST(NOW() AS VARCHAR)) >= 12",
+      "true")
+
     // comparisons are deterministic
     testAllApis(
       localTimestamp() === localTimestamp(),

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -979,25 +979,6 @@ public class SqlDateTimeUtils {
 	}
 
 	/**
-	 * Returns current timestamp(count by seconds).
-	 *
-	 * @return current timestamp.
-	 */
-	public static long now() {
-		return System.currentTimeMillis() / 1000;
-	}
-
-	/**
-	 * Returns current timestamp(count by seconds) with offset.
-	 *
-	 * @param offset value(count by seconds).
-	 * @return current timestamp with offset.
-	 */
-	public static long now(long offset) {
-		return now() + offset;
-	}
-
-	/**
 	 * Convert unix timestamp (seconds since '1970-01-01 00:00:00' UTC) to datetime string
 	 * in the "yyyy-MM-dd HH:mm:ss" format.
 	 */


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When calling `NOW()` function, it will throw compile exception. The root reason is that the return type of `NOW()` is `TIMESTAMP`, however the runtime method returns `long` type. 

Actually, `NOW()` is synonyms for `CURRENT_TIMESTAMP`, so we can simply use the same code generation for `NOW`.

## Brief change log

- Add code generation for `NOW()` to use the same generation of `CURRENT_TIMESTAMP`.
- Remove util method of `now()` in `SqlDateTimeUtils`

## Verifying this change

- Added tests in `NonDeterministicTests` which can reproduce this exception.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
