### PR TITLE
[FLINK-19909] Shutdown application cluster in attached mode when job cancelled.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -148,8 +148,8 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
 						return dispatcherGateway.shutDownCluster(ApplicationStatus.SUCCEEDED);
 					}
 
-					final Optional<ApplicationFailureException> exception =
-							ExceptionUtils.findThrowable(t, ApplicationFailureException.class);
+					final Optional<UnsuccessfulExecutionException> exception =
+							ExceptionUtils.findThrowable(t, UnsuccessfulExecutionException.class);
 
 					if (exception.isPresent()) {
 						final ApplicationStatus applicationStatus = exception.get().getStatus();
@@ -284,7 +284,7 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
 			}
 
 			throw new CompletionException(
-					ApplicationFailureException.fromJobResult(
+					UnsuccessfulExecutionException.fromJobResult(
 							result, application.getUserCodeClassLoader()));
 		});
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -127,7 +127,7 @@ public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway 
 						return jobResult.toJobExecutionResult(classLoader);
 					} catch (Throwable t) {
 						throw new CompletionException(
-								ApplicationFailureException.fromJobResult(jobResult, classLoader));
+								UnsuccessfulExecutionException.fromJobResult(jobResult, classLoader));
 					}
 				});
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -126,7 +126,8 @@ public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway 
 					try {
 						return jobResult.toJobExecutionResult(classLoader);
 					} catch (Throwable t) {
-						throw new CompletionException(new Exception("Job " + jobId + " failed", t));
+						throw new CompletionException(
+								ApplicationFailureException.fromJobResult(jobResult, classLoader));
 					}
 				});
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/UnsuccessfulExecutionException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/UnsuccessfulExecutionException.java
@@ -32,11 +32,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  * application with a given {@link ApplicationStatus}.
  */
 @Internal
-public class ApplicationFailureException extends JobExecutionException {
+public class UnsuccessfulExecutionException extends JobExecutionException {
 
 	private final ApplicationStatus status;
 
-	public ApplicationFailureException(
+	public UnsuccessfulExecutionException(
 			final JobID jobID,
 			final ApplicationStatus status,
 			final String message,
@@ -49,7 +49,7 @@ public class ApplicationFailureException extends JobExecutionException {
 		return status;
 	}
 
-	public static ApplicationFailureException fromJobResult(
+	public static UnsuccessfulExecutionException fromJobResult(
 			final JobResult result,
 			final ClassLoader userClassLoader) {
 
@@ -70,8 +70,8 @@ public class ApplicationFailureException extends JobExecutionException {
 			final ApplicationStatus status = result.getApplicationStatus();
 
 			return status == ApplicationStatus.CANCELED || status == ApplicationStatus.FAILED
-					? new ApplicationFailureException(jobID, status, "Application Status: " + status.name(), t)
-					: new ApplicationFailureException(jobID, ApplicationStatus.UNKNOWN, "Job failed for unknown reason.", t);
+					? new UnsuccessfulExecutionException(jobID, status, "Application Status: " + status.name(), t)
+					: new UnsuccessfulExecutionException(jobID, ApplicationStatus.UNKNOWN, "Job failed for unknown reason.", t);
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -234,7 +234,7 @@ public class ApplicationDispatcherBootstrapTest {
 				});
 
 		final CompletableFuture<Void> applicationFuture = runApplication(dispatcherBuilder, 2);
-		final ApplicationFailureException exception = assertException(applicationFuture, ApplicationFailureException.class);
+		final UnsuccessfulExecutionException exception = assertException(applicationFuture, UnsuccessfulExecutionException.class);
 		assertEquals(exception.getStatus(), ApplicationStatus.FAILED);
 	}
 
@@ -408,7 +408,7 @@ public class ApplicationDispatcherBootstrapTest {
 
 		final CompletableFuture<Void> applicationFuture =
 				bootstrap.getApplicationCompletionFuture();
-		assertException(applicationFuture, ApplicationFailureException.class);
+		assertException(applicationFuture, UnsuccessfulExecutionException.class);
 
 		assertEquals(clusterShutdown.get(), ApplicationStatus.CANCELED);
 	}
@@ -513,7 +513,7 @@ public class ApplicationDispatcherBootstrapTest {
 
 		final CompletableFuture<Acknowledge> applicationFuture = bootstrap.getClusterShutdownFuture();
 
-		final ApplicationFailureException exception = assertException(applicationFuture, ApplicationFailureException.class);
+		final UnsuccessfulExecutionException exception = assertException(applicationFuture, UnsuccessfulExecutionException.class);
 		assertEquals(exception.getStatus(), ApplicationStatus.UNKNOWN);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/MultiExecuteJob.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/MultiExecuteJob.java
@@ -32,6 +32,7 @@ public class MultiExecuteJob {
 
 	public static void main(String[] args) throws Exception {
 		int noOfExecutes = Integer.parseInt(args[0]);
+		boolean attached  = args.length > 1 && Boolean.parseBoolean(args[1]);
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
@@ -44,7 +45,12 @@ public class MultiExecuteJob {
 			env.fromCollection(input)
 					.map(element -> element + 1)
 					.output(new DiscardingOutputFormat<>());
-			env.executeAsync();
+
+			if (attached) {
+				env.execute();
+			} else {
+				env.executeAsync();
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently when executing an application in Attached Application mode
    we do not shutdown the cluster when the job is cancelled. That is
    because the exception thrown does not include the STATUS with which
    the job failed, so we cannot distinguish between different reasons
    of unsuccessful termination. This commit fixes this.

## Brief change log

The `EmbeddedJobClient.getJobExecutionResult()` now throws the same exception as the execution in detached mode. This includes the usual exception thrown by the `jobResult.toJobExecutionResult(classLoader)` wrapped into an `UnsuccessfulTerminationException` which also includes the `ApplicationStatus`.

## Verifying this change

Test was added in the `ApplicationDispatcherBootstrapTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
