### PR TITLE
[hotfix] Fix dependency version of flink-test-utils

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -74,7 +74,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-			<version>1.12-SNAPSHOT</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Use ${project.version} for the version of flink-test-utils instead of 1.12-SNAPSHOT