### PR TITLE
[FLINK-19138][python] Support directly specifying input_types and result_types as DataTypes.ROW

### DIFF
--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -92,6 +92,17 @@ class PyFlinkBatchUserDefinedTableFunctionTests(UserDefinedTableFunctionTests,
     def _get_output(self, t):
         return self.collect(t)
 
+    def test_row_type_as_input_types_and_result_types(self):
+        # test input_types and result_types are DataTypes.ROW
+        a = udtf(lambda i: i,
+                 input_types=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]),
+                 result_types=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]))
+
+        self.assertEqual(a._input_types,
+                         [DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())])])
+        self.assertEqual(a._result_types,
+                         [DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())])])
+
 
 class MultiEmit(TableFunction, unittest.TestCase):
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -287,7 +287,9 @@ class UserDefinedFunctionWrapper(object):
                 .format(type(func)))
 
         if input_types is not None:
-            if not isinstance(input_types, collections.Iterable):
+            from pyflink.table.types import RowType
+            if not isinstance(input_types, collections.Iterable) \
+                    or isinstance(input_types, RowType):
                 input_types = [input_types]
 
             for input_type in input_types:
@@ -396,7 +398,9 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
         super(UserDefinedTableFunctionWrapper, self).__init__(
             func, input_types, "general", deterministic, name)
 
-        if not isinstance(result_types, collections.Iterable):
+        from pyflink.table.types import RowType
+        if not isinstance(result_types, collections.Iterable) \
+                or isinstance(result_types, RowType):
             result_types = [result_types]
 
         for result_type in result_types:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will  support directly specifying input_types and result_types as `DataTypes.ROW`*


## Brief change log

  - *support directly specifying `input_types` and `result_types` as `DataTypes.ROW` in `UserDefinedFunctionWrapper`*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
