### PR TITLE
[FLINK-19946][Connectors / HBase]Support sink parallelism configuration for Hbase connector

### DIFF
--- a/docs/dev/table/connectors/hbase.md
+++ b/docs/dev/table/connectors/hbase.md
@@ -165,6 +165,13 @@ Connector Options
       can be set to <code>'0'</code> with the flush interval set allowing for complete async processing of buffered actions.
       </td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>Defines the parallelism of the HBase sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/hbase.zh.md
+++ b/docs/dev/table/connectors/hbase.zh.md
@@ -158,6 +158,13 @@ ON myTopic.key = hTable.rowkey;
       <td>写入的参数选项。刷写缓存行的间隔。它能提升写入 HBase 数据库的性能，但是也可能增加延迟。设置为 "0" 关闭此选项。注意："sink.buffer-flush.max-size" 和 "sink.buffer-flush.max-rows" 同时设置为 "0"，刷写选项整个异步处理缓存行为。
       </td>
     </tr>
+    <tr>
+      <td><h5>sink.parallelism</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>为 HBase sink operator 定义并行度。默认情况下，并行度由框架决定，和链在一起的上游 operator 一样。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.flink.table.factories.FactoryUtil.createTableFactoryHelper;
 
 /**
@@ -138,6 +139,7 @@ public class HBase1DynamicTableFactory implements DynamicTableSourceFactory, Dyn
 		writeBuilder.setBufferFlushMaxSizeInBytes(helper.getOptions().get(SINK_BUFFER_FLUSH_MAX_SIZE).getBytes());
 		writeBuilder.setBufferFlushIntervalMillis(helper.getOptions().get(SINK_BUFFER_FLUSH_INTERVAL).toMillis());
 		writeBuilder.setBufferFlushMaxRows(helper.getOptions().get(SINK_BUFFER_FLUSH_MAX_ROWS));
+		writeBuilder.setParallelism(helper.getOptions().getOptional(SINK_PARALLELISM).orElse(null));
 		String nullStringLiteral = helper.getOptions().get(NULL_STRING_LITERAL);
 		HBaseTableSchema hbaseSchema = HBaseTableSchema.fromTableSchema(tableSchema);
 
@@ -169,6 +171,7 @@ public class HBase1DynamicTableFactory implements DynamicTableSourceFactory, Dyn
 		set.add(SINK_BUFFER_FLUSH_MAX_SIZE);
 		set.add(SINK_BUFFER_FLUSH_MAX_ROWS);
 		set.add(SINK_BUFFER_FLUSH_INTERVAL);
+		set.add(SINK_PARALLELISM);
 		return set;
 	}
 

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/sink/HBaseDynamicTableSink.java
@@ -69,7 +69,7 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
 			writeOptions.getBufferFlushMaxSizeInBytes(),
 			writeOptions.getBufferFlushMaxRows(),
 			writeOptions.getBufferFlushIntervalMillis());
-		return SinkFunctionProvider.of(sinkFunction);
+		return SinkFunctionProvider.of(sinkFunction, writeOptions.getParallelism());
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseDynamicTableFactoryTest.java
@@ -30,11 +30,13 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.ExceptionUtils;
@@ -208,6 +210,23 @@ public class HBaseDynamicTableFactoryTest {
 			.build();
 		HBaseWriteOptions actual = ((HBaseDynamicTableSink) sink).getWriteOptions();
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testParallelismOptions() {
+		Map<String, String> options = getAllOptions();
+		options.put("sink.parallelism", "2");
+
+		TableSchema schema = TableSchema.builder()
+			.field(ROWKEY, STRING())
+			.build();
+
+		DynamicTableSink sink = createTableSink(schema, options);
+		assertTrue(sink instanceof HBaseDynamicTableSink);
+		HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
+		SinkFunctionProvider provider = (SinkFunctionProvider) hbaseSink.getSinkRuntimeProvider(
+			new SinkRuntimeProviderContext(false));
+		assertEquals(2, (long) provider.getParallelism().get());
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
@@ -40,6 +40,7 @@ import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.flink.table.factories.FactoryUtil.createTableFactoryHelper;
 
 /**
@@ -131,6 +132,7 @@ public class HBase2DynamicTableFactory implements DynamicTableSourceFactory, Dyn
 		writeBuilder.setBufferFlushMaxSizeInBytes(helper.getOptions().get(SINK_BUFFER_FLUSH_MAX_SIZE).getBytes());
 		writeBuilder.setBufferFlushIntervalMillis(helper.getOptions().get(SINK_BUFFER_FLUSH_INTERVAL).toMillis());
 		writeBuilder.setBufferFlushMaxRows(helper.getOptions().get(SINK_BUFFER_FLUSH_MAX_ROWS));
+		writeBuilder.setParallelism(helper.getOptions().getOptional(SINK_PARALLELISM).orElse(null));
 		String nullStringLiteral = helper.getOptions().get(NULL_STRING_LITERAL);
 		HBaseTableSchema hbaseSchema = HBaseTableSchema.fromTableSchema(tableSchema);
 
@@ -163,6 +165,7 @@ public class HBase2DynamicTableFactory implements DynamicTableSourceFactory, Dyn
 		set.add(SINK_BUFFER_FLUSH_MAX_SIZE);
 		set.add(SINK_BUFFER_FLUSH_MAX_ROWS);
 		set.add(SINK_BUFFER_FLUSH_INTERVAL);
+		set.add(SINK_PARALLELISM);
 		return set;
 	}
 

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/sink/HBaseDynamicTableSink.java
@@ -67,7 +67,7 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
 			writeOptions.getBufferFlushMaxSizeInBytes(),
 			writeOptions.getBufferFlushMaxRows(),
 			writeOptions.getBufferFlushIntervalMillis());
-		return SinkFunctionProvider.of(sinkFunction);
+		return SinkFunctionProvider.of(sinkFunction, writeOptions.getParallelism());
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
@@ -29,11 +29,13 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.ExceptionUtils;
@@ -199,6 +201,23 @@ public class HBaseDynamicTableFactoryTest {
 			.build();
 		HBaseWriteOptions actual = ((HBaseDynamicTableSink) sink).getWriteOptions();
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testParallelismOptions() {
+		Map<String, String> options = getAllOptions();
+		options.put("sink.parallelism", "2");
+
+		TableSchema schema = TableSchema.builder()
+			.field(ROWKEY, STRING())
+			.build();
+
+		DynamicTableSink sink = createTableSink(schema, options);
+		assertTrue(sink instanceof HBaseDynamicTableSink);
+		HBaseDynamicTableSink hbaseSink = (HBaseDynamicTableSink) sink;
+		SinkFunctionProvider provider = (SinkFunctionProvider) hbaseSink.getSinkRuntimeProvider(
+			new SinkRuntimeProviderContext(false));
+		assertEquals(2, (long) provider.getParallelism().get());
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseWriteOptions.java
@@ -36,14 +36,17 @@ public class HBaseWriteOptions implements Serializable {
 	private final long bufferFlushMaxSizeInBytes;
 	private final long bufferFlushMaxRows;
 	private final long bufferFlushIntervalMillis;
+	private final Integer parallelism;
 
 	private HBaseWriteOptions(
 			long bufferFlushMaxSizeInBytes,
 			long bufferFlushMaxMutations,
-			long bufferFlushIntervalMillis) {
+			long bufferFlushIntervalMillis,
+			Integer parallelism) {
 		this.bufferFlushMaxSizeInBytes = bufferFlushMaxSizeInBytes;
 		this.bufferFlushMaxRows = bufferFlushMaxMutations;
 		this.bufferFlushIntervalMillis = bufferFlushIntervalMillis;
+		this.parallelism = parallelism;
 	}
 
 	public long getBufferFlushMaxSizeInBytes() {
@@ -58,12 +61,17 @@ public class HBaseWriteOptions implements Serializable {
 		return bufferFlushIntervalMillis;
 	}
 
+	public Integer getParallelism() {
+		return parallelism;
+	}
+
 	@Override
 	public String toString() {
 		return "HBaseWriteOptions{" +
 			"bufferFlushMaxSizeInBytes=" + bufferFlushMaxSizeInBytes +
 			", bufferFlushMaxRows=" + bufferFlushMaxRows +
 			", bufferFlushIntervalMillis=" + bufferFlushIntervalMillis +
+			", parallelism=" + parallelism +
 			'}';
 	}
 
@@ -78,12 +86,13 @@ public class HBaseWriteOptions implements Serializable {
 		HBaseWriteOptions that = (HBaseWriteOptions) o;
 		return bufferFlushMaxSizeInBytes == that.bufferFlushMaxSizeInBytes &&
 			bufferFlushMaxRows == that.bufferFlushMaxRows &&
-			bufferFlushIntervalMillis == that.bufferFlushIntervalMillis;
+			bufferFlushIntervalMillis == that.bufferFlushIntervalMillis &&
+			parallelism == that.parallelism;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(bufferFlushMaxSizeInBytes, bufferFlushMaxRows, bufferFlushIntervalMillis);
+		return Objects.hash(bufferFlushMaxSizeInBytes, bufferFlushMaxRows, bufferFlushIntervalMillis, parallelism);
 	}
 
 	/**
@@ -101,6 +110,7 @@ public class HBaseWriteOptions implements Serializable {
 		private long bufferFlushMaxSizeInBytes = ConnectionConfiguration.WRITE_BUFFER_SIZE_DEFAULT;
 		private long bufferFlushMaxRows = 0;
 		private long bufferFlushIntervalMillis = 0;
+		private Integer parallelism;
 
 		/**
 		 * Optional. Sets when to flush a buffered request based on the memory size of rows currently added.
@@ -130,13 +140,23 @@ public class HBaseWriteOptions implements Serializable {
 		}
 
 		/**
+		 * Optional. Defines the parallelism of the JDBC sink operator.
+		 * By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.
+		 */
+		public Builder setParallelism(Integer parallelism) {
+			this.parallelism = parallelism;
+			return this;
+		}
+
+		/**
 		 * Creates a new instance of {@link HBaseWriteOptions}.
 		 */
 		public HBaseWriteOptions build() {
 			return new HBaseWriteOptions(
 				bufferFlushMaxSizeInBytes,
 				bufferFlushMaxRows,
-				bufferFlushIntervalMillis);
+				bufferFlushIntervalMillis,
+				parallelism);
 		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

Support sink parallelism configuration for Hbase connector


## Brief change log

  - Support sink parallelism configuration for Hbase connector

## Verifying this change

This change added tests and can be verified as follows:

  - HBaseDynamicTableFactoryTest#testParallelismOptions
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
