### PR TITLE
[FLINK-19927][coordination] Enable ExecutionStateUpdateListener state updates in EG independent from legacy scheduling

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1697,11 +1697,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			final ExecutionState newExecutionState,
 			final Throwable error) {
 
+		executionStateUpdateListener.onStateUpdate(execution.getAttemptId(), newExecutionState);
+
 		if (!isLegacyScheduling()) {
 			return;
 		}
-
-		executionStateUpdateListener.onStateUpdate(execution.getAttemptId(), newExecutionState);
 
 		// see what this means for us. currently, the first FAILED state means -> FAILED
 		if (newExecutionState == ExecutionState.FAILED) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -51,6 +52,7 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -92,8 +94,8 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 	public void testExecutionDeploymentReconciliation() throws Exception {
 		JobMasterBuilder.TestingOnCompletionActions onCompletionActions = new JobMasterBuilder.TestingOnCompletionActions();
 
-		final CompletableFuture<Void> taskDeploymentFuture = new CompletableFuture<>();
-		JobMaster jobMaster = createAndStartJobMaster(onCompletionActions, taskDeploymentFuture);
+		TestingExecutionDeploymentTrackerWrapper deploymentTrackerWrapper = new TestingExecutionDeploymentTrackerWrapper();
+		JobMaster jobMaster = createAndStartJobMaster(onCompletionActions, deploymentTrackerWrapper);
 		JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 		RPC_SERVICE_RESOURCE.getTestingRpcService().registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
@@ -103,7 +105,7 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 
 		registerTaskExecutorAndOfferSlots(jobMasterGateway, taskExecutorGateway, localUnresolvedTaskManagerLocation);
 
-		taskDeploymentFuture.get();
+		ExecutionAttemptID deployedExecution = deploymentTrackerWrapper.getTaskDeploymentFuture().get();
 		assertFalse(taskCancellationFuture.isDone());
 
 		ExecutionAttemptID unknownDeployment = new ExecutionAttemptID();
@@ -115,6 +117,7 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 		));
 
 		assertThat(taskCancellationFuture.get(), is(unknownDeployment));
+		assertThat(deploymentTrackerWrapper.getStopFuture().get(), is(deployedExecution));
 
 		assertThat(onCompletionActions.getJobReachedGloballyTerminalStateFuture().get().getState(), is(JobStatus.FAILED));
 	}
@@ -125,12 +128,12 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 	 */
 	@Test
 	public void testExecutionDeploymentReconciliationForPendingExecution() throws Exception {
-		final CompletableFuture<ExecutionAttemptID> taskSubmissionFuture = new CompletableFuture<>();
-		final CompletableFuture<Void> taskDeploymentAcknowledgedFuture = new CompletableFuture<>();
-		JobMaster jobMaster = createAndStartJobMaster(taskDeploymentAcknowledgedFuture);
+		TestingExecutionDeploymentTrackerWrapper deploymentTrackerWrapper = new TestingExecutionDeploymentTrackerWrapper();
+		JobMaster jobMaster = createAndStartJobMaster(deploymentTrackerWrapper);
 		JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 		RPC_SERVICE_RESOURCE.getTestingRpcService().registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
+		final CompletableFuture<ExecutionAttemptID> taskSubmissionFuture = new CompletableFuture<>();
 		final CompletableFuture<ExecutionAttemptID> taskCancellationFuture = new CompletableFuture<>();
 		final CompletableFuture<Acknowledge> taskSubmissionAcknowledgeFuture = new CompletableFuture<>();
 		TaskExecutorGateway taskExecutorGateway = createTaskExecutorGateway(taskCancellationFuture, taskSubmissionFuture, taskSubmissionAcknowledgeFuture);
@@ -148,22 +151,15 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 
 		taskSubmissionAcknowledgeFuture.complete(Acknowledge.get());
 
-		taskDeploymentAcknowledgedFuture.get();
+		deploymentTrackerWrapper.getTaskDeploymentFuture().get();
 		assertFalse(taskCancellationFuture.isDone());
 	}
 
