### PR TITLE
[FLINK-19953] Translation in docs/ops/memory/mem_setup.zh.md

### DIFF
--- a/docs/ops/memory/mem_setup.zh.md
+++ b/docs/ops/memory/mem_setup.zh.md
@@ -30,7 +30,7 @@ Apache Flink 基于 JVM 的高效处理能力，依赖于其对各组件内存�
 {:toc}
 
 本文接下来介绍的内存配置方法适用于 *1.10* 及以上版本的 TaskManager 进程和 *1.11* 及以上版本的 JobManager 进程。
-Flink 在 *1.10* 和 *1.11* 版本中对内存配置部分进行了较大幅度的改动，从早期版本升级的用户请参考[升级指南](mem_migration.html)。
+Flink 在 *1.10* 和 *1.11* 版本中对内存配置部分进行了较大幅度的改动，从早期版本升级的用户请参考[升级指南]({% link ops/memory/mem_migration.zh.md %})。
 
 <a name="configure-total-memory" />
 
@@ -41,7 +41,7 @@ Flink JVM 进程的*进程总内存（Total Process Memory）*包含了由 Flink
 其中堆外内存包括*直接内存（Direct Memory）*和*本地内存（Native Memory）*。
 
 <center>
-  <img src="{{ site.baseurl }}/fig/process_mem_model.svg" width="300px" alt="Flink's process memory model" usemap="#process-mem-model">
+  <img src="{% link /fig/process_mem_model.svg %}" width="300px" alt="Flink's process memory model" usemap="#process-mem-model">
 </center>
 <br />
 
@@ -49,27 +49,27 @@ Flink JVM 进程的*进程总内存（Total Process Memory）*包含了由 Flink
 
 | &nbsp;&nbsp;**配置项**&nbsp;&nbsp; | &nbsp;&nbsp;**TaskManager 配置参数**&nbsp;&nbsp;                                 | &nbsp;&nbsp;**JobManager 配置参数**&nbsp;&nbsp;                                |
 | :------------------------------------ | :---------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
