### PR TITLE
[FLINK-19645][tests] Fix akka rpc timeout issue of ShuffleCompressionITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.test.runtime;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.runtime.execution.Environment;
@@ -81,6 +82,7 @@ public class ShuffleCompressionITCase {
 	public void testDataCompressionForBoundedBlockingShuffle() throws Exception {
 		Configuration configuration = new Configuration();
 		configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, true);
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "60 s");
 
 		JobGraph jobGraph = createJobGraph(
 			ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH);
@@ -92,6 +94,7 @@ public class ShuffleCompressionITCase {
 		Configuration configuration = new Configuration();
 		configuration.setBoolean(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED, true);
 		configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM, 1);
+		configuration.setString(AkkaOptions.ASK_TIMEOUT, "60 s");
 
 		JobGraph jobGraph = createJobGraph(
 			ScheduleMode.LAZY_FROM_SOURCES, ResultPartitionType.BLOCKING, ExecutionMode.BATCH);


### PR DESCRIPTION
## What is the purpose of the change

Fix akka rpc timeout issue of ShuffleCompressionITCase by increasing the timeout configuration.

## Brief change log

  - Fix akka rpc timeout issue of ShuffleCompressionITCase by increasing the timeout configuration.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
