### PR TITLE
[FLINK-20003] Improve slot report logging messages

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -174,10 +174,12 @@ class JobScopedResourceTracker {
 			}
 		}
 
-		LOG.debug("Detected excess resources for job {}: {}", jobId, excessResources);
-		for (ExcessResource excessResource : excessResources) {
-			resourceToRequirementMapping.decrementCount(excessResource.requirementProfile, excessResource.resourceProfile, excessResource.numExcessResources);
-			this.excessResources.incrementCount(excessResource.resourceProfile, excessResource.numExcessResources);
+		if (!excessResources.isEmpty()) {
+			LOG.debug("Detected excess resources for job {}: {}", jobId, excessResources);
+			for (ExcessResource excessResource : excessResources) {
+				resourceToRequirementMapping.decrementCount(excessResource.requirementProfile, excessResource.resourceProfile, excessResource.numExcessResources);
+				this.excessResources.incrementCount(excessResource.resourceProfile, excessResource.numExcessResources);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -60,8 +61,13 @@ public class SlotReport implements Serializable, Iterable<SlotStatus> {
 
 	@Override
 	public String toString() {
-		return "SlotReport{" +
-			"slotsStatus=" + slotsStatus +
-			'}';
+		final String lineSeparator = slotsStatus.size() == 1 || slotsStatus.size() > 10
+			? ""
+			: System.lineSeparator();
+
+		return slotsStatus.stream()
+			.map(SlotStatus::toString)
+			.map(s -> "\t" + s)
+			.collect(Collectors.joining(lineSeparator, "SlotReport{" + lineSeparator, "}"));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
@@ -63,11 +63,10 @@ public class SlotReport implements Serializable, Iterable<SlotStatus> {
 	public String toString() {
 		final String lineSeparator = slotsStatus.size() == 1 || slotsStatus.size() > 10
 			? ""
-			: System.lineSeparator();
+			: System.lineSeparator() + "\t";
 
 		return slotsStatus.stream()
 			.map(SlotStatus::toString)
-			.map(s -> "\t" + s)
 			.collect(Collectors.joining(lineSeparator, "SlotReport{" + lineSeparator, "}"));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotStatus.java
@@ -134,9 +134,9 @@ public class SlotStatus implements Serializable {
 	public String toString() {
 		return "SlotStatus{" +
 			"slotID=" + slotID +
-			", resourceProfile=" + resourceProfile +
 			", allocationID=" + allocationID +
 			", jobID=" + jobID +
+			", resourceProfile=" + resourceProfile +
 			'}';
 	}
 }


### PR DESCRIPTION
With this PR, SlotStatus#toString prints the resource profile at the end (because it is usually the least interesting bit), and SlotReport#toString introduces line-breaks and indentation if the number of slots is between 2 and 10 (inclusive).

The idea behind making the line-breaks conditional is that I did not want to severely increase the log messages in extreme environments (say many task executors with 1 slot, or very with with hundreds of slots)