### PR TITLE
[FLINK-19890][table][fs-connector] Introduce LimitableBulkFormat to wrap BulkFormat when limit pushed down

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/BulkDecodingFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/BulkDecodingFormat.java
@@ -33,11 +33,6 @@ import java.util.List;
 public interface BulkDecodingFormat<T> extends DecodingFormat<BulkFormat<T, FileSourceSplit>> {
 
 	/**
-	 * Provides the expected maximum number of produced records for limiting on a best-effort basis.
-	 */
-	default void applyLimit(long limit) {}
-
-	/**
 	 * Provides a list of filters in conjunctive form  for filtering on a best-effort basis.
 	 */
 	default void applyFilters(List<ResolvedExpression> filters) {}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * A {@link BulkFormat} that can limit output record number.
+ */
+public class LimitableBulkFormat<T, SplitT extends FileSourceSplit> implements BulkFormat<T, SplitT> {
+
+	private final BulkFormat<T, SplitT> format;
+	private final long limit;
+
+	private long numRead = 0;
+
+	private LimitableBulkFormat(BulkFormat<T, SplitT> format, long limit) {
+		this.format = format;
+		this.limit = limit;
+	}
+
+	@Override
+	public Reader<T> createReader(Configuration config, SplitT split) throws IOException {
+		return new LimitableReader(format.createReader(config, split));
+	}
+
+	@Override
+	public Reader<T> restoreReader(Configuration config, SplitT split) throws IOException {
+		return new LimitableReader(format.restoreReader(config, split));
+	}
+
+	@Override
+	public boolean isSplittable() {
+		return format.isSplittable();
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return format.getProducedType();
+	}
+
+	private class LimitableReader implements Reader<T> {
+
+		private final Reader<T> reader;
+
+		private LimitableReader(Reader<T> reader) {
+			this.reader = reader;
+		}
+
+		@Nullable
+		@Override
+		public RecordIterator<T> readBatch() throws IOException {
+			if (reachLimit()) {
+				return null;
+			}
+			return new LimitableIterator(reader.readBatch());
+		}
+
+		@Override
+		public void close() throws IOException {
+			reader.close();
+		}
+	}
+
+	private class LimitableIterator implements RecordIterator<T> {
+
+		private final RecordIterator<T> iterator;
+
+		private LimitableIterator(RecordIterator<T> iterator) {
+			this.iterator = iterator;
+		}
+
+		@Nullable
+		@Override
+		public RecordAndPosition<T> next() {
+			if (reachLimit()) {
+				return null;
+			}
+			numRead++;
+			return iterator.next();
+		}
+
+		@Override
+		public void releaseBatch() {
+			iterator.releaseBatch();
+		}
+	}
+
+	private boolean reachLimit() {
+		return numRead >= limit;
+	}
+
+	public static <T, SplitT extends FileSourceSplit> BulkFormat<T, SplitT> create(
+			BulkFormat<T, SplitT> format, Long limit) {
+		return limit == null ? format : new LimitableBulkFormat<>(format, limit);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
@@ -80,7 +80,9 @@ public class LimitableBulkFormat<T, SplitT extends FileSourceSplit> implements B
 			if (reachLimit()) {
 				return null;
 			}
-			return new LimitableIterator(reader.readBatch());
+
+			RecordIterator<T> batch = reader.readBatch();
+			return batch == null ? null : new LimitableIterator(batch);
 		}
 
 		@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
@@ -33,10 +33,12 @@ import java.io.IOException;
  */
 public class LimitableBulkFormat<T, SplitT extends FileSourceSplit> implements BulkFormat<T, SplitT> {
 
+	private static final long serialVersionUID = 1L;
+
 	private final BulkFormat<T, SplitT> format;
 	private final long limit;
 
-	private long numRead = 0;
+	private transient long numRead = 0;
 
 	private LimitableBulkFormat(BulkFormat<T, SplitT> format, long limit) {
 		this.format = format;

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/LimitableBulkFormatTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/LimitableBulkFormatTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.impl.StreamFormatAdapter;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.reader.TextLineFormat;
+import org.apache.flink.connector.file.src.util.Utils;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test for {@link LimitableBulkFormat}.
+ */
+public class LimitableBulkFormatTest {
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void test() throws IOException {
+		// prepare file
+		File file = TEMP_FOLDER.newFile();
+		file.createNewFile();
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < 10000; i++) {
+			builder.append(i).append("\n");
+		}
+		FileUtils.writeFileUtf8(file, builder.toString());
+
+		// read
+		BulkFormat<String, FileSourceSplit> format = LimitableBulkFormat.create(
+				new StreamFormatAdapter<>(new TextLineFormat()), 22L);
+
+		BulkFormat.Reader<String> reader = format.createReader(
+				new Configuration(), new FileSourceSplit("id", new Path(file.toURI()), 0, file.length()));
+
+		AtomicInteger i = new AtomicInteger(0);
+		Utils.forEachRemaining(reader, s -> i.incrementAndGet());
+		Assert.assertEquals(22, i.get());
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

User requirement:
Users need to look at a few random pieces of data in a table to see what the data looks like. So users often use the SQL:
"select * from table limit 10"
For a large table, expect to end soon because only a few pieces of data are queried.
For DataStream or BoundedStream, they are push based execution models, so the downstream cannot control the end of source operator.
We need push down limit to source operator, so that source operator can end early.

Implement a LimitableBulkFormat wrapper to limit output record number in the file source.

## Brief change log

- Introduce `LimitableBulkFormat`
- Integrate to `FileSystemTableSource`

## Verifying this change

This change is already covered by existing tests, such as `FileSystemITCaseBase.testLimitPushDown`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
