### PR TITLE
[FLINK-17295] Make ExecutionAttemptID random again

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -49,7 +49,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
@@ -101,7 +100,7 @@ public class SavepointEnvironment implements Environment {
 	private SavepointEnvironment(RuntimeContext ctx, Configuration configuration, int maxParallelism, int indexOfSubtask, PrioritizedOperatorSubtaskState prioritizedOperatorSubtaskState) {
 		this.jobID = new JobID();
 		this.vertexID = new JobVertexID();
-		this.attemptID = new ExecutionAttemptID(jobID, new ExecutionVertexID(vertexID, 0), 0);
+		this.attemptID = new ExecutionAttemptID();
 		this.ctx = Preconditions.checkNotNull(ctx);
 		this.configuration = Preconditions.checkNotNull(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -217,7 +217,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 		this.executor = checkNotNull(executor);
 		this.vertex = checkNotNull(vertex);
-		this.attemptId = new ExecutionAttemptID(vertex.getJobId(), vertex.getID(), attemptNumber);
+		this.attemptId = new ExecutionAttemptID();
 		this.rpcTimeout = checkNotNull(rpcTimeout);
 
 		this.globalModVersion = globalModVersion;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
@@ -19,14 +19,10 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.util.AbstractID;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.util.Preconditions;
 
-import java.util.Objects;
 
 /**
  * Unique identifier for the attempt to execute a tasks. Multiple attempts happen
@@ -36,62 +32,30 @@ public class ExecutionAttemptID implements java.io.Serializable {
 
 	private static final long serialVersionUID = -1169683445778281344L;
 
-	private final JobID jobId;
-	private final ExecutionVertexID executionVertexId;
-	private final int attemptNumber;
+	private final AbstractID executonAttemptId;
 
-	/**
-	 * Get a random execution attempt id.
-	 */
 	public ExecutionAttemptID() {
-		this(new JobID(), new ExecutionVertexID(new JobVertexID(), 0), 0);
+		this(new AbstractID());
 	}
 
-	public ExecutionAttemptID(JobID jobId, ExecutionVertexID executionVertexId, int attemptNumber) {
-		Preconditions.checkState(attemptNumber >= 0);
-		this.jobId = Preconditions.checkNotNull(jobId);
-		this.executionVertexId = Preconditions.checkNotNull(executionVertexId);
-		this.attemptNumber = attemptNumber;
+	private ExecutionAttemptID(AbstractID id) {
+		this.executonAttemptId = id;
+	}
+
+	@VisibleForTesting
+	public ExecutionAttemptID(ExecutionAttemptID toCopy) {
+		this.executonAttemptId = new AbstractID(toCopy.executonAttemptId);
 	}
 
 	public void writeTo(ByteBuf buf) {
-		writeJobIdTo(buf);
-		executionVertexId.writeTo(buf);
-		buf.writeInt(this.attemptNumber);
+		buf.writeLong(this.executonAttemptId.getLowerPart());
+		buf.writeLong(this.executonAttemptId.getUpperPart());
 	}
 
 	public static ExecutionAttemptID fromByteBuf(ByteBuf buf) {
-		final JobID jobId = jobIdFromByteBuf(buf);
-		final ExecutionVertexID executionVertexId = ExecutionVertexID.fromByteBuf(buf);
-		final int attemptNumber = buf.readInt();
-		return new ExecutionAttemptID(jobId, executionVertexId, attemptNumber);
+		return new ExecutionAttemptID(new AbstractID(buf.readLong(), buf.readLong()));
 	}
 
-	private static JobID jobIdFromByteBuf(ByteBuf buf) {
-		final long lower = buf.readLong();
-		final long upper = buf.readLong();
-		return new JobID(lower, upper);
-	}
-
-	private void writeJobIdTo(ByteBuf buf) {
-		buf.writeLong(jobId.getLowerPart());
-		buf.writeLong(jobId.getUpperPart());
-	}
-
-	@VisibleForTesting
-	public int getAttemptNumber() {
-		return attemptNumber;
-	}
-
-	@VisibleForTesting
-	public ExecutionVertexID getExecutionVertexId() {
-		return executionVertexId;
-	}
-
-	@VisibleForTesting
-	public JobID getJobId() {
-		return jobId;
-	}
 
 	@Override
 	public boolean equals(Object obj) {
@@ -99,9 +63,7 @@ public class ExecutionAttemptID implements java.io.Serializable {
 			return true;
 		} else if (obj != null && obj.getClass() == getClass()) {
 			ExecutionAttemptID that = (ExecutionAttemptID) obj;
-			return that.jobId.equals(this.jobId)
-				&& that.executionVertexId.equals(this.executionVertexId)
-				&& that.attemptNumber == this.attemptNumber;
+			return that.executonAttemptId.equals(this.executonAttemptId);
 		} else {
 			return false;
 		}
@@ -109,11 +71,12 @@ public class ExecutionAttemptID implements java.io.Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(jobId, executionVertexId, attemptNumber);
+		return executonAttemptId.hashCode();
 	}
 
 	@Override
 	public String toString() {
-		return jobId.toString() + "_" + executionVertexId.toString() + "_" + attemptNumber;
+		return executonAttemptId.toString();
 	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionAttemptID.java
@@ -32,24 +32,24 @@ public class ExecutionAttemptID implements java.io.Serializable {
 
 	private static final long serialVersionUID = -1169683445778281344L;
 
-	private final AbstractID executonAttemptId;
+	private final AbstractID executionAttemptId;
 
 	public ExecutionAttemptID() {
 		this(new AbstractID());
 	}
 
 	private ExecutionAttemptID(AbstractID id) {
-		this.executonAttemptId = id;
+		this.executionAttemptId = id;
 	}
 
 	@VisibleForTesting
 	public ExecutionAttemptID(ExecutionAttemptID toCopy) {
-		this.executonAttemptId = new AbstractID(toCopy.executonAttemptId);
+		this.executionAttemptId = new AbstractID(toCopy.executionAttemptId);
 	}
 
 	public void writeTo(ByteBuf buf) {
-		buf.writeLong(this.executonAttemptId.getLowerPart());
-		buf.writeLong(this.executonAttemptId.getUpperPart());
+		buf.writeLong(this.executionAttemptId.getLowerPart());
+		buf.writeLong(this.executionAttemptId.getUpperPart());
 	}
 
 	public static ExecutionAttemptID fromByteBuf(ByteBuf buf) {
@@ -63,7 +63,7 @@ public class ExecutionAttemptID implements java.io.Serializable {
 			return true;
 		} else if (obj != null && obj.getClass() == getClass()) {
 			ExecutionAttemptID that = (ExecutionAttemptID) obj;
-			return that.executonAttemptId.equals(this.executonAttemptId);
+			return that.executionAttemptId.equals(this.executionAttemptId);
 		} else {
 			return false;
 		}
@@ -71,12 +71,12 @@ public class ExecutionAttemptID implements java.io.Serializable {
 
 	@Override
 	public int hashCode() {
-		return executonAttemptId.hashCode();
+		return executionAttemptId.hashCode();
 	}
 
 	@Override
 	public String toString() {
-		return executonAttemptId.toString();
+		return executionAttemptId.toString();
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -512,7 +512,7 @@ public abstract class NettyMessage {
 			ByteBuf result = null;
 
 			try {
-				result = allocateBuffer(allocator, ID, 20 + 40 + 4 + 16 + 4);
+				result = allocateBuffer(allocator, ID, 20 + 16 + 4 + 16 + 4);
 
 				partitionId.getPartitionId().writeTo(result);
 				partitionId.getProducerId().writeTo(result);
@@ -573,7 +573,7 @@ public abstract class NettyMessage {
 				// TODO Directly serialize to Netty's buffer
 				ByteBuffer serializedEvent = EventSerializer.toSerializedEvent(event);
 
-				result = allocateBuffer(allocator, ID, 4 + serializedEvent.remaining() + 20 + 40 + 16);
+				result = allocateBuffer(allocator, ID, 4 + serializedEvent.remaining() + 20 + 16 + 16);
 
 				result.writeInt(serializedEvent.remaining());
 				result.writeBytes(serializedEvent);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1655,7 +1655,7 @@ public class JobMasterTest extends TestLogger {
 			final ResultPartitionDeploymentDescriptor partition = tdd.getProducedPartitions().iterator().next();
 
 			final ExecutionAttemptID executionAttemptId = tdd.getExecutionAttemptId();
-			final ExecutionAttemptID copiedExecutionAttemptId = new ExecutionAttemptID(executionAttemptId.getJobId(), executionAttemptId.getExecutionVertexId(), executionAttemptId.getAttemptNumber());
+			final ExecutionAttemptID copiedExecutionAttemptId = new ExecutionAttemptID(executionAttemptId);
 
 			// finish the producer task
 			jobMasterGateway.updateTaskExecutionState(new TaskExecutionState(producerConsumerJobGraph.getJobID(), executionAttemptId, ExecutionState.FINISHED)).get();


### PR DESCRIPTION
## What is the purpose of the change

Note: This is a follow up/alternative pull request to https://github.com/apache/flink/pull/13892.

While debugging FLINK-19805, we noticed that re-using the exact same ExecutionAttemptID across multiple leader sessions can lead to severe inconsistencies in the system. This PR makes the ExecutionAttemptID fully random again.