### PR TITLE
[FLINK-19896][table-blink] Improve first-n-row fetching in the Rank o…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -51,15 +51,13 @@ import org.apache.flink.table.runtime.operators.rank.RankType;
 import org.apache.flink.table.runtime.operators.rank.RetractableTopNFunction;
 import org.apache.flink.table.runtime.operators.rank.UpdatableTopNFunction;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.runtime.typeutils.TypeCheckUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.apache.flink.table.types.logical.TimestampKind;
 
 import java.util.Collections;
 import java.util.List;
@@ -211,17 +209,9 @@ public class StreamExecRank extends ExecNodeBase<RowData>
 
         AbstractTopNFunction processFunction;
         if (rankStrategy instanceof RankProcessStrategy.AppendFastStrategy) {
-            boolean isAppendOnlyFirstN = false;
-            if (sortFields.length == 1) {
-                LogicalType sortKeyType = inputType.getChildren().get(sortFields[0]);
-                if (sortKeyType instanceof LocalZonedTimestampType
-                        && ((LocalZonedTimestampType)sortKeyType).getKind()
-                            == TimestampKind.PROCTIME
-                        && sortSpec.getFieldSpec(0).getIsAscendingOrder()) {
-                        isAppendOnlyFirstN = true;
-                }
-            }
-            if (isAppendOnlyFirstN) {
+            if (sortFields.length == 1
+                    && TypeCheckUtils.isProcTime(inputType.getChildren().get(sortFields[0]))
+                    && sortSpec.getFieldSpec(0).getIsAscendingOrder()) {
                 processFunction =
                         new AppendOnlyFirstNFunction(
                                 minIdleStateRetentionTime,

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -67,7 +67,9 @@ public class RankJsonPlanITCase extends JsonPlanTestBase {
                         + " where c <= 2";
         executeSqlWithJsonPlanVerified(sql).await();
 
-        List<String> expected = Arrays.asList("+I[book, 1, 1]", "+I[book, 2, 2]", "+I[fruit, 4, 1]", "+I[fruit, 3, 2]");
+        List<String> expected =
+                Arrays.asList(
+                        "+I[book, 1, 1]", "+I[book, 2, 2]", "+I[fruit, 4, 1]", "+I[fruit, 3, 2]");
         assertResult(expected, TestValuesTableFactory.getResults("result1"));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -50,4 +50,24 @@ public class RankJsonPlanITCase extends JsonPlanTestBase {
         List<String> expected = Arrays.asList("+I[1, a, 1]", "+I[3, b, 1]", "+I[5, c, 1]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));
     }
+
+    @Test
+    public void testFirstN() throws ExecutionException, InterruptedException, IOException {
+        createTestValuesSourceTable(
+                "MyTable1",
+                JavaScalaConversionUtil.toJava(TestData.data4()),
+                "a varchar",
+                "b int",
+                "c int",
+                "t as proctime()");
+        createTestNonInsertOnlyValuesSinkTable("`result1`", "a varchar", "b int", "c bigint");
+        String sql =
+                "insert into `result1` select * from "
+                        + "(select a, b, row_number() over(partition by a order by t asc) as c from MyTable1)"
+                        + " where c <= 2";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected = Arrays.asList("+I[book, 1, 1]", "+I[book, 2, 2]", "+I[fruit, 4, 1]", "+I[fruit, 3, 2]");
+        assertResult(expected, TestValuesTableFactory.getResults("result1"));
+    }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
+
+/**
+ * A variant of {@link AppendOnlyTopNFunction} to handle first-n case.
+ *
+ * <p>The input stream should only contain INSERT messages.
+ */
+public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
+
+    private static final long serialVersionUID = -889227691088906246L;
+
+    private final long minRetentionTime;
+    // state stores a counter to record the occurrence of key.
+    private ValueState<Integer> state;
+
+    public AppendOnlyFirstNFunction(
+            long minRetentionTime,
+            long maxRetentionTime,
+            InternalTypeInfo<RowData> inputRowType,
+            GeneratedRecordComparator sortKeyGeneratedRecordComparator,
+            RowDataKeySelector sortKeySelector,
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber) {
+        super(
+                minRetentionTime,
+                maxRetentionTime,
+                inputRowType,
+                sortKeyGeneratedRecordComparator,
+                sortKeySelector,
+                rankType,
+                rankRange,
+                generateUpdateBefore,
+                outputRankNumber);
+        this.minRetentionTime = minRetentionTime;
+    }
+
+    @Override
+    public void open(Configuration configure) throws Exception {
+        super.open(configure);
+        ValueStateDescriptor<Integer> stateDesc =
+                new ValueStateDescriptor<>("counterState", Types.INT);
+        StateTtlConfig ttlConfig = createTtlConfig(minRetentionTime);
+        if (ttlConfig.isEnabled()) {
+            stateDesc.enableTimeToLive(ttlConfig);
+        }
+        state = getRuntimeContext().getState(stateDesc);
+    }
+
+    @Override
+    public void processElement(RowData input, Context context, Collector<RowData> out)
+            throws Exception {
+        initRankEnd(input);
+
+        // check message should be insert only.
+        Preconditions.checkArgument(input.getRowKind() == RowKind.INSERT);
+        int currentRank = state.value() == null ? 0 : state.value();
+        // ignore record if it does not belong to the first-n rows
+        if (currentRank >= rankEnd) {
+            return;
+        }
+        currentRank += 1;
+        state.update(currentRank);
+
+        if (outputRankNumber) {
+            collectInsert(out, input, currentRank);
+        } else {
+            collectInsert(out, input);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank;
+
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+
+/** Tests for {@link AppendOnlyFirstNFunction}. */
+public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
+    @Override
+    AbstractTopNFunction createFunction(
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber) {
+        return new AppendOnlyFirstNFunction(
+                minTime.toMilliseconds(),
+                maxTime.toMilliseconds(),
+                inputRowType,
+                generatedSortKeyComparator,
+                sortKeySelector,
+                rankType,
+                rankRange,
+                generateUpdateBefore,
+                outputRankNumber);
+    }
+
+    @Override
+    @Test
+    public void testDisableGenerateUpdateBefore() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12));
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(insertRecord("fruit", 1L, 33));
+        expectedOutput.add(insertRecord("fruit", 1L, 44));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    @Test
+    public void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+        expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+        expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+        expectedOutput.add(insertRecord("fruit", 1L, 44, 2L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    @Test
+    public void testOutputRankNumberWithConstantRankRange() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+        expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+        expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+        expectedOutput.add(insertRecord("fruit", 1L, 44, 2L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    @Test
+    public void testConstantRankRangeWithOffset() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(2, 2), true, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12));
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(insertRecord("fruit", 1L, 33));
+        expectedOutput.add(insertRecord("fruit", 1L, 44));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    @Test
+    public void testConstantRankRangeWithoutOffset() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12));
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(insertRecord("fruit", 1L, 33));
+        expectedOutput.add(insertRecord("fruit", 1L, 44));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    @Test
+    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), false, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 33));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(insertRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+        expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+        expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fetching first N rows is a special case of TopN, which currently is supported by the Rank operator. However, the full-fledged TopN implementation is heavyweight in that it involves sort key comparison and raw row buffering. This leads to large state and memory buffer that is not needed for the first-n-row case. This PR introduces a lightweight variant of TopN function to handle it more efficiently. 

## Brief change log

  -  Add `AppendOnlyFirstNFunction` as a variant of AppendOnlyTopNFunction
  -  Modify `StreamExecRank` to instantiate `AppendOnlyFirstNFunciton` when the first-n-row case is determined  

## Verifying this change

This change added tests and can be verified as follows:

  -  Added unit tests in`AppendOnlyFirstNFunctionTest` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
