### PR TITLE
[FLINK-19972][serialization] add more hints in case of serializer incompatbilities

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -134,12 +135,16 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 				serializationProxy.read(inView);
 
 				if (!keySerializerRestored) {
+					// fetch current serializer now because if it is incompatible, we can't access
+					// it anymore to improve the error message
+					TypeSerializer<K> currentSerializer =
+						keySerializerProvider.currentSchemaSerializer();
 					// check for key serializer compatibility; this also reconfigures the
 					// key serializer to be compatible, if it is required and is possible
 					TypeSerializerSchemaCompatibility<K> keySerializerSchemaCompat =
 						keySerializerProvider.setPreviousSerializerSnapshotForRestoredState(serializationProxy.getKeySerializerSnapshot());
 					if (keySerializerSchemaCompat.isCompatibleAfterMigration() || keySerializerSchemaCompat.isIncompatible()) {
-						throw new StateMigrationException("The new key serializer must be compatible.");
+						throw new StateMigrationException("The new key serializer (" + currentSerializer + ") must be compatible with the previous key serializer (" + keySerializerProvider.previousSchemaSerializer() + ").");
 					}
 
 					keySerializerRestored = true;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -568,19 +568,28 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		@SuppressWarnings("unchecked")
 		RegisteredKeyValueStateBackendMetaInfo<N, SV> restoredKvStateMetaInfo = oldStateInfo.f1;
 
+		// fetch current serializer now because if it is incompatible, we can't access
+		// it anymore to improve the error message
+		TypeSerializer<N> previousNamespaceSerializer =
+			restoredKvStateMetaInfo.getNamespaceSerializer();
+
 		TypeSerializerSchemaCompatibility<N> s = restoredKvStateMetaInfo.updateNamespaceSerializer(namespaceSerializer);
 		if (s.isCompatibleAfterMigration() || s.isIncompatible()) {
-			throw new StateMigrationException("The new namespace serializer must be compatible.");
+			throw new StateMigrationException("The new namespace serializer (" + namespaceSerializer + ") must be compatible with the old namespace serializer (" + previousNamespaceSerializer + ").");
 		}
 
 		restoredKvStateMetaInfo.checkStateMetaInfo(stateDesc);
+
+		// fetch current serializer now because if it is incompatible, we can't access
+		// it anymore to improve the error message
+		TypeSerializer<SV> previousStateSerializer = restoredKvStateMetaInfo.getStateSerializer();
 
 		TypeSerializerSchemaCompatibility<SV> newStateSerializerCompatibility =
 			restoredKvStateMetaInfo.updateStateSerializer(stateSerializer);
 		if (newStateSerializerCompatibility.isCompatibleAfterMigration()) {
 			migrateStateValues(stateDesc, oldStateInfo);
 		} else if (newStateSerializerCompatibility.isIncompatible()) {
-			throw new StateMigrationException("The new state serializer cannot be incompatible.");
+			throw new StateMigrationException("The new state serializer (" + stateSerializer + ") must not be incompatible with the old state serializer (" + previousStateSerializer + ").");
 		}
 
 		return restoredKvStateMetaInfo;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state.restore;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
@@ -186,12 +187,16 @@ public abstract class AbstractRocksDBRestoreOperation<K> implements RocksDBResto
 			new KeyedBackendSerializationProxy<>(userCodeClassLoader);
 		serializationProxy.read(dataInputView);
 		if (!isKeySerializerCompatibilityChecked) {
+			// fetch current serializer now because if it is incompatible, we can't access
+			// it anymore to improve the error message
+			TypeSerializer<K> currentSerializer =
+				keySerializerProvider.currentSchemaSerializer();
 			// check for key serializer compatibility; this also reconfigures the
 			// key serializer to be compatible, if it is required and is possible
 			TypeSerializerSchemaCompatibility<K> keySerializerSchemaCompat =
 				keySerializerProvider.setPreviousSerializerSnapshotForRestoredState(serializationProxy.getKeySerializerSnapshot());
 			if (keySerializerSchemaCompat.isCompatibleAfterMigration() || keySerializerSchemaCompat.isIncompatible()) {
-				throw new StateMigrationException("The new key serializer must be compatible.");
+				throw new StateMigrationException("The new key serializer (" + currentSerializer + ") must be compatible with the previous key serializer (" + keySerializerProvider.previousSchemaSerializer() + ").");
 			}
 
 			isKeySerializerCompatibilityChecked = true;


### PR DESCRIPTION
## What is the purpose of the change

This PR improves the exceptions which are thrown when the key/namespace/state type serializers are not compatible any more and the user has to figure out what went wrong.

## Brief change log

Enhance the exception messages to include both the old serializer's `toString()` representation as well as the new one's

## Verifying this change

This change is a trivial rework or error messages without any test coverage.

I verified it locally for the memory state back-end.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **partially**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/13927)
<!-- Reviewable:end -->
