### PR TITLE
[FLINK-19958] Add the IOException to all the I/O related methods' signature in Sink API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Committer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Committer.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.connector.sink;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -35,7 +36,7 @@ public interface Committer<CommT> extends AutoCloseable {
 	 * Commit the given list of {@link CommT}.
 	 * @param committables A list of information needed to commit data staged by the sink.
 	 * @return A list of {@link CommT} needed to re-commit, which is needed in case we implement a "commit-with-retry" pattern.
-	 * @throws Exception if the commit operation fail and do not want to retry any more.
+	 * @throws IOException if the commit operation fail and do not want to retry any more.
 	 */
-	List<CommT> commit(List<CommT> committables) throws Exception;
+	List<CommT> commit(List<CommT> committables) throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/GlobalCommitter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/GlobalCommitter.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.connector.sink;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -39,27 +40,38 @@ public interface GlobalCommitter<CommT, GlobalCommT> extends AutoCloseable {
 	 * Find out which global committables need to be retried when recovering from the failure.
 	 * @param globalCommittables A list of {@link GlobalCommT} for which we want to verify
 	 *                              which ones were successfully committed and which ones did not.
+	 *
 	 * @return A list of {@link GlobalCommT} that should be committed again.
+	 *
+	 * @throws IOException if fail to filter the recovered committables.
 	 */
-	List<GlobalCommT> filterRecoveredCommittables(List<GlobalCommT> globalCommittables);
+	List<GlobalCommT> filterRecoveredCommittables(List<GlobalCommT> globalCommittables) throws IOException;
 
 	/**
 	 * Compute an aggregated committable from a list of committables.
 	 * @param committables A list of {@link CommT} to be combined into a {@link GlobalCommT}.
+	 *
 	 * @return an aggregated committable
+	 *
+	 * @throws IOException if fail to combine the given committables.
 	 */
-	GlobalCommT combine(List<CommT> committables);
+	GlobalCommT combine(List<CommT> committables) throws IOException;
 
 	/**
 	 * Commit the given list of {@link GlobalCommT}.
+	 *
 	 * @param globalCommittables a list of {@link GlobalCommT}.
+	 *
 	 * @return A list of {@link GlobalCommT} needed to re-commit, which is needed in case we implement a "commit-with-retry" pattern.
-	 * @throws Exception if the commit operation fail and do not want to retry any more.
+	 *
+	 * @throws IOException if the commit operation fail and do not want to retry any more.
 	 */
-	List<GlobalCommT> commit(List<GlobalCommT> globalCommittables) throws Exception;
+	List<GlobalCommT> commit(List<GlobalCommT> globalCommittables) throws IOException;
 
 	/**
 	 * Signals that there is no committable any more.
+	 *
+	 * @throws IOException if fail to handle this notification.
 	 */
-	void endOfInput();
+	void endOfInput() throws IOException;
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
@@ -46,21 +47,35 @@ public interface Sink<InputT, CommT, WriterStateT, GlobalCommT> extends Serializ
 
 	/**
 	 * Create a {@link SinkWriter}.
+	 *
 	 * @param context the runtime context.
 	 * @param states the writer's state.
+	 *
 	 * @return A sink writer.
+	 *
+	 * @throws IOException if fail to create a writer.
 	 */
-	SinkWriter<InputT, CommT, WriterStateT> createWriter(InitContext context, List<WriterStateT> states);
+	SinkWriter<InputT, CommT, WriterStateT> createWriter(
+			InitContext context,
+			List<WriterStateT> states) throws IOException;
 
 	/**
 	 * Creates a {@link Committer}.
+	 *
+	 * @return A committer.
+	 *
+	 * @throws IOException if fail to create a committer.
 	 */
-	Optional<Committer<CommT>> createCommitter();
+	Optional<Committer<CommT>> createCommitter() throws IOException;
 
 	/**
 	 * Creates a {@link GlobalCommitter}.
+	 *
+	 * @return A global committer.
+	 *
+	 * @throws IOException if fail to create a global committer.
 	 */
-	Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter();
+	Optional<GlobalCommitter<CommT, GlobalCommT>> createGlobalCommitter() throws IOException;
 
 	/**
 	 * Returns the serializer of the committable type.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.connector.sink;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -37,10 +38,13 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
 
 	/**
 	 * Add an element to the writer.
+	 *
 	 * @param element The input record
 	 * @param context The additional information about the input record
+	 *
+	 * @throws IOException if fail to add an element.
 	 */
-	void write(InputT element, Context context);
+	void write(InputT element, Context context) throws IOException;
 
 	/**
 	 * Prepare for a commit.
@@ -49,13 +53,17 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
 	 *
 	 * @param flush Whether flushing the un-staged data or not
 	 * @return The data is ready to commit.
+	 *
+	 * @throws IOException if fail to prepare for a commit.
 	 */
-	List<CommT> prepareCommit(boolean flush);
+	List<CommT> prepareCommit(boolean flush) throws IOException;
 
 	/**
 	 * @return The writer's state.
+	 *
+	 * @throws IOException if fail to snapshot writer's state.
 	 */
-	List<WriterStateT> snapshotState();
+	List<WriterStateT> snapshotState() throws IOException;
 
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractStreamingCommitterOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -76,7 +77,7 @@ abstract class AbstractStreamingCommitterOperator<InputT, CommT> extends Abstrac
 	 *
 	 * @param committables A list of committables
 	 */
-	abstract void recoveredCommittables(List<CommT> committables);
+	abstract void recoveredCommittables(List<CommT> committables) throws IOException;
 
 	/**
 	 * Prepares a commit.
@@ -85,7 +86,7 @@ abstract class AbstractStreamingCommitterOperator<InputT, CommT> extends Abstrac
 	 *
 	 * @return A list of committables that could be committed in the following checkpoint complete.
 	 */
-	abstract List<CommT> prepareCommit(List<InputT> input);
+	abstract List<CommT> prepareCommit(List<InputT> input) throws IOException;
 
 	/**
 	 * Commits a list of committables.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/BatchCommitterOperatorFactory.java
@@ -24,6 +24,9 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -46,11 +49,15 @@ public final class BatchCommitterOperatorFactory<CommT> extends AbstractStreamOp
 	@SuppressWarnings("unchecked")
 	public <T extends StreamOperator<CommT>> T createStreamOperator(
 			StreamOperatorParameters<CommT> parameters) {
-		final BatchCommitterOperator<CommT> committerOperator =
-				new BatchCommitterOperator<>(
-						sink.createCommitter().orElseThrow(
-								() -> new IllegalStateException(
-										"Could not create committer from the sink")));
+		final BatchCommitterOperator<CommT> committerOperator;
+		try {
+			committerOperator = new BatchCommitterOperator<>(
+					sink.createCommitter().orElseThrow(
+							() -> new IllegalStateException(
+									"Could not create committer from the sink")));
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Could not create the Committer.", e);
+		}
 		committerOperator.setup(
 				parameters.getContainingTask(),
 				parameters.getStreamConfig(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperator.java
@@ -42,7 +42,7 @@ final class StatelessSinkWriterOperator<InputT, CommT> extends AbstractSinkWrite
 	}
 
 	@Override
-	SinkWriter<InputT, CommT, ?> createWriter() {
+	SinkWriter<InputT, CommT, ?> createWriter() throws Exception {
 		return sink.createWriter(createInitContext(), Collections.emptyList());
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingGlobalCommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingGlobalCommitterOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,14 +59,14 @@ public final class StreamingGlobalCommitterOperator<CommT, GlobalCommT> extends 
 	}
 
 	@Override
-	void recoveredCommittables(List<GlobalCommT> committables) {
+	void recoveredCommittables(List<GlobalCommT> committables) throws IOException {
 		final List<GlobalCommT> recovered = globalCommitter.
 				filterRecoveredCommittables(checkNotNull(committables));
 		recoveredGlobalCommittables.addAll(recovered);
 	}
 
 	@Override
-	List<GlobalCommT> prepareCommit(List<CommT> input) {
+	List<GlobalCommT> prepareCommit(List<CommT> input) throws IOException {
 		checkNotNull(input);
 		final List<GlobalCommT> result =
 				new ArrayList<>(recoveredGlobalCommittables);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingGlobalCommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StreamingGlobalCommitterOperatorFactory.java
@@ -21,6 +21,9 @@ package org.apache.flink.streaming.runtime.operators.sink;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -40,13 +43,17 @@ public class StreamingGlobalCommitterOperatorFactory<CommT, GlobalCommT> extends
 
 	@Override
 	AbstractStreamingCommitterOperator<CommT, GlobalCommT> createStreamingCommitterOperator() {
-		return new StreamingGlobalCommitterOperator<>(
-				sink.createGlobalCommitter()
-						.orElseThrow(() -> new IllegalStateException(
-								"Could not create global committer from the sink")),
-				sink.getGlobalCommittableSerializer()
-						.orElseThrow(() -> new IllegalStateException(
-								"Could not create global committable serializer from the sink")));
+		try {
+			return new StreamingGlobalCommitterOperator<>(
+					sink.createGlobalCommitter()
+							.orElseThrow(() -> new IllegalStateException(
+									"Could not create global committer from the sink")),
+					sink.getGlobalCommittableSerializer()
+							.orElseThrow(() -> new IllegalStateException(
+									"Could not create global committable serializer from the sink")));
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Could not create the GlobalCommitter.", e);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the current Sink API some method does not throw any exception, which should throw intuitively for example `SinkWriter::write`. Some method throw the normal `Exception`, which might be too general.

 So in this pr we want to add a IOException to all the I/O related methods signature.


## Brief change log

  - *Add `IOException` to the `Sink:createWriter/createCommiter/createGlobalCommitter`*
  - *Add `IOException` to the `SinkWriter::writer/prepareCommit/snapshotState`*
  - *Add `IOException` to the `Committer::commit`*
  - *Add `IOException` to the `GlobalCommitter::filterRecoveredCommittables/combine/commit/endOfInput`*


## Verifying this change


This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
