### PR TITLE
[FLINK-19743] Add metric definitions in FLIP-33 and report some of them by default.

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
@@ -26,15 +26,15 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.connector.file.src.testutils.TestingFileSystem;
+import org.apache.flink.connector.testutils.source.reader.TestingSourceMetricGroup;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import org.junit.After;
 import org.junit.Test;
@@ -186,8 +186,8 @@ public class FileSourceHeavyThroughputTest {
 	private static final class NoOpReaderContext implements SourceReaderContext {
 
 		@Override
-		public MetricGroup metricGroup() {
-			return new UnregisteredMetricsGroup();
+		public SourceMetricGroup metricGroup() {
+			return new TestingSourceMetricGroup();
 		}
 
 		@Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
@@ -19,8 +19,8 @@
 package org.apache.flink.api.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.MetricGroup;
 
 /**
  * The class that expose some context from runtime to the {@link SourceReader}.
@@ -31,7 +31,7 @@ public interface SourceReaderContext {
 	/**
 	 * @return The metric group this source belongs to.
 	 */
-	MetricGroup metricGroup();
+	SourceMetricGroup metricGroup();
 
 	/**
 	 * Gets the configuration with which Flink was started.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/metrics/SourceMetricGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/metrics/SourceMetricGroup.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * An interface that defines the metric names of the Source (FLIP-27). The interface
+ * also exposes the methods for the predefined metrics that need to be updated by
+ * the Source implementations.
+ */
+public interface SourceMetricGroup extends MetricGroup {
+	// Source metrics convention specified in FLIP-33.
+	String CURRENT_FETCH_EVENT_TIME_LAG = "currentFetchEventTimeLag";
+	String CURRENT_EMIT_EVENT_TIME_LAG = "currentEmitEventTimeLag";
+	String WATERMARK_LAG = "watermarkLag";
+	String SOURCE_IDLE_TIME = "sourceIdleTime";
+	String PENDING_BYTES = "pendingBytes";
+	String PENDING_RECORDS = "pendingRecords";
+	String IO_NUM_RECORDS_IN_ERRORS = "numRecordsInErrors";
+
+	/**
+	 * @return the counter to record number of records received by the SourceReader.
+	 */
+	Counter getNumRecordsInCounter();
+
+	/**
+	 * @return the counter to record number of bytes received by the SourceReader.
+	 */
+	Counter getNumBytesInCounter();
+
+	/**
+	 * @return the counter to record the errors encountered when reading the records.
+	 */
+	Counter getNumRecordsInErrorsCounter();
+
+}

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceTest.java
@@ -24,9 +24,10 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import org.junit.Test;
@@ -106,8 +107,8 @@ public class NumberSequenceSourceTest {
 	private static final class DummyReaderContext implements SourceReaderContext {
 
 		@Override
-		public MetricGroup metricGroup() {
-			return new UnregisteredMetricsGroup();
+		public SourceMetricGroup metricGroup() {
+			return new DummySourceMetricsGroup();
 		}
 
 		@Override
@@ -166,6 +167,25 @@ public class NumberSequenceSourceTest {
 
 		public ArrayList<E> getEmittedRecords() {
 			return emittedRecords;
+		}
+	}
+
+	private static final class DummySourceMetricsGroup
+		extends UnregisteredMetricsGroup implements SourceMetricGroup {
+
+		@Override
+		public Counter getNumRecordsInCounter() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Counter getNumBytesInCounter() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Counter getNumRecordsInErrorsCounter() {
+			throw new UnsupportedOperationException();
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceMetricGroup.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceMetricGroup.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source.mocks;
+
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+/**
+ * A testing implementation of {@link org.apache.flink.api.connector.source.metrics.SourceMetricGroup}.
+ * This class is not supposed to be used by classes out of the flink-core module. Please use
+ * TestingSourceMetricGroup in flink-connector-test-utils instead.
+ */
+public class MockSourceMetricGroup extends UnregisteredMetricsGroup implements SourceMetricGroup {
+	private final Counter numRecordsInCounter = new SimpleCounter();
+	private final Counter numBytesInCounter = new SimpleCounter();
+	private final Counter numRecordsInErrorsCounter = new SimpleCounter();
+
+	@Override
+	public Counter getNumRecordsInCounter() {
+		return numRecordsInCounter;
+	}
+
+	@Override
+	public Counter getNumBytesInCounter() {
+		return numBytesInCounter;
+	}
+
+	@Override
+	public Counter getNumRecordsInErrorsCounter() {
+		return numRecordsInErrorsCounter;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/SourceMetricGroupImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/SourceMetricGroupImpl.java
@@ -1,0 +1,76 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.util.clock.SystemClock;
+
+import java.util.function.Supplier;
+
+/**
+ * A metric group that adds source specific metrics to the SourceOperator.
+ * It adds Source specific metrics to the OperatorMetricsGroup.
+ */
+public class SourceMetricGroupImpl extends ProxyMetricGroup<OperatorMetricGroup> implements SourceMetricGroup {
+	private final Counter numRecordsInCounter;
+	private final Counter numRecordsInErrorsCounter;
+	private final Counter numBytesIn;
+	private final Supplier<Long> currentWatermarkSupplier;
+
+	public SourceMetricGroupImpl(
+			OperatorMetricGroup operatorMetricGroup,
+			Counter numBytesInCounter,
+			Supplier<Long> currentWatermarkSupplier) {
+		super(operatorMetricGroup);
+		this.numRecordsInCounter = operatorMetricGroup.getIOMetricGroup().getNumRecordsInCounter();
+		this.numRecordsInErrorsCounter = operatorMetricGroup.counter(SourceMetricGroup.IO_NUM_RECORDS_IN_ERRORS);
+		this.numBytesIn = numBytesInCounter;
+		this.currentWatermarkSupplier = currentWatermarkSupplier;
+		operatorMetricGroup.gauge(
+				SourceMetricGroup.WATERMARK_LAG,
+				() -> {
+					long currentWatermark = currentWatermarkSupplier.get();
+					if (currentWatermark < 0) {
+						return -1L;
+					} else {
+						return SystemClock.getInstance().absoluteTimeMillis() - currentWatermark;
+					}
+				});
+	}
+
+	@Override
+	public Counter getNumRecordsInCounter() {
+		return numRecordsInCounter;
+	}
+
+	public Counter getNumBytesInCounter() {
+		return numBytesIn;
+	}
+
+	public Counter getNumRecordsInErrorsCounter() {
+		return numRecordsInErrorsCounter;
+	}
+
+	@VisibleForTesting
+	public Supplier<Long> getCurrentWatermarkSupplier() {
+		return currentWatermarkSupplier;
+	}
+}

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -90,6 +90,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -64,6 +64,12 @@ public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T
 		// no periodic watermarks
 	}
 
+	@Override
+	public long getWatermark() {
+		// No watermark.
+		return -1L;
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -63,6 +63,13 @@ public interface TimestampsAndWatermarks<T> {
 	 */
 	void stopPeriodicWatermarkEmits();
 
+	/**
+	 * Get the current watermark.
+	 *
+	 * @return the current watermark.
+	 */
+	long getWatermark();
+
 	// ------------------------------------------------------------------------
 	//  factories
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -83,4 +83,8 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 			throw new ExceptionInChainedOperatorException(e);
 		}
 	}
+
+	public long getMaxWatermarkSoFar() {
+		return maxWatermarkSoFar;
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/CollectingDataOutput.java
@@ -30,9 +30,9 @@ import java.util.List;
 /**
  * A test utility implementation of {@link PushingAsyncDataInput.DataOutput} that collects all events.
  */
-final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
+public final class CollectingDataOutput<E> implements PushingAsyncDataInput.DataOutput<E> {
 
-	final List<Object> events = new ArrayList<>();
+	public final List<Object> events = new ArrayList<>();
 
 	@Override
 	public void emitWatermark(Watermark watermark) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testutils.source.reader.TestingSourceMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
@@ -36,7 +37,7 @@ import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 /**
  * A SourceOperator extension to simplify test setup.
  */
-public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit> {
+public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -80,7 +81,8 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 			timeService,
 			new Configuration(),
 			"localhost",
-			emitProgressiveWatermarks);
+			emitProgressiveWatermarks,
+			new TestingSourceMetricGroup());
 
 		this.subtaskIndex = subtaskIndex;
 		this.parallelism = parallelism;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -137,9 +137,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, barrier.getCheckpointOptions(), false);
 			processSingleStepUntil(testHarness, checkpointFuture::isDone);
 
-			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
-			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
-			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("42", 42L));
+			expectedOutput.add(new StreamRecord<>("42", 42L));
+			expectedOutput.add(new StreamRecord<>("42", 42L));
 			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
 			expectedOutput.add(new StreamRecord<>("44", TimestampAssigner.NO_TIMESTAMP));
 			expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
@@ -202,7 +202,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
 			addSourceRecords(testHarness, 0, 42, 43, 44);
 			processSingleStepUntil(testHarness, () -> !testHarness.getOutput().isEmpty());
-			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("42", 42L));
 
 			CheckpointBarrier barrier = createBarrier(testHarness);
 			Future<Boolean> checkpointFuture = testHarness.getStreamTask().triggerCheckpointAsync(metaData, barrier.getCheckpointOptions(), false);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.eventtime.TimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -113,8 +112,8 @@ public class MultipleInputStreamTaskTest {
 			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
 
 			addSourceRecords(testHarness, 1, 42, 43);
-			expectedOutput.add(new StreamRecord<>("42", TimestampAssigner.NO_TIMESTAMP));
-			expectedOutput.add(new StreamRecord<>("43", TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("42", 42));
+			expectedOutput.add(new StreamRecord<>("43", 43));
 			testHarness.processElement(new StreamRecord<>("Hello", initialTime + 1), 0);
 			expectedOutput.add(new StreamRecord<>("Hello", initialTime + 1));
 			testHarness.processElement(new StreamRecord<>(42.44d, initialTime + 3), 1);
@@ -419,7 +418,7 @@ public class MultipleInputStreamTaskTest {
 			testHarness.processElement(new Watermark(initialTime), 0, 1);
 
 			addSourceRecords(testHarness, 1, initialTime);
-			expectedOutput.add(new StreamRecord<>("" + (initialTime), TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("" + (initialTime), initialTime));
 
 			testHarness.processElement(new Watermark(initialTime), 1, 0);
 
@@ -443,7 +442,7 @@ public class MultipleInputStreamTaskTest {
 			testHarness.processElement(new Watermark(initialTime + 3), 0, 1);
 
 			addSourceRecords(testHarness, 1, initialTime + 3);
-			expectedOutput.add(new StreamRecord<>("" + (initialTime + 3), TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("" + (initialTime + 3), initialTime + 3));
 
 			testHarness.processElement(new Watermark(initialTime + 3), 1, 0);
 			testHarness.processElement(new Watermark(initialTime + 2), 1, 1);
@@ -463,7 +462,7 @@ public class MultipleInputStreamTaskTest {
 			testHarness.processElement(new Watermark(initialTime + 4), 0, 1);
 
 			addSourceRecords(testHarness, 1, initialTime + 4);
-			expectedOutput.add(new StreamRecord<>("" + (initialTime + 4), TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("" + (initialTime + 4), initialTime + 4));
 
 			testHarness.processElement(new Watermark(initialTime + 4), 1, 0);
 			expectedOutput.add(new Watermark(initialTime + 4));
@@ -518,7 +517,7 @@ public class MultipleInputStreamTaskTest {
 				// we wake up the source and emit watermark
 				addSourceRecords(testHarness, 1, initialTime + 5);
 				testHarness.processAll();
-				expectedOutput.add(new StreamRecord<>("" + (initialTime + 5), TimestampAssigner.NO_TIMESTAMP));
+				expectedOutput.add(new StreamRecord<>("" + (initialTime + 5), initialTime + 5));
 				expectedOutput.add(new Watermark(initialTime + 5));
 				// the source should go back to being idle immediately, but AbstractStreamOperatorV2
 				// should have updated it's watermark by then.
@@ -534,7 +533,7 @@ public class MultipleInputStreamTaskTest {
 
 			// make source active once again, emit a watermark and go idle again.
 			addSourceRecords(testHarness, 1, initialTime + 10);
-			expectedOutput.add(new StreamRecord<>("" + (initialTime + 10), TimestampAssigner.NO_TIMESTAMP));
+			expectedOutput.add(new StreamRecord<>("" + (initialTime + 10), initialTime + 10));
 			expectedOutput.add(StreamStatus.ACTIVE);
 			expectedOutput.add(StreamStatus.IDLE);
 			testHarness.processAll();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.eventtime.TimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -143,7 +142,7 @@ public class SourceOperatorStreamTaskTest {
 
 			// Build expected output to verify the results
 			Queue<Object> expectedOutput = new LinkedList<>();
-			expectedRecords.forEach(r -> expectedOutput.offer(new StreamRecord<>(r, TimestampAssigner.NO_TIMESTAMP)));
+			expectedRecords.forEach(r -> expectedOutput.offer(new StreamRecord<>(r, r)));
 			// Add barrier to the expected output.
 			expectedOutput.add(new CheckpointBarrier(checkpointId, checkpointId, checkpointOptions));
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
@@ -20,9 +20,8 @@ package org.apache.flink.connector.testutils.source.reader;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,7 @@ import java.util.List;
  */
 public class TestingReaderContext implements SourceReaderContext {
 
-	private final UnregisteredMetricsGroup metrics = new UnregisteredMetricsGroup();
+	private final TestingSourceMetricGroup metrics = new TestingSourceMetricGroup();
 
 	private final Configuration config;
 
@@ -51,7 +50,7 @@ public class TestingReaderContext implements SourceReaderContext {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public MetricGroup metricGroup() {
+	public SourceMetricGroup metricGroup() {
 		return metrics;
 	}
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSourceMetricGroup.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSourceMetricGroup.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testutils.source.reader;
+
+import org.apache.flink.api.connector.source.metrics.SourceMetricGroup;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+/**
+ * A testing implementation of {@link SourceMetricGroup}.
+ */
+public class TestingSourceMetricGroup extends UnregisteredMetricsGroup implements SourceMetricGroup {
+	private final Counter numRecordsInCounter = new SimpleCounter();
+	private final Counter numBytesInCounter = new SimpleCounter();
+	private final Counter numRecordsInErrorsCounter = new SimpleCounter();
+
+	@Override
+	public Counter getNumRecordsInCounter() {
+		return numRecordsInCounter;
+	}
+
+	@Override
+	public Counter getNumBytesInCounter() {
+		return numBytesInCounter;
+	}
+
+	@Override
+	public Counter getNumRecordsInErrorsCounter() {
+		return numRecordsInErrorsCounter;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
This patch does the following:
* Moved the `MetricNames` from flink-runtime to flink-core and added the metrics defined in FLIP-33.
* Improved the `SourceReaderBase` API to allow additional information to be passed from the `SplitReader` to `RecordEmitter`. So that the implementations do not have to put some common information in the records themselves.
* Report some of the metrics by default.

Metrics implemented by the SourceOperator / ReaderOutput:
1. currentEmitEventTimeLag (at a sampling frequency of once per second)
2. watermarkLag

Metrics implemented in the `SourceReaderBase` (can be overridden by individual implementations):
1. numRecordsIn / numRecordsInPerSecond
2. sourceIdleTime

Metrics left for individual implementations to report in `SplitReader` / `RecordEmitter` :
1. numBytesIn / numBytesInPerSecond
2. currentFetchEventTime
3. pendingBytes
4. pendingRecords
5. numRecordsInErrors (errors in SplitReader and record emitter)

## Brief change log
* Moved the `MetricNames` from flink-runtime to flink-core and added the metrics defined in FLIP-33.
* Improved the `SourceReaderBase` API to allow additional information to be passed from the `SplitReader` to `RecordEmitter`. So that the implementations do not have to put some common information in the records themselves.
* Report some of the metrics by default.

## Verifying this change

Unit tests have been added to test the metrics reporting and additional information passing between `SplitReader` and `RecordEmitter`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
