### PR TITLE
[FLINK-19986] Skip license check for scala 2.12 profile

### DIFF
--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -105,9 +105,11 @@ EXIT_CODE=$(($EXIT_CODE+$?))
 check_shaded_artifacts_connector_elasticsearch 6
 EXIT_CODE=$(($EXIT_CODE+$?))
 
-echo "============ Run license check ============" 
+echo "============ Run license check ============"
 
-${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $CI_DIR $(pwd) || exit $?
+if [[ ${PROFILE} != *"scala-2.12"* ]]; then
+  ${CI_DIR}/license_check.sh $MVN_CLEAN_COMPILE_OUT $CI_DIR $(pwd) || exit $?
+fi
 
 exit $EXIT_CODE
 


### PR DESCRIPTION
After adding the license checker, the Scala 2.12 profile failed in the nightly build. Since we are not adjusting the NOTICE files for Scala 2.12, we can skip the check in that profile.

I validated this change in my personal Azure: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8625&view=logs&j=208eba80-6d47-5681-45f9-cb4798d9b139&t=ae1b6704-512c-523e-c96a-3588e44b5903