### PR TITLE
[FLINK-19959][table-planner-blink] Multiple input creation algorithm now considers related inputs when deducing input priorities

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraph.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraph.java
@@ -139,6 +139,19 @@ class TopologyGraph {
 		return result;
 	}
 
+	/**
+	 * Make the distance of node A at least as far as node B by adding edges
+	 * from all inputs of node B to node A.
+	 */
+	void makeAsFarAs(ExecNode<?, ?> a, ExecNode<?, ?> b) {
+		TopologyNode nodeA = getOrCreateTopologyNode(a);
+		TopologyNode nodeB = getOrCreateTopologyNode(b);
+
+		for (TopologyNode input : nodeB.inputs) {
+			link(input.execNode, nodeA.execNode);
+		}
+	}
+
 	@VisibleForTesting
 	boolean canReach(ExecNode<?, ?> from, ExecNode<?, ?> to) {
 		TopologyNode fromNode = getOrCreateTopologyNode(from);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculatorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculatorTest.java
@@ -36,17 +36,45 @@ import java.util.Map;
 public class InputOrderCalculatorTest {
 
 	@Test
+	public void testCheckPipelinedPath() {
+		// P = ExecEdge.DamBehavior.PIPELINED, E = ExecEdge.DamBehavior.END_INPUT B = ExecEdge.DamBehavior.BLOCKING
+		//
+		// 0 -P-> 1 ----E----\
+		//         \-P-\      \
+		// 2 ----E----> 3 -P-> 4
+		// 5 -P-> 6 -B-/
+		TestingBatchExecNode[] nodes = new TestingBatchExecNode[7];
+		for (int i = 0; i < nodes.length; i++) {
+			nodes[i] = new TestingBatchExecNode();
+		}
+		nodes[1].addInput(nodes[0]);
+		nodes[3].addInput(nodes[1]);
+		nodes[3].addInput(nodes[2], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.END_INPUT).build());
+		nodes[3].addInput(nodes[6], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+		nodes[4].addInput(nodes[1], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.END_INPUT).build());
+		nodes[4].addInput(nodes[3]);
+		nodes[6].addInput(nodes[5]);
+
+		Assert.assertFalse(
+			InputOrderCalculator.checkPipelinedPath(nodes[4], new HashSet<>(
+				Arrays.asList(nodes[2], nodes[5], nodes[6]))));
+		Assert.assertTrue(
+			InputOrderCalculator.checkPipelinedPath(nodes[4], new HashSet<>(
+				Arrays.asList(nodes[0], nodes[2]))));
+	}
+
+	@Test
 	public void testCalculateInputOrder() {
 		// P = ExecEdge.DamBehavior.PIPELINED, B = ExecEdge.DamBehavior.BLOCKING
 		// P1 = PIPELINED + priority 1
 		//
-		// 0 -(P0)-> 3 -(B0)-\
+		// 0 -(P1)-> 3 -(B0)-\
 		//                    6 -(B0)-\
 		//            /-(P1)-/         \
-		// 1 -(P0)-> 4                  8
+		// 1 -(P1)-> 4                  8
 		//            \-(B0)-\         /
 		//                    7 -(P1)-/
-		// 2 -(P0)-> 5 -(P1)-/
+		// 2 -(P1)-> 5 -(P1)-/
 		TestingBatchExecNode[] nodes = new TestingBatchExecNode[9];
 		for (int i = 0; i < nodes.length; i++) {
 			nodes[i] = new TestingBatchExecNode();
@@ -70,6 +98,73 @@ public class InputOrderCalculatorTest {
 		Assert.assertEquals(0, result.get(nodes[3]).intValue());
 		Assert.assertEquals(1, result.get(nodes[1]).intValue());
 		Assert.assertEquals(2, result.get(nodes[5]).intValue());
+	}
+
+	@Test
+	public void testCalculateInputOrderWithRelatedBoundaries() {
+		// P = ExecEdge.DamBehavior.PIPELINED, B = ExecEdge.DamBehavior.BLOCKING
+		// P1 = PIPELINED + priority 1
+		//
+		// /------------(P0)------------\
+		// 0 -(P0)-> 1 -(B0)-> 2 -(P0)-> 4 -(P1)-> 5
+		//           3 -(P1)-/           6 -(B0)-/
+		TestingBatchExecNode[] nodes = new TestingBatchExecNode[7];
+		for (int i = 0; i < nodes.length; i++) {
+			nodes[i] = new TestingBatchExecNode();
+		}
+		nodes[1].addInput(nodes[0]);
+		nodes[2].addInput(nodes[1], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+		nodes[2].addInput(nodes[3], ExecEdge.builder().priority(1).build());
+		nodes[4].addInput(nodes[0]);
+		nodes[4].addInput(nodes[2]);
+		nodes[5].addInput(nodes[4], ExecEdge.builder().priority(1).build());
+		nodes[5].addInput(nodes[6], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+
+		InputOrderCalculator calculator = new InputOrderCalculator(
+			nodes[5],
+			new HashSet<>(Arrays.asList(nodes[0], nodes[1], nodes[3], nodes[6])),
+			ExecEdge.DamBehavior.BLOCKING);
+		Map<ExecNode<?, ?>, Integer> result = calculator.calculate();
+		Assert.assertEquals(4, result.size());
+		Assert.assertEquals(1, result.get(nodes[0]).intValue());
+		Assert.assertEquals(1, result.get(nodes[1]).intValue());
+		Assert.assertEquals(2, result.get(nodes[3]).intValue());
+		Assert.assertEquals(0, result.get(nodes[6]).intValue());
+	}
+
+	@Test
+	public void testCalculateInputOrderWithUnaffectedRelatedBoundaries() {
+		// P = ExecEdge.DamBehavior.PIPELINED, B = ExecEdge.DamBehavior.BLOCKING
+		// P1 = PIPELINED + priority 1
+		//
+		// 0 --(P0)-> 1 -------(B0)-----> 2 -(P0)-\
+		//  \          \--(B0)-> 3 -(P1)-/         4
+		//   \-(B0)-> 5 -------(P1)-----> 6 -(P0)-/
+		//                     7 --(B0)--/
+		TestingBatchExecNode[] nodes = new TestingBatchExecNode[8];
+		for (int i = 0; i < nodes.length; i++) {
+			nodes[i] = new TestingBatchExecNode();
+		}
+		nodes[1].addInput(nodes[0]);
+		nodes[2].addInput(nodes[1], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+		nodes[2].addInput(nodes[3], ExecEdge.builder().priority(1).build());
+		nodes[3].addInput(nodes[1], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+		nodes[4].addInput(nodes[2]);
+		nodes[4].addInput(nodes[6]);
+		nodes[5].addInput(nodes[0], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+		nodes[6].addInput(nodes[5], ExecEdge.builder().priority(1).build());
+		nodes[6].addInput(nodes[7], ExecEdge.builder().damBehavior(ExecEdge.DamBehavior.BLOCKING).build());
+
+		InputOrderCalculator calculator = new InputOrderCalculator(
+			nodes[4],
+			new HashSet<>(Arrays.asList(nodes[1], nodes[3], nodes[5], nodes[7])),
+			ExecEdge.DamBehavior.BLOCKING);
+		Map<ExecNode<?, ?>, Integer> result = calculator.calculate();
+		Assert.assertEquals(4, result.size());
+		Assert.assertEquals(0, result.get(nodes[1]).intValue());
+		Assert.assertEquals(1, result.get(nodes[3]).intValue());
+		Assert.assertEquals(1, result.get(nodes[5]).intValue());
+		Assert.assertEquals(0, result.get(nodes[7]).intValue());
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraphTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraphTest.java
@@ -157,4 +157,16 @@ public class TopologyGraphTest {
 		Assert.assertEquals(2, result.get(nodes[5]).intValue());
 		Assert.assertEquals(2, result.get(nodes[7]).intValue());
 	}
+
+	@Test
+	public void testMakeAsFarAs() {
+		Tuple2<TopologyGraph, TestingBatchExecNode[]> tuple2 = buildTopologyGraph();
+		TopologyGraph graph = tuple2.f0;
+		TestingBatchExecNode[] nodes = tuple2.f1;
+
+		graph.makeAsFarAs(nodes[4], nodes[7]);
+		Map<ExecNode<?, ?>, Integer> distances = graph.calculateMaximumDistance();
+		Assert.assertEquals(4, distances.get(nodes[7]).intValue());
+		Assert.assertEquals(4, distances.get(nodes[4]).intValue());
+	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testAvoidIncludingCalcAfterNonChainableSource">
+  <TestCase name="testAvoidIncludingCalcAfterNonChainableSource[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM x
@@ -48,7 +48,39 @@ MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftOut
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testIncludeCalcForChainableSource">
+  <TestCase name="testAvoidIncludingCalcAfterNonChainableSource[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM x
+  LEFT JOIN y ON x.a = y.d
+  LEFT JOIN t ON x.a = t.a
+  WHERE x.b > 10
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], nx=[$3], d=[$4], e=[$5], f=[$6], ny=[$7], a0=[$8], b0=[$9], c0=[$10])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalJoin(condition=[=($0, $8)], joinType=[left])
+      :- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, b, c, nx, d, e, f, ny, a0, b0, c0], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, b, c, nx, d, e, f, ny], build=[right])\n:  :- [#2] Calc(select=[a, b, c, nx], where=[>(b, 10)])\n:  +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Calc(select=[a, b, c, nx], where=[>(b, 10)])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
++- Exchange(distribution=[broadcast])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIncludeCalcForChainableSource[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM chainable
@@ -79,7 +111,7 @@ MultipleInputNode(readOrder=[0,0,1], members=[\nNestedLoopJoin(joinType=[LeftOut
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testAvoidIncludingSingleton">
+  <TestCase name="testAvoidIncludingSingleton[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 WITH T1 AS (SELECT COUNT(*) AS cnt FROM z)
@@ -125,7 +157,53 @@ MultipleInputNode(readOrder=[0,0,1], members=[\nUnion(all=[true], union=[a])\n:-
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testAvoidIncludingUnionFromInputSide">
+  <TestCase name="testAvoidIncludingSingleton[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH T1 AS (SELECT COUNT(*) AS cnt FROM z)
+SELECT * FROM
+  (SELECT a FROM x INNER JOIN y ON x.a = y.d)
+  UNION ALL
+  (SELECT a FROM t FULL JOIN T1 ON t.a > T1.cnt)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[true])
+:- LogicalProject(a=[$0])
+:  +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+:     :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+:     +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
++- LogicalProject(a=[$0])
+   +- LogicalJoin(condition=[>($0, $3)], joinType=[full])
+      :- LogicalTableScan(table=[[default_catalog, default_database, t]])
+      +- LogicalAggregate(group=[{}], cnt=[COUNT()])
+         +- LogicalProject($f0=[0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, z, source: [TestTableSource(g, h, i, nz)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,0,1], members=[\nUnion(all=[true], union=[a])\n:- Calc(select=[a])\n:  +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, d], build=[left])\n:     :- [#2] Exchange(distribution=[broadcast])\n:     +- [#3] Calc(select=[d])\n+- [#1] Calc(select=[a])\n])
+:- Calc(select=[a])
+:  +- NestedLoopJoin(joinType=[FullOuterJoin], where=[>(a, cnt)], select=[a, cnt], build=[right], singleRowJoin=[true])
+:     :- Exchange(distribution=[single])
+:     :  +- Calc(select=[a])
+:     :     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:     +- SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS cnt])
+:        +- Exchange(distribution=[single])
+:           +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0])
+:              +- Calc(select=[0 AS $f0])
+:                 +- LegacyTableSourceScan(table=[[default_catalog, default_database, z, source: [TestTableSource(g, h, i, nz)]]], fields=[g, h, i, nz])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[a])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
++- Calc(select=[d])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAvoidIncludingUnionFromInputSide[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
@@ -158,7 +236,40 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, d, e, f, ny
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testBasicMultipleInput">
+  <TestCase name="testAvoidIncludingUnionFromInputSide[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+  (SELECT a FROM (SELECT a FROM x) UNION ALL (SELECT a FROM t)) T1
+  LEFT JOIN y ON T1.a = y.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
++- LogicalJoin(condition=[=($0, $1)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$0])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, d, e, f, ny], build=[right])
+:- Union(all=[true], union=[a])
+:  :- Calc(select=[a])
+:  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
+:  +- Calc(select=[a])
+:     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
++- Exchange(distribution=[broadcast])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testBasicMultipleInput[shuffleMode: ALL_EDGES_PIPELINED]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
@@ -198,7 +309,108 @@ MultipleInputNode(readOrder=[2,1,1,0], members=[\nHashJoin(joinType=[InnerJoin],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testIncludeUnionForChainableSource">
+  <TestCase name="testNoPriorityConstraint[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM x
+  INNER JOIN y ON x.a = y.d
+  INNER JOIN t ON x.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], nx=[$3], d=[$4], e=[$5], f=[$6], ny=[$7], a0=[$8], b0=[$9], c0=[$10])
++- LogicalJoin(condition=[=($0, $8)], joinType=[inner])
+   :- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(members=[\nSortMergeJoin(joinType=[InnerJoin], where=[=(a, a0)], select=[a, b, c, nx, d, e, f, ny, a0, b0, c0])\n:- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, nx, d, e, f, ny])\n:  :- [#2] Exchange(distribution=[hash[a]])\n:  +- [#3] Exchange(distribution=[hash[d]])\n+- [#1] Exchange(distribution=[hash[a]])\n])
+:- Exchange(distribution=[hash[a]])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Exchange(distribution=[hash[a]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
++- Exchange(distribution=[hash[d]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testBasicMultipleInput[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+  (SELECT a FROM x INNER JOIN y ON x.a = y.d) T1
+  INNER JOIN
+  (SELECT d FROM y INNER JOIN t ON y.d = t.a) T2
+  ON T1.a = T2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$1])
++- LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+   :- LogicalProject(a=[$0])
+   :  +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :     :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   +- LogicalProject(d=[$0])
+      +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[2,1,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, d], build=[right])\n:- Calc(select=[a])\n:  +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, d], build=[right])\n:     :- [#1] Exchange(distribution=[hash[a]])\n:     +- [#2] Exchange(distribution=[hash[d]])\n+- Calc(select=[d])\n   +- HashJoin(joinType=[InnerJoin], where=[=(d, a)], select=[d, a], build=[right])\n      :- [#2] Exchange(distribution=[hash[d]])\n      +- [#4] Exchange(distribution=[hash[a]])\n])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
+:- Exchange(distribution=[hash[d]], reuse_id=[1])
+:  +- Calc(select=[d])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+:- Reused(reference_id=[1])
++- Exchange(distribution=[hash[a]])
+   +- Calc(select=[a])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIncludeCalcForChainableSource[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM chainable
+  LEFT JOIN y ON chainable.a = y.d
+  LEFT JOIN t ON chainable.a = t.a
+  WHERE chainable.a > 10
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4], a0=[$5], b=[$6], c=[$7])
++- LogicalFilter(condition=[>($0, 10)])
+   +- LogicalJoin(condition=[=($0, $5)], joinType=[left])
+      :- LogicalJoin(condition=[=($0, $1)], joinType=[left])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, chainable]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,0,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, d, e, f, ny, a0, b, c], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, d, e, f, ny], build=[right])\n:  :- Calc(select=[a], where=[>(a, 10)])\n:  :  +- [#3] BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])\n:  +- [#2] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Exchange(distribution=[broadcast])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
++- BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIncludeUnionForChainableSource[shuffleMode: ALL_EDGES_PIPELINED]">
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
@@ -229,7 +441,7 @@ MultipleInputNode(readOrder=[0,1,1], members=[\nNestedLoopJoin(joinType=[LeftOut
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinWithAggAsProbe">
+  <TestCase name="testJoinWithAggAsProbe[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 WITH T AS (SELECT a, d FROM x INNER JOIN y ON x.a = y.d)
@@ -274,7 +486,52 @@ HashJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, cnt, d, sm], buil
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testKeepMultipleInputWithOneMemberForChainableSource">
+  <TestCase name="testJoinWithAggAsProbe[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH T AS (SELECT a, d FROM x INNER JOIN y ON x.a = y.d)
+SELECT * FROM
+  (SELECT a, COUNT(*) AS cnt FROM T GROUP BY a) T1
+  LEFT JOIN
+  (SELECT d, SUM(a) AS sm FROM T GROUP BY d) T2
+  ON T1.a = T2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], cnt=[$1], d=[$2], sm=[$3])
++- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+   :- LogicalAggregate(group=[{0}], cnt=[COUNT()])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :        :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   +- LogicalAggregate(group=[{0}], sm=[SUM($1)])
+      +- LogicalProject(d=[$4], a=[$0])
+         +- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+            :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+            +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, cnt, d, sm], build=[right])
+:- Exchange(distribution=[hash[a]])
+:  +- HashAggregate(isMerge=[false], groupBy=[a], select=[a, COUNT(*) AS cnt])
+:     +- Calc(select=[a])
+:        +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, d], build=[right], reuse_id=[1])
+:           :- Exchange(distribution=[hash[a]])
+:           :  +- Calc(select=[a])
+:           :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
+:           +- Exchange(distribution=[hash[d]])
+:              +- Calc(select=[d])
+:                 +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
++- HashAggregate(isMerge=[false], groupBy=[d], select=[d, SUM(a) AS sm])
+   +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testKeepMultipleInputWithOneMemberForChainableSource[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[SELECT * FROM chainable LEFT JOIN x ON chainable.a = x.a]]>
     </Resource>
@@ -295,7 +552,28 @@ MultipleInputNode(readOrder=[1,0], members=[\nNestedLoopJoin(joinType=[LeftOuter
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testManyMultipleInputs">
+  <TestCase name="testKeepMultipleInputWithOneMemberForChainableSource[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM chainable LEFT JOIN x ON chainable.a = x.a]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], a0=[$1], b=[$2], c=[$3], nx=[$4])
++- LogicalJoin(condition=[=($0, $1)], joinType=[left])
+   :- LogicalTableScan(table=[[default_catalog, default_database, chainable]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[1,0], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, a0, b, c, nx], build=[right])\n:- [#1] BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])\n+- [#2] Exchange(distribution=[broadcast])\n])
+:- BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])
++- Exchange(distribution=[broadcast])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testManyMultipleInputs[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[
 WITH
@@ -389,6 +667,346 @@ MultipleInputNode(readOrder=[0,0,1,1], members=[\nUnion(all=[true], union=[b, sd
             :- Reused(reference_id=[2])
             :- Reused(reference_id=[3])
             +- Reused(reference_id=[4])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testManyMultipleInputs[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (
+    SELECT a, ny, nz FROM x
+      LEFT JOIN y ON x.a = y.ny
+      LEFT JOIN z ON x.a = z.nz),
+  T2 AS (
+    SELECT T1.a AS a, t.b AS b, d, T1.ny AS ny, nz FROM T1
+      LEFT JOIN t ON T1.a = t.a
+      INNER JOIN y ON T1.a = y.d),
+  T3 AS (
+    SELECT T1.a AS a, t.b AS b, d, T1.ny AS ny, nz FROM T1
+      LEFT JOIN y ON T1.a = y.d
+      INNER JOIN t ON T1.a = t.a),
+  T4 AS (SELECT b, SUM(d) AS sd, SUM(ny) AS sy, SUM(nz) AS sz FROM T2 GROUP BY b),
+  T5 AS (SELECT b, SUM(d) AS sd, SUM(ny) AS sy, SUM(nz) AS sz FROM T3 GROUP BY b)
+SELECT * FROM
+  (SELECT t.b, sd, sy, sz FROM T4 LEFT JOIN t ON T4.b = t.b)
+  UNION ALL
+  (SELECT y.e, sd, sy, sz FROM T5 LEFT JOIN y ON T5.b = y.e)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[true])
+:- LogicalProject(b=[$5], sd=[$1], sy=[$2], sz=[$3])
+:  +- LogicalJoin(condition=[=($0, $5)], joinType=[left])
+:     :- LogicalAggregate(group=[{0}], sd=[SUM($1)], sy=[SUM($2)], sz=[SUM($3)])
+:     :  +- LogicalProject(b=[$4], d=[$6], ny=[$1], nz=[$2])
+:     :     +- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
+:     :        :- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+:     :        :  :- LogicalProject(a=[$0], ny=[$7], nz=[$11])
+:     :        :  :  +- LogicalJoin(condition=[=($0, $11)], joinType=[left])
+:     :        :  :     :- LogicalJoin(condition=[=($0, $7)], joinType=[left])
+:     :        :  :     :  :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+:     :        :  :     :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+:     :        :  :     +- LogicalTableScan(table=[[default_catalog, default_database, z, source: [TestTableSource(g, h, i, nz)]]])
+:     :        :  +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+:     :        +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+:     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
++- LogicalProject(e=[$5], sd=[$1], sy=[$2], sz=[$3])
+   +- LogicalJoin(condition=[=($0, $5)], joinType=[left])
+      :- LogicalAggregate(group=[{0}], sd=[SUM($1)], sy=[SUM($2)], sz=[SUM($3)])
+      :  +- LogicalProject(b=[$8], d=[$3], ny=[$1], nz=[$2])
+      :     +- LogicalJoin(condition=[=($0, $7)], joinType=[inner])
+      :        :- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+      :        :  :- LogicalProject(a=[$0], ny=[$7], nz=[$11])
+      :        :  :  +- LogicalJoin(condition=[=($0, $11)], joinType=[left])
+      :        :  :     :- LogicalJoin(condition=[=($0, $7)], joinType=[left])
+      :        :  :     :  :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+      :        :  :     :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+      :        :  :     +- LogicalTableScan(table=[[default_catalog, default_database, z, source: [TestTableSource(g, h, i, nz)]]])
+      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,0,1,1], members=[\nUnion(all=[true], union=[b, sd, sy, sz])\n:- Calc(select=[b0 AS b, sd, sy, sz])\n:  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(b, b0)], select=[b, sd, sy, sz, b0], build=[right])\n:     :- HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_SUM(sum$0) AS sd, Final_SUM(sum$1) AS sy, Final_SUM(sum$2) AS sz])\n:     :  +- [#3] Exchange(distribution=[hash[b]])\n:     +- [#1] Exchange(distribution=[broadcast])\n+- Calc(select=[e, sd, sy, sz])\n   +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(b, e)], select=[b, sd, sy, sz, e], build=[right])\n      :- HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_SUM(sum$0) AS sd, Final_SUM(sum$1) AS sy, Final_SUM(sum$2) AS sz])\n      :  +- [#4] Exchange(distribution=[hash[b]])\n      +- [#2] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[b])
+:     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c], reuse_id=[1])
+:- Exchange(distribution=[broadcast])
+:  +- Calc(select=[e])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+:- Exchange(distribution=[hash[b]])
+:  +- LocalHashAggregate(groupBy=[b], select=[b, Partial_SUM(d) AS sum$0, Partial_SUM(ny) AS sum$1, Partial_SUM(nz) AS sum$2])
+:     +- Calc(select=[b, d, ny, nz])
+:        +- MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, ny, nz, b, d], build=[right])\n:- Calc(select=[a, ny, nz, b])\n:  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, ny, nz, a0, b], build=[right])\n:     :- [#2] MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, nz)], select=[a, ny, nz], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, ny)], select=[a, ny], build=[right])\n:  :- [#2] Calc(select=[a])\n:  +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])\n:     +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:           :- Exchange(distribution=[broadcast], reuse_id=[4])
+:           :  +- Calc(select=[d])
+:           :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+:           :- MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, nz)], select=[a, ny, nz], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, ny)], select=[a, ny], build=[right])\n:  :- [#2] Calc(select=[a])\n:  +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n], reuse_id=[3])
+:           :  :- Exchange(distribution=[broadcast])
+:           :  :  +- Calc(select=[nz])
+:           :  :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, z, source: [TestTableSource(g, h, i, nz)]]], fields=[g, h, i, nz])
+:           :  :- Calc(select=[a])
+:           :  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
+:           :  +- Exchange(distribution=[broadcast])
+:           :     +- Calc(select=[ny])
+:           :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+:           +- Exchange(distribution=[broadcast], reuse_id=[2])
+:              +- Calc(select=[a, b])
+:                 +- Reused(reference_id=[1])
++- Exchange(distribution=[hash[b]])
+   +- LocalHashAggregate(groupBy=[b], select=[b, Partial_SUM(d) AS sum$0, Partial_SUM(ny) AS sum$1, Partial_SUM(nz) AS sum$2])
+      +- Calc(select=[b, d, ny, nz])
+         +- MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[InnerJoin], where=[=(a, a0)], select=[a, ny, nz, d, a0, b], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, ny, nz, d], build=[right])\n:  :- [#2] MultipleInputNode(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, nz)], select=[a, ny, nz], build=[right])\n:- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, ny)], select=[a, ny], build=[right])\n:  :- [#2] Calc(select=[a])\n:  +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])\n:  +- [#3] Exchange(distribution=[broadcast])\n+- [#1] Exchange(distribution=[broadcast])\n])
+            :- Reused(reference_id=[2])
+            :- Reused(reference_id=[3])
+            +- Reused(reference_id=[4])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRelatedInputsWithAgg[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+  T2 AS (
+    SELECT a, b FROM
+      (SELECT a, b FROM T1)
+      UNION ALL
+      (SELECT COUNT(x.a) AS a, x.b AS b FROM x GROUP BY x.b))
+SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$2], b0=[$3], c=[$4])
++- LogicalJoin(condition=[=($0, $5)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$4], b=[$0])
+   :  :  +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+   :  :     :- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   :  :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalProject(a=[$1], b=[$0])
+   :     +- LogicalAggregate(group=[{0}], a=[COUNT($1)])
+   :        +- LogicalProject(b=[$1], a=[$0])
+   :           +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], a0=[CAST($0):BIGINT])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, a0, b0, c])
++- MultipleInputNode(readOrder=[0,1,0,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a00)], select=[a, b, a0, b0, c, a00], build=[right])\n:- Union(all=[true], union=[a, b])\n:  :- Calc(select=[CAST(a) AS a, CAST(d) AS b])\n:  :  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, a], build=[right])\n:  :     :- [#2] Calc(select=[d])\n:  :     +- [#3] Exchange(distribution=[broadcast])\n:  +- Calc(select=[CAST(a) AS a, b])\n:     +- HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS a])\n:        +- [#4] Exchange(distribution=[hash[b]])\n+- [#1] Exchange(distribution=[broadcast])\n])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[a, b, c, CAST(a) AS a0])
+   :     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+   :- Calc(select=[d])
+   :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[a])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0])
+         +- Calc(select=[b, a])
+            +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testIncludeUnionForChainableSource[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM
+  (SELECT a FROM (SELECT a FROM chainable) UNION ALL (SELECT a FROM t)) T1
+  LEFT JOIN y ON T1.a = y.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
++- LogicalJoin(condition=[=($0, $1)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$0])
+   :  :  +- LogicalTableScan(table=[[default_catalog, default_database, chainable]])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,1,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, d)], select=[a, d, e, f, ny], build=[right])\n:- Union(all=[true], union=[a])\n:  :- [#2] BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])\n:  +- [#3] Calc(select=[a])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+:- BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])
++- Calc(select=[a])
+   +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRelatedInputs[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+  T2 AS (
+    SELECT a, b FROM
+      (SELECT a, b FROM T1)
+      UNION ALL
+      (SELECT x.a AS a, x.b AS b FROM x))
+SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$2], b0=[$3], c=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$4], b=[$0])
+   :  :  +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+   :  :     :- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   :  :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalProject(a=[$0], b=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,1,2,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, b, a0, b0, c], build=[right])\n:- Union(all=[true], union=[a, b])\n:  :- Calc(select=[a, CAST(d) AS b])\n:  :  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, a], build=[right])\n:  :     :- [#3] Calc(select=[d])\n:  :     +- [#4] Exchange(distribution=[broadcast])\n:  +- [#2] Calc(select=[a, b])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Calc(select=[a, b])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+:- Calc(select=[d])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[a])
+      +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNoPriorityConstraint[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM x
+  INNER JOIN y ON x.a = y.d
+  INNER JOIN t ON x.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], nx=[$3], d=[$4], e=[$5], f=[$6], ny=[$7], a0=[$8], b0=[$9], c0=[$10])
++- LogicalJoin(condition=[=($0, $8)], joinType=[inner])
+   :- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :  :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(members=[\nSortMergeJoin(joinType=[InnerJoin], where=[=(a, a0)], select=[a, b, c, nx, d, e, f, ny, a0, b0, c0])\n:- SortMergeJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, nx, d, e, f, ny])\n:  :- [#2] Exchange(distribution=[hash[a]])\n:  +- [#3] Exchange(distribution=[hash[d]])\n+- [#1] Exchange(distribution=[hash[a]])\n])
+:- Exchange(distribution=[hash[a]])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Exchange(distribution=[hash[a]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
++- Exchange(distribution=[hash[d]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRelatedInputsWithAgg[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+  T2 AS (
+    SELECT a, b FROM
+      (SELECT a, b FROM T1)
+      UNION ALL
+      (SELECT COUNT(x.a) AS a, x.b AS b FROM x GROUP BY x.b))
+SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$2], b0=[$3], c=[$4])
++- LogicalJoin(condition=[=($0, $5)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$4], b=[$0])
+   :  :  +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+   :  :     :- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   :  :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalProject(a=[$1], b=[$0])
+   :     +- LogicalAggregate(group=[{0}], a=[COUNT($1)])
+   :        +- LogicalProject(b=[$1], a=[$0])
+   :           +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], a0=[CAST($0):BIGINT])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, a0, b0, c])
++- MultipleInputNode(readOrder=[0,2,1,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a00)], select=[a, b, a0, b0, c, a00], build=[right])\n:- Union(all=[true], union=[a, b])\n:  :- Calc(select=[CAST(a) AS a, CAST(d) AS b])\n:  :  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, a], build=[right])\n:  :     :- [#2] Calc(select=[d])\n:  :     +- [#3] Exchange(distribution=[broadcast])\n:  +- Calc(select=[CAST(a) AS a, b])\n:     +- HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS a])\n:        +- [#4] Exchange(distribution=[hash[b]])\n+- [#1] Exchange(distribution=[broadcast])\n])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[a, b, c, CAST(a) AS a0])
+   :     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+   :- Calc(select=[d])
+   :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
+   :- Exchange(distribution=[broadcast])
+   :  +- Calc(select=[a])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+   +- Exchange(distribution=[hash[b]])
+      +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0])
+         +- Calc(select=[b, a])
+            +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRelatedInputs[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH
+  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+  T2 AS (
+    SELECT a, b FROM
+      (SELECT a, b FROM T1)
+      UNION ALL
+      (SELECT x.a AS a, x.b AS b FROM x))
+SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$2], b0=[$3], c=[$4])
++- LogicalJoin(condition=[=($0, $2)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$4], b=[$0])
+   :  :  +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+   :  :     :- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
+   :  :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   :  +- LogicalProject(a=[$0], b=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+MultipleInputNode(readOrder=[0,1,2,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJoin], where=[=(a, a0)], select=[a, b, a0, b0, c], build=[right])\n:- Union(all=[true], union=[a, b])\n:  :- Calc(select=[a, CAST(d) AS b])\n:  :  +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[=(d, a)], select=[d, a], build=[right])\n:  :     :- [#3] Calc(select=[d])\n:  :     +- [#4] Exchange(distribution=[broadcast])\n:  +- [#2] Calc(select=[a, b])\n+- [#1] Exchange(distribution=[broadcast])\n])
+:- Exchange(distribution=[broadcast])
+:  +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:- Calc(select=[a, b])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+:- Calc(select=[d])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[a])
+      +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase
+import org.apache.flink.types.Row
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import org.junit.{Before, Test}
+
+import scala.collection.JavaConversions._
+import scala.util.Random
+
+@RunWith(classOf[Parameterized])
+/**
+ * IT cases for multiple input.
+ *
+ * <p>This test class works by comparing the results with and without multiple input.
+ * The following IT cases are picked from
+ * [[org.apache.flink.table.planner.plan.batch.sql.MultipleInputCreationTest]].
+ */
+class MultipleInputITCase(shuffleMode: String) extends BatchTestBase {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+
+    registerCollection(
+      "x",
+      MultipleInputITCase.dataX,
+      MultipleInputITCase.rowType,
+      "a, b, c, nx",
+      MultipleInputITCase.nullables)
+    registerCollection(
+      "y",
+      MultipleInputITCase.dataY,
+      MultipleInputITCase.rowType,
+      "d, e, f, ny",
+      MultipleInputITCase.nullables)
+    registerCollection(
+      "z",
+      MultipleInputITCase.dataZ,
+      MultipleInputITCase.rowType,
+      "g, h, i, nz",
+      MultipleInputITCase.nullables)
+    registerCollection(
+      "t",
+      MultipleInputITCase.dataT,
+      MultipleInputITCase.rowType,
+      "a, b, c, nt",
+      MultipleInputITCase.nullables)
+
+    tEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, shuffleMode)
+  }
+
+  @Test
+  def testBasicMultipleInput(): Unit = {
+    checkMultipleInputResult(
+      """
+        |SELECT * FROM
+        |  (SELECT a FROM x INNER JOIN y ON x.a = y.d) T1
+        |  INNER JOIN
+        |  (SELECT d FROM y INNER JOIN t ON y.d = t.a) T2
+        |  ON T1.a = T2.d
+        |""".stripMargin)
+  }
+
+  @Test
+  def testManyMultipleInputs(): Unit = {
+    checkMultipleInputResult(
+      """
+        |WITH
+        |  T1 AS (
+        |    SELECT a, ny, nz FROM x
+        |      LEFT JOIN y ON x.a = y.ny
+        |      LEFT JOIN z ON x.a = z.nz),
+        |  T2 AS (
+        |    SELECT T1.a AS a, t.b AS b, d, T1.ny AS ny, nz FROM T1
+        |      LEFT JOIN t ON T1.a = t.a
+        |      INNER JOIN y ON T1.a = y.d),
+        |  T3 AS (
+        |    SELECT T1.a AS a, t.b AS b, d, T1.ny AS ny, nz FROM T1
+        |      LEFT JOIN y ON T1.a = y.d
+        |      INNER JOIN t ON T1.a = t.a),
+        |  T4 AS (SELECT b, SUM(d) AS sd, SUM(ny) AS sy, SUM(nz) AS sz FROM T2 GROUP BY b),
+        |  T5 AS (SELECT b, SUM(d) AS sd, SUM(ny) AS sy, SUM(nz) AS sz FROM T3 GROUP BY b)
+        |SELECT * FROM
+        |  (SELECT t.b, sd, sy, sz FROM T4 LEFT JOIN t ON T4.b = t.b)
+        |  UNION ALL
+        |  (SELECT y.e, sd, sy, sz FROM T5 LEFT JOIN y ON T5.b = y.e)
+        |""".stripMargin)
+  }
+
+  @Test
+  def testJoinWithAggAsProbe(): Unit = {
+    checkMultipleInputResult(
+      """
+        |WITH T AS (SELECT a, d FROM x INNER JOIN y ON x.a = y.d)
+        |SELECT * FROM
+        |  (SELECT a, COUNT(*) AS cnt FROM T GROUP BY a) T1
+        |  LEFT JOIN
+        |  (SELECT d, SUM(a) AS sm FROM T GROUP BY d) T2
+        |  ON T1.a = T2.d
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testNoPriorityConstraint(): Unit = {
+    checkMultipleInputResult(
+      """
+        |SELECT * FROM x
+        |  INNER JOIN y ON x.a = y.d
+        |  INNER JOIN t ON x.a = t.a
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testRelatedInputs(): Unit = {
+    checkMultipleInputResult(
+      """
+        |WITH
+        |  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+        |  T2 AS (
+        |    SELECT a, b FROM
+        |      (SELECT a, b FROM T1)
+        |      UNION ALL
+        |      (SELECT x.a AS a, x.b AS b FROM x))
+        |SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+        |""".stripMargin
+    )
+  }
+
+  @Test
+  def testRelatedInputsWithAgg(): Unit = {
+    checkMultipleInputResult(
+      """
+        |WITH
+        |  T1 AS (SELECT x.a AS a, y.d AS b FROM y LEFT JOIN x ON y.d = x.a),
+        |  T2 AS (
+        |    SELECT a, b FROM
+        |      (SELECT a, b FROM T1)
+        |      UNION ALL
+        |      (SELECT COUNT(x.a) AS a, x.b AS b FROM x GROUP BY x.b))
+        |SELECT * FROM T2 LEFT JOIN t ON T2.a = t.a
+        |""".stripMargin
+    )
+  }
+
+  def checkMultipleInputResult(sql: String): Unit = {
+    tEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED, false)
+    val expected = executeQuery(sql)
+    tEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED, true)
+    checkResult(sql, expected)
+  }
+}
+
+object MultipleInputITCase {
+
+  @Parameters(name = "shuffleMode: {0}")
+  def parameters: Array[String] = Array("ALL_EDGES_BLOCKING", "ALL_EDGES_PIPELINED")
+
+  def generateRandomData(): Seq[Row] = {
+    val data = new java.util.ArrayList[Row]()
+    val numRows = Random.nextInt(30)
+    lazy val strs = Seq("multiple", "input", "itcase")
+    for (_ <- 0 until numRows) {
+      data.add(BatchTestBase.row(
+        Random.nextInt(3),
+        Random.nextInt(3).longValue(),
+        strs(Random.nextInt(3)),
+        Random.nextInt(3)))
+    }
+    data
+  }
+
+  lazy val rowType = new RowTypeInfo(INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, INT_TYPE_INFO)
+  lazy val nullables: Array[Boolean] = Array(true, true, true, true)
+
+  lazy val dataX: Seq[Row] = generateRandomData()
+  lazy val dataY: Seq[Row] = generateRandomData()
+  lazy val dataZ: Seq[Row] = generateRandomData()
+  lazy val dataT: Seq[Row] = generateRandomData()
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is a fix for FLINK-19959. See the ticket for an explanation of the bug.

## Brief change log

 - Multiple input creation algorithm now considers related inputs when deducing input priorities

## Verifying this change

This change is already covered by existing tests, also this change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
