### PR TITLE
[FLINK-19365][hive] Migrate Hive source to FLIP-27 source interface f…

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -171,6 +171,20 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- format dependencies -->
 
 		<dependency>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -57,9 +57,9 @@ class HiveParallelismInference {
 	 * Apply limit to calculate the parallelism.
 	 * Here limit is the limit in query <code>SELECT * FROM xxx LIMIT [limit]</code>.
 	 */
-	int limit(long limit) {
-		if (limit > 0) {
-			parallelism = Math.min(parallelism, (int) limit / 1000);
+	int limit(Long limit) {
+		if (limit != null) {
+			parallelism = Math.min(parallelism, limit.intValue() / 1000);
 		}
 
 		// make sure that parallelism is at least 1

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -59,7 +59,7 @@ class HiveParallelismInference {
 	 */
 	int limit(Long limit) {
 		if (limit != null) {
-			parallelism = Math.min(parallelism, limit.intValue() / 1000);
+			parallelism = Math.min(parallelism, (int) (limit / 1000));
 		}
 
 		// make sure that parallelism is at least 1

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.file.src.AbstractFileSource;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connectors.hive.read.HiveBulkFormatAdapter;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.connector.file.src.FileSource.DEFAULT_SPLIT_ASSIGNER;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
+
+/**
+ * A unified data source that reads a hive table.
+ */
+public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> implements ResultTypeQueryable<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	// DataType of the records to be returned, with projection applied (if any)
+	private final DataType producedDataType;
+
+	HiveSource(
+			JobConf jobConf,
+			CatalogTable catalogTable,
+			List<HiveTablePartition> partitions,
+			int[] projectedFields,
+			long limit,
+			String hiveVersion,
+			boolean useMapRedReader,
+			boolean isStreamingSource,
+			DataType producedDataType) {
+		super(
+				new org.apache.flink.core.fs.Path[1],
+				new HiveSourceFileEnumerator.Provider(partitions, new JobConfWrapper(jobConf)),
+				DEFAULT_SPLIT_ASSIGNER,
+				createBulkFormat(new JobConf(jobConf), catalogTable, projectedFields, hiveVersion, producedDataType, useMapRedReader, limit),
+				null);
+		Preconditions.checkArgument(!isStreamingSource, "HiveSource currently only supports bounded mode");
+		this.producedDataType = producedDataType;
+	}
+
+	@Override
+	public SimpleVersionedSerializer<HiveSourceSplit> getSplitSerializer() {
+		return HiveSourceSplitSerializer.INSTANCE;
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return (TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(producedDataType);
+	}
+
+	private static BulkFormat<RowData, HiveSourceSplit> createBulkFormat(
+			JobConf jobConf,
+			CatalogTable catalogTable,
+			@Nullable int[] projectedFields,
+			String hiveVersion,
+			DataType producedDataType,
+			boolean useMapRedReader,
+			long limit) {
+		checkNotNull(catalogTable, "catalogTable can not be null.");
+		return new HiveBulkFormatAdapter(
+				new JobConfWrapper(jobConf),
+				catalogTable.getPartitionKeys(),
+				catalogTable.getSchema().getFieldNames(),
+				catalogTable.getSchema().getFieldDataTypes(),
+				projectedFields != null ? projectedFields : IntStream.range(0, catalogTable.getSchema().getFieldCount()).toArray(),
+				hiveVersion,
+				producedDataType,
+				useMapRedReader,
+				limit);
+	}
+
+	public static List<HiveSourceSplit> createInputSplits(
+			int minNumSplits,
+			List<HiveTablePartition> partitions,
+			JobConf jobConf) throws IOException {
+		List<HiveSourceSplit> hiveSplits = new ArrayList<>();
+		FileSystem fs = null;
+		for (HiveTablePartition partition : partitions) {
+			StorageDescriptor sd = partition.getStorageDescriptor();
+			Path inputPath = new Path(sd.getLocation());
+			if (fs == null) {
+				fs = inputPath.getFileSystem(jobConf);
+			}
+			// it's possible a partition exists in metastore but the data has been removed
+			if (!fs.exists(inputPath)) {
+				continue;
+			}
+			InputFormat format;
+			try {
+				format = (InputFormat)
+						Class.forName(sd.getInputFormat(), true, Thread.currentThread().getContextClassLoader()).newInstance();
+			} catch (Exception e) {
+				throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
+			}
+			ReflectionUtils.setConf(format, jobConf);
+			jobConf.set(INPUT_DIR, sd.getLocation());
+			//TODO: we should consider how to calculate the splits according to minNumSplits in the future.
+			org.apache.hadoop.mapred.InputSplit[] splitArray = format.getSplits(jobConf, minNumSplits);
+			for (org.apache.hadoop.mapred.InputSplit inputSplit : splitArray) {
+				Preconditions.checkState(inputSplit instanceof FileSplit,
+						"Unsupported InputSplit type: " + inputSplit.getClass().getName());
+				hiveSplits.add(new HiveSourceSplit((FileSplit) inputSplit, partition, null));
+			}
+		}
+
+		return hiveSplits;
+	}
+
+	public static int getNumFiles(List<HiveTablePartition> partitions, JobConf jobConf) throws IOException {
+		int numFiles = 0;
+		FileSystem fs = null;
+		for (HiveTablePartition partition : partitions) {
+			StorageDescriptor sd = partition.getStorageDescriptor();
+			Path inputPath = new Path(sd.getLocation());
+			if (fs == null) {
+				fs = inputPath.getFileSystem(jobConf);
+			}
+			// it's possible a partition exists in metastore but the data has been removed
+			if (!fs.exists(inputPath)) {
+				continue;
+			}
+			numFiles += fs.listStatus(inputPath).length;
+		}
+		return numFiles;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.mapred.JobConf;
 import javax.annotation.Nullable;
 
 import java.util.List;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.connector.file.src.FileSource.DEFAULT_SPLIT_ASSIGNER;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -50,7 +49,6 @@ public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> imp
 			JobConf jobConf,
 			CatalogTable catalogTable,
 			List<HiveTablePartition> partitions,
-			int[] projectedFields,
 			@Nullable Long limit,
 			String hiveVersion,
 			boolean useMapRedReader,
@@ -60,7 +58,7 @@ public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> imp
 				new org.apache.flink.core.fs.Path[1],
 				new HiveSourceFileEnumerator.Provider(partitions, new JobConfWrapper(jobConf)),
 				DEFAULT_SPLIT_ASSIGNER,
-				createBulkFormat(new JobConf(jobConf), catalogTable, projectedFields, hiveVersion, producedDataType, useMapRedReader, limit),
+				createBulkFormat(new JobConf(jobConf), catalogTable, hiveVersion, producedDataType, useMapRedReader, limit),
 				null);
 		Preconditions.checkArgument(!isStreamingSource, "HiveSource currently only supports bounded mode");
 	}
@@ -73,7 +71,6 @@ public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> imp
 	private static BulkFormat<RowData, HiveSourceSplit> createBulkFormat(
 			JobConf jobConf,
 			CatalogTable catalogTable,
-			@Nullable int[] projectedFields,
 			String hiveVersion,
 			RowType producedDataType,
 			boolean useMapRedReader,
@@ -84,7 +81,6 @@ public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> imp
 				catalogTable.getPartitionKeys(),
 				catalogTable.getSchema().getFieldNames(),
 				catalogTable.getSchema().getFieldDataTypes(),
-				projectedFields != null ? projectedFields : IntStream.range(0, catalogTable.getSchema().getFieldCount()).toArray(),
 				hiveVersion,
 				producedDataType,
 				useMapRedReader,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link FileEnumerator} implementation for hive source, which generates splits based on {@link HiveTablePartition}s.
+ */
+public class HiveSourceFileEnumerator implements FileEnumerator {
+
+	// For non-partition hive table, partitions only contains one partition which partitionValues is empty.
+	private final List<HiveTablePartition> partitions;
+	private final JobConf jobConf;
+
+	public HiveSourceFileEnumerator(List<HiveTablePartition> partitions, JobConf jobConf) {
+		this.partitions = partitions;
+		this.jobConf = jobConf;
+	}
+
+	@Override
+	public Collection<FileSourceSplit> enumerateSplits(Path[] paths, int minDesiredSplits) throws IOException {
+		return new ArrayList<>(HiveSource.createInputSplits(minDesiredSplits, partitions, jobConf));
+	}
+
+	/**
+	 * A factory to create {@link HiveSourceFileEnumerator}.
+	 */
+	public static class Provider implements FileEnumerator.Provider {
+
+		private static final long serialVersionUID = 1L;
+
+		private final List<HiveTablePartition> partitions;
+		private final JobConfWrapper jobConfWrapper;
+
+		public Provider(List<HiveTablePartition> partitions, JobConfWrapper jobConfWrapper) {
+			this.partitions = partitions;
+			this.jobConfWrapper = jobConfWrapper;
+		}
+
+		@Override
+		public FileEnumerator create() {
+			return new HiveSourceFileEnumerator(partitions, jobConfWrapper.conf());
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -20,14 +20,23 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.Preconditions;
 
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
 
 /**
  * A {@link FileEnumerator} implementation for hive source, which generates splits based on {@link HiveTablePartition}s.
@@ -45,7 +54,62 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
 
 	@Override
 	public Collection<FileSourceSplit> enumerateSplits(Path[] paths, int minDesiredSplits) throws IOException {
-		return new ArrayList<>(HiveSource.createInputSplits(minDesiredSplits, partitions, jobConf));
+		return new ArrayList<>(createInputSplits(minDesiredSplits, partitions, jobConf));
+	}
+
+	public static List<HiveSourceSplit> createInputSplits(
+			int minNumSplits,
+			List<HiveTablePartition> partitions,
+			JobConf jobConf) throws IOException {
+		List<HiveSourceSplit> hiveSplits = new ArrayList<>();
+		FileSystem fs = null;
+		for (HiveTablePartition partition : partitions) {
+			StorageDescriptor sd = partition.getStorageDescriptor();
+			org.apache.hadoop.fs.Path inputPath = new org.apache.hadoop.fs.Path(sd.getLocation());
+			if (fs == null) {
+				fs = inputPath.getFileSystem(jobConf);
+			}
+			// it's possible a partition exists in metastore but the data has been removed
+			if (!fs.exists(inputPath)) {
+				continue;
+			}
+			InputFormat format;
+			try {
+				format = (InputFormat)
+						Class.forName(sd.getInputFormat(), true, Thread.currentThread().getContextClassLoader()).newInstance();
+			} catch (Exception e) {
+				throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
+			}
+			ReflectionUtils.setConf(format, jobConf);
+			jobConf.set(INPUT_DIR, sd.getLocation());
+			//TODO: we should consider how to calculate the splits according to minNumSplits in the future.
+			org.apache.hadoop.mapred.InputSplit[] splitArray = format.getSplits(jobConf, minNumSplits);
+			for (org.apache.hadoop.mapred.InputSplit inputSplit : splitArray) {
+				Preconditions.checkState(inputSplit instanceof FileSplit,
+						"Unsupported InputSplit type: " + inputSplit.getClass().getName());
+				hiveSplits.add(new HiveSourceSplit((FileSplit) inputSplit, partition, null));
+			}
+		}
+
+		return hiveSplits;
+	}
+
+	public static int getNumFiles(List<HiveTablePartition> partitions, JobConf jobConf) throws IOException {
+		int numFiles = 0;
+		FileSystem fs = null;
+		for (HiveTablePartition partition : partitions) {
+			StorageDescriptor sd = partition.getStorageDescriptor();
+			org.apache.hadoop.fs.Path inputPath = new org.apache.hadoop.fs.Path(sd.getLocation());
+			if (fs == null) {
+				fs = inputPath.getFileSystem(jobConf);
+			}
+			// it's possible a partition exists in metastore but the data has been removed
+			if (!fs.exists(inputPath)) {
+				continue;
+			}
+			numFiles += fs.listStatus(inputPath).length;
+		}
+		return numFiles;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceSplitSerializer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceSplitSerializer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.FileSourceSplitSerializer;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * SerDe for {@link HiveSourceSplit}.
+ */
+public class HiveSourceSplitSerializer implements SimpleVersionedSerializer<HiveSourceSplit> {
+
+	private static final int VERSION = 1;
+
+	public static final HiveSourceSplitSerializer INSTANCE = new HiveSourceSplitSerializer();
+
+	private HiveSourceSplitSerializer() {
+	}
+
+	@Override
+	public int getVersion() {
+		return VERSION;
+	}
+
+	@Override
+	public byte[] serialize(HiveSourceSplit split) throws IOException {
+		checkArgument(split.getClass() == HiveSourceSplit.class, "Cannot serialize subclasses of HiveSourceSplit");
+
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+			serialize(outputStream, split);
+		}
+		return byteArrayOutputStream.toByteArray();
+	}
+
+	@Override
+	public HiveSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+		if (version == 1) {
+			try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+				return deserializeV1(inputStream);
+			}
+		} else {
+			throw new IOException("Unknown version: " + version);
+		}
+	}
+
+	private void serialize(ObjectOutputStream outputStream, HiveSourceSplit split) throws IOException {
+		byte[] superBytes = FileSourceSplitSerializer.INSTANCE.serialize(new FileSourceSplit(
+				split.splitId(), split.path(), split.offset(), split.length(), split.hostnames(), split.getReaderPosition().orElse(null)));
+		outputStream.writeInt(superBytes.length);
+		outputStream.write(superBytes);
+		outputStream.writeObject(split.getHiveTablePartition());
+	}
+
+	private HiveSourceSplit deserializeV1(ObjectInputStream inputStream) throws IOException {
+		try {
+			int superLen = inputStream.readInt();
+			byte[] superBytes = new byte[superLen];
+			inputStream.readFully(superBytes);
+			FileSourceSplit superSplit = FileSourceSplitSerializer.INSTANCE.deserialize(FileSourceSplitSerializer.INSTANCE.getVersion(), superBytes);
+			HiveTablePartition hiveTablePartition = (HiveTablePartition) inputStream.readObject();
+			return new HiveSourceSplit(
+					superSplit.splitId(),
+					superSplit.path(),
+					superSplit.offset(),
+					superSplit.length(),
+					superSplit.hostnames(),
+					superSplit.getReaderPosition().orElse(null),
+					hiveTablePartition);
+		} catch (ClassNotFoundException e) {
+			throw new IOException("Failed to deserialize HiveSourceSplit", e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -187,7 +187,6 @@ public class HiveTableSource implements
 				jobConf,
 				catalogTable,
 				allHivePartitions,
-				projectedFields,
 				limit,
 				hiveVersion,
 				flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER),

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.ArrayResultIterator;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
+import org.apache.flink.table.catalog.hive.client.HiveShim;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.filesystem.PartitionValueConverter;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.io.IOConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.mapred.JobConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.connector.file.src.util.CheckpointedPosition.NO_OFFSET;
+import static org.apache.flink.table.data.vector.VectorizedColumnBatch.DEFAULT_SIZE;
+
+/**
+ * A BulkFormat implementation for HiveSource. This implementation delegates reading to other BulkFormat instances,
+ * because different hive partitions may need different BulkFormat to do the reading.
+ */
+public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSplit> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveBulkFormatAdapter.class);
+
+	// schema evolution configs are not available in older versions of IOConstants, let's define them ourselves
+	private static final String SCHEMA_EVOLUTION_COLUMNS = "schema.evolution.columns";
+	private static final String SCHEMA_EVOLUTION_COLUMNS_TYPES = "schema.evolution.columns.types";
+
+	private final JobConfWrapper jobConfWrapper;
+	private final List<String> partitionKeys;
+	private final String[] fieldNames;
+	private final DataType[] fieldTypes;
+	// indices of fields to be returned, with projection applied (if any)
+	private final int[] selectedFields;
+	private final String hiveVersion;
+	private final HiveShim hiveShim;
+	private final DataType producedDataType;
+	private final boolean useMapRedReader;
+	// We should limit the input read count of the splits, -1 represents no limit.
+	private final long limit;
+
+	public HiveBulkFormatAdapter(JobConfWrapper jobConfWrapper, List<String> partitionKeys, String[] fieldNames, DataType[] fieldTypes,
+			int[] selectedFields, String hiveVersion, DataType producedDataType, boolean useMapRedReader, long limit) {
+		this.jobConfWrapper = jobConfWrapper;
+		this.partitionKeys = partitionKeys;
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		this.selectedFields = selectedFields;
+		this.hiveVersion = hiveVersion;
+		this.hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
+		this.producedDataType = producedDataType;
+		this.useMapRedReader = useMapRedReader;
+		this.limit = limit;
+	}
+
+	@Override
+	public Reader<RowData> createReader(Configuration config, HiveSourceSplit split)
+			throws IOException {
+		return createBulkFormatForSplit(split).createReader(config, split);
+	}
+
+	@Override
+	public Reader<RowData> restoreReader(Configuration config, HiveSourceSplit split) throws IOException {
+		return createBulkFormatForSplit(split).restoreReader(config, split);
+	}
+
+	@Override
+	public boolean isSplittable() {
+		return true;
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return (TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(producedDataType);
+	}
+
+	private BulkFormat<RowData, ? super HiveSourceSplit> createBulkFormatForSplit(HiveSourceSplit split) {
+		if (!useMapRedReader && useParquetVectorizedRead(split.getHiveTablePartition())) {
+			// TODO: need a way to support limit push down
+			return ParquetColumnarRowInputFormat.createPartitionedFormat(
+					jobConfWrapper.conf(),
+					(RowType) producedDataType.getLogicalType(),
+					partitionKeys,
+					jobConfWrapper.conf().get(HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
+							HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal),
+					(PartitionValueConverter) (colName, valStr, type) -> split.getHiveTablePartition().getPartitionSpec().get(colName),
+					DEFAULT_SIZE,
+					hiveVersion.startsWith("3"),
+					false
+			);
+		} else {
+			return new HiveMapRedBulkFormat();
+		}
+	}
+
+	private boolean useParquetVectorizedRead(HiveTablePartition partition) {
+		boolean isParquet = partition.getStorageDescriptor().getSerdeInfo().getSerializationLib()
+				.toLowerCase().contains("parquet");
+		if (!isParquet) {
+			return false;
+		}
+
+		for (int i : selectedFields) {
+			if (isVectorizationUnsupported(fieldTypes[i].getLogicalType())) {
+				LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
+				return false;
+			}
+		}
+
+		LOG.info("Use flink parquet ColumnarRowData reader.");
+		return true;
+	}
+
+	private static boolean isVectorizationUnsupported(LogicalType t) {
+		switch (t.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+			case BOOLEAN:
+			case BINARY:
+			case VARBINARY:
+			case DECIMAL:
+			case TINYINT:
+			case SMALLINT:
+			case INTEGER:
+			case BIGINT:
+			case FLOAT:
+			case DOUBLE:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return false;
+			case TIMESTAMP_WITH_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+			case INTERVAL_DAY_TIME:
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case DISTINCT_TYPE:
+			case STRUCTURED_TYPE:
+			case NULL:
+			case RAW:
+			case SYMBOL:
+			default:
+				return true;
+		}
+	}
+
+	private class HiveMapRedBulkFormat implements BulkFormat<RowData, HiveSourceSplit> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Reader<RowData> createReader(Configuration config, HiveSourceSplit split)
+				throws IOException {
+			return new HiveReader(split);
+		}
+
+		@Override
+		public Reader<RowData> restoreReader(Configuration config, HiveSourceSplit split) throws IOException {
+			assert split.getReaderPosition().isPresent();
+			HiveReader hiveReader = new HiveReader(split);
+			hiveReader.seek(split.getReaderPosition().get().getRecordsAfterOffset());
+			return hiveReader;
+		}
+
+		@Override
+		public boolean isSplittable() {
+			return true;
+		}
+
+		@Override
+		public TypeInformation<RowData> getProducedType() {
+			return (TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(producedDataType);
+		}
+	}
+
+	private class HiveReader implements BulkFormat.Reader<RowData> {
+
+		private final HiveMapredSplitReader hiveMapredSplitReader;
+		private final RowDataSerializer serializer;
+		private long numRead = 0;
+
+		private HiveReader(HiveSourceSplit split) throws IOException {
+			JobConf clonedConf = new JobConf(jobConfWrapper.conf());
+			addSchemaToConf(clonedConf);
+			HiveTableInputSplit oldSplit = new HiveTableInputSplit(-1, split.toMapRedSplit(), clonedConf, split.getHiveTablePartition());
+			hiveMapredSplitReader = new HiveMapredSplitReader(clonedConf, partitionKeys, fieldTypes, selectedFields, oldSplit, hiveShim);
+			serializer = new RowDataSerializer((RowType) producedDataType.getLogicalType());
+		}
+
+		@Override
+		public RecordIterator<RowData> readBatch() throws IOException {
+			RowData[] records = new RowData[DEFAULT_SIZE];
+			final long skipCount = numRead;
+			int num = 0;
+			while (!hiveMapredSplitReader.reachedEnd() && num < DEFAULT_SIZE && !reachLimit()) {
+				records[num++] = serializer.copy(nextRecord());
+			}
+			if (num == 0) {
+				return null;
+			}
+			ArrayResultIterator<RowData> iterator = new ArrayResultIterator<>();
+			iterator.set(records, num, NO_OFFSET, skipCount);
+			return iterator;
+		}
+
+		@Override
+		public void close() throws IOException {
+			hiveMapredSplitReader.close();
+		}
+
+		private RowData nextRecord() throws IOException {
+			RowData res = hiveMapredSplitReader.nextRecord(null);
+			numRead++;
+			return res;
+		}
+
+		private boolean reachLimit() {
+			return limit > 0 && numRead >= limit;
+		}
+
+		private void seek(long toSkip) throws IOException {
+			while (!hiveMapredSplitReader.reachedEnd() && toSkip > 0) {
+				nextRecord();
+				toSkip--;
+			}
+		}
+
+		// Hive readers may rely on the schema info in configuration
+		private void addSchemaToConf(JobConf jobConf) {
+			// set columns/types -- including partition cols
+			List<String> typeStrs = Arrays.stream(fieldTypes)
+					.map(t -> HiveTypeUtil.toHiveTypeInfo(t, true).toString())
+					.collect(Collectors.toList());
+			jobConf.set(IOConstants.COLUMNS, String.join(",", fieldNames));
+			jobConf.set(IOConstants.COLUMNS_TYPES, String.join(",", typeStrs));
+			// set schema evolution -- excluding partition cols
+			int numNonPartCol = fieldNames.length - partitionKeys.size();
+			jobConf.set(SCHEMA_EVOLUTION_COLUMNS, String.join(",", Arrays.copyOfRange(fieldNames, 0, numNonPartCol)));
+			jobConf.set(SCHEMA_EVOLUTION_COLUMNS_TYPES, String.join(",", typeStrs.subList(0, numNonPartCol)));
+
+			// in older versions, parquet reader also expects the selected col indices in conf, excluding part cols
+			String readColIDs = Arrays.stream(selectedFields)
+					.filter(i -> i < numNonPartCol)
+					.mapToObj(String::valueOf)
+					.collect(Collectors.joining(","));
+			jobConf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, readColIDs);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveSourceSplit.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveSourceSplit.java
@@ -20,7 +20,6 @@ package org.apache.flink.connectors.hive.read;
 
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
-import org.apache.flink.connectors.hive.FlinkHiveException;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.core.fs.Path;
 
@@ -79,11 +78,7 @@ public class HiveSourceSplit extends FileSourceSplit {
 
 	@Override
 	public FileSourceSplit updateWithCheckpointedPosition(@Nullable CheckpointedPosition position) {
-		try {
-			return new HiveSourceSplit(toMapRedSplit(), hiveTablePartition, position);
-		} catch (IOException e) {
-			throw new FlinkHiveException("Failed to update checkpoint position for split:" + toString(), e);
-		}
+		return new HiveSourceSplit(splitId(), path(), offset(), length(), hostnames(), position, hiveTablePartition);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveSourceSplit.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveSourceSplit.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.util.CheckpointedPosition;
+import org.apache.flink.connectors.hive.FlinkHiveException;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.mapred.FileSplit;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A wrapper class that wraps info needed for a file input split.
+ * Right now, it contains info about the partition of the split.
+ */
+public class HiveSourceSplit extends FileSourceSplit {
+
+	private static final long serialVersionUID = 1L;
+
+	protected final HiveTablePartition hiveTablePartition;
+
+	public HiveSourceSplit(
+			FileSplit fileSplit,
+			HiveTablePartition hiveTablePartition,
+			@Nullable CheckpointedPosition readerPosition) throws IOException {
+		this(
+				fileSplit.toString(),
+				new Path(fileSplit.getPath().toString()),
+				fileSplit.getStart(),
+				fileSplit.getLength(),
+				fileSplit.getLocations(),
+				readerPosition,
+				hiveTablePartition
+		);
+	}
+
+	public HiveSourceSplit(
+			String id,
+			Path filePath,
+			long offset,
+			long length,
+			String[] hostnames,
+			@Nullable CheckpointedPosition readerPosition,
+			HiveTablePartition hiveTablePartition) {
+		super(id, filePath, offset, length, hostnames, readerPosition);
+		this.hiveTablePartition = checkNotNull(hiveTablePartition, "hiveTablePartition can not be null");
+	}
+
+	public HiveTablePartition getHiveTablePartition() {
+		return hiveTablePartition;
+	}
+
+	public FileSplit toMapRedSplit() {
+		return new FileSplit(new org.apache.hadoop.fs.Path(path().toString()), offset(), length(), hostnames());
+	}
+
+	@Override
+	public FileSourceSplit updateWithCheckpointedPosition(@Nullable CheckpointedPosition position) {
+		try {
+			return new HiveSourceSplit(toMapRedSplit(), hiveTablePartition, position);
+		} catch (IOException e) {
+			throw new FlinkHiveException("Failed to update checkpoint position for split:" + toString(), e);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "HiveSourceSplit{" +
+				"hiveTablePartition=" + hiveTablePartition +
+				'}';
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -90,8 +90,8 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 	// indices of fields to be returned, with projection applied (if any)
 	private int[] selectedFields;
 
-	//We should limit the input read count of this splits, -1 represents no limit.
-	private long limit;
+	//We should limit the input read count of this splits, null represents no limit.
+	private Long limit;
 
 	private boolean useMapRedReader;
 
@@ -105,7 +105,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 			CatalogTable catalogTable,
 			List<HiveTablePartition> partitions,
 			int[] projectedFields,
-			long limit,
+			Long limit,
 			String hiveVersion,
 			boolean useMapRedReader) {
 		super(jobConf.getCredentials());
@@ -255,7 +255,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 
 	@Override
 	public boolean reachedEnd() throws IOException {
-		if (limit > 0 && currentReadCount >= limit) {
+		if (limit != null && currentReadCount >= limit) {
 			return true;
 		} else {
 			return reader.reachedEnd();
@@ -381,7 +381,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 		fieldNames = (String[]) in.readObject();
 		partitions = (List<HiveTablePartition>) in.readObject();
 		selectedFields = (int[]) in.readObject();
-		limit = (long) in.readObject();
+		limit = (Long) in.readObject();
 		hiveVersion = (String) in.readObject();
 		useMapRedReader = in.readBoolean();
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleFactoryTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-
 /**
  * Test for {@link HiveModuleFactory}.
  */


### PR DESCRIPTION
…or batch

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Migrate hive connector to FLIP-27 source for batch reading


## Brief change log

  - Implement `HiveSourceSplit` as sub-class of `FileSourceSplit`. It remembers the partition which a split belongs to.
  - Implement `HiveSourceSplitSerializer` as SerDe for `HiveSourceSplit`.
  - Implement `HiveSource` as sub-class of `AbstractFileSource`, and works with `RowData` and `HiveSourceSplit`.
  - Implement `HiveSourceFileEnumerator` as an implementation of `FileEnumerator`, but it generates splits based on partitions rather than paths.
  - Implement `HiveBulkFormatAdapter` as an implementation of `BulkFormat<RowData, HiveSourceSplit>`. It delegates the reading to other BulkFormat instances based on the information we have from each partition to read.
  - Update `PartitionValueConverter` to take partition col name when converting the partition value. This makes it easier for hive to reuse `ParquetColumnarRowInputFormat` because the partition values have been pre-computed.


## Verifying this change

Existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
