### PR TITLE
[FLINK-19987] Fix Hbase1.4 tests on Hadoop 3.1.3

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -217,6 +217,10 @@ under the License.
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION


## What is the purpose of the change

The Hbase tests were failing in the Hadoop 3.1.3 profile. This was caused by the newly added `org.apache.hbase:hbase-common:jar:tests:1.4.3:test` dependency, which pulls in `com.google.guava:guava:jar:12.0.1:compile`.
I therefore excluded the guava dependency to pull the correct guava dependency which Hadoop needs when running on 3.1.3.




## Verifying this change

I verified this with a Hadoop 3.1.3 build: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8626&view=logs&j=66592496-52df-56bb-d03e-37509e1d9d0f


