### PR TITLE
[hotfix] Do not emit EndOfChannelRecoveryEvent for Approximate Local …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
 
+import java.io.IOException;
+
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -90,6 +92,11 @@ public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
 			isBlocked = false;
 			sequenceNumber = 0;
 		}
+	}
+
+	@Override
+	public void finishReadRecoveredState(boolean notifyAndBlockOnCompletion) throws IOException {
+		// The Approximate Local Recovery can not work with unaligned checkpoint for now, so no need to recover channel state
 	}
 
 	/** for testing only. */


### PR DESCRIPTION
…Recovery

## What is the purpose of the change

This PR is to disable emitting EndOfChannelRecoveryEvent for Approximate Local Recovery. EndOfChannelRecoveryEvent is introduced in [FLINK-19856][network] Emit EndOfChannelRecoveryEvent.

There is a problem if only part of the graph (not the entire graph) is restarted:

source  -> map (1/2) -> sink
             -> map (2/2) ->

Let's say map(1/2) fails and only "map (1/2) -> sink" would restart. There is no way map (2/2) can send the EndOfChannelRecoveryEvent to the sink, because map (2/2)'s produced partition does not fail.

In this case, sink would fail to send resume consumption notification back to map (1/2) because it waits for map (2/2) to send the EndOfChannelRecoveryEvent, which will never happen. 

## Brief change log
Override `finishReadRecoveredState` method in PipelinedApproximateSubpartition to do nothing.


## Verifying this change

ITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)