### PR TITLE
[FLINK-19276][json][connector-kafka] Support reading Debezium metadata

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchema.java
@@ -229,24 +229,25 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 		}
 
 		private void emitRow(@Nullable GenericRowData physicalKeyRow, @Nullable GenericRowData physicalValueRow) {
-			final int metadataArity = metadataConverters.length;
 			final RowKind rowKind;
 			if (physicalValueRow == null) {
 				if (upsertMode) {
 					rowKind = RowKind.DELETE;
 				} else {
 					throw new DeserializationException(
-							"Get null value in non-upsert mode. Could not to set rowkind for input record.");
+							"Invalid null value received in non-upsert mode. Could not to set row kind for output record.");
 				}
 			} else {
 				rowKind = physicalValueRow.getRowKind();
 			}
 
+			final int metadataArity = metadataConverters.length;
 			final GenericRowData producedRow = new GenericRowData(
 					rowKind,
 					physicalArity + metadataArity);
 
 			for (int keyPos = 0; keyPos < keyProjection.length; keyPos++) {
+				assert physicalKeyRow != null;
 				producedRow.setField(keyProjection[keyPos], physicalKeyRow.getField(keyPos));
 			}
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -64,6 +64,7 @@ import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link UpsertKafkaDynamicTableFactory}.
@@ -113,11 +114,11 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 
 		DecodingFormat<DeserializationSchema<RowData>> keyDecodingFormat =
 				new TestFormatFactory.DecodingFormatMock(
-						",", true, ChangelogMode.insertOnly());
+						",", true, ChangelogMode.insertOnly(), Collections.emptyMap());
 
 		DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
 				new TestFormatFactory.DecodingFormatMock(
-						",", true, ChangelogMode.insertOnly());
+						",", true, ChangelogMode.insertOnly(), Collections.emptyMap());
 
 		// Construct table source using options and table source factory
 		final DynamicTableSource actualSource = createActualSource(SOURCE_SCHEMA, getFullSourceOptions());
@@ -160,7 +161,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 				SINK_VALUE_FIELDS,
 				null,
 				SINK_TOPIC,
-				UPSERT_KAFKA_SOURCE_PROPERTIES,
+				UPSERT_KAFKA_SINK_PROPERTIES,
 				null);
 
 		// Test sink format.
@@ -196,7 +197,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 			SINK_VALUE_FIELDS,
 			null,
 			SINK_TOPIC,
-			UPSERT_KAFKA_SOURCE_PROPERTIES,
+			UPSERT_KAFKA_SINK_PROPERTIES,
 			100);
 		assertEquals(expectedSink, actualSink);
 
@@ -204,6 +205,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 			actualSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
 		assertThat(provider, instanceOf(SinkFunctionProvider.class));
 		final SinkFunctionProvider sinkFunctionProvider = (SinkFunctionProvider) provider;
