### PR TITLE
[FLINK-19947][Connectors / Common]Support sink parallelism configuration for Print connector

### DIFF
--- a/docs/dev/table/connectors/print.md
+++ b/docs/dev/table/connectors/print.md
@@ -139,5 +139,12 @@ Connector Options
       <td>Boolean</td>
       <td>True, if the format should print to standard error instead of standard out.</td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the Print sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
+    </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/print.zh.md
+++ b/docs/dev/table/connectors/print.zh.md
@@ -139,5 +139,12 @@ LIKE source_table (EXCLUDING ALL)
       <td>Boolean</td>
       <td>如果 format 需要打印为标准错误而不是标准输出，则为 True 。</td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>为 Print sink operator 定义并行度。默认情况下，并行度由框架决定，和链在一起的上游 operator 一致。</td>
+    </tr>
     </tbody>
 </table>

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
@@ -33,6 +33,8 @@ import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
+import javax.annotation.Nullable;
+
 import java.util.HashSet;
 import java.util.Set;
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
@@ -105,7 +105,7 @@ public class PrintTableSinkFactory implements DynamicTableSinkFactory {
 		private final DataType type;
 		private final String printIdentifier;
 		private final boolean stdErr;
-		private final Integer parallelism;
+		private final @Nullable Integer parallelism;
 
 		private PrintSink(DataType type, String printIdentifier, boolean stdErr, Integer parallelism) {
 			this.type = type;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/PrintConnectorITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/PrintConnectorITCase.java
@@ -35,6 +35,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -89,7 +90,7 @@ public class PrintConnectorITCase extends StreamingTestBase {
 				"'standard-error'='false')");
 		DataType type = tEnv().from("print_t").getSchema().toRowDataType();
 		Row row = Row.of(1, 1.1);
-		tEnv().fromValues(type, Arrays.asList(row)).executeInsert("print_t").await();
+		tEnv().fromValues(type, Collections.singleton(row)).executeInsert("print_t").await();
 
 		String expectedLine1 = "test_print:1> +I(" +
 			/* 0 */ "1," +


### PR DESCRIPTION

## What is the purpose of the change

Support sink parallelism configuration for Print connector


## Brief change log
 - Support sink parallelism configuration for Print connector

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