-| Flink 总内存                    | [`taskmanager.memory.flink.size`](../config.html#taskmanager-memory-flink-size)     | [`jobmanager.memory.flink.size`](../config.html#jobmanager-memory-flink-size)     |
-| 进程总内存                  | [`taskmanager.memory.process.size`](../config.html#taskmanager-memory-process-size) | [`jobmanager.memory.process.size`](../config.html#jobmanager-memory-process-size) |
+| Flink 总内存                    | [`taskmanager.memory.flink.size`]({% link ops/config.zh.md %}#taskmanager-memory-flink-size)     | [`jobmanager.memory.flink.size`]({% link ops/config.zh.md %}#jobmanager-memory-flink-size)     |
+| 进程总内存                  | [`taskmanager.memory.process.size`]({% link ops/config.zh.md %}#taskmanager-memory-process-size) | [`jobmanager.memory.process.size`]({% link ops/config.zh.md %}#jobmanager-memory-process-size) |
 {:.table-bordered}
 <br/>
 
 <span class="label label-info">提示</span>
-关于本地执行，请分别参考 [TaskManager](mem_setup_tm.html#local-execution) 和 [JobManager](mem_setup_jobmanager.html#local-execution) 的相关文档。
+关于本地执行，请分别参考 [TaskManager]({% link ops/memory/mem_setup_tm.zh.md %}#local-execution) 和 [JobManager]({% link ops/memory/mem_setup_jobmanager.zh.md %}#local-execution) 的相关文档。
 
 Flink 会根据默认值或其他配置参数自动调整剩余内存部分的大小。
-关于各内存部分的更多细节，请分别参考 [TaskManager](mem_setup_tm.html) 和 [JobManager](mem_setup_jobmanager.html) 的相关文档。
+关于各内存部分的更多细节，请分别参考 [TaskManager]({% link ops/memory/mem_setup_tm.zh.md %}) 和 [JobManager]({% link ops/memory/mem_setup_jobmanager.zh.md %}) 的相关文档。
 
-对于[独立部署模式（Standalone Deployment）](../deployment/cluster_setup.html)，如果你希望指定由 Flink 应用本身使用的内存大小，最好选择配置 *Flink 总内存*。
+对于[独立部署模式（Standalone Deployment）]({% link ops/deployment/cluster_setup.zh.md %})，如果你希望指定由 Flink 应用本身使用的内存大小，最好选择配置 *Flink 总内存*。
 *Flink 总内存*会进一步划分为 *JVM 堆内存*和*堆外内存*。
-更多详情请参考[如何为独立部署模式配置内存](mem_tuning.html#configure-memory-for-standalone-deployment)。
+更多详情请参考[如何为独立部署模式配置内存]({% link ops/memory/mem_tuning.zh.md %}#configure-memory-for-standalone-deployment)。
 
 通过配置*进程总内存*可以指定由 Flink *JVM 进程*使用的总内存大小。
-对于容器化部署模式（Containerized Deployment），这相当于申请的容器（Container）大小，详情请参考[如何配置容器内存](mem_tuning.html#configure-memory-for-containers)（[Kubernetes](../deployment/kubernetes.html)、[Yarn](../deployment/yarn_setup.html) 或 [Mesos](../deployment/mesos.html)）。
+对于容器化部署模式（Containerized Deployment），这相当于申请的容器（Container）大小，详情请参考[如何配置容器内存]({% link ops/memory/mem_tuning.zh.md %}#configure-memory-for-containers)（[Kubernetes]({% link ops/deployment/kubernetes.zh.md %})、[Yarn]({% link ops/deployment/yarn_setup.zh.md %}) 或 [Mesos]({% link ops/deployment/mesos.zh.md %})）。
 
 此外，还可以通过设置 *Flink 总内存*的特定内部组成部分的方式来进行内存配置。
 不同进程需要设置的内存组成部分是不一样的。
-详情请分别参考 [TaskManager](mem_setup_tm.html#configure-heap-and-managed-memory) 和 [JobManager](mem_setup_jobmanager.html#configure-jvm-heap) 的相关文档。
+详情请分别参考 [TaskManager]({% link ops/memory/mem_setup_tm.zh.md %}#configure-heap-and-managed-memory) 和 [JobManager]({% link ops/memory/mem_setup_jobmanager.zh.md %}#configure-jvm-heap) 的相关文档。
 
 <span class="label label-info">提示</span>
 以上三种方式中，用户需要至少选择其中一种进行配置（本地运行除外），否则 Flink 将无法启动。
@@ -77,9 +77,9 @@ Flink 会根据默认值或其他配置参数自动调整剩余内存部分的�
 
 | &nbsp;&nbsp;**TaskManager:**&nbsp;&nbsp;                                                                                                                                        | &nbsp;&nbsp;**JobManager:**&nbsp;&nbsp;                                      |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------- |
-| [`taskmanager.memory.flink.size`](../config.html#taskmanager-memory-flink-size)                                                                                                       | [`jobmanager.memory.flink.size`](../config.html#jobmanager-memory-flink-size)     |
-| [`taskmanager.memory.process.size`](../config.html#taskmanager-memory-process-size)                                                                                                   | [`jobmanager.memory.process.size`](../config.html#jobmanager-memory-process-size) |
-| [`taskmanager.memory.task.heap.size`](../config.html#taskmanager-memory-task-heap-size) 和 <br/> [`taskmanager.memory.managed.size`](../config.html#taskmanager-memory-managed-size) | [`jobmanager.memory.heap.size`](../config.html#jobmanager-memory-heap-size)       |
+| [`taskmanager.memory.flink.size`]({% link ops/config.zh.md %}#taskmanager-memory-flink-size)                                                                                                       | [`jobmanager.memory.flink.size`]({% link ops/config.zh.md %}#jobmanager-memory-flink-size)     |
+| [`taskmanager.memory.process.size`]({% link ops/config.zh.md %}#taskmanager-memory-process-size)                                                                                                   | [`jobmanager.memory.process.size`]({% link ops/config.zh.md %}#jobmanager-memory-process-size) |
+| [`taskmanager.memory.task.heap.size`]({% link ops/config.zh.md %}#taskmanager-memory-task-heap-size) 和 <br/> [`taskmanager.memory.managed.size`]({% link ops/config.zh.md %}#taskmanager-memory-managed-size) | [`jobmanager.memory.heap.size`]({% link ops/config.zh.md %}#jobmanager-memory-heap-size)       |
 {:.table-bordered}
 <br/>
 
@@ -101,14 +101,14 @@ Flink 进程启动时，会根据配置的和自动推导出的各内存部分�
 | *-XX:MaxMetaspaceSize*                    | JVM Metaspace                                      | JVM Metaspace                                     |
 {:.table-bordered}
 (\*) Keep in mind that you might not be able to use the full amount of heap memory depending on the GC algorithm used. Some GC algorithms allocate a certain amount of heap memory for themselves. 
-This will lead to a different maximum being returned by the [Heap metrics](../../monitoring/metrics.html#memory).
+This will lead to a different maximum being returned by the [Heap metrics]({% link monitoring/metrics.zh.md %}#memory).
 <br/>
 (\*\*) 请注意，堆外内存也包括了用户代码使用的本地内存（非直接内存）。
 <br/>
-(\*\*\*) 只有在 [`jobmanager.memory.enable-jvm-direct-memory-limit`](../config.html#jobmanager-memory-enable-jvm-direct-memory-limit) 设置为 `true` 时，JobManager 才会设置 *JVM 直接内存限制*。
+(\*\*\*) 只有在 [`jobmanager.memory.enable-jvm-direct-memory-limit`]({% link ops/config.zh.md %}#jobmanager-memory-enable-jvm-direct-memory-limit) 设置为 `true` 时，JobManager 才会设置 *JVM 直接内存限制*。
 <br/><br/>
 
-相关内存部分的配置方法，请同时参考 [TaskManager](mem_setup_tm.html#detailed-memory-model) 和 [JobManager](mem_setup_jobmanager.html#detailed-configuration) 的详细内存模型。
+相关内存部分的配置方法，请同时参考 [TaskManager]({% link ops/memory/mem_setup_tm.zh.md %}#detailed-memory-model) 和 [JobManager]({% link ops/memory/mem_setup_jobmanager.zh.md %}#detailed-configuration) 的详细内存模型。
 
 <a name="capped-fractionated-components" />
 
@@ -118,7 +118,7 @@ This will lead to a different maximum being returned by the [Heap metrics](../..
 * *JVM 开销*：可以配置占用*进程总内存*的固定比例
 * *网络内存*：可以配置占用 *Flink 总内存*的固定比例（仅针对 TaskManager）
 
-相关内存部分的配置方法，请同时参考 [TaskManager](mem_setup_tm.html#detailed-memory-model) 和 [JobManager](mem_setup_jobmanager.html#detailed-configuration) 的详细内存模型。
+相关内存部分的配置方法，请同时参考 [TaskManager]({% link ops/memory/mem_setup_tm.zh.md %}#detailed-memory-model) 和 [JobManager]({% link ops/memory/mem_setup_jobmanager.zh.md %}#detailed-configuration) 的详细内存模型。
 
 这些内存部分的大小必须在相应的最大值、最小值范围内，否则 Flink 将无法启动。
 最大值、最小值具有默认值，也可以通过相应的配置参数进行设置。

--- a/docs/ops/memory/mem_setup.zh.md
+++ b/docs/ops/memory/mem_setup.zh.md
@@ -100,8 +100,7 @@ Flink 进程启动时，会根据配置的和自动推导出的各内存部分�
 | *-XX:MaxDirectMemorySize*<br/>（TaskManager 始终设置，JobManager 见注释）                 | 框架堆外内存 + 任务堆外内存(\*\*) + 网络内存     | 堆外内存 (\*\*) (\*\*\*)                               |
 | *-XX:MaxMetaspaceSize*                    | JVM Metaspace                                      | JVM Metaspace                                     |
 {:.table-bordered}
-(\*) Keep in mind that you might not be able to use the full amount of heap memory depending on the GC algorithm used. Some GC algorithms allocate a certain amount of heap memory for themselves. 
-This will lead to a different maximum being returned by the [Heap metrics]({% link monitoring/metrics.zh.md %}#memory).
+(\*) 请记住，根据所使用的 GC 算法，你可能无法使用到全部堆内存。一些 GC 算法会为它们自身分配一定量的堆内存。这会导致[堆的指标]({% link monitoring/metrics.zh.md %}#memory)返回一个不同的最大值。
 <br/>
 (\*\*) 请注意，堆外内存也包括了用户代码使用的本地内存（非直接内存）。
 <br/>


### PR DESCRIPTION

## What is the purpose of the change

Translate docs/ops/memory/mem_setup.zh.md according to [FLINK-19904](https://github.com/apache/flink/commit/c6043a5f0e190a196d5407c4497f42fe9c905f33)


## Brief change log

- Translate the new sentence.
- Change link format

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
