### PR TITLE
[FLINK-19990][table-planner-blink] MultipleInputNodeCreationProcessor#isChainableSource now considers DataStreamScanProvider

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessor.java
@@ -18,10 +18,11 @@
 
 package org.apache.flink.table.planner.plan.processors;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
-import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.planner.plan.nodes.common.CommonPhysicalTableSourceScan;
 import org.apache.flink.table.planner.plan.nodes.exec.AbstractExecNodeExactlyOnceVisitor;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
@@ -34,7 +35,6 @@ import org.apache.flink.table.planner.plan.nodes.process.DAGProcessContext;
 import org.apache.flink.table.planner.plan.nodes.process.DAGProcessor;
 import org.apache.flink.table.planner.plan.processors.utils.InputOrderCalculator;
 import org.apache.flink.table.planner.plan.processors.utils.InputPriorityConflictResolver;
-import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.calcite.rel.RelDistribution;
@@ -87,7 +87,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 		// group nodes into multiple input groups
 		createMultipleInputGroups(orderedWrappers);
 		// apply optimizations to remove unnecessary nodes out of multiple input groups
-		optimizeMultipleInputGroups(orderedWrappers);
+		optimizeMultipleInputGroups(orderedWrappers, context);
 
 		// create the real multiple input nodes
 		return createMultipleInputNodes(rootWrappers);
@@ -218,7 +218,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 	// Multiple Input Groups Optimizing
 	// --------------------------------------------------------------------------------
 
-	private void optimizeMultipleInputGroups(List<ExecNodeWrapper> orderedWrappers) {
+	private void optimizeMultipleInputGroups(List<ExecNodeWrapper> orderedWrappers, DAGProcessContext context) {
 		// wrappers are checked in topological order from sources to sinks
 		for (int i = orderedWrappers.size() - 1; i >= 0; i--) {
 			ExecNodeWrapper wrapper = orderedWrappers.get(i);
@@ -238,7 +238,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 				// as we're paying extra function calls for this, unless one of the united
 				// input is a FLIP-27 source
 				shouldRemove = wrapper.inputs.stream().noneMatch(
-					inputWrapper -> isChainableSource(inputWrapper.execNode));
+					inputWrapper -> isChainableSource(inputWrapper.execNode, context));
 			} else if (wrapper.inputs.size() == 1) {
 				// optimization 2. for one-input operators we'll remove it unless its input
 				// is an exchange or a FLIP-27 source, this is mainly to avoid the following
@@ -250,7 +250,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 				// directly shuffling large amount of records from the source without filtering
 				// by the calc
 				ExecNode<?, ?> input = wrapper.inputs.get(0).execNode;
-				shouldRemove = !(input instanceof Exchange) && !isChainableSource(input);
+				shouldRemove = !(input instanceof Exchange) && !isChainableSource(input, context);
 			}
 
 			// optimization 3. for singleton operations (for example singleton global agg)
@@ -286,7 +286,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 				// unless one of its input is a FLIP-27 source (for maximizing source chaining),
 				// however unions do not apply to this optimization because they're not real operators
 				if (isUnion || wrapper.inputs.stream().noneMatch(
-					inputWrapper -> isChainableSource(inputWrapper.execNode))) {
+					inputWrapper -> isChainableSource(inputWrapper.execNode, context))) {
 					wrapper.group.removeRoot();
 				}
 				continue;
@@ -391,7 +391,8 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 		return true;
 	}
 
