### PR TITLE
[BP-1.11][FLINK-19948][table-planner-blink] Fix calling NOW() function throws compile exception

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -242,9 +242,6 @@ object BuiltInMethods {
     "strToDate",
     classOf[String], classOf[String])
 
-  val NOW = Types.lookupMethod(
-    classOf[SqlDateTimeUtils], "now")
-
   val DATE_FORMAT_STRING_STRING_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils], "dateFormat", classOf[String],
     classOf[String], classOf[String], classOf[TimeZone])

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -491,6 +491,11 @@ object FunctionGenerator {
     new CurrentTimePointCallGen(false))
 
   addSqlFunction(
+    NOW,
+    Seq(),
+    new CurrentTimePointCallGen(false))
+
+  addSqlFunction(
     CURRENT_TIMESTAMP,
     Seq(),
     new CurrentTimePointCallGen(false))
@@ -544,11 +549,6 @@ object FunctionGenerator {
     TANH,
     Seq(DECIMAL),
     BuiltInMethods.TANH_DEC)
-
-  addSqlFunctionMethod(
-    NOW,
-    Seq(),
-    BuiltInMethods.NOW)
 
   addSqlFunctionMethod(
     UNIX_TIMESTAMP,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
@@ -58,6 +58,13 @@ class NonDeterministicTests extends ExpressionTestBase {
   }
 
   @Test
+  def testNow(): Unit = {
+    testSqlApi(
+      "NOW() > TIMESTAMP '1970-01-01 00:00:00'",
+      "true")
+  }
+
+  @Test
   def testLocalTimestamp(): Unit = {
     testAllApis(
       localTimestamp().isGreater("1970-01-01 00:00:00".toTimestamp),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3196,6 +3196,10 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "CHAR_LENGTH(CAST(LOCALTIME AS VARCHAR)) >= 5",
       "true")
 
+    testSqlApi(
+      "CHAR_LENGTH(CAST(NOW() AS VARCHAR)) >= 12",
+      "true")
+
     // comparisons are deterministic
     testAllApis(
       localTimestamp() === localTimestamp(),

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -979,25 +979,6 @@ public class SqlDateTimeUtils {
 	}
 
 	/**
-	 * Returns current timestamp(count by seconds).
-	 *
-	 * @return current timestamp.
-	 */
-	public static long now() {
-		return System.currentTimeMillis() / 1000;
-	}
-
-	/**
-	 * Returns current timestamp(count by seconds) with offset.
-	 *
-	 * @param offset value(count by seconds).
-	 * @return current timestamp with offset.
-	 */
-	public static long now(long offset) {
-		return now() + offset;
-	}
-
-	/**
 	 * Convert unix timestamp (seconds since '1970-01-01 00:00:00' UTC) to datetime string
 	 * in the "yyyy-MM-dd HH:mm:ss" format.
 	 */


### PR DESCRIPTION
This is a cherry-pick back to release-1.11 branch. 