### PR TITLE
[FLINK-20001] Don't use setAllVerticesInSameSlotSharingGroupByDefault in StreamGraphGenerator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -278,14 +278,12 @@ public class StreamGraphGenerator {
 				checkpointConfig.disableCheckpointing();
 			}
 
-			graph.setAllVerticesInSameSlotSharingGroupByDefault(false);
 			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED);
 			graph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
 			setDefaultBufferTimeout(-1);
 			setBatchStateBackendAndTimerService(graph);
 		} else {
 			graph.setStateBackend(stateBackend);
-			graph.setAllVerticesInSameSlotSharingGroupByDefault(true);
 			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED);
 			graph.setScheduleMode(ScheduleMode.EAGER);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -79,7 +79,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						true));
 	}
 
@@ -100,7 +99,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						false));
 	}
 
@@ -130,7 +128,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
-						false,
 						false));
 	}
 
@@ -179,7 +176,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						false));
 	}
 
@@ -195,7 +191,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
-						false,
 						false));
 	}
 
@@ -211,7 +206,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						false));
 	}
 
@@ -231,7 +225,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						false));
 	}
 
@@ -247,7 +240,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
-						false,
 						false));
 
 		final StreamGraph streamingGraph = generateStreamGraph(RuntimeExecutionMode.STREAMING, bounded);
@@ -256,7 +248,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 				hasProperties(
 						GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
 						ScheduleMode.EAGER,
-						true,
 						false));
 	}
 
@@ -290,7 +281,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 	private static TypeSafeMatcher<StreamGraph> hasProperties(
 			final GlobalDataExchangeMode exchangeMode,
 			final ScheduleMode scheduleMode,
-			final boolean allVerticesShareSameSlotGroup,
 			final boolean isCheckpointingEnable) {
 
 		return new TypeSafeMatcher<StreamGraph>() {
@@ -298,7 +288,6 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 			protected boolean matchesSafely(StreamGraph actualStreamGraph) {
 				return exchangeMode == actualStreamGraph.getGlobalDataExchangeMode()
 						&& scheduleMode == actualStreamGraph.getScheduleMode()
-						&& actualStreamGraph.isAllVerticesInSameSlotSharingGroupByDefault() == allVerticesShareSameSlotGroup
 						&& actualStreamGraph.getCheckpointConfig().isCheckpointingEnabled() == isCheckpointingEnable;
 			}
 


### PR DESCRIPTION
I think the default of having all vertices in the same slot sharing
group should be good for both BATCH and STREAMING right now. We can
reconsider actually setting this flag in the future.

Background information: this is a special setting that was introduced
for the Table API Blink runner/planner, which does special things with
slot sharing (or lack thereof) and is more aware of memory requirements
and such. For general DataStream/DataSet programs changing the setting
doesn't make sense.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