-	private boolean isChainableSource(ExecNode<?, ?> node) {
+	@VisibleForTesting
+	static boolean isChainableSource(ExecNode<?, ?> node, DAGProcessContext context) {
 		if (node instanceof BatchExecBoundedStreamScan) {
 			BatchExecBoundedStreamScan scan = (BatchExecBoundedStreamScan) node;
 			return scan.boundedStreamTable().dataStream().getTransformation() instanceof SourceTransformation;
@@ -399,9 +400,11 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 			StreamExecDataStreamScan scan = (StreamExecDataStreamScan) node;
 			return scan.dataStreamTable().dataStream().getTransformation() instanceof SourceTransformation;
 		} else if (node instanceof CommonPhysicalTableSourceScan) {
-			CommonPhysicalTableSourceScan scan = (CommonPhysicalTableSourceScan) node;
-			return scan.tableSource().getScanRuntimeProvider(
-				ScanRuntimeProviderContext.INSTANCE) instanceof SourceProvider;
+			// translateToPlan will cache the transformation,
+			// this is OK because sources do not have any input so the transformation will never change.
+			Transformation<?> transformation = ((ExecNode) node).translateToPlan(
+				Preconditions.checkNotNull(context).getPlanner());
+			return transformation instanceof SourceTransformation;
 		}
 		return false;
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.processors;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.mocks.MockSource;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.expressions.ApiExpressionUtils;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.process.DAGProcessContext;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.util.FileUtils;
+
+import org.apache.calcite.rel.RelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Tests for {@link MultipleInputNodeCreationProcessor}.
+ */
+public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
+
+	private final BatchTableTestUtil batchUtil = batchTestUtil(new TableConfig());
+	private final StreamTableTestUtil streamUtil = streamTestUtil(new TableConfig());
+
+	@Test
+	public void testIsChainableDataStreamSource() {
+		createChainableStream(batchUtil);
+		assertChainableSource("chainableStream", batchUtil, true);
+		createChainableStream(streamUtil);
+		assertChainableSource("chainableStream", streamUtil, true);
+	}
+
+	@Test
+	public void testNonChainableDataStreamSource() {
+		createNonChainableStream(batchUtil);
+		assertChainableSource("nonChainableStream", batchUtil, false);
+		createNonChainableStream(streamUtil);
+		assertChainableSource("nonChainableStream", streamUtil, false);
+	}
+
+	@Test
+	public void testIsChainableTableSource() throws IOException {
+		createTestFileSource(batchUtil.tableEnv(), "fileSource1", "Source");
+		assertChainableSource("fileSource1", batchUtil, true);
+		createTestFileSource(streamUtil.tableEnv(), "fileSource1", "Source");
+		assertChainableSource("fileSource1", streamUtil, true);
+
+		createTestFileSource(batchUtil.tableEnv(), "fileSource2", "DataStream");
+		assertChainableSource("fileSource2", batchUtil, true);
+		createTestFileSource(streamUtil.tableEnv(), "fileSource2", "DataStream");
+		assertChainableSource("fileSource2", streamUtil, true);
+	}
+
+	@Test
+	public void testNonChainableTableSource() throws IOException {
+		createTestValueSource(batchUtil.tableEnv(), "valueSource1", "DataStream");
+		assertChainableSource("valueSource1", batchUtil, false);
+		createTestValueSource(streamUtil.tableEnv(), "valueSource1", "DataStream");
+		assertChainableSource("valueSource1", streamUtil, false);
+
+		createTestValueSource(batchUtil.tableEnv(), "valueSource2", "SourceFunction");
+		assertChainableSource("valueSource2", batchUtil, false);
+		createTestValueSource(streamUtil.tableEnv(), "valueSource2", "SourceFunction");
+		assertChainableSource("valueSource2", streamUtil, false);
+
+		createTestValueSource(batchUtil.tableEnv(), "valueSource3", "InputFormat");
+		assertChainableSource("valueSource3", batchUtil, false);
+		createTestValueSource(streamUtil.tableEnv(), "valueSource3", "InputFormat");
+		assertChainableSource("valueSource3", streamUtil, false);
+	}
+
+	private void assertChainableSource(String name, TableTestUtil util, boolean expected) {
+		String sql = "SELECT * FROM " + name;
+		Table table = util.tableEnv().sqlQuery(sql);
+		RelNode relNode = TableTestUtil.toRelNode(table);
+		RelNode optimizedRel = util.getPlanner().optimize(relNode);
+		ExecNode<?, ?> execNode = (ExecNode<?, ?>) optimizedRel;
+		while (!execNode.getInputNodes().isEmpty()) {
+			execNode = execNode.getInputNodes().get(0);
+		}
+		DAGProcessContext context = new DAGProcessContext(util.getPlanner());
+		Assert.assertEquals(expected, MultipleInputNodeCreationProcessor.isChainableSource(execNode, context));
+	}
+
+	private void createChainableStream(TableTestUtil util) {
+		DataStreamSource<Integer> dataStream = util.getStreamEnv().fromSource(
+			new MockSource(Boundedness.BOUNDED, 1),
+			WatermarkStrategy.noWatermarks(),
+			"chainableStream");
+		TableTestUtil.createTemporaryView(
+			util.tableEnv(),
+			"chainableStream",
+			dataStream,
+			scala.Option.apply(new Expression[] {ApiExpressionUtils.unresolvedRef("a")}),
+			scala.Option.empty(),
+			scala.Option.empty());
+	}
+
+	private void createNonChainableStream(TableTestUtil util) {
+		DataStreamSource<Integer> dataStream = util.getStreamEnv().fromElements(1, 2, 3);
+		TableTestUtil.createTemporaryView(
+			util.tableEnv(),
+			"nonChainableStream",
+			dataStream,
+			scala.Option.apply(new Expression[] {ApiExpressionUtils.unresolvedRef("a")}),
+			scala.Option.empty(),
+			scala.Option.empty());
+	}
+
+	private void createTestFileSource(TableEnvironment tEnv, String name, String runtimeSource) throws IOException {
+		File file = tempFolder().newFile();
+		file.delete();
+		file.createNewFile();
+		FileUtils.writeFileUtf8(file, "1\n2\n3\n");
+		tEnv.executeSql("CREATE TABLE " + name + "(\n" +
+			"  a STRING\n" +
+			") WITH (\n" +
+			"  'connector' = 'filesource',\n" +
+			"  'path' = '" + file.toURI() + "',\n" +
+			"  'runtime-source' = '" + runtimeSource + "'\n" +
+			")");
+	}
+
+	private void createTestValueSource(TableEnvironment tEnv, String name, String runtimeSource) {
+		tEnv.executeSql("CREATE TABLE " + name + "(\n" +
+			"  a STRING\n" +
+			") WITH (\n" +
+			"  'connector' = 'values',\n" +
+			"  'bounded' = 'true',\n" +
+			"  'runtime-source' = '" + runtimeSource + "'\n" +
+			")");
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.scala
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.connector.source.Boundedness
 import org.apache.flink.api.connector.source.mocks.MockSource
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.utils.{TableTestBase, TableTestUtil}
@@ -326,13 +324,12 @@ class MultipleInputCreationTest(shuffleMode: String) extends TableTestBase {
   }
 
   def createChainableTableSource(): Unit = {
-    val env = new StreamExecutionEnvironment(new LocalStreamEnvironment())
-    val dataStream = env.fromSource(
+    val dataStream = util.getStreamEnv.fromSource(
       new MockSource(Boundedness.BOUNDED, 1),
       WatermarkStrategy.noWatermarks[Integer],
-      "chainable").javaStream
-    val tableEnv = util.tableEnv
-    TableTestUtil.createTemporaryView[Integer](tableEnv, "chainable", dataStream, Some(Array('a)))
+      "chainable")
+    TableTestUtil.createTemporaryView[Integer](
+      util.tableEnv, "chainable", dataStream, Some(Array('a)))
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

`MultipleInputNodeCreationProcessor#isChainableSource` now only considers SourceProvider. However `DataStreamScanProvider` providing `DataStream` with `SourceTransformation` are also chainable sources, and we need to take them into consideration.

## Brief change log

 - `MultipleInputNodeCreationProcessor#isChainableSource` now considers DataStreamScanProvider

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