-	private JobMaster createAndStartJobMaster(CompletableFuture<Void> taskDeploymentFuture) throws Exception {
-		return createAndStartJobMaster(new JobMasterBuilder.TestingOnCompletionActions(), taskDeploymentFuture);
+	private JobMaster createAndStartJobMaster(ExecutionDeploymentTracker executionDeploymentTracker) throws Exception {
+		return createAndStartJobMaster(new JobMasterBuilder.TestingOnCompletionActions(), executionDeploymentTracker);
 	}
 
-	private JobMaster createAndStartJobMaster(OnCompletionActions onCompletionActions, CompletableFuture<Void> taskDeploymentFuture) throws Exception {
-		ExecutionDeploymentTracker executionDeploymentTracker = new DefaultExecutionDeploymentTracker() {
-			@Override
-			public void completeDeploymentOf(ExecutionAttemptID executionAttemptId) {
-				super.completeDeploymentOf(executionAttemptId);
-				taskDeploymentFuture.complete(null);
-			}
-		};
+	private JobMaster createAndStartJobMaster(OnCompletionActions onCompletionActions, ExecutionDeploymentTracker executionDeploymentTracker) throws Exception {
 
 		JobMaster jobMaster = new JobMasterBuilder(JobGraphTestUtils.createSingleVertexJobGraph(), RPC_SERVICE_RESOURCE.getTestingRpcService())
 			.withFatalErrorHandler(testingFatalErrorHandlerResource.getFatalErrorHandler())
@@ -209,5 +205,53 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 		Collection<SlotOffer> slotOffers = Collections.singleton(new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN));
 
 		jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), slotOffers, testingTimeout).get();
+	}
+
+	private static class TestingExecutionDeploymentTrackerWrapper implements ExecutionDeploymentTracker {
+		private final ExecutionDeploymentTracker originalTracker;
+		private final CompletableFuture<ExecutionAttemptID> taskDeploymentFuture;
+		private final CompletableFuture<ExecutionAttemptID> stopFuture;
+
+		private TestingExecutionDeploymentTrackerWrapper() {
+			this(new DefaultExecutionDeploymentTracker());
+		}
+
+		private TestingExecutionDeploymentTrackerWrapper(ExecutionDeploymentTracker originalTracker) {
+			this.originalTracker = originalTracker;
+			this.taskDeploymentFuture = new CompletableFuture<>();
+			this.stopFuture = new CompletableFuture<>();
+		}
+
+		@Override
+		public void startTrackingPendingDeploymentOf(
+				ExecutionAttemptID executionAttemptId,
+				ResourceID host) {
+			originalTracker.startTrackingPendingDeploymentOf(executionAttemptId, host);
+		}
+
+		@Override
+		public void completeDeploymentOf(ExecutionAttemptID executionAttemptId) {
+			originalTracker.completeDeploymentOf(executionAttemptId);
+			taskDeploymentFuture.complete(executionAttemptId);
+		}
+
+		@Override
+		public void stopTrackingDeploymentOf(ExecutionAttemptID executionAttemptId) {
+			originalTracker.stopTrackingDeploymentOf(executionAttemptId);
+			stopFuture.complete(executionAttemptId);
+		}
+
+		@Override
+		public Map<ExecutionAttemptID, ExecutionDeploymentState> getExecutionsOn(ResourceID host) {
+			return originalTracker.getExecutionsOn(host);
+		}
+
+		public CompletableFuture<ExecutionAttemptID> getTaskDeploymentFuture() {
+			return taskDeploymentFuture;
+		}
+
+		public CompletableFuture<ExecutionAttemptID> getStopFuture() {
+			return stopFuture;
+		}
 	}
 }


### PR DESCRIPTION
The state updates for `ExecutionStateUpdateListener` in `ExecutionGraph#notifyExecutionChange` are not done at the moment because `ExecutionGraph#notifyExecutionChange` is currently enabled only for legacy scheduling. This prevents from stopping deployment tracking for execution state TM/JM reconciliation, hence memory leaks. The state update handling is supposed to be done only in `SchedulerNG` (`DefaultScheduler`), not in legacy code of `ExecutionGraph`. However, this generally requires more refactoring for execution deployment tracking and reconciliation.

Hence, this PR just enables ExecutionStateUpdateListener state updates in `ExecutionGraph#notifyExecutionChange` for `SchedulerNG` as a quick fix, before we [refactor the execution deployment tracking and reconciliation](https://issues.apache.org/jira/browse/FLINK-19954).

`JobMasterExecutionDeploymentReconciliationTest#testExecutionDeploymentReconciliation` is also extended with the check that `ExecutionStateUpdateListener` is called and the execution deployment tracking is stopped. The PR also refactors tests in `JobMasterExecutionDeploymentReconciliationTest` and introduces `TestingExecutionDeploymentTrackerWrapper` to facilitate `ExecutionDeploymentTracker` call checks.