### PR TITLE
[FLINK-19942][Connectors / JDBC]Support sink parallelism configuration to JDBC connector

### DIFF
--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -236,6 +236,13 @@ Connector Options
       <td>Integer</td>
       <td>The max retry times if writing records to database failed.</td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the JDBC sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
+    </tr>          
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/jdbc.zh.md
+++ b/docs/dev/table/connectors/jdbc.zh.md
@@ -236,6 +236,13 @@ Connector Options
       <td>Integer</td>
       <td>The max retry times if writing records to database failed.</td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the JDBC sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcOptions.java
@@ -22,6 +22,8 @@ import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialects;
 
+import javax.annotation.Nullable;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -38,12 +40,14 @@ public class JdbcOptions extends JdbcConnectionOptions {
 
 	private String tableName;
 	private JdbcDialect dialect;
+	private final @Nullable Integer parallelism;
 
 	private JdbcOptions(String dbURL, String tableName, String driverName, String username,
-						String password, JdbcDialect dialect) {
+						String password, JdbcDialect dialect, Integer parallelism) {
 		super(dbURL, driverName, username, password);
 		this.tableName = tableName;
 		this.dialect = dialect;
+		this.parallelism = parallelism;
 	}
 
 	public String getTableName() {
@@ -52,6 +56,10 @@ public class JdbcOptions extends JdbcConnectionOptions {
 
 	public JdbcDialect getDialect() {
 		return dialect;
+	}
+
+	public Integer getParallelism() {
+		return parallelism;
 	}
 
 	public static Builder builder() {
@@ -67,10 +75,16 @@ public class JdbcOptions extends JdbcConnectionOptions {
 				Objects.equals(driverName, options.driverName) &&
 				Objects.equals(username, options.username) &&
 				Objects.equals(password, options.password) &&
-				Objects.equals(dialect.getClass().getName(), options.dialect.getClass().getName());
+				Objects.equals(dialect.getClass().getName(), options.dialect.getClass().getName()) &&
+				Objects.equals(parallelism, options.parallelism);
 		} else {
 			return false;
 		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(url, tableName, driverName, username, password, dialect, parallelism);
 	}
 
 	/**
@@ -83,6 +97,7 @@ public class JdbcOptions extends JdbcConnectionOptions {
 		private String username;
 		private String password;
 		private JdbcDialect dialect;
+		private Integer parallelism;
 
 		/**
 		 * required, table name.
@@ -134,6 +149,11 @@ public class JdbcOptions extends JdbcConnectionOptions {
 			return this;
 		}
 
+		public Builder setParallelism(Integer parallelism) {
+			this.parallelism = parallelism;
+			return this;
+		}
+
 		public JdbcOptions build() {
 			checkNotNull(dbURL, "No dbURL supplied.");
 			checkNotNull(tableName, "No tableName supplied.");
@@ -150,7 +170,7 @@ public class JdbcOptions extends JdbcConnectionOptions {
 				});
 			}
 
-			return new JdbcOptions(dbURL, tableName, driverName, username, password, dialect);
+			return new JdbcOptions(dbURL, tableName, driverName, username, password, dialect, parallelism);
 		}
 	}
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -191,7 +191,8 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		final JdbcOptions.Builder builder = JdbcOptions.builder()
 			.setDBUrl(url)
 			.setTableName(readableConfig.get(TABLE_NAME))
-			.setDialect(JdbcDialects.get(url).get());
+			.setDialect(JdbcDialects.get(url).get())
+			.setParallelism(readableConfig.getOptional(FactoryUtil.SINK_PARALLELISM).orElse(null));
 
 		readableConfig.getOptional(DRIVER).ifPresent(builder::setDriverName);
 		readableConfig.getOptional(USERNAME).ifPresent(builder::setUsername);
@@ -272,6 +273,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 		optionalOptions.add(SINK_BUFFER_FLUSH_MAX_ROWS);
 		optionalOptions.add(SINK_BUFFER_FLUSH_INTERVAL);
 		optionalOptions.add(SINK_MAX_RETRIES);
+		optionalOptions.add(FactoryUtil.SINK_PARALLELISM);
 		return optionalOptions;
 	}
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSink.java
@@ -84,7 +84,7 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
 		builder.setJdbcExecutionOptions(executionOptions);
 		builder.setRowDataTypeInfo(rowDataTypeInformation);
 		builder.setFieldDataTypes(tableSchema.getFieldDataTypes());
-		return OutputFormatProvider.of(builder.build());
+		return OutputFormatProvider.of(builder.build(), jdbcOptions.getParallelism());
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactoryTest.java
@@ -207,6 +207,39 @@ public class JdbcDynamicTableFactoryTest {
 	}
 
 	@Test
+	public void testJDBCSinkWithParallelism() {
+		Map<String, String> properties = getAllOptions();
+		properties.put("sink.parallelism", "2");
+
+		DynamicTableSink actual = createTableSink(properties);
+
+		JdbcOptions options = JdbcOptions.builder()
+			.setDBUrl("jdbc:derby:memory:mydb")
+			.setTableName("mytable")
+			.setParallelism(2)
+			.build();
+		JdbcExecutionOptions executionOptions = JdbcExecutionOptions.builder()
+			.withBatchSize(100)
+			.withBatchIntervalMs(1000)
+			.withMaxRetries(3)
+			.build();
+		JdbcDmlOptions dmlOptions = JdbcDmlOptions.builder()
+			.withTableName(options.getTableName())
+			.withDialect(options.getDialect())
+			.withFieldNames(schema.getFieldNames())
+			.withKeyFields("bbb", "aaa")
+			.build();
+
+		JdbcDynamicTableSink expected = new JdbcDynamicTableSink(
+			options,
+			executionOptions,
+			dmlOptions,
+			schema);
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
 	public void testJdbcValidation() {
 		// only password, no username
 		try {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.data.RowData;
 
+import java.util.Optional;
+
 /**
  * Provider of an {@link OutputFormat} instance as a runtime implementation for {@link DynamicTableSink}.
  */
@@ -34,6 +36,23 @@ public interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvid
 	 */
 	static OutputFormatProvider of(OutputFormat<RowData> outputFormat) {
 		return () -> outputFormat;
+	}
+
+	/**
+	 * Helper method for creating a static provider with a provided sink parallelism.
+	 */
+	static OutputFormatProvider of(OutputFormat<RowData> outputFormat, Integer sinkParallelism) {
+		return new OutputFormatProvider() {
+			@Override
+			public OutputFormat<RowData> createOutputFormat() {
+				return outputFormat;
+			}
+
+			@Override
+			public Optional<Integer> getParallelism() {
+				return Optional.ofNullable(sinkParallelism);
+			}
+		};
 	}
 
 	/**


### PR DESCRIPTION

## What is the purpose of the change

*Support sink parallelism configuration to JDBC connector*


## Brief change log

  - *Support sink parallelism configuration to JDBC connector*


## Verifying this change



This change added tests and can be verified as follows:
  - *JdbcDynamicTableFactoryTest#testJDBCSinkWithParallelism*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)