### PR TITLE
[FLINK-19941][Connectors / Kafka]Support sink parallelism configuration to Kafka connector

### DIFF
--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -184,6 +184,18 @@ Connector Options
       <td>String</td>
       <td>Defines the delivery semantic for the Kafka sink. Valid enumerationns are <code>'at-lease-once'</code>, <code>'exactly-once'</code> and <code>'none'</code>. See <a href='#consistency-guarantees'>Consistency guarantees</a> for more details. </td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism for the Kafka sink.If not specified,the parallelism are
+      <ul>
+        <li><code>Chained</code>: Use upstream parallelism.</li>
+        <li><code>Non-Chained</code>: Use global parallelism setting</li>
+      </ul>
+      </td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -189,10 +189,10 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Integer</td>
-      <td>Defines the parallelism for the Kafka sink.If not specified,the parallelism are
+      <td>Defines the parallelism for the Kafka sink. If not specified, the parallelism are
       <ul>
         <li><code>Chained</code>: Use upstream parallelism.</li>
-        <li><code>Non-Chained</code>: Use global parallelism setting</li>
+        <li><code>Non-Chained</code>: Use global parallelism setting.</li>
       </ul>
       </td>
     </tr>

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -189,12 +189,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Integer</td>
-      <td>Defines the parallelism for the Kafka sink. If not specified, the parallelism are
-      <ul>
-        <li><code>Chained</code>: Use upstream parallelism.</li>
-        <li><code>Non-Chained</code>: Use global parallelism setting.</li>
-      </ul>
-      </td>
+      <td>Defines the parallelism of the Kafka sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -190,12 +190,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Integer</td>
-      <td>Defines the parallelism for the Kafka sink. If not specified, the parallelism are
-      <ul>
-        <li><code>Chained</code>: Use upstream parallelism.</li>
-        <li><code>Non-Chained</code>: Use global parallelism setting.</li>
-      </ul>
-      </td>
+      <td>Defines the parallelism of the Kafka sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -185,6 +185,18 @@ Connector Options
       <td>Defines the delivery semantic for the Kafka sink. Valid enumerationns are <code>'at-lease-once'</code>, <code>'exactly-once'</code> and <code>'none'</code>.
       See <a href='#consistency-guarantees'>Consistency guarantees</a> for more details. </td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism for the Kafka sink.If not specified,the parallelism are
+      <ul>
+        <li><code>Chained</code>: Use upstream parallelism.</li>
+        <li><code>Non-Chained</code>: Use global parallelism setting</li>
+      </ul>
+      </td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -190,10 +190,10 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Integer</td>
-      <td>Defines the parallelism for the Kafka sink.If not specified,the parallelism are
+      <td>Defines the parallelism for the Kafka sink. If not specified, the parallelism are
       <ul>
         <li><code>Chained</code>: Use upstream parallelism.</li>
-        <li><code>Non-Chained</code>: Use global parallelism setting</li>
+        <li><code>Non-Chained</code>: Use global parallelism setting.</li>
       </ul>
       </td>
     </tr>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -105,6 +105,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	/** Sink commit semantic.*/
 	protected final KafkaSinkSemantic semantic;
 
+	protected final Integer parallelism;
 	public KafkaDynamicSink(
 			DataType physicalDataType,
 			@Nullable EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat,
@@ -115,7 +116,8 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 			String topic,
 			Properties properties,
 			@Nullable FlinkKafkaPartitioner<RowData> partitioner,
-			KafkaSinkSemantic semantic) {
+			KafkaSinkSemantic semantic,
+			Integer parallelism) {
 		// Format attributes
 		this.physicalDataType = Preconditions.checkNotNull(physicalDataType, "Physical data type must not be null.");
 		this.keyEncodingFormat = keyEncodingFormat;
@@ -130,6 +132,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 		this.properties = Preconditions.checkNotNull(properties, "Properties must not be null.");
 		this.partitioner = partitioner;
 		this.semantic = Preconditions.checkNotNull(semantic, "Semantic must not be null.");
+		this.parallelism = parallelism;
 	}
 
 	@Override
@@ -175,7 +178,8 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 				topic,
 				properties,
 				partitioner,
