### PR TITLE
[FLINK-19284][python][doc] Add documentation about how to use Python UDF in the Java Table API.

### DIFF
--- a/docs/dev/python/datastream-api-users-guide/dependency_management.zh.md
+++ b/docs/dev/python/datastream-api-users-guide/dependency_management.zh.md
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<a name="java-dependency"/>
+<a name="java-dependency-in-python-program"/>
 
 # Java 依赖管理
 
@@ -39,7 +39,7 @@ stream_execution_environment.add_classpaths("file:///my/jar/path/connector.jar",
 {% endhighlight %}
 **注意：** 这些 API 能被多次调用。
 
-<a name="python-dependency"/>
+<a name="python-dependency-in-python-program"/>
 
 # Python 依赖管理
 如果 Python DataStream 程序中应用到了 Python 第三方依赖，用户可以使用以下 API 配置依赖信息，或在提交作业时直接通过[命令行参数]({% link ops/cli.zh.md %}#usage)配置。

--- a/docs/dev/python/faq.md
+++ b/docs/dev/python/faq.md
@@ -76,7 +76,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-For details about the APIs of adding Java dependency, you can refer to [the relevant documentation]({% link dev/python/table-api-users-guide/dependency_management.md %}#java-dependency)
+For details about the APIs of adding Java dependency, you can refer to [the relevant documentation]({% link dev/python/table-api-users-guide/dependency_management.md %}#java-dependency-in-python-program)
 
 ## Adding Python Files
 You can use the command-line arguments `pyfs` or the API `add_python_file` of `TableEnvironment` to add python file dependencies which could be python files, python packages or local directories.

--- a/docs/dev/python/faq.zh.md
+++ b/docs/dev/python/faq.zh.md
@@ -60,7 +60,7 @@ $ # 指定用于执行python UDF workers (用户自定义函数工作者) 的pyt
 $ table_env.get_config().set_python_executable("venv.zip/venv/bin/python")
 {% endhighlight %}
 
-如果需要了解`add_python_archive`和`set_python_executable`用法的详细信息，请参阅[相关文档]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#python-dependency)。
+如果需要了解`add_python_archive`和`set_python_executable`用法的详细信息，请参阅[相关文档]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#python-dependency-in-python-program)。
 
 ## 添加Jar文件
 
@@ -75,7 +75,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-有关添加Java依赖项的API的详细信息，请参阅[相关文档]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#java-dependency)。
+有关添加Java依赖项的API的详细信息，请参阅[相关文档]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#java-dependency-in-python-program)。
 
 ## 添加Python文件
 您可以使用命令行参数`pyfs`或TableEnvironment的API `add_python_file`添加python文件依赖，这些依赖可以是python文件，python软件包或本地目录。

--- a/docs/dev/python/table-api-users-guide/dependency_management.md
+++ b/docs/dev/python/table-api-users-guide/dependency_management.md
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Java Dependency
+# Java Dependency in Python Program
 
 If third-party Java dependencies are used, you can specify the dependencies with the following Python Table APIs or through [command line arguments]({% link ops/cli.md %}#usage) directly when submitting the job.
 
@@ -36,7 +36,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-# Python Dependency
+# Python Dependency in Python Program
 
 If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through [command line arguments]({% link ops/cli.md %}#usage) directly when submitting the job.
 
@@ -108,3 +108,27 @@ table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
     </tr>
   </tbody>
 </table>
+
+# Python Dependency in Java/Scala Program
+
+If Python UDFs is created via the [CREATE FUNCTION SQL Statement]({% link  dev/table/sql/create.md %}#create-function) 
+and used in Java/Scala program, usually the Python environment need to be well prepared and the Python dependencies need 
+to be well configured via [Python configuration options]({% link dev/python/table-api-users-guide/python_config.md %}) 
+or [Python commandline options]({% link ops/cli.md %}#usage).
+
+If you are using Python UDF in a Java/Scala program for the first time, you can prepare the Python environment and 
+specify the Python dependencies as follows: 
+
+1. Prepare a **portable** Python environment which has installed PyFlink, for Mac/Linux users we prepare a 
+[convenient script]({% link downloads/setup-pyflink-virtual-env.sh %}) to create a miniconda environment with PyFlink 
+installed. If your Python UDFs have additional dependencies, you need to install them in the environment.
+2. Set the configuration option `python.client.executable` to the Python interpreter path of the Python environment 
+above at the beginning of your program. 
+3. Set the configuration option `python.files` to the paths of the Python files which define the 
+Python UDFs, use "," as the separator of paths at the beginning of your program. 
+4. Pack the Python environment to a zip file, and set the configuration option `python.archives` to the path of the zip 
+file at the beginning of your program. 
+5. Set the configuration option `python.executable` to the Python interpreter path in the zip file created above at the 
+beginning of your program, e.g. for the zip file generated from the 
+[convenient script]({% link downloads/setup-pyflink-virtual-env.sh %}), the value of the configuration option should be 
+"venv.zip/venv/bin/python".

--- a/docs/dev/python/table-api-users-guide/dependency_management.zh.md
+++ b/docs/dev/python/table-api-users-guide/dependency_management.zh.md
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<a name="java-dependency"/>
+<a name="java-dependency-in-python-program"/>
 
 # Java 依赖管理
 
@@ -38,7 +38,7 @@ table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///
 table_env.get_config().get_configuration().set_string("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-<a name="python-dependency"/>
+<a name="python-dependency-in-python-program"/>
 
 # Python 依赖管理
 
@@ -112,3 +112,30 @@ table_env.get_config().set_python_executable("py_env.zip/py_env/bin/python")
     </tr>
   </tbody>
 </table>
+
+<a name="python-dependency-in-javascala-program"/>
+
+# Java/Scala程序中的Python依赖管理
+
+If Python UDFs is created via the [CREATE FUNCTION SQL Statement]({% link  dev/table/sql/create.zh.md %}#create-function) 
+and used in Java/Scala program, usually the Python environment need to be well prepared and the Python dependencies need 
+to be well configured via [Python configuration options]({% link dev/python/table-api-users-guide/python_config.zh.md %}) 
+or [Python commandline options]({% link ops/cli.zh.md %}#usage).
+
+If you are using Python UDF in a Java/Scala program for the first time, you can prepare the Python environment and 
+specify the Python dependencies as follows: 
+
+1. Prepare a **portable** Python environment which has installed PyFlink, for Mac/Linux users we prepare a 
+[convenient script]({% link downloads/setup-pyflink-virtual-env.sh %}) to create a miniconda environment with PyFlink 
+installed. If your Python UDFs have additional dependencies, you need to install them in the environment.
+2. Set the configuration option `python.client.executable` to the Python interpreter path of the Python environment 
+above at the beginning of your program. 
+3. Set the configuration option `python.files` to the paths of the Python files which define the 
+Python UDFs, use "," as the separator of paths at the beginning of your program. 
+4. Pack the Python environment to a zip file, and set the configuration option `python.archives` to the path of the zip 
+file at the beginning of your program. 
+5. Set the configuration option `python.executable` to the Python interpreter path in the zip file created above at the 
+beginning of your program, e.g. for the zip file generated from the 
+[convenient script]({% link downloads/setup-pyflink-virtual-env.sh %}), the value of the configuration option 
+ `python.executable` should be "venv.zip/venv/bin/python".
+

--- a/docs/dev/python/table-api-users-guide/table_environment.md
+++ b/docs/dev/python/table-api-users-guide/table_environment.md
@@ -548,7 +548,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
 ### Dependency Management
 
 These APIs are used to manage the Python dependencies which are required by the Python UDFs.
-Please refer to the [Dependency Management]({% link dev/python/table-api-users-guide/dependency_management.md %}#python-dependency) documentation for more details.
+Please refer to the [Dependency Management]({% link dev/python/table-api-users-guide/dependency_management.md %}#python-dependency-in-python-program) documentation for more details.
 
 <table class="table table-bordered">
   <thead>

--- a/docs/dev/python/table-api-users-guide/table_environment.zh.md
+++ b/docs/dev/python/table-api-users-guide/table_environment.zh.md
@@ -543,7 +543,7 @@ TableEnvironment API
 ### 依赖管理
 
 这些 APIs 用来管理 Python UDFs 所需要的 Python 依赖。
-更多细节可查阅 [依赖管理]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#python-dependency)。
+更多细节可查阅 [依赖管理]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#python-dependency-in-python-program)。
 
 <table class="table table-bordered">
   <thead>

--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -743,6 +743,8 @@ env.sqlQuery("SELECT HashFunction(myField) FROM MyTable")
 
 If you intend to implement or call functions in Python, please refer to the [Python Scalar Functions]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}#scalar-functions) documentation for more details.
 
+If you intend to use Python UDFs in Java/Scala program, you need to register them via SQL, please refer to the [CREATE FUNCTION Statement]({% link dev/table/sql/create.md %}#create-function) documentation for more details.
+
 {% top %}
 
 Table Functions
@@ -900,6 +902,8 @@ env.sqlQuery(
 If you intend to implement functions in Scala, do not implement a table function as a Scala `object`. Scala `object`s are singletons and will cause concurrency issues.
 
 If you intend to implement or call functions in Python, please refer to the [Python Table Functions]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}#table-functions) documentation for more details.
+
+If you intend to use Python UDFs in Java/Scala program, you need to register them via SQL, please refer to the [CREATE FUNCTION Statement]({% link dev/table/sql/create.md %}#create-function) documentation for more details.
 
 {% top %}
 
@@ -1246,6 +1250,10 @@ def merge(accumulator: ACC, iterable: java.lang.Iterable[ACC]): Unit
 </div>
 
 </div>
+
+If you intend to implement or call functions in Python, please refer to the [Python Table Functions]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}#aggregation-functions) documentation for more details.
+
+If you intend to use Python UDFs in Java/Scala program, you need to register them via SQL, please refer to the [CREATE FUNCTION Statement]({% link  dev/table/sql/create.md %}#create-function) documentation for more details.
 
 {% top %}
 

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -711,6 +711,8 @@ env.sqlQuery("SELECT HashFunction(myField) FROM MyTable")
 
 如果你打算使用 Python 实现或调用标量函数，详情可参考 [Python 标量函数]({% link dev/python/table-api-users-guide/udfs/python_udfs.zh.md %}#标量函数scalarfunction)。
 
+如果你打算在Java/Scala程序中使用Python函数，你需要先使用SQL语句注册它们，详情可参考[CREATE FUNCTION语句]({% link dev/table/sql/create.zh.md %}#create-function).
+
 {% top %}
 
 表值函数
@@ -868,6 +870,8 @@ env.sqlQuery(
 如果你打算使用 Scala，不要把表值函数声明为 Scala `object`，Scala `object` 是单例对象，将导致并发问题。
 
 如果你打算使用 Python 实现或调用表值函数，详情可参考 [Python 表值函数]({% link dev/python/table-api-users-guide/udfs/python_udfs.zh.md %}#表值函数)。
+
+如果你打算在Java/Scala程序中使用Python函数，你需要先使用SQL语句注册它们，详情可参考[CREATE FUNCTION语句]({% link dev/table/sql/create.zh.md %}#create-function).
 
 {% top %}
 
@@ -1346,6 +1350,8 @@ t_env.sql_query("SELECT user, wAvg(points, level) AS avgPoints FROM userScores G
 {% endhighlight %}
 </div>
 </div>
+
+如果你打算在Java/Scala程序中使用Python函数，你需要先使用SQL语句注册它们，详情可参考[CREATE FUNCTION语句]({% link dev/table/sql/create.zh.md %}#create-function).
 
 {% top %}
 

--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -431,6 +431,8 @@ If the language tag is JAVA/SCALA, the identifier is the full classpath of the U
 
 If the language tag is PYTHON, the identifier is the fully qualified name of the UDF, e.g. `pyflink.table.tests.test_udf.add`. For the implementation of Python UDF, please refer to [Python UDFs]({% link dev/python/table-api-users-guide/udfs/python_udfs.md %}) for more details.
 
+If the language tag is PYTHON but current program is writing in Java/Scala, usually you need to [configure the Python dependencies]({% link dev/python/table-api-users-guide/dependency_management.md %}#python-dependency-in-javascala-program).
+
 **TEMPORARY**
 
 Create temporary catalog function that has catalog and database namespaces and overrides catalog functions.

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -431,6 +431,8 @@ CREATE [TEMPORARY|TEMPORARY SYSTEM] FUNCTION
 
 如果 language tag 是 PYTHON ，则 identifier 是 UDF 对象的全限定名，例如 `pyflink.table.tests.test_udf.add`。关于 PYTHON UDF 的实现，请参考 [Python UDFs]({% link dev/python/table-api-users-guide/udfs/python_udfs.zh.md %})。
 
+如果 language tag 是 PYTHON 而执行SQL的程序是Java/Scala，通常需要先[配置Python依赖]({% link dev/python/table-api-users-guide/dependency_management.zh.md %}#python-dependency-in-javascala-program)，程序才能正常执行。
+
 **TEMPORARY**
 
 创建一个有 catalog 和数据库命名空间的临时 catalog function ，并覆盖原有的 catalog function 。


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds documentation about how to use Python UDF in the Java Table API.*


## Brief change log

  - *Add documentation about how to use Python UDF in the Java Table API.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
