### PR TITLE
[FLINK-20002] Add a StreamExecutionEnvironment#getExecutionEnvironment(Configuration) method

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -149,12 +149,17 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
 			final ClassLoader userCodeClassLoader,
 			final boolean enforceSingleJobExecution,
 			final boolean suppressSysout) {
-		StreamExecutionEnvironmentFactory factory = () -> new StreamContextEnvironment(
-			executorServiceLoader,
-			configuration,
-			userCodeClassLoader,
-			enforceSingleJobExecution,
-			suppressSysout);
+		StreamExecutionEnvironmentFactory factory = conf -> {
+			Configuration mergedConfiguration = new Configuration();
+			mergedConfiguration.addAll(configuration);
+			mergedConfiguration.addAll(conf);
+			return new StreamContextEnvironment(
+				executorServiceLoader,
+				mergedConfiguration,
+				userCodeClassLoader,
+				enforceSingleJobExecution,
+				suppressSysout);
+		};
 		initializeContextEnvironment(factory);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamPlanEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamPlanEnvironment.java
@@ -54,7 +54,10 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 	}
 
 	public void setAsContext() {
-		StreamExecutionEnvironmentFactory factory = () -> this;
+		StreamExecutionEnvironmentFactory factory = conf -> {
+			this.configure(conf, getUserClassloader());
+			return this;
+		};
 		initializeContextEnvironment(factory);
 	}
 

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellStreamEnvironment.java
@@ -95,7 +95,7 @@ public class ScalaShellStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	public static void disableAllContextAndOtherEnvironments() {
-		initializeContextEnvironment(() -> {
+		initializeContextEnvironment(configuration -> {
 			throw new UnsupportedOperationException("Execution Environment is already defined for this shell.");
 		});
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
@@ -54,7 +55,6 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 	 */
 	public LocalStreamEnvironment(@Nonnull Configuration configuration) {
 		super(validateAndGetConfiguration(configuration));
-		setParallelism(1);
 	}
 
 	private static Configuration validateAndGetConfiguration(final Configuration configuration) {
@@ -66,6 +66,9 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		final Configuration effectiveConfiguration = new Configuration(checkNotNull(configuration));
 		effectiveConfiguration.set(DeploymentOptions.TARGET, "local");
 		effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
+		if (!configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).isPresent()) {
+			configuration.set(CoreOptions.DEFAULT_PARALLELISM, 1);
+		}
 		return effectiveConfiguration;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
@@ -34,9 +33,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * The LocalStreamEnvironment is a StreamExecutionEnvironment that runs the program locally,
  * multi-threaded, in the JVM where the environment is instantiated. It spawns an embedded
  * Flink cluster in the background and executes the program on that cluster.
- *
- * <p>When this environment is instantiated, it uses a default parallelism of {@code 1}. The default
- * parallelism can be set via {@link #setParallelism(int)}.
  */
 @Public
 public class LocalStreamEnvironment extends StreamExecutionEnvironment {
@@ -66,9 +62,6 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		final Configuration effectiveConfiguration = new Configuration(checkNotNull(configuration));
 		effectiveConfiguration.set(DeploymentOptions.TARGET, "local");
 		effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
-		if (!configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).isPresent()) {
-			configuration.set(CoreOptions.DEFAULT_PARALLELISM, 1);
-		}
 		return effectiveConfiguration;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -2053,6 +2053,10 @@ public class StreamExecutionEnvironment {
 	 * method returns a local execution environment, as returned by
 	 * {@link #createLocalEnvironment(Configuration)}.
 	 *
+	 * <p>When executed from the command line the given configuration is stacked on top of the
+	 * global configuration which comes from the {@code flink-conf.yaml}, potentially overriding
+	 * duplicated options.
+	 *
 	 * @param configuration The configuration to instantiate the environment with.
 	 * @return The execution environment of the context in which the program is
 	 * executed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -49,6 +49,7 @@ import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
@@ -2043,9 +2044,23 @@ public class StreamExecutionEnvironment {
 	 * executed.
 	 */
 	public static StreamExecutionEnvironment getExecutionEnvironment() {
+		return getExecutionEnvironment(new Configuration());
+	}
+
+	/**
+	 * Creates an execution environment that represents the context in which the
+	 * program is currently executed. If the program is invoked standalone, this
+	 * method returns a local execution environment, as returned by
+	 * {@link #createLocalEnvironment(Configuration)}.
+	 *
+	 * @param configuration The configuration to instantiate the environment with.
+	 * @return The execution environment of the context in which the program is
+	 * executed.
+	 */
+	public static StreamExecutionEnvironment getExecutionEnvironment(Configuration configuration) {
 		return Utils.resolveFactory(threadLocalContextEnvironmentFactory, contextEnvironmentFactory)
-			.map(StreamExecutionEnvironmentFactory::createExecutionEnvironment)
-			.orElseGet(StreamExecutionEnvironment::createLocalEnvironment);
+			.map(factory -> factory.createExecutionEnvironment(configuration))
+			.orElseGet(() -> StreamExecutionEnvironment.createLocalEnvironment(configuration));
 	}
 
 	/**
@@ -2088,12 +2103,30 @@ public class StreamExecutionEnvironment {
 	 * @return A local execution environment with the specified parallelism.
 	 */
 	public static LocalStreamEnvironment createLocalEnvironment(int parallelism, Configuration configuration) {
-		final LocalStreamEnvironment currentEnvironment;
+		Configuration copyOfConfiguration = new Configuration();
+		copyOfConfiguration.addAll(configuration);
+		copyOfConfiguration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+		return createLocalEnvironment(copyOfConfiguration);
+	}
 
-		currentEnvironment = new LocalStreamEnvironment(configuration);
-		currentEnvironment.setParallelism(parallelism);
-
-		return currentEnvironment;
+	/**
+	 * Creates a {@link LocalStreamEnvironment}. The local execution environment
+	 * will run the program in a multi-threaded fashion in the same JVM as the
+	 * environment was created in.
+	 *
+	 * 	@param configuration
+	 * 		Pass a custom configuration into the cluster
+	 * @return A local execution environment with the specified parallelism.
+	 */
+	public static LocalStreamEnvironment createLocalEnvironment(Configuration configuration) {
+		if (configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).isPresent()) {
+			return new LocalStreamEnvironment(configuration);
+		} else {
+			Configuration copyOfConfiguration = new Configuration();
+			copyOfConfiguration.addAll(configuration);
+			copyOfConfiguration.set(CoreOptions.DEFAULT_PARALLELISM, defaultLocalParallelism);
+			return new LocalStreamEnvironment(copyOfConfiguration);
+		}
 	}
 
 	/**
@@ -2116,7 +2149,7 @@ public class StreamExecutionEnvironment {
 			conf.setInteger(RestOptions.PORT, RestOptions.PORT.defaultValue());
 		}
 
-		return createLocalEnvironment(defaultLocalParallelism, conf);
+		return createLocalEnvironment(conf);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentFactory.java
@@ -18,11 +18,13 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
 
 /**
  * Factory class for stream execution environments.
  */
 @PublicEvolving
+@FunctionalInterface
 public interface StreamExecutionEnvironmentFactory {
 
 	/**
@@ -30,5 +32,6 @@ public interface StreamExecutionEnvironmentFactory {
 	 *
 	 * @return A StreamExecutionEnvironment.
 	 */
-	StreamExecutionEnvironment createExecutionEnvironment();
+	StreamExecutionEnvironment createExecutionEnvironment(Configuration configuration);
+
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -68,11 +68,15 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 			final Collection<Path> jarFiles,
 			final Collection<URL> classpaths) {
 
-		StreamExecutionEnvironmentFactory factory = () -> new TestStreamEnvironment(
+		StreamExecutionEnvironmentFactory factory = conf -> {
+			TestStreamEnvironment env = new TestStreamEnvironment(
 				miniCluster,
 				parallelism,
 				jarFiles,
 				classpaths);
+			env.configure(conf, env.getUserClassloader());
+			return env;
+		};
 
 		initializeContextEnvironment(factory);
 	}

--- a/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamBatchExecutionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamBatchExecutionITCase.java
@@ -23,14 +23,12 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
-import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.CloseableIterator;
@@ -39,7 +37,6 @@ import org.apache.flink.util.CollectionUtil;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -133,12 +130,13 @@ public class DataStreamBatchExecutionITCase {
 
 		Configuration config = new Configuration();
 		config.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
-		config.set(CoreOptions.DEFAULT_PARALLELISM, 1);
-		// trick the collecting sink into working even in the face of failures 🙏
-		config.set(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofMillis(42));
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(
 			config);
+		env.setParallelism(1);
+
+		// trick the collecting sink into working even in the face of failures 🙏
+		env.enableCheckpointing(42);
 
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, Time.milliseconds(1)));
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a method to instantiate a StreamExecutionEnvironment with a given `Configuration`. It is a shortcut for 
```
StreamExecutionEnvironment env = new *StreamExecutionEnvironment(Configuration);
env.configure(Configuration);
```


## Verifying this change

Added tests in:
* `StreamExecutionEnvironmentComplexConfigurationTest`
* Changed the way environment is instantiated in `DataStreamBatchExecutionITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