-				semantic);
+				semantic,
+				parallelism);
 		copy.metadataKeys = metadataKeys;
 		return copy;
 	}
@@ -296,12 +300,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	 */
 	@Override
 	public Optional<Integer> getParallelism() {
-		String parallelism = properties.getProperty(KafkaOptions.SINK_PARALLELISM.key());
-		if (parallelism != null && StringUtils.isNumeric(parallelism)) {
-			return Optional.of(Integer.parseInt(parallelism));
-		} else {
-			return Optional.empty();
-		}
+		return parallelism != null ? Optional.of(parallelism) : Optional.empty();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -38,7 +38,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.header.Header;
 
 import javax.annotation.Nullable;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -297,6 +297,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 		}
 		return format.createRuntimeEncoder(context, physicalFormatDataType);
 	}
+
 	// --------------------------------------------------------------------------------------------
 	// Metadata handling
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.connectors.kafka.table;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaSerializationSchema.MetadataConverter;
@@ -49,7 +48,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Stream;
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -150,17 +150,7 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 		final FlinkKafkaProducer<RowData> kafkaProducer =
 				createKafkaProducer(keySerialization, valueSerialization);
 
-		return new SinkFunctionProvider() {
-			@Override
-			public SinkFunction<RowData> createSinkFunction() {
-				return kafkaProducer;
-			}
-
-			@Override
-			public Optional<Integer> getParallelism() {
-				return parallelism == null ? Optional.empty() : Optional.of(parallelism);
-			}
-		};
+		return SinkFunctionProvider.of(kafkaProducer, parallelism);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -63,7 +63,6 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCA
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_STARTUP_SPECIFIC_OFFSETS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARALLELISM;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_SEMANTIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.StartupOptions;
@@ -79,6 +78,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.get
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getStartupOptions;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateTableSinkOptions;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateTableSourceOptions;
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 
 /**
  * Factory for creating configured instances of {@link KafkaDynamicSource} and {@link KafkaDynamicSink}.

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -196,6 +196,8 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
 		final String keyPrefix = tableOptions.getOptional(KEY_FIELDS_PREFIX).orElse(null);
 
+		final Integer parallelism = tableOptions.getOptional(SINK_PARALLELISM).orElse(null);
+
 		return createKafkaTableSink(
 				physicalDataType,
 				keyEncodingFormat.orElse(null),
@@ -206,7 +208,8 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 				tableOptions.get(TOPIC).get(0),
 				getKafkaProperties(context.getCatalogTable().getOptions()),
 				getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
-				getSinkSemantic(tableOptions));
+				getSinkSemantic(tableOptions),
+				parallelism);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -299,7 +302,8 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 			String topic,
 			Properties properties,
 			FlinkKafkaPartitioner<RowData> partitioner,
-			KafkaSinkSemantic semantic) {
+			KafkaSinkSemantic semantic,
+			Integer parallelism) {
 		return new KafkaDynamicSink(
 				physicalDataType,
 				keyEncodingFormat,
@@ -310,6 +314,7 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 				topic,
 				properties,
 				partitioner,
-				semantic);
+				semantic,
+				parallelism);
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -63,6 +63,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCA
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_STARTUP_SPECIFIC_OFFSETS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SCAN_TOPIC_PARTITION_DISCOVERY;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARALLELISM;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_PARTITIONER;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.SINK_SEMANTIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.StartupOptions;
@@ -117,6 +118,7 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 		options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
 		options.add(SINK_PARTITIONER);
 		options.add(SINK_SEMANTIC);
+		options.add(SINK_PARALLELISM);
 		return options;
 	}
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -188,6 +188,11 @@ public class KafkaOptions {
 			.defaultValue("at-least-once")
 			.withDescription("Optional semantic when commit. Valid enumerationns are [\"at-least-once\", \"exactly-once\", \"none\"]");
 
+	public static final ConfigOption<Integer> SINK_PARALLELISM = ConfigOptions.key("sink.parallelism")
+			.intType()
+			.noDefaultValue()
+			.withDescription("Optional parallelism for Kafka Producer.");
+
 	// --------------------------------------------------------------------------------------------
 	// Option enumerations
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -187,12 +187,6 @@ public class KafkaOptions {
 			.stringType()
 			.defaultValue("at-least-once")
 			.withDescription("Optional semantic when commit. Valid enumerationns are [\"at-least-once\", \"exactly-once\", \"none\"]");
-
-	public static final ConfigOption<Integer> SINK_PARALLELISM = ConfigOptions.key("sink.parallelism")
-			.intType()
-			.noDefaultValue()
-			.withDescription("Optional parallelism for Kafka Producer.");
-
 	// --------------------------------------------------------------------------------------------
 	// Option enumerations
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -187,6 +187,7 @@ public class KafkaOptions {
 			.stringType()
 			.defaultValue("at-least-once")
 			.withDescription("Optional semantic when commit. Valid enumerationns are [\"at-least-once\", \"exactly-once\", \"none\"]");
+
 	// --------------------------------------------------------------------------------------------
 	// Option enumerations
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -288,7 +288,8 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				TOPIC,
 				KAFKA_SINK_PROPERTIES,
 				new FlinkFixedPartitioner<>(),
-				KafkaSinkSemantic.EXACTLY_ONCE
+				KafkaSinkSemantic.EXACTLY_ONCE,
+				null
 			);
 		assertEquals(expectedSink, actualSink);
 
@@ -330,7 +331,8 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				TOPIC,
 				KAFKA_FINAL_SINK_PROPERTIES,
 				new FlinkFixedPartitioner<>(),
-				KafkaSinkSemantic.EXACTLY_ONCE
+				KafkaSinkSemantic.EXACTLY_ONCE,
+				null
 			);
 
 		assertEquals(expectedSink, actualSink);
@@ -502,7 +504,8 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 			String topic,
 			Properties properties,
 			@Nullable FlinkKafkaPartitioner<RowData> partitioner,
-			KafkaSinkSemantic semantic) {
+			KafkaSinkSemantic semantic,
+			Integer parallelism) {
 		return new KafkaDynamicSink(
 				physicalDataType,
 				keyEncodingFormat,
@@ -513,7 +516,8 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				topic,
 				properties,
 				partitioner,
-				semantic);
+				semantic,
+				parallelism);
 	}
 
 	private static DynamicTableSource createTableSource(Map<String, String> options) {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -459,7 +459,11 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 			options -> options.put("sink.parallelism", "1"));
 
 		KafkaDynamicSink sink = (KafkaDynamicSink) createTableSink(modifiedOptions);
-		assertEquals(1, (long) sink.getParallelism().get());
+		final DynamicTableSink.SinkRuntimeProvider provider =
+			sink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+		assertThat(provider, instanceOf(SinkFunctionProvider.class));
+		final SinkFunctionProvider sinkFunctionProvider = (SinkFunctionProvider) provider;
+		assertEquals(1, (long) sinkFunctionProvider.getParallelism().get());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -450,6 +450,16 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		}
 	}
 
+	@Test
+	public void testSinkWithParallelism() {
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+			getBasicSourceOptions(),
+			options -> options.put("sink.parallelism", "1"));
+
+		KafkaDynamicSink sink = (KafkaDynamicSink) createTableSink(modifiedOptions);
+		assertEquals(1, (long) sink.getParallelism().get());
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Utilities
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -23,6 +23,8 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
+import java.util.Optional;
+
 /**
  * Provider of a {@link SinkFunction} instance as a runtime implementation for {@link DynamicTableSink}.
  */
@@ -34,6 +36,24 @@ public interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvid
 	 */
 	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction) {
 		return () -> sinkFunction;
+	}
+
+	/**
+	 * Helper method for creating a SinkFunction provider with a provided sink parallelism.
+	 */
+	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction, Integer sinkParallelism) {
+		return new SinkFunctionProvider() {
+
+			@Override
+			public SinkFunction<RowData> createSinkFunction() {
+				return sinkFunction;
+			}
+
+			@Override
+			public Optional<Integer> getParallelism() {
+				return Optional.ofNullable(sinkParallelism);
+			}
+		};
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change

*Support sink parallelism configuration to Kafka connector*


## Brief change log

  - *Support sink parallelism configuration to Kafka connector*


## Verifying this change



This change added tests and can be verified as follows:
  - *KafkaDynamicTableFactoryTest#testSinkWithParallelism*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