+		assertTrue(sinkFunctionProvider.getParallelism().isPresent());
 		assertEquals(100, (long) sinkFunctionProvider.getParallelism().get());
 	}
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.json.TimestampFormat;
+import org.apache.flink.formats.json.debezium.DebeziumJsonDeserializationSchema.MetadataConverter;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.types.RowKind;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * {@link DecodingFormat} for Debezium using JSON encoding.
+ */
+public class DebeziumJsonDecodingFormat implements DecodingFormat<DeserializationSchema<RowData>> {
+
+	// --------------------------------------------------------------------------------------------
+	// Mutable attributes
+	// --------------------------------------------------------------------------------------------
+
+	private List<String> metadataKeys;
+
+	// --------------------------------------------------------------------------------------------
+	// Debezium-specific attributes
+	// --------------------------------------------------------------------------------------------
+
+	private final boolean schemaInclude;
+
+	private final boolean ignoreParseErrors;
+
+	private final TimestampFormat timestampFormat;
+
+	public DebeziumJsonDecodingFormat(
+			boolean schemaInclude,
+			boolean ignoreParseErrors,
+			TimestampFormat timestampFormat) {
+		this.schemaInclude = schemaInclude;
+		this.ignoreParseErrors = ignoreParseErrors;
+		this.timestampFormat = timestampFormat;
+		this.metadataKeys = Collections.emptyList();
+	}
+
+	@Override
+	public DeserializationSchema<RowData> createRuntimeDecoder(
+			DynamicTableSource.Context context,
+			DataType physicalDataType) {
+
+		final List<ReadableMetadata> readableMetadata = metadataKeys.stream()
+				.map(k ->
+						Stream.of(ReadableMetadata.values())
+							.filter(rm -> rm.key.equals(k))
+							.findFirst()
+							.orElseThrow(IllegalStateException::new))
+				.collect(Collectors.toList());
+
+		final List<DataTypes.Field> metadataFields = readableMetadata.stream()
+				.map(m -> DataTypes.FIELD(m.key, m.dataType))
+				.collect(Collectors.toList());
+
+		final DataType producedDataType = DataTypeUtils.appendRowFields(physicalDataType, metadataFields);
+
+		final TypeInformation<RowData> producedTypeInfo =
+				context.createTypeInformation(producedDataType);
+
+		return new DebeziumJsonDeserializationSchema(
+				physicalDataType,
+				readableMetadata,
+				producedTypeInfo,
+				schemaInclude,
+				ignoreParseErrors,
+				timestampFormat);
+	}
+
+	@Override
+	public Map<String, DataType> listReadableMetadata() {
+		final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+		Stream.of(ReadableMetadata.values()).forEachOrdered(m -> metadataMap.put(m.key, m.dataType));
+		return metadataMap;
+	}
+
+	@Override
+	public void applyReadableMetadata(List<String> metadataKeys) {
+		this.metadataKeys = metadataKeys;
+	}
+
+	@Override
+	public ChangelogMode getChangelogMode() {
+		return ChangelogMode.newBuilder()
+				.addContainedKind(RowKind.INSERT)
+				.addContainedKind(RowKind.UPDATE_BEFORE)
+				.addContainedKind(RowKind.UPDATE_AFTER)
+				.addContainedKind(RowKind.DELETE)
+				.build();
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Metadata handling
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * List of metadata that can be read with this format.
+	 */
+	enum ReadableMetadata {
+		SCHEMA(
+				"schema",
+				DataTypes.STRING().nullable(),
+				false,
+				DataTypes.FIELD("schema", DataTypes.STRING()),
+				GenericRowData::getString
+		),
+
+		INGESTION_TIMESTAMP(
+				"ingestion-timestamp",
+				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+				true,
+				DataTypes.FIELD("ts_ms", DataTypes.BIGINT()),
+				(row, pos) -> {
+					return TimestampData.fromEpochMillis(row.getLong(pos));
+				}
+		),
+
+		SOURCE_TIMESTAMP(
+				"source.timestamp",
+				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+				true,
+				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+				(row, pos) -> {
+					final StringData timestamp = (StringData) readProperty(row, pos, KEY_SOURCE_TIMESTAMP);
+					if (timestamp == null) {
+						return null;
+					}
+					return TimestampData.fromEpochMillis(Long.parseLong(timestamp.toString()));
+				}
+		),
+
+		SOURCE_DATABASE(
+				"source.database",
+				DataTypes.STRING().nullable(),
+				true,
+				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+				(row, pos) -> {
+					return readProperty(row, pos, KEY_SOURCE_DATABASE);
+				}
+		),
+
+		SOURCE_SCHEMA(
+				"source.schema",
+				DataTypes.STRING().nullable(),
+				true,
+				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+				(row, pos) -> {
+					return readProperty(row, pos, KEY_SOURCE_SCHEMA);
+				}
+		),
+
+		SOURCE_TABLE(
+				"source.table",
+				DataTypes.STRING().nullable(),
+				true,
+				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+				(row, pos) -> {
+					return readProperty(row, pos, KEY_SOURCE_TABLE);
+				}
+		),
+
+		SOURCE_PROPERTIES(
+				"source.properties",
+				// key and value of the map are nullable to make handling easier in queries
+				DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
+				true,
+				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+				GenericRowData::getMap
+		);
+
+		final String key;
+
+		final DataType dataType;
+
+		final boolean isJsonPayload;
+
+		final DataTypes.Field requiredJsonField;
+
+		final MetadataConverter converter;
+
+		ReadableMetadata(
+				String key,
+				DataType dataType,
+				boolean isJsonPayload,
+				DataTypes.Field requiredJsonField,
+				MetadataConverter converter) {
+			this.key = key;
+			this.dataType = dataType;
+			this.isJsonPayload = isJsonPayload;
+			this.requiredJsonField = requiredJsonField;
+			this.converter = converter;
+		}
+	}
+
+	private static final StringData KEY_SOURCE_TIMESTAMP = StringData.fromString("ts_ms");
+
+	private static final StringData KEY_SOURCE_DATABASE = StringData.fromString("db");
+
+	private static final StringData KEY_SOURCE_SCHEMA = StringData.fromString("schema");
+
+	private static final StringData KEY_SOURCE_TABLE = StringData.fromString("table");
+
+	private static Object readProperty(GenericRowData row, int pos, StringData key) {
+		final GenericMapData map = (GenericMapData) row.getMap(pos);
+		if (map == null) {
+			return null;
+		}
+		return map.get(key);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -72,6 +72,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -1109,6 +1110,24 @@ public final class DataTypes {
 		protected abstract AbstractDataType<?> getAbstractDataType();
 
 		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			AbstractField that = (AbstractField) o;
+			return name.equals(that.name)
+				&& Objects.equals(description, that.description);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, description);
+		}
+
+		@Override
 		public String toString() {
 			if (description != null) {
 				return String.format(
@@ -1147,6 +1166,26 @@ public final class DataTypes {
 		protected AbstractDataType<?> getAbstractDataType() {
 			return dataType;
 		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			Field field = (Field) o;
+			return dataType.equals(field.dataType);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), dataType);
+		}
 	}
 
 	/**
@@ -1172,6 +1211,26 @@ public final class DataTypes {
 		@Override
 		protected AbstractDataType<?> getAbstractDataType() {
 			return dataType;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			UnresolvedField that = (UnresolvedField) o;
+			return dataType.equals(that.dataType);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), dataType);
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/DecodingFormat.java
@@ -38,7 +38,7 @@ public interface DecodingFormat<I> extends Format {
 	/**
 	 * Creates runtime decoder implementation that is configured to produce data of the given data type.
 	 */
-	I createRuntimeDecoder(DynamicTableSource.Context context, DataType producedDataType);
+	I createRuntimeDecoder(DynamicTableSource.Context context, DataType physicalDataType);
 
 	/**
 	 * Returns the map of metadata keys and their corresponding data types that can be produced by this

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/EncodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/EncodingFormat.java
@@ -38,7 +38,7 @@ public interface EncodingFormat<I> extends Format {
 	/**
 	 * Creates runtime encoder implementation that is configured to consume data of the given data type.
 	 */
-	I createRuntimeEncoder(DynamicTableSink.Context context, DataType consumedDataType);
+	I createRuntimeEncoder(DynamicTableSink.Context context, DataType physicalDataType);
 
 	/**
 	 * Returns the map of metadata keys and their corresponding data types that can be consumed by this
@@ -63,7 +63,7 @@ public interface EncodingFormat<I> extends Format {
 	 * <p>See {@link SupportsWritingMetadata} for more information.
 	 *
 	 * <p>Note: This method is only used if the outer {@link DynamicTableSink} implements {@link SupportsWritingMetadata}
-	 * and calls this method in {@link SupportsWritingMetadata#applyWritableMetadata(List)}.
+	 * and calls this method in {@link SupportsWritingMetadata#applyWritableMetadata(List, DataType)}.
 	 */
 	@SuppressWarnings("unused")
 	default void applyWritableMetadata(List<String> metadataKeys) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -131,12 +131,14 @@ public class FactoryUtilTest {
 			"key.test-format.changelog-mode\n" +
 			"key.test-format.delimiter\n" +
 			"key.test-format.fail-on-missing\n" +
+			"key.test-format.readable-metadata\n" +
 			"property-version\n" +
 			"target\n" +
 			"value.format\n" +
 			"value.test-format.changelog-mode\n" +
 			"value.test-format.delimiter\n" +
-			"value.test-format.fail-on-missing");
+			"value.test-format.fail-on-missing\n" +
+			"value.test-format.readable-metadata");
 		testError(options -> {
 			options.put("this-is-not-consumed", "42");
 			options.put("this-is-also-not-consumed", "true");
@@ -283,6 +285,11 @@ public class FactoryUtilTest {
 
 		@Override
 		public Map<String, String> getProperties() {
+			return options;
+		}
+
+		@Override
+		public Map<String, String> getOptions() {
 			return options;
 		}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.BOOLEAN;
 import static org.apache.flink.table.api.DataTypes.DOUBLE;
 import static org.apache.flink.table.api.DataTypes.FIELD;
@@ -92,6 +93,37 @@ public class DataTypeUtilsTest {
 		assertThat(
 			DataTypeUtils.projectRow(topLevelRow, new int[][]{{1, 1, 0}, {2}}),
 			equalTo(ROW(FIELD("a1_b1_c0", BOOLEAN()), FIELD("a1_b1_c0_$0", INT()))));
+	}
+
+	@Test
+	public void testAppendRowFields() {
+		{
+			final DataType row = ROW(
+					FIELD("a0", BOOLEAN()),
+					FIELD("a1", DOUBLE()),
+					FIELD("a2", INT()));
+
+			final DataType expectedRow = ROW(
+					FIELD("a0", BOOLEAN()),
+					FIELD("a1", DOUBLE()),
+					FIELD("a2", INT()),
+					FIELD("a3", BIGINT()),
+					FIELD("a4", TIMESTAMP(3)));
+
+			assertThat(
+					DataTypeUtils.appendRowFields(row, Arrays.asList(FIELD("a3", BIGINT()), FIELD("a4", TIMESTAMP(3)))),
+					equalTo(expectedRow));
+		}
+
+		{
+			final DataType row = ROW();
+
+			final DataType expectedRow = ROW(FIELD("a", BOOLEAN()), FIELD("b", INT()));
+
+			assertThat(
+					DataTypeUtils.appendRowFields(row, Arrays.asList(FIELD("a", BOOLEAN()), FIELD("b", INT()))),
+					equalTo(expectedRow));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This exposes metadata for the Debezium JSON format according to FLIP-107.

Note: A complete end-to-end test for Kafka + Debezium is missing yet.

## Brief change log

- Update the Kafka connector to expose format specific metadata.
- Reconfigure the internal JsonRowDataDeserializationSchema to read additional fields.
- Let DebeziumJsonDeserializationSchema access and convert those additional fields to metadata columns.

## Verifying this change

This change added tests and can be verified as follows: `DebeziumJsonSerDeSchemaTest`, `KafkaDynamicTableFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
