### PR TITLE
[hotfix][doc] Chage link format in some docs

### DIFF
--- a/docs/concepts/flink-architecture.md
+++ b/docs/concepts/flink-architecture.md
@@ -42,7 +42,7 @@ main components interact to execute applications and recover from failures.
 
 The Flink runtime consists of two types of processes: a _JobManager_ and one or more _TaskManagers_.
 
-<img src="{{ site.baseurl }}/fig/processes.svg" alt="The processes involved in executing a Flink dataflow" class="offset" width="70%" />
+<img src="{% link /fig/processes.svg %}" alt="The processes involved in executing a Flink dataflow" class="offset" width="70%" />
 
 The *Client* is not part of the runtime and program execution, but is used to
 prepare and send a dataflow to the JobManager.  After that, the client can
@@ -118,7 +118,7 @@ link dev/stream/operators/index.md %}#task-chaining-and-resource-groups) for det
 The sample dataflow in the figure below is executed with five subtasks, and
 hence with five parallel threads.
 
-<img src="{{ site.baseurl }}/fig/tasks_chains.svg" alt="Operator chaining into Tasks" class="offset" width="80%" />
+<img src="{% link /fig/tasks_chains.svg %}" alt="Operator chaining into Tasks" class="offset" width="80%" />
 
 {% top %}
 
@@ -143,7 +143,7 @@ in the same JVM share TCP connections (via multiplexing) and heartbeat
 messages. They may also share data sets and data structures, thus reducing the
 per-task overhead.
 
-<img src="{{ site.baseurl }}/fig/tasks_slots.svg" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
+<img src="{% link /fig/tasks_slots.svg %}" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
 
 By default, Flink allows subtasks to share slots even if they are subtasks of
 different tasks, so long as they are from the same job. The result is that one
@@ -161,7 +161,7 @@ two main benefits:
     the slotted resources, while making sure that the heavy subtasks are fairly
     distributed among the TaskManagers.
 
-<img src="{{ site.baseurl }}/fig/slot_sharing.svg" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
+<img src="{% link /fig/slot_sharing.svg %}" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
 
 ## Flink Application Execution
 

--- a/docs/concepts/flink-architecture.zh.md
+++ b/docs/concepts/flink-architecture.zh.md
@@ -42,7 +42,7 @@ main components interact to execute applications and recover from failures.
 
 The Flink runtime consists of two types of processes: a _JobManager_ and one or more _TaskManagers_.
 
-<img src="{{ site.baseurl }}/fig/processes.svg" alt="The processes involved in executing a Flink dataflow" class="offset" width="70%" />
+<img src="{% link /fig/processes.svg %}" alt="The processes involved in executing a Flink dataflow" class="offset" width="70%" />
 
 The *Client* is not part of the runtime and program execution, but is used to
 prepare and send a dataflow to the JobManager.  After that, the client can
@@ -118,7 +118,7 @@ link dev/stream/operators/index.zh.md %}#task-chaining-and-resource-groups) for 
 The sample dataflow in the figure below is executed with five subtasks, and
 hence with five parallel threads.
 
-<img src="{{ site.baseurl }}/fig/tasks_chains.svg" alt="Operator chaining into Tasks" class="offset" width="80%" />
+<img src="{% link /fig/tasks_chains.svg %}" alt="Operator chaining into Tasks" class="offset" width="80%" />
 
 {% top %}
 
@@ -143,7 +143,7 @@ in the same JVM share TCP connections (via multiplexing) and heartbeat
 messages. They may also share data sets and data structures, thus reducing the
 per-task overhead.
 
-<img src="{{ site.baseurl }}/fig/tasks_slots.svg" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
+<img src="{% link /fig/tasks_slots.svg %}" alt="A TaskManager with Task Slots and Tasks" class="offset" width="80%" />
 
 By default, Flink allows subtasks to share slots even if they are subtasks of
 different tasks, so long as they are from the same job. The result is that one
@@ -161,7 +161,7 @@ two main benefits:
     the slotted resources, while making sure that the heavy subtasks are fairly
     distributed among the TaskManagers.
 
-<img src="{{ site.baseurl }}/fig/slot_sharing.svg" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
+<img src="{% link /fig/slot_sharing.svg %}" alt="TaskManagers with shared Task Slots" class="offset" width="80%" />
 
 ## Flink Application Execution
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -40,7 +40,7 @@ implement these concepts.
 
 Flink offers different levels of abstraction for developing streaming/batch applications.
 
-<img src="{{ site.baseurl }}/fig/levels_of_abstraction.svg" alt="Programming levels of abstraction" class="offset" width="80%" />
+<img src="{% link /fig/levels_of_abstraction.svg %}" alt="Programming levels of abstraction" class="offset" width="80%" />
 
   - The lowest level abstraction simply offers **stateful and timely stream processing**. It is
     embedded into the [DataStream API]({% link dev/datastream_api.md %}) via the [Process
@@ -83,7 +83,7 @@ Flink offers different levels of abstraction for developing streaming/batch appl
 
   - The highest level abstraction offered by Flink is **SQL**. This abstraction
     is similar to the *Table API* both in semantics and expressiveness, but
-    represents programs as SQL query expressions.  The [SQL]({{ site.baseurl
-    }}{% link dev/table/index.md %}#sql) abstraction closely interacts with the
+    represents programs as SQL query expressions.  The [SQL](
+    {% link dev/table/index.md %}#sql) abstraction closely interacts with the
     Table API, and SQL queries can be executed over tables defined in the
     *Table API*.

--- a/docs/concepts/index.zh.md
+++ b/docs/concepts/index.zh.md
@@ -34,9 +34,9 @@ under the License.
 
 Flink 为流式/批式处理应用程序的开发提供了不同级别的抽象。
 
-<img src="{{ site.baseurl }}/fig/levels_of_abstraction.svg" alt="Programming levels of abstraction" class="offset" width="80%" />
+<img src="{% link /fig/levels_of_abstraction.svg %}" alt="Programming levels of abstraction" class="offset" width="80%" />
 
-  - Flink API 最底层的抽象为**有状态实时流处理**。其抽象实现是 [Process Function]({{ site.baseurl }}{% link dev/stream/operators/process_function.zh.md %})，并且 **Process Function** 被 Flink 框架集成到了 [DataStream API]({{ site.baseurl}}{% link dev/datastream_api.zh.md %}) 中来为我们使用。它允许用户在应用程序中自由地处理来自单流或多流的事件（数据），并提供具有全局一致性和容错保障的*状态*。此外，用户可以在此层抽象中注册事件时间（event time）和处理时间（processing time）回调方法，从而允许程序可以实现复杂计算。
+  - Flink API 最底层的抽象为**有状态实时流处理**。其抽象实现是 [Process Function]({% link dev/stream/operators/process_function.zh.md %})，并且 **Process Function** 被 Flink 框架集成到了 [DataStream API]({% link dev/datastream_api.zh.md %}) 中来为我们使用。它允许用户在应用程序中自由地处理来自单流或多流的事件（数据），并提供具有全局一致性和容错保障的*状态*。此外，用户可以在此层抽象中注册事件时间（event time）和处理时间（processing time）回调方法，从而允许程序可以实现复杂计算。
 
   - Flink API 第二层抽象是 **Core APIs**。实际上，许多应用程序不需要使用到上述最底层抽象的 API，而是可以使用 **Core APIs** 进行编程：其中包含 [DataStream API]({% link dev/datastream_api.zh.md %})（应用于有界/无界数据流场景）和 [DataSet API]({% link dev/batch/index.zh.md %})（应用于有界数据集场景）两部分。Core APIs 提供的流式 API（Fluent API）为数据处理提供了通用的模块组件，例如各种形式的用户自定义转换（transformations）、联接（joins）、聚合（aggregations）、窗口（windows）和状态（state）操作等。此层 API 中处理的数据类型在每种编程语言中都有其对应的类。
 
@@ -46,4 +46,4 @@ Flink 为流式/批式处理应用程序的开发提供了不同级别的抽象�
 
     表和 *DataStream*/*DataSet* 可以进行无缝切换，Flink 允许用户在编写应用程序时将 *Table API* 与 *DataStream*/*DataSet* API 混合使用。
 
-  - Flink API 最顶层抽象是 **SQL**。这层抽象在语义和程序表达式上都类似于 *Table API*，但是其程序实现都是 SQL 查询表达式。[SQL]({{ site.baseurl}}{% link dev/table/index.zh.md %}#sql) 抽象与 Table API 抽象之间的关联是非常紧密的，并且 SQL 查询语句可以在 *Table API* 中定义的表上执行。
+  - Flink API 最顶层抽象是 **SQL**。这层抽象在语义和程序表达式上都类似于 *Table API*，但是其程序实现都是 SQL 查询表达式。[SQL]({% link dev/table/index.zh.md %}#sql) 抽象与 Table API 抽象之间的关联是非常紧密的，并且 SQL 查询语句可以在 *Table API* 中定义的表上执行。

--- a/docs/concepts/stateful-stream-processing.md
+++ b/docs/concepts/stateful-stream-processing.md
@@ -46,8 +46,8 @@ Some examples of stateful operations:
     to events that occurred in the past.
 
 Flink needs to be aware of the state in order to make it fault tolerant using
-[checkpoints]({{ site.baseurl}}{% link dev/stream/state/checkpointing.md %})
-and [savepoints]({{ site.baseurl }}{%link ops/state/savepoints.md %}).
+[checkpoints]({% link dev/stream/state/checkpointing.md %})
+and [savepoints]({%link ops/state/savepoints.md %}).
 
 Knowledge about the state also allows for rescaling Flink applications, meaning
 that Flink takes care of redistributing state across parallel instances.
@@ -73,7 +73,7 @@ are local operations, guaranteeing consistency without transaction overhead.
 This alignment also allows Flink to redistribute the state and adjust the
 stream partitioning transparently.
 
-<img src="{{ site.baseurl }}/fig/state_partitioning.svg" alt="State and Partitioning" class="offset" width="50%" />
+<img src="{% link /fig/state_partitioning.svg %}" alt="State and Partitioning" class="offset" width="50%" />
 
 Keyed State is further organized into so-called *Key Groups*. Key Groups are
 the atomic unit by which Flink can redistribute Keyed State; there are exactly
@@ -157,7 +157,7 @@ the stream at the same time, which means that various snapshots may happen
 concurrently.
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/stream_barriers.svg" alt="Checkpoint barriers in data streams" style="width:60%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/stream_barriers.svg %}" alt="Checkpoint barriers in data streams" style="width:60%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 Stream barriers are injected into the parallel data flow at the stream sources.
@@ -180,7 +180,7 @@ for records from before <i>S<sub>n</sub></i>, since at that point these records
 topology.
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/stream_aligning.svg" alt="Aligning data streams at operators with multiple inputs" style="width:100%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/stream_aligning.svg %}" alt="Aligning data streams at operators with multiple inputs" style="width:100%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 Operators that receive more than one input stream need to *align* the input
@@ -212,7 +212,7 @@ snapshot barriers from their input streams, and before emitting the barriers to
 their output streams. At that point, all updates to the state from records
 before the barriers have been made, and no updates that depend on records
 from after the barriers have been applied. Because the state of a snapshot may
-be large, it is stored in a configurable *[state backend]({{ site.baseurl }}{%
+be large, it is stored in a configurable *[state backend]({%
 link ops/state/state_backends.md %})*. By default, this is the JobManager's
 memory, but for production use a distributed reliable storage should be
 configured (such as HDFS). After the state has been stored, the operator
@@ -227,7 +227,7 @@ The resulting snapshot now contains:
     snapshot
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/checkpointing.svg" alt="Illustration of the Checkpointing Mechanism" style="width:100%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/checkpointing.svg %}" alt="Illustration of the Checkpointing Mechanism" style="width:100%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 #### Recovery
@@ -300,7 +300,7 @@ snapshot of the key/value state and store that snapshot as part of a
 checkpoint. State backends can be configured without changing your application
 logic.
 
-<img src="{{ site.baseurl }}/fig/checkpoints.svg" alt="checkpoints and snapshots" class="offset" width="60%" />
+<img src="{% link /fig/checkpoints.svg %}" alt="checkpoints and snapshots" class="offset" width="60%" />
 
 {% top %}
 
@@ -348,7 +348,7 @@ give *exactly once* guarantees even in *at least once* mode.
 
 ## State and Fault Tolerance in Batch Programs
 
-Flink executes [batch programs](../dev/batch/index.html) as a special case of
+Flink executes [batch programs]({% link dev/batch/index.md %}) as a special case of
 streaming programs, where the streams are bounded (finite number of elements).
 A *DataSet* is treated internally as a stream of data. The concepts above thus
 apply to batch programs in the same way as well as they apply to streaming

--- a/docs/concepts/stateful-stream-processing.zh.md
+++ b/docs/concepts/stateful-stream-processing.zh.md
@@ -46,8 +46,8 @@ Some examples of stateful operations:
     to events that occurred in the past.
 
 Flink needs to be aware of the state in order to make it fault tolerant using
-[checkpoints]({{ site.baseurl}}{% link dev/stream/state/checkpointing.zh.md %})
-and [savepoints]({{ site.baseurl }}{%link ops/state/savepoints.zh.md %}).
+[checkpoints]({% link dev/stream/state/checkpointing.zh.md %})
+and [savepoints]({%link ops/state/savepoints.zh.md %}).
 
 Knowledge about the state also allows for rescaling Flink applications, meaning
 that Flink takes care of redistributing state across parallel instances.
@@ -73,7 +73,7 @@ are local operations, guaranteeing consistency without transaction overhead.
 This alignment also allows Flink to redistribute the state and adjust the
 stream partitioning transparently.
 
-<img src="{{ site.baseurl }}/fig/state_partitioning.svg" alt="State and Partitioning" class="offset" width="50%" />
+<img src="{% link /fig/state_partitioning.svg %}" alt="State and Partitioning" class="offset" width="50%" />
 
 Keyed State is further organized into so-called *Key Groups*. Key Groups are
 the atomic unit by which Flink can redistribute Keyed State; there are exactly
@@ -155,7 +155,7 @@ the stream at the same time, which means that various snapshots may happen
 concurrently.
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/stream_barriers.svg" alt="Checkpoint barriers in data streams" style="width:60%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/stream_barriers.svg %}" alt="Checkpoint barriers in data streams" style="width:60%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 Stream barriers are injected into the parallel data flow at the stream sources.
@@ -178,7 +178,7 @@ for records from before <i>S<sub>n</sub></i>, since at that point these records
 topology.
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/stream_aligning.svg" alt="Aligning data streams at operators with multiple inputs" style="width:100%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/stream_aligning.svg %}" alt="Aligning data streams at operators with multiple inputs" style="width:100%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 Operators that receive more than one input stream need to *align* the input
@@ -208,7 +208,7 @@ snapshot barriers from their input streams, and before emitting the barriers to
 their output streams. At that point, all updates to the state from records
 before the barriers will have been made, and no updates that depend on records
 from after the barriers have been applied. Because the state of a snapshot may
-be large, it is stored in a configurable *[state backend]({{ site.baseurl }}{%
+be large, it is stored in a configurable *[state backend]({%
 link ops/state/state_backends.zh.md %})*. By default, this is the JobManager's
 memory, but for production use a distributed reliable storage should be
 configured (such as HDFS). After the state has been stored, the operator
@@ -223,7 +223,7 @@ The resulting snapshot now contains:
     snapshot
 
 <div style="text-align: center">
-  <img src="{{ site.baseurl }}/fig/checkpointing.svg" alt="Illustration of the Checkpointing Mechanism" style="width:100%; padding-top:10px; padding-bottom:10px;" />
+  <img src="{% link /fig/checkpointing.svg %}" alt="Illustration of the Checkpointing Mechanism" style="width:100%; padding-top:10px; padding-bottom:10px;" />
 </div>
 
 #### Recovery
@@ -254,7 +254,7 @@ snapshot of the key/value state and store that snapshot as part of a
 checkpoint. State backends can be configured without changing your application
 logic.
 
-<img src="{{ site.baseurl }}/fig/checkpoints.svg" alt="checkpoints and snapshots" class="offset" width="60%" />
+<img src="{% link /fig/checkpoints.svg %}" alt="checkpoints and snapshots" class="offset" width="60%" />
 
 {% top %}
 
@@ -302,7 +302,7 @@ give *exactly once* guarantees even in *at least once* mode.
 
 ## State and Fault Tolerance in Batch Programs
 
-Flink executes [batch programs](../dev/batch/index.html) as a special case of
+Flink executes [batch programs]({% link dev/batch/index.zh.md %}) as a special case of
 streaming programs, where the streams are bounded (finite number of elements).
 A *DataSet* is treated internally as a stream of data. The concepts above thus
 apply to batch programs in the same way as well as they apply to streaming
@@ -319,6 +319,6 @@ programs, with minor exceptions:
 
   - The DataSet API introduces special synchronized (superstep-based)
     iterations, which are only possible on bounded streams. For details, check
-    out the [iteration docs]({{ site.baseurl }}/dev/batch/iterations.html).
+    out the [iteration docs]({% link dev/batch/iterations.zh.md %}).
 
 {% top %}

--- a/docs/concepts/timely-stream-processing.md
+++ b/docs/concepts/timely-stream-processing.md
@@ -95,7 +95,7 @@ one can refer to different notions of *time*:
   real-time, they will use some *processing time* operations in order to
   guarantee that they are progressing in a timely fashion.
 
-<img src="{{ site.baseurl }}/fig/event_processing_time.svg" alt="Event Time and Processing Time" class="offset" width="80%" />
+<img src="{% link /fig/event_processing_time.svg %}" alt="Event Time and Processing Time" class="offset" width="80%" />
 
 {% top %}
 
@@ -137,7 +137,7 @@ watermarks flowing inline. In this example the events are in order (with
 respect to their timestamps), meaning that the watermarks are simply periodic
 markers in the stream.
 
-<img src="{{ site.baseurl }}/fig/stream_watermark_in_order.svg" alt="A data stream with events (in order) and watermarks" class="center" width="65%" />
+<img src="{% link /fig/stream_watermark_in_order.svg %}" alt="A data stream with events (in order) and watermarks" class="center" width="65%" />
 
 Watermarks are crucial for *out-of-order* streams, as illustrated below, where
 the events are not ordered by their timestamps.  In general a watermark is a
@@ -146,7 +146,7 @@ timestamp should have arrived.  Once a watermark reaches an operator, the
 operator can advance its internal *event time clock* to the value of the
 watermark.
 
-<img src="{{ site.baseurl }}/fig/stream_watermark_out_of_order.svg" alt="A data stream with events (out of order) and watermarks" class="center" width="65%" />
+<img src="{% link /fig/stream_watermark_out_of_order.svg %}" alt="A data stream with events (out of order) and watermarks" class="center" width="65%" />
 
 Note that event time is inherited by a freshly created stream element (or
 elements) from either the event that produced them or from watermark that
@@ -171,7 +171,7 @@ As its input streams update their event times, so does the operator.
 The figure below shows an example of events and watermarks flowing through
 parallel streams, and operators tracking event time.
 
-<img src="{{ site.baseurl }}/fig/parallel_streams_watermarks.svg" alt="Parallel data streams and operators with events and watermarks" class="center" width="80%" />
+<img src="{% link /fig/parallel_streams_watermarks.svg %}" alt="Parallel data streams and operators with events and watermarks" class="center" width="80%" />
 
 ## Lateness
 
@@ -204,7 +204,7 @@ Windows can be *time driven* (example: every 30 seconds) or *data driven*
 windows, such as *tumbling windows* (no overlap), *sliding windows* (with
 overlap), and *session windows* (punctuated by a gap of inactivity).
 
-<img src="{{ site.baseurl }}/fig/windows.svg" alt="Time- and Count Windows" class="offset" width="80%" />
+<img src="{% link /fig/windows.svg %}" alt="Time- and Count Windows" class="offset" width="80%" />
 
 Please check out this [blog
 post](https://flink.apache.org/news/2015/12/04/Introducing-windows.html) for

--- a/docs/concepts/timely-stream-processing.zh.md
+++ b/docs/concepts/timely-stream-processing.zh.md
@@ -95,7 +95,7 @@ one can refer to different notions of *time*:
   real-time, they will use some *processing time* operations in order to
   guarantee that they are progressing in a timely fashion.
 
-<img src="{{ site.baseurl }}/fig/event_processing_time.svg" alt="Event Time and Processing Time" class="offset" width="80%" />
+<img src="{% link /fig/event_processing_time.svg %}" alt="Event Time and Processing Time" class="offset" width="80%" />
 
 {% top %}
 
@@ -137,7 +137,7 @@ watermarks flowing inline. In this example the events are in order (with
 respect to their timestamps), meaning that the watermarks are simply periodic
 markers in the stream.
 
-<img src="{{ site.baseurl }}/fig/stream_watermark_in_order.svg" alt="A data stream with events (in order) and watermarks" class="center" width="65%" />
+<img src="{% link /fig/stream_watermark_in_order.svg %}" alt="A data stream with events (in order) and watermarks" class="center" width="65%" />
 
 Watermarks are crucial for *out-of-order* streams, as illustrated below, where
 the events are not ordered by their timestamps.  In general a watermark is a
@@ -146,7 +146,7 @@ timestamp should have arrived.  Once a watermark reaches an operator, the
 operator can advance its internal *event time clock* to the value of the
 watermark.
 
-<img src="{{ site.baseurl }}/fig/stream_watermark_out_of_order.svg" alt="A data stream with events (out of order) and watermarks" class="center" width="65%" />
+<img src="{% link /fig/stream_watermark_out_of_order.svg %}" alt="A data stream with events (out of order) and watermarks" class="center" width="65%" />
 
 Note that event time is inherited by a freshly created stream element (or
 elements) from either the event that produced them or from watermark that
@@ -171,7 +171,7 @@ As its input streams update their event times, so does the operator.
 The figure below shows an example of events and watermarks flowing through
 parallel streams, and operators tracking event time.
 
-<img src="{{ site.baseurl }}/fig/parallel_streams_watermarks.svg" alt="Parallel data streams and operators with events and watermarks" class="center" width="80%" />
+<img src="{% link /fig/parallel_streams_watermarks.svg %}" alt="Parallel data streams and operators with events and watermarks" class="center" width="80%" />
 
 ## Lateness
 
@@ -204,7 +204,7 @@ Windows can be *time driven* (example: every 30 seconds) or *data driven*
 windows, such as *tumbling windows* (no overlap), *sliding windows* (with
 overlap), and *session windows* (punctuated by a gap of inactivity).
 
-<img src="{{ site.baseurl }}/fig/windows.svg" alt="Time- and Count Windows" class="offset" width="80%" />
+<img src="{% link /fig/windows.svg %}" alt="Time- and Count Windows" class="offset" width="80%" />
 
 Please check out this [blog
 post](https://flink.apache.org/news/2015/12/04/Introducing-windows.html) for

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -123,7 +123,7 @@ mvn clean install
 
 ## Hadoop Versions
 
-Please see the [Hadoop integration section]({{ site.baseurl }}/ops/deployment/hadoop.html) on how to handle Hadoop classes and versions.
+Please see the [Hadoop integration section]({% link ops/deployment/hadoop.md %}) on how to handle Hadoop classes and versions.
 
 ## Scala Versions
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -127,7 +127,7 @@ mvn clean install
 
 ## Hadoop 版本
 
-请查看 [Hadoop 集成模块]({{ site.baseurl }}/ops/deployment/hadoop.html) 一节中关于处理 Hadoop 的类和版本问题的方法。
+请查看 [Hadoop 集成模块]({% link ops/deployment/hadoop.zh.md %}) 一节中关于处理 Hadoop 的类和版本问题的方法。
 
 ## Scala 版本
 

--- a/docs/flinkDev/ide_setup.md
+++ b/docs/flinkDev/ide_setup.md
@@ -27,8 +27,8 @@ under the License.
 
 The sections below describe how to import the Flink project into an IDE
 for the development of Flink itself. For writing Flink programs, please
-refer to the [Java API]({{ site.baseurl }}/dev/project-configuration.html)
-and the [Scala API]({{ site.baseurl }}/dev/project-configuration)
+refer to the [Java API]({% link dev/project-configuration.md %})
+and the [Scala API]({% link dev/project-configuration.md %})
 quickstart guides.
 
 **NOTE:** Whenever something is not working in your IDE, try with the Maven

--- a/docs/flinkDev/ide_setup.zh.md
+++ b/docs/flinkDev/ide_setup.zh.md
@@ -27,8 +27,8 @@ under the License.
 
 The sections below describe how to import the Flink project into an IDE
 for the development of Flink itself. For writing Flink programs, please
-refer to the [Java API]({{ site.baseurl }}/dev/project-configuration.html)
-and the [Scala API]({{ site.baseurl }}/dev/project-configuration)
+refer to the [Java API]({% link dev/project-configuration.zh.md %})
+and the [Scala API]({% link dev/project-configuration.zh.md %})
 quickstart guides.
 
 **NOTE:** Whenever something is not working in your IDE, try with the Maven

--- a/docs/internals/job_scheduling.md
+++ b/docs/internals/job_scheduling.md
@@ -43,7 +43,7 @@ parallelism of 3. A pipeline consists of the sequence Source - Map - Reduce. On 
 3 slots each, the program will be executed as described below.
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/slots.svg" alt="Assigning Pipelines of Tasks to Slots" height="250px" style="text-align: center;"/>
+<img src="{% link /fig/slots.svg %}" alt="Assigning Pipelines of Tasks to Slots" height="250px" style="text-align: center;"/>
 </div>
 
 Internally, Flink defines through {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java "SlotSharingGroup" %}
@@ -70,7 +70,7 @@ which tracks the status of the operator as a whole.
 Besides the vertices, the ExecutionGraph also contains the {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java "IntermediateResult" %} and the {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java "IntermediateResultPartition" %}. The former tracks the state of the *IntermediateDataSet*, the latter the state of each of its partitions.
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/job_and_execution_graph.svg" alt="JobGraph and ExecutionGraph" height="400px" style="text-align: center;"/>
+<img src="{% link /fig/job_and_execution_graph.svg %}" alt="JobGraph and ExecutionGraph" height="400px" style="text-align: center;"/>
 </div>
 
 Each ExecutionGraph has a job status associated with it.
@@ -91,7 +91,7 @@ Locally terminal means that the execution of the job has been terminated on the 
 Consequently, a job which reaches the *suspended* state won't be completely cleaned up.
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/job_status.svg" alt="States and Transitions of Flink job" height="500px" style="text-align: center;"/>
+<img src="{% link /fig/job_status.svg %}" alt="States and Transitions of Flink job" height="500px" style="text-align: center;"/>
 </div>
 
 During the execution of the ExecutionGraph, each parallel task goes through multiple stages, from *created* to *finished* or *failed*. The diagram below illustrates the
@@ -99,7 +99,7 @@ states and possible transitions between them. A task may be executed multiple ti
 For that reason, the execution of an ExecutionVertex is tracked in an {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java "Execution" %}. Each ExecutionVertex has a current Execution, and prior Executions.
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/state_machine.svg" alt="States and Transitions of Task Executions" height="300px" style="text-align: center;"/>
+<img src="{% link /fig/state_machine.svg %}" alt="States and Transitions of Task Executions" height="300px" style="text-align: center;"/>
 </div>
 
 {% top %}

--- a/docs/internals/job_scheduling.zh.md
+++ b/docs/internals/job_scheduling.zh.md
@@ -36,7 +36,7 @@ Flink 通过 _Task Slots_ 来定义执行资源。每个 TaskManager 有一到�
 下图很好的阐释了这一点，一个由数据源、*MapFunction* 和 *ReduceFunction* 组成的 Flink 作业，其中数据源和 MapFunction 的并行度为 4 ，ReduceFunction 的并行度为 3 。流水线由一系列的 Source - Map - Reduce 组成，运行在 2 个 TaskManager 组成的集群上，每个 TaskManager 包含 3 个 slot，整个作业的运行如下图所示。
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/slots.svg" alt="Assigning Pipelines of Tasks to Slots" height="250px" style="text-align: center;"/>
+<img src="{% link /fig/slots.svg %}" alt="Assigning Pipelines of Tasks to Slots" height="250px" style="text-align: center;"/>
 </div>
 
 Flink 内部通过 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java "SlotSharingGroup" %} 和 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationGroup.java "CoLocationGroup" %} 来定义哪些 task 可以共享一个 slot， 哪些 task 必须严格放到同一个 slot。
@@ -51,7 +51,7 @@ JobManager 会接收到一个 {% gh_link /flink-runtime/src/main/java/org/apache
 JobManager 会将 JobGraph 转换成 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ "ExecutionGraph" %}。可以将 ExecutionGraph 理解为并行版本的 JobGraph，对于每一个顶点 JobVertex，它的每个并行子 task 都有一个 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java "ExecutionVertex" %}。一个并行度为 100 的算子会有 1 个 JobVertext 和 100 个 ExecutionVertex。ExecutionVertex 会跟踪子 task 的执行状态。 同一个 JobVertext 的所有 ExecutionVertex 都通过 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java "ExecutionJobVertex" %} 来持有，并跟踪整个算子的运行状态。ExecutionGraph 除了这些顶点，还包含中间数据结果和分片情况 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java "IntermediateResult" %} 和 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java "IntermediateResultPartition" %}。前者跟踪中间结果的状态，后者跟踪每个分片的状态。
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/job_and_execution_graph.svg" alt="JobGraph and ExecutionGraph" height="400px" style="text-align: center;"/>
+<img src="{% link /fig/job_and_execution_graph.svg %}" alt="JobGraph and ExecutionGraph" height="400px" style="text-align: center;"/>
 </div>
 
 每个 ExecutionGraph 都有一个与之相关的作业状态信息，用来描述当前的作业执行状态。
@@ -63,13 +63,13 @@ Flink 作业刚开始会处于 *created* 状态，然后切换到 *running* 状�
 *Finished*、*canceled* 和 *failed* 会导致全局的终结状态，并且触发作业的清理。跟这些状态不同，*suspended* 状态只是一个局部的终结。局部的终结意味着作业的执行已经被对应的 JobManager 终结，但是集群中另外的 JobManager 依然可以从高可用存储里获取作业信息并重启。因此一个处于 *suspended* 状态的作业不会被彻底清理掉。
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/job_status.svg" alt="States and Transitions of Flink job" height="500px" style="text-align: center;"/>
+<img src="{% link /fig/job_status.svg %}" alt="States and Transitions of Flink job" height="500px" style="text-align: center;"/>
 </div>
 
 在整个 ExecutionGraph 执行期间，每个并行 task 都会经历多个阶段，从 *created* 状态到 *finished* 或 *failed*。下图展示了各种状态以及他们之间的转换关系。由于一个 task 可能会被执行多次(比如在异常恢复时)，ExecutionVertex 的执行是由 {% gh_link /flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java "Execution" %} 来跟踪的，每个 ExecutionVertex 会记录当前的执行，以及之前的执行。
 
 <div style="text-align: center;">
-<img src="{{ site.baseurl }}/fig/state_machine.svg" alt="States and Transitions of Task Executions" height="300px" style="text-align: center;"/>
+<img src="{% link /fig/state_machine.svg %}" alt="States and Transitions of Task Executions" height="300px" style="text-align: center;"/>
 </div>
 
 {% top %}

--- a/docs/internals/task_lifecycle.md
+++ b/docs/internals/task_lifecycle.md
@@ -89,10 +89,10 @@ and skips any intermediate phases between the phase the operator was in when the
 **Checkpoints:** The `snapshotState()` method of the operator is called asynchronously to the rest of the methods described 
 above whenever a checkpoint barrier is received. Checkpoints are performed during the processing phase, *i.e.* after the 
 operator is opened and before it is closed. The responsibility of this method is to store the current state of the operator 
-to the specified [state backend]({{ site.baseurl }}/ops/state/state_backends.html) from where it will be retrieved when 
+to the specified [state backend]({% link ops/state/state_backends.md %}) from where it will be retrieved when 
 the job resumes execution after a failure. Below we include a brief description of Flink's checkpointing mechanism, 
 and for a more detailed discussion on the principles around checkpointing in Flink please read the corresponding documentation: 
-[Data Streaming Fault Tolerance]({{ site.baseurl }}/learn-flink/fault_tolerance.html).
+[Data Streaming Fault Tolerance]({% link learn-flink/fault_tolerance.md %}).
 
 ## Task Lifecycle
 
@@ -125,7 +125,7 @@ first step for the task is to retrieve its initial, task-wide state. This is don
 particularly important in two cases:
 
 1. when the task is recovering from a failure and restarts from the last successful checkpoint
-2. when resuming from a [savepoint]({{ site.baseurl }}/ops/state/savepoints.html). 
+2. when resuming from a [savepoint]({% link ops/state/savepoints.md %}). 
 
 If it is the first time the task is executed, the initial task state is empty. 
 

--- a/docs/internals/task_lifecycle.zh.md
+++ b/docs/internals/task_lifecycle.zh.md
@@ -89,10 +89,10 @@ and skips any intermediate phases between the phase the operator was in when the
 **Checkpoints:** The `snapshotState()` method of the operator is called asynchronously to the rest of the methods described 
 above whenever a checkpoint barrier is received. Checkpoints are performed during the processing phase, *i.e.* after the 
 operator is opened and before it is closed. The responsibility of this method is to store the current state of the operator 
-to the specified [state backend]({{ site.baseurl }}/ops/state/state_backends.html) from where it will be retrieved when 
+to the specified [state backend]({% link ops/state/state_backends.zh.md %}) from where it will be retrieved when 
 the job resumes execution after a failure. Below we include a brief description of Flink's checkpointing mechanism, 
 and for a more detailed discussion on the principles around checkpointing in Flink please read the corresponding documentation: 
-[Data Streaming Fault Tolerance]({{ site.baseurl }}/learn-flink/fault_tolerance.html).
+[Data Streaming Fault Tolerance]({% link learn-flink/fault_tolerance.zh.md %}).
 
 ## Task Lifecycle
 
@@ -125,7 +125,7 @@ first step for the task is to retrieve its initial, task-wide state. This is don
 particularly important in two cases:
 
 1. when the task is recovering from a failure and restarts from the last successful checkpoint
-2. when resuming from a [savepoint]({{ site.baseurl }}/ops/state/savepoints.html). 
+2. when resuming from a [savepoint]({% link ops/state/savepoints.zh.md %}). 
 
 If it is the first time the task is executed, the initial task state is empty. 
 

--- a/docs/learn-flink/datastream_api.md
+++ b/docs/learn-flink/datastream_api.md
@@ -151,7 +151,7 @@ execution. Each parallel slice of your job will be executed in a *task slot*.
 
 Note that if you don't call execute(), your application won't be run.
 
-<img src="{{ site.baseurl }}/fig/distributed-runtime.svg" alt="Flink runtime: client, job manager, task managers" class="offset" width="80%" />
+<img src="{% link /fig/distributed-runtime.svg %}" alt="Flink runtime: client, job manager, task managers" class="offset" width="80%" />
 
 This distributed runtime depends on your application being serializable. It also requires that all
 dependencies are available to each node in the cluster.

--- a/docs/learn-flink/datastream_api.zh.md
+++ b/docs/learn-flink/datastream_api.zh.md
@@ -142,7 +142,7 @@ DataStream API 将你的应用构建为一个 job graph，并附加到 `StreamEx
 
 注意，如果没有调用 execute()，应用就不会运行。
 
-<img src="{{ site.baseurl }}/fig/distributed-runtime.svg" alt="Flink runtime: client, job manager, task managers" class="offset" width="80%" />
+<img src="{% link /fig/distributed-runtime.svg %}" alt="Flink runtime: client, job manager, task managers" class="offset" width="80%" />
 
 此分布式运行时取决于你的应用是否是可序列化的。它还要求所有依赖对集群中的每个节点均可用。
 

--- a/docs/learn-flink/etl.md
+++ b/docs/learn-flink/etl.md
@@ -155,7 +155,7 @@ rides
 Every `keyBy` causes a network shuffle that repartitions the stream. In general this is pretty
 expensive, since it involves network communication along with serialization and deserialization.
 
-<img src="{{ site.baseurl }}/fig/keyBy.png" alt="keyBy and network shuffle" class="offset" width="45%" />
+<img src="{% link /fig/keyBy.png %}" alt="keyBy and network shuffle" class="offset" width="45%" />
 
 In the example above, the key has been specified by a field name, "startCell". This style of key
 selection has the drawback that the compiler is unable to infer the type of the field being used for
@@ -431,13 +431,13 @@ of sources and sinks.
 
 Sometimes instead of applying a pre-defined transformation like this:
 
-<img src="{{ site.baseurl }}/fig/transformation.svg" alt="simple transformation" class="offset" width="45%" />
+<img src="{% link /fig/transformation.svg %}" alt="simple transformation" class="offset" width="45%" />
 
 you want to be able to dynamically alter some aspects of the transformation -- by streaming in
 thresholds, or rules, or other parameters. The pattern in Flink that supports this is something
 called _connected streams_, wherein a single operator has two input streams, like this:
 
-<img src="{{ site.baseurl }}/fig/connected-streams.svg" alt="connected streams" class="offset" width="45%" />
+<img src="{% link /fig/connected-streams.svg %}" alt="connected streams" class="offset" width="45%" />
 
 Connected streams can also be used to implement streaming joins.
 

--- a/docs/learn-flink/etl.zh.md
+++ b/docs/learn-flink/etl.zh.md
@@ -135,7 +135,7 @@ rides
 
 每个 `keyBy` 会通过 shuffle 来为数据流进行重新分区。总体来说这个开销是很大的，它涉及网络通信、序列化和反序列化。
 
-<img src="{{ site.baseurl }}/fig/keyBy.png" alt="keyBy and network shuffle" class="offset" width="45%" />
+<img src="{% link /fig/keyBy.png %}" alt="keyBy and network shuffle" class="offset" width="45%" />
 
 在上面的例子中，将 "startCell" 这个字段定义为键。这种选择键的方式有个缺点，就是编译器无法推断用作键的字段的类型，所以 Flink 会将键值作为元组传递，这有时候会比较难处理。所以最好还是使用一个合适的 KeySelector，
 
@@ -251,7 +251,7 @@ minutesByStartCell
 * **持久性**: Flink 状态是容错的，例如，它可以自动按一定的时间间隔产生 checkpoint，并且在任务失败后进行恢复
 * **纵向可扩展性**: Flink 状态可以存储在集成的 RocksDB 实例中，这种方式下可以通过增加本地磁盘来扩展空间
 * **横向可扩展性**: Flink 状态可以随着集群的扩缩容重新分布
-* **可查询性**: Flink 状态可以通过使用 [状态查询 API]({{ site.baseurl }}{% link dev/stream/state/queryable_state.zh.md %}) 从外部进行查询。
+* **可查询性**: Flink 状态可以通过使用 [状态查询 API]({% link dev/stream/state/queryable_state.zh.md %}) 从外部进行查询。
 
 在本节中你将学习如何使用 Flink 的 API 来管理 keyed state。
 
@@ -355,11 +355,11 @@ keyHasBeenSeen.clear()
 
 相比于下面这种预先定义的转换：
 
-<img src="{{ site.baseurl }}/fig/transformation.svg" alt="simple transformation" class="offset" width="45%" />
+<img src="{% link /fig/transformation.svg %}" alt="simple transformation" class="offset" width="45%" />
 
 有时你想要更灵活地调整转换的某些功能，比如数据流的阈值、规则或者其他参数。Flink 支持这种需求的模式称为 _connected streams_ ，一个单独的算子有两个输入流。
 
-<img src="{{ site.baseurl }}/fig/connected-streams.svg" alt="connected streams" class="offset" width="45%" />
+<img src="{% link /fig/connected-streams.svg %}" alt="connected streams" class="offset" width="45%" />
 
 connected stream 也可以被用来实现流的关联。
 

--- a/docs/learn-flink/index.md
+++ b/docs/learn-flink/index.md
@@ -62,7 +62,7 @@ exchange, or sensor readings from a machine on a factory floor, data is created 
 But when you analyze data, you can either organize your processing around _bounded_ or _unbounded_
 streams, and which of these paradigms you choose has profound consequences.
 
-<img src="{{ site.baseurl }}/fig/bounded-unbounded.png" alt="Bounded and unbounded streams" class="offset" width="90%" />
+<img src="{% link /fig/bounded-unbounded.png %}" alt="Bounded and unbounded streams" class="offset" width="90%" />
 
 **Batch processing** is the paradigm at work when you process a bounded data stream. In this mode of
 operation you can choose to ingest the entire dataset before producing any results, which means that
@@ -76,7 +76,7 @@ In Flink, applications are composed of **streaming dataflows** that may be trans
 user-defined **operators**. These dataflows form directed graphs that start with one or more
 **sources**, and end in one or more **sinks**.
 
-<img src="{{ site.baseurl }}/fig/program_dataflow.svg" alt="A DataStream program, and its dataflow." class="offset" width="80%" />
+<img src="{% link /fig/program_dataflow.svg %}" alt="A DataStream program, and its dataflow." class="offset" width="80%" />
 
 Often there is a one-to-one correspondence between the transformations in the program and the
 operators in the dataflow. Sometimes, however, one transformation may consist of multiple operators.
@@ -86,7 +86,7 @@ distributed logs, like Apache Kafka or Kinesis. But flink can also consume bound
 from a variety of data sources. Similarly, the streams of results being produced by a Flink
 application can be sent to a wide variety of systems that can be connected as sinks.
 
-<img src="{{ site.baseurl }}/fig/flink-application-sources-sinks.png" alt="Flink application with sources and sinks" class="offset" width="90%" />
+<img src="{% link /fig/flink-application-sources-sinks.png %}" alt="Flink application with sources and sinks" class="offset" width="90%" />
 
 ### Parallel Dataflows
 
@@ -101,7 +101,7 @@ operator.
 Different operators of the same program may have different levels of
 parallelism.
 
-<img src="{{ site.baseurl }}/fig/parallel_dataflow.svg" alt="A parallel dataflow" class="offset" width="80%" />
+<img src="{% link /fig/parallel_dataflow.svg %}" alt="A parallel dataflow" class="offset" width="80%" />
 
 Streams can transport data between two operators in a *one-to-one* (or
 *forwarding*) pattern, or in a *redistributing* pattern:
@@ -163,13 +163,13 @@ and you can see that a fully-connected network shuffle is occurring between the 
 operators. This is being done to partition the stream by some key, so that all of the events that
 need to be processed together, will be.
 
-<img src="{{ site.baseurl }}/fig/parallel-job.png" alt="State is sharded" class="offset" width="65%" />
+<img src="{% link /fig/parallel-job.png %}" alt="State is sharded" class="offset" width="65%" />
 
 State is always accessed locally, which helps Flink applications achieve high throughput and
 low-latency. You can choose to keep state on the JVM heap, or if it is too large, in efficiently
 organized on-disk data structures. 
 
-<img src="{{ site.baseurl }}/fig/local-state.png" alt="State is local" class="offset" width="90%" />
+<img src="{% link /fig/local-state.png %}" alt="State is local" class="offset" width="90%" />
 
 {% top %}
 

--- a/docs/learn-flink/index.zh.md
+++ b/docs/learn-flink/index.zh.md
@@ -50,7 +50,7 @@ under the License.
 
 在自然环境中，数据的产生原本就是流式的。无论是来自 Web 服务器的事件数据，证券交易所的交易数据，还是来自工厂车间机器上的传感器数据，其数据都是流式的。但是当你分析数据时，可以围绕 _有界流_（_bounded_）或 _无界流_（_unbounded_）两种模型来组织处理数据，当然，选择不同的模型，程序的执行和处理方式也都会不同。
 
-<img src="{{ site.baseurl }}/fig/bounded-unbounded.png" alt="Bounded and unbounded streams" class="offset" width="90%" />
+<img src="{% link /fig/bounded-unbounded.png %}" alt="Bounded and unbounded streams" class="offset" width="90%" />
 
 **批处理**是有界数据流处理的范例。在这种模式下，你可以选择在计算结果输出之前输入整个数据集，这也就意味着你可以对整个数据集的数据进行排序、统计或汇总计算后再输出结果。
 
@@ -58,13 +58,13 @@ under the License.
 
 在 Flink 中，应用程序由用户自定义**算子**转换而来的**流式 dataflows** 所组成。这些流式 dataflows 形成了有向图，以一个或多个**源**（source）开始，并以一个或多个**汇**（sink）结束。
 
-<img src="{{ site.baseurl }}/fig/program_dataflow.svg" alt="A DataStream program, and its dataflow." class="offset" width="80%" />
+<img src="{% link /fig/program_dataflow.svg %}" alt="A DataStream program, and its dataflow." class="offset" width="80%" />
 
 通常，程序代码中的 transformation 和 dataflow 中的算子（operator）之间是一一对应的。但有时也会出现一个 transformation 包含多个算子的情况，如上图所示。
 
 Flink 应用程序可以消费来自消息队列或分布式日志这类流式数据源（例如 Apache Kafka 或 Kinesis）的实时数据，也可以从各种的数据源中消费有界的历史数据。同样，Flink 应用程序生成的结果流也可以发送到各种数据汇中。
 
-<img src="{{ site.baseurl }}/fig/flink-application-sources-sinks.png" alt="Flink application with sources and sinks" class="offset" width="90%" />
+<img src="{% link /fig/flink-application-sources-sinks.png %}" alt="Flink application with sources and sinks" class="offset" width="90%" />
 
 ### 并行 Dataflows
 
@@ -72,7 +72,7 @@ Flink 程序本质上是分布式并行程序。在程序执行期间，一个�
 
 算子子任务数就是其对应算子的**并行度**。在同一程序中，不同算子也可能具有不同的并行度。
 
-<img src="{{ site.baseurl }}/fig/parallel_dataflow.svg" alt="A parallel dataflow" class="offset" width="80%" />
+<img src="{% link /fig/parallel_dataflow.svg %}" alt="A parallel dataflow" class="offset" width="80%" />
 
 Flink 算子之间可以通过*一对一*（*直传*）模式或*重新分发*模式传输数据：
 
@@ -102,11 +102,11 @@ Flink 应用程序可以在分布式群集上并行运行，其中每个算子�
 
 如下图的 Flink 作业，其前三个算子的并行度为 2，最后一个 sink 算子的并行度为 1，其中第三个算子是有状态的，并且你可以看到第二个算子和第三个算子之间是全互联的（fully-connected），它们之间通过网络进行数据分发。通常情况下，实现这种类型的 Flink 程序是为了通过某些键对数据流进行分区，以便将需要一起处理的事件进行汇合，然后做统一计算处理。
 
-<img src="{{ site.baseurl }}/fig/parallel-job.png" alt="State is sharded" class="offset" width="65%" />
+<img src="{% link /fig/parallel-job.png %}" alt="State is sharded" class="offset" width="65%" />
 
 Flink 应用程序的状态访问都在本地进行，因为这有助于其提高吞吐量和降低延迟。通常情况下 Flink 应用程序都是将状态存储在 JVM 堆上，但如果状态太大，我们也可以选择将其以结构化数据格式存储在高速磁盘中。
 
-<img src="{{ site.baseurl }}/fig/local-state.png" alt="State is local" class="offset" width="90%" />
+<img src="{% link /fig/local-state.png %}" alt="State is local" class="offset" width="90%" />
 
 {% top %}
 

--- a/docs/learn-flink/streaming_analytics.md
+++ b/docs/learn-flink/streaming_analytics.md
@@ -200,7 +200,7 @@ stream.
 
 Flink has several built-in types of window assigners, which are illustrated below:
 
-<img src="{{ site.baseurl }}/fig/window-assigners.svg" alt="Window assigners" class="center" width="80%" />
+<img src="{% link /fig/window-assigners.svg %}" alt="Window assigners" class="center" width="80%" />
 
 Some examples of what these window assigners might be used for, and how to specify them:
 

--- a/docs/monitoring/back_pressure.md
+++ b/docs/monitoring/back_pressure.md
@@ -38,7 +38,7 @@ Take a simple `Source -> Sink` job as an example. If you see a warning for `Sour
 
 Back pressure monitoring works by repeatedly taking back pressure samples of your running tasks. The JobManager triggers repeated calls to `Task.isBackPressured()` for the tasks of your job.
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling.png %}" class="img-responsive">
 <!-- https://docs.google.com/drawings/d/1O5Az3Qq4fgvnISXuSf-MqBlsLDpPolNB7EQG7A3dcTk/edit?usp=sharing -->
 
 Internally, back pressure is judged based on the availability of output buffers. If there is no available buffer (at least one) for output, then it indicates that there is back pressure for the task.
@@ -70,14 +70,14 @@ This means that the JobManager triggered a back pressure sample of the running t
 
 Note that clicking the row, you trigger the sample for all subtasks of this operator.
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_in_progress.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_in_progress.png %}" class="img-responsive">
 
 ### Back Pressure Status
 
 If you see status **OK** for the tasks, there is no indication of back pressure. **HIGH** on the other hand means that the tasks are back pressured.
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_ok.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_ok.png %}" class="img-responsive">
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_high.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_high.png %}" class="img-responsive">
 
 {% top %}

--- a/docs/monitoring/back_pressure.zh.md
+++ b/docs/monitoring/back_pressure.zh.md
@@ -40,7 +40,7 @@ Flink Web 界面提供了一个选项卡来监控正在运行 Job 的反压行�
 
 通过不断对每个 Task 的反压状态采样来进行反压监控。JobManager 会触发对 Task `Task.isBackPressured()` 的重复调用。
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling.png %}" class="img-responsive">
 <!-- https://docs.google.com/drawings/d/1O5Az3Qq4fgvnISXuSf-MqBlsLDpPolNB7EQG7A3dcTk/edit?usp=sharing -->
 
 Task 是否反压是基于输出 Buffer 的可用性判断的，如果一个用于数据输出的 Buffer 都没有了，则表明 Task 被反压了。
@@ -73,14 +73,14 @@ Task 是否反压是基于输出 Buffer 的可用性判断的，如果一个用�
 
 注意，点击该行，可触发该算子所有 SubTask 的采样。
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_in_progress.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_in_progress.png %}" class="img-responsive">
 
 ### 反压状态
 
 如果你看到 Task 的状态为 **OK** 表示没有反压。**HIGH** 表示这个 Task 被反压。
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_ok.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_ok.png %}" class="img-responsive">
 
-<img src="{{ site.baseurl }}/fig/back_pressure_sampling_high.png" class="img-responsive">
+<img src="{% link /fig/back_pressure_sampling_high.png %}" class="img-responsive">
 
 {% top %}

--- a/docs/monitoring/checkpoint_monitoring.md
+++ b/docs/monitoring/checkpoint_monitoring.md
@@ -53,7 +53,7 @@ The overview tabs lists the following statistics. Note that these statistics don
 The checkpoint history keeps statistics about recently triggered checkpoints, including those that are currently in progress.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-history.png" width="700px" alt="Checkpoint Monitoring: History">
+  <img src="{% link /fig/checkpoint_monitoring-history.png %}" width="700px" alt="Checkpoint Monitoring: History">
 </center>
 
 - **ID**: The ID of the triggered checkpoint. The IDs are incremented for each checkpoint, starting at 1.
@@ -68,7 +68,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 For subtasks there are a couple of more detailed stats available.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-history-subtasks.png" width="700px" alt="Checkpoint Monitoring: History">
+  <img src="{% link /fig/checkpoint_monitoring-history-subtasks.png %}" width="700px" alt="Checkpoint Monitoring: History">
 </center>
 
 - **Sync Duration**: The duration of the synchronous part of the checkpoint. This includes snapshotting state of the operators and blocks all other activity on the subtask (processing records, firing timers, etc).
@@ -90,7 +90,7 @@ web.checkpoints.history: 15
 The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, Checkpointed Data Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-summary.png" width="700px" alt="Checkpoint Monitoring: Summary">
+  <img src="{% link /fig/checkpoint_monitoring-summary.png %}" width="700px" alt="Checkpoint Monitoring: Summary">
 </center>
 
 Note that these statistics don't survive a JobManager loss and are reset to if your JobManager fails over.
@@ -111,19 +111,19 @@ The configuration list your streaming configuration:
 When you click on a *More details* link for a checkpoint, you get a Minimum/Average/Maximum summary over all its operators and also the detailed numbers per single subtask.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details.png" width="700px" alt="Checkpoint Monitoring: Details">
+  <img src="{% link /fig/checkpoint_monitoring-details.png %}" width="700px" alt="Checkpoint Monitoring: Details">
 </center>
 
 #### Summary per Operator
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details_summary.png" width="700px" alt="Checkpoint Monitoring: Details Summary">
+  <img src="{% link /fig/checkpoint_monitoring-details_summary.png %}" width="700px" alt="Checkpoint Monitoring: Details Summary">
 </center>
 
 #### All Subtask Statistics
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details_subtasks.png" width="700px" alt="Checkpoint Monitoring: Subtasks">
+  <img src="{% link /fig/checkpoint_monitoring-details_subtasks.png %}" width="700px" alt="Checkpoint Monitoring: Subtasks">
 </center>
 
 {% top %}

--- a/docs/monitoring/checkpoint_monitoring.zh.md
+++ b/docs/monitoring/checkpoint_monitoring.zh.md
@@ -53,7 +53,7 @@ The overview tabs lists the following statistics. Note that these statistics don
 The checkpoint history keeps statistics about recently triggered checkpoints, including those that are currently in progress.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-history.png" width="700px" alt="Checkpoint Monitoring: History">
+  <img src="{% link /fig/checkpoint_monitoring-history.png %}" width="700px" alt="Checkpoint Monitoring: History">
 </center>
 
 - **ID**: The ID of the triggered checkpoint. The IDs are incremented for each checkpoint, starting at 1.
@@ -68,7 +68,7 @@ The checkpoint history keeps statistics about recently triggered checkpoints, in
 For subtasks there are a couple of more detailed stats available.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-history-subtasks.png" width="700px" alt="Checkpoint Monitoring: History">
+  <img src="{% link /fig/checkpoint_monitoring-history-subtasks.png %}" width="700px" alt="Checkpoint Monitoring: History">
 </center>
 
 - **Sync Duration**: The duration of the synchronous part of the checkpoint. This includes snapshotting state of the operators and blocks all other activity on the subtask (processing records, firing timers, etc).
@@ -90,7 +90,7 @@ web.checkpoints.history: 15
 The summary computes a simple min/average/maximum statistics over all completed checkpoints for the End to End Duration, Checkpointed Data Size, and Bytes Buffered During Alignment (see [History](#history) for details about what these mean).
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-summary.png" width="700px" alt="Checkpoint Monitoring: Summary">
+  <img src="{% link /fig/checkpoint_monitoring-summary.png %}" width="700px" alt="Checkpoint Monitoring: Summary">
 </center>
 
 Note that these statistics don't survive a JobManager loss and are reset to if your JobManager fails over.
@@ -111,19 +111,19 @@ The configuration list your streaming configuration:
 When you click on a *More details* link for a checkpoint, you get a Minimum/Average/Maximum summary over all its operators and also the detailed numbers per single subtask.
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details.png" width="700px" alt="Checkpoint Monitoring: Details">
+  <img src="{% link /fig/checkpoint_monitoring-details.png %}" width="700px" alt="Checkpoint Monitoring: Details">
 </center>
 
 #### Summary per Operator
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details_summary.png" width="700px" alt="Checkpoint Monitoring: Details Summary">
+  <img src="{% link /fig/checkpoint_monitoring-details_summary.png %}" width="700px" alt="Checkpoint Monitoring: Details Summary">
 </center>
 
 #### All Subtask Statistics
 
 <center>
-  <img src="{{ site.baseurl }}/fig/checkpoint_monitoring-details_subtasks.png" width="700px" alt="Checkpoint Monitoring: Subtasks">
+  <img src="{% link /fig/checkpoint_monitoring-details_subtasks.png %}" width="700px" alt="Checkpoint Monitoring: Subtasks">
 </center>
 
 {% top %}

--- a/docs/monitoring/debugging_classloading.md
+++ b/docs/monitoring/debugging_classloading.md
@@ -78,7 +78,7 @@ YARN classloading differs between single job deployments and sessions:
 
 **Mesos**
 
-Mesos setups following [this documentation](../ops/deployment/mesos.html) currently behave very much like the a
+Mesos setups following [this documentation]({% link ops/deployment/mesos.md %}) currently behave very much like the a
 YARN session: The TaskManager and JobManager processes are started with the Flink framework classes in the Java classpath, job
 classes are loaded dynamically when the jobs are submitted.
 
@@ -100,13 +100,13 @@ In most cases, this works well and no additional configuration from the user is 
 
 However, there are cases when the inverted classloading causes problems (see below, ["X cannot be cast to X"](#x-cannot-be-cast-to-x-exceptions)). 
 For user code classloading, you can revert back to Java's default mode by configuring the ClassLoader resolution order via
-[`classloader.resolve-order`](../ops/config.html#classloader-resolve-order) in the Flink config to `parent-first`
+[`classloader.resolve-order`]({% link ops/config.md %}#classloader-resolve-order) in the Flink config to `parent-first`
 (from Flink's default `child-first`).
 
 Please note that certain classes are always resolved in a *parent-first* way (through the parent ClassLoader first), because they
 are shared between Flink's core and the plugin/user code or the plugin/user-code facing APIs. The packages for these classes are configured via 
-[`classloader.parent-first-patterns-default`](../ops/config.html#classloader-parent-first-patterns-default) and
-[`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional).
+[`classloader.parent-first-patterns-default`]({% link ops/config.md %}#classloader-parent-first-patterns-default) and
+[`classloader.parent-first-patterns-additional`]({% link ops/config.md %}#classloader-parent-first-patterns-additional).
 To add new packages to be *parent-first* loaded, please set the `classloader.parent-first-patterns-additional` config option.
 
 
@@ -143,8 +143,8 @@ In setups with dynamic classloading, you may see an exception in the style `com.
 This means that multiple versions of the class `com.foo.X` have been loaded by different class loaders, and types of that class are attempted to be assigned to each other.
 
 One common reason is that a library is not compatible with Flink's *inverted classloading* approach. You can turn off inverted classloading
-to verify this (set [`classloader.resolve-order: parent-first`](../ops/config.html#classloader-resolve-order) in the Flink config) or exclude
-the library from inverted classloading (set [`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional)
+to verify this (set [`classloader.resolve-order: parent-first`]({% link ops/config.md %}#classloader-resolve-order) in the Flink config) or exclude
+the library from inverted classloading (set [`classloader.parent-first-patterns-additional`]({% link ops/config.md %}#classloader-parent-first-patterns-additional)
 in the Flink config).
 
 Another cause can be cached object instances, as produced by some libraries like *Apache Avro*, or by interning objects (for example via Guava's Interners).
@@ -171,7 +171,7 @@ Common causes for class leaks and suggested fixes:
     interners, or Avro's class/object caches in the serializers.
 
   - *JDBC*: JDBC drivers leak references outside the user code classloader. To ensure that these classes are only loaded once
-   you should either add the driver jars to Flink's `lib/` folder, or add the driver classes to the list of parent-first loaded class via [`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional).
+   you should either add the driver jars to Flink's `lib/` folder, or add the driver classes to the list of parent-first loaded class via [`classloader.parent-first-patterns-additional`]({% link ops/config.md %}#classloader-parent-first-patterns-additional).
 
 
 ## Resolving Dependency Conflicts with Flink using the maven-shade-plugin.

--- a/docs/monitoring/debugging_classloading.zh.md
+++ b/docs/monitoring/debugging_classloading.zh.md
@@ -78,7 +78,7 @@ YARN classloading differs between single job deployments and sessions:
 
 **Mesos**
 
-Mesos setups following [this documentation](../ops/deployment/mesos.html) currently behave very much like the a
+Mesos setups following [this documentation]({% link ops/deployment/mesos.zh.md %}) currently behave very much like the a
 YARN session: The TaskManager and JobManager processes are started with the Flink framework classes in the Java classpath, job
 classes are loaded dynamically when the jobs are submitted.
 
@@ -100,13 +100,13 @@ In most cases, this works well and no additional configuration from the user is 
 
 However, there are cases when the inverted classloading causes problems (see below, ["X cannot be cast to X"](#x-cannot-be-cast-to-x-exceptions)). 
 For user code classloading, you can revert back to Java's default mode by configuring the ClassLoader resolution order via
-[`classloader.resolve-order`](../ops/config.html#classloader-resolve-order) in the Flink config to `parent-first`
+[`classloader.resolve-order`]({% link ops/config.zh.md %}#classloader-resolve-order) in the Flink config to `parent-first`
 (from Flink's default `child-first`).
 
 Please note that certain classes are always resolved in a *parent-first* way (through the parent ClassLoader first), because they
 are shared between Flink's core and the plugin/user code or the plugin/user-code facing APIs. The packages for these classes are configured via 
-[`classloader.parent-first-patterns-default`](../ops/config.html#classloader-parent-first-patterns-default) and
-[`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional).
+[`classloader.parent-first-patterns-default`]({% link ops/config.zh.md %}#classloader-parent-first-patterns-default) and
+[`classloader.parent-first-patterns-additional`]({% link ops/config.zh.md %}#classloader-parent-first-patterns-additional).
 To add new packages to be *parent-first* loaded, please set the `classloader.parent-first-patterns-additional` config option.
 
 
@@ -143,8 +143,8 @@ In setups with dynamic classloading, you may see an exception in the style `com.
 This means that multiple versions of the class `com.foo.X` have been loaded by different class loaders, and types of that class are attempted to be assigned to each other.
 
 One common reason is that a library is not compatible with Flink's *inverted classloading* approach. You can turn off inverted classloading
-to verify this (set [`classloader.resolve-order: parent-first`](../ops/config.html#classloader-resolve-order) in the Flink config) or exclude
-the library from inverted classloading (set [`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional)
+to verify this (set [`classloader.resolve-order: parent-first`]({% link ops/config.zh.md %}#classloader-resolve-order) in the Flink config) or exclude
+the library from inverted classloading (set [`classloader.parent-first-patterns-additional`]({% link ops/config.zh.md %}#classloader-parent-first-patterns-additional)
 in the Flink config).
 
 Another cause can be cached object instances, as produced by some libraries like *Apache Avro*, or by interning objects (for example via Guava's Interners).
@@ -171,7 +171,7 @@ Common causes for class leaks and suggested fixes:
     interners, or Avro's class/object caches in the serializers.
 
   - *JDBC*: JDBC drivers leak references outside the user code classloader. To ensure that these classes are only loaded once
-   you should either add the driver jars to Flink's `lib/` folder, or add the driver classes to the list of parent-first loaded class via [`classloader.parent-first-patterns-additional`](../ops/config.html#classloader-parent-first-patterns-additional).
+   you should either add the driver jars to Flink's `lib/` folder, or add the driver classes to the list of parent-first loaded class via [`classloader.parent-first-patterns-additional`]({% link ops/config.zh.md %}#classloader-parent-first-patterns-additional).
 
 
 ## Resolving Dependency Conflicts with Flink using the maven-shade-plugin.

--- a/docs/monitoring/debugging_event_time.md
+++ b/docs/monitoring/debugging_event_time.md
@@ -27,11 +27,11 @@ under the License.
 
 ## Monitoring Current Event Time
 
-Flink's [event time]({{ site.baseurl }}/dev/event_time.html) and watermark support are powerful features for handling
+Flink's [event time]({% link dev/event_time.md %}) and watermark support are powerful features for handling
 out-of-order events. However, it's harder to understand what exactly is going on because the progress of time
 is tracked within the system.
 
-Low watermarks of each task can be accessed through Flink web interface or [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
+Low watermarks of each task can be accessed through Flink web interface or [metrics system]({% link monitoring/metrics.md %}).
 
 Each Task in Flink exposes a metric called `currentInputWatermark` that represents the lowest watermark received
 by this task. This long value represents the "current event time".
@@ -43,7 +43,7 @@ and selecting the `<taskNr>.currentInputWatermark` metric. In the new box you'll
 the current low watermark of the task.
 
 Another way of getting the metric is using one of the **metric reporters**, as described in the documentation
-for the [metrics system]({{ site.baseurl }}/monitoring/metrics.html).
+for the [metrics system]({% link monitoring/metrics.md %}).
 For local setups, we recommend using the JMX metric reporter and a tool like [VisualVM](https://visualvm.github.io/).
 
 

--- a/docs/monitoring/historyserver.md
+++ b/docs/monitoring/historyserver.md
@@ -71,7 +71,7 @@ historyserver.archive.fs.refresh-interval: 10000
 
 The contained archives are downloaded and cached in the local filesystem. The local directory for this is configured via `historyserver.web.tmpdir`.
 
-Check out the configuration page for a [complete list of configuration options]({{ site.baseurl }}/ops/config.html#history-server).
+Check out the configuration page for a [complete list of configuration options]({% link ops/config.md %}#history-server).
 
 ## Available Requests
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1031,7 +1031,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
 </table>
 
 
-### Network (Deprecated: use [Default shuffle service metrics]({{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service))
+### Network (Deprecated: use [Default shuffle service metrics](#default-shuffle-service))
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -1385,7 +1385,7 @@ Metrics related to data exchange between task executors using netty network comm
     <tr>
       <th rowspan="2"><strong>Task</strong></th>
       <td>checkpointAlignmentTime</td>
-      <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds). This is the time between receiving first and the last checkpoint barrier. You can find more information in the [Monitoring State and Checkpoints section]({{ site.baseurl }}/ops/state/large_state_tuning.html#monitoring-state-and-checkpoints)</td>
+      <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds). This is the time between receiving first and the last checkpoint barrier. You can find more information in the [Monitoring State and Checkpoints section]({% link ops/state/large_state_tuning.md %}#monitoring-state-and-checkpoints)</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -1397,7 +1397,7 @@ Metrics related to data exchange between task executors using netty network comm
 </table>
 
 ### RocksDB
-Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({{ site.baseurl }}/ops/config.html#rocksdb-native-metrics)
+Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({% link ops/config.md %}#rocksdb-native-metrics)
 
 ### IO
 <table class="table table-bordered">
@@ -1413,48 +1413,48 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     <tr>
       <th rowspan="1"><strong>Job (only available on TaskManager)</strong></th>
       <td>[&lt;source_id&gt;.[&lt;source_subtask_index&gt;.]]&lt;operator_id&gt;.&lt;operator_subtask_index&gt;.latency</td>
-      <td>The latency distributions from a given source (subtask) to an operator subtask (in milliseconds), depending on the <a href="{{ site.baseurl }}/ops/config.html#metrics-latency-granularity">latency granularity</a>.</td>
+      <td>The latency distributions from a given source (subtask) to an operator subtask (in milliseconds), depending on the <a href="{% link ops/config.md %}#metrics-latency-granularity">latency granularity</a>.</td>
       <td>Histogram</td>
     </tr>
     <tr>
       <th rowspan="14"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInLocalPerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBytesInRemote</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInRemotePerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInLocal</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInLocalPerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInRemote</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInRemotePerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
@@ -1836,7 +1836,7 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
 
 Flink allows to track the latency of records travelling through the system. This feature is disabled by default.
 To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
-[Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval) or `ExecutionConfig`.
+[Flink configuration]({% link ops/config.md %}#metrics-latency-interval) or `ExecutionConfig`.
 
 At the `latencyTrackingInterval`, the sources will periodically emit a special record, called a `LatencyMarker`.
 The marker contains a timestamp from the time when the record has been emitted at the sources.
@@ -1850,7 +1850,7 @@ the markers will reflect that.
 
 The `LatencyMarker`s are used to derive a distribution of the latency between the sources of the topology and each 
 downstream operator. These distributions are reported as histogram metrics. The granularity of these distributions can 
-be controlled in the [Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval). For the highest 
+be controlled in the [Flink configuration]({% link ops/config.md %}#metrics-latency-interval). For the highest 
 granularity `subtask` Flink will derive the latency distribution between every source subtask and every downstream 
 subtask, which results in quadratic (in the terms of the parallelism) number of histograms. 
 
@@ -1863,7 +1863,7 @@ purposes.
 
 ## REST API integration
 
-Metrics can be queried through the [Monitoring REST API]({{ site.baseurl }}/monitoring/rest_api.html).
+Metrics can be queried through the [Monitoring REST API]({% link monitoring/rest_api.md %}).
 
 Below is a list of available endpoints, with a sample JSON response. All endpoints are of the sample form `http://hostname:8081/jobmanager/metrics`, below we list only the *path* part of the URLs.
 

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -586,7 +586,7 @@ metrics.reporter.my_other_reporter.port: 10000
 {% endhighlight %}
 
 **Important:** The jar containing the reporter must be accessible when Flink is started. Reporters that support the
- `factory.class` property can be loaded as [plugins]({{ site.baseurl }}/ops/plugins). Otherwise the jar must be placed
+ `factory.class` property can be loaded as [plugins]({% link ops/plugins.zh.md %}). Otherwise the jar must be placed
  in the /lib folder. Reporters that are shipped with Flink (i.e., all reporters documented on this page) are available
  by default.
 
@@ -1030,7 +1030,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
 </table>
 
 
-### Network (Deprecated: use [Default shuffle service metrics]({{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service))
+### Network (Deprecated: use [Default shuffle service metrics]({% link monitoring/metrics.zh.md %}#default-shuffle-service))
 <table class="table table-bordered">
   <thead>
     <tr>
@@ -1384,7 +1384,7 @@ Metrics related to data exchange between task executors using netty network comm
     <tr>
       <th rowspan="2">Task</th>
       <td>checkpointAlignmentTime</td>
-      <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds). This is the time between receiving first and the last checkpoint barrier. You can find more information in the [Monitoring State and Checkpoints section]({{ site.baseurl }}/ops/state/large_state_tuning.html#monitoring-state-and-checkpoints)</td>
+      <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds). This is the time between receiving first and the last checkpoint barrier. You can find more information in the [Monitoring State and Checkpoints section]({% link ops/state/large_state_tuning.zh.md %}#monitoring-state-and-checkpoints)</td>
       <td>Gauge</td>
     </tr>
     <tr>
@@ -1396,7 +1396,7 @@ Metrics related to data exchange between task executors using netty network comm
 </table>
 
 ### RocksDB
-Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({{ site.baseurl }}/ops/config.html#rocksdb-native-metrics)
+Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({% link ops/config.zh.md %}#rocksdb-native-metrics)
 
 ### IO
 <table class="table table-bordered">
@@ -1412,48 +1412,48 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     <tr>
       <th rowspan="1"><strong>Job (only available on TaskManager)</strong></th>
       <td>[&lt;source_id&gt;.[&lt;source_subtask_index&gt;.]]&lt;operator_id&gt;.&lt;operator_subtask_index&gt;.latency</td>
-      <td>The latency distributions from a given source (subtask) to an operator subtask (in milliseconds), depending on the <a href="{{ site.baseurl }}/ops/config.html#metrics-latency-granularity">latency granularity</a>.</td>
+      <td>The latency distributions from a given source (subtask) to an operator subtask (in milliseconds), depending on the <a href="{% link ops/config.zh.md %}#metrics-latency-granularity">latency granularity</a>.</td>
       <td>Histogram</td>
     </tr>
     <tr>
       <th rowspan="13"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInLocalPerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBytesInRemote</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBytesInRemotePerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInLocal</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInLocalPerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
       <td>numBuffersInRemote</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
     </tr>
     <tr>
       <td>numBuffersInRemotePerSecond</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service">Default shuffle service metrics</a>.</td>
+      <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{% link monitoring/metrics.zh.md %}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Meter</td>
     </tr>
     <tr>
@@ -1835,7 +1835,7 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
 
 Flink allows to track the latency of records travelling through the system. This feature is disabled by default.
 To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
-[Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval) or `ExecutionConfig`.
+[Flink configuration]({% link ops/config.zh.md %}#metrics-latency-interval) or `ExecutionConfig`.
 
 At the `latencyTrackingInterval`, the sources will periodically emit a special record, called a `LatencyMarker`.
 The marker contains a timestamp from the time when the record has been emitted at the sources.
@@ -1849,7 +1849,7 @@ the markers will reflect that.
 
 The `LatencyMarker`s are used to derive a distribution of the latency between the sources of the topology and each
 downstream operator. These distributions are reported as histogram metrics. The granularity of these distributions can
-be controlled in the [Flink configuration]({{ site.baseurl }}/ops/config.html#metrics-latency-interval). For the highest
+be controlled in the [Flink configuration]({% link ops/config.zh.md %}#metrics-latency-interval). For the highest
 granularity `subtask` Flink will derive the latency distribution between every source subtask and every downstream 
 subtask, which results in quadratic (in the terms of the parallelism) number of histograms. 
 
@@ -1862,7 +1862,7 @@ purposes.
 
 ## REST API integration
 
-Metrics can be queried through the [Monitoring REST API]({{ site.baseurl }}/monitoring/rest_api.html).
+Metrics can be queried through the [Monitoring REST API]({% link monitoring/rest_api.zh.md %}).
 
 Below is a list of available endpoints, with a sample JSON response. All endpoints are of the sample form `http://hostname:8081/jobmanager/metrics`, below we list only the *path* part of the URLs.
 

--- a/docs/try-flink/datastream_api.md
+++ b/docs/try-flink/datastream_api.md
@@ -446,14 +446,14 @@ For the first version, the fraud detector should output an alert for any account
 Imagine your fraud detector processes the following stream of transactions for a particular account.
 
 <p class="text-center">
-    <img alt="Transactions" width="80%" src="{{ site.baseurl }}/fig/fraud-transactions.svg"/>
+    <img alt="Transactions" width="80%" src="{% link /fig/fraud-transactions.svg %}"/>
 </p>
 
 Transactions 3 and 4 should be marked as fraudulent because it is a small transaction, $0.09, followed by a large one, $510.
 Alternatively, transactions 7, 8, and 9 are not fraud because the small amount of $0.02 is not immediately followed by the large one; instead, there is an intermediate transaction that breaks the pattern.
 
 To do this, the fraud detector must _remember_ information across events; a large transaction is only fraudulent if the previous one was small.
-Remembering information across events requires [state]({{ site.baseurl }}/concepts/glossary.html#managed-state), and that is why we decided to use a [KeyedProcessFunction]({{ site.baseurl }}/dev/stream/operators/process_function.html). 
+Remembering information across events requires [state]({% link concepts/glossary.md %}#managed-state), and that is why we decided to use a [KeyedProcessFunction]({% link dev/stream/operators/process_function.md %}). 
 It provides fine-grained control over both state and time, which will allow us to evolve our algorithm with more complex requirements throughout this walkthrough.
 
 The most straightforward implementation is a boolean flag that is set whenever a small transaction is processed.
@@ -466,7 +466,7 @@ Hence, the fraud detector would possibly miss alerts if the application ever had
 
 To address these challenges, Flink provides primitives for fault-tolerant state that are almost as easy to use as regular member variables.
 
-The most basic type of state in Flink is [ValueState]({{ site.baseurl }}/dev/stream/state/state.html#using-managed-keyed-state), a data type that adds fault tolerance to any variable it wraps.
+The most basic type of state in Flink is [ValueState]({% link dev/stream/state/state.md %}#using-managed-keyed-state), a data type that adds fault tolerance to any variable it wraps.
 `ValueState` is a form of _keyed state_, meaning it is only available in operators that are applied in a _keyed context_; any operator immediately following `DataStream#keyBy`.
 A _keyed state_ of an operator is automatically scoped to the key of the record that is currently processed.
 In this example, the key is the account id for the current transaction (as declared by `keyBy()`), and `FraudDetector` maintains an independent state for each account. 

--- a/docs/try-flink/datastream_api.zh.md
+++ b/docs/try-flink/datastream_api.zh.md
@@ -30,6 +30,8 @@ Flink 支持对状态和时间的细粒度控制，以此来实现复杂的事�
 * This will be replaced by the TOC
 {:toc}
 
+<a name="what-are-you-building"></a>
+
 ## 你要搭建一个什么系统
 
 在当今数字时代，信用卡欺诈行为越来越被重视。
@@ -40,14 +42,20 @@ Flink 支持对状态和时间的细粒度控制，以此来实现复杂的事�
 在这个教程中，你将会建立一个针对可疑信用卡交易行为的反欺诈检测系统。
 通过使用一组简单的规则，你将了解到 Flink 如何为我们实现复杂业务逻辑并实时执行。
 
+<a name="prerequisites"></a>
+
 ## 准备条件
 
 这个代码练习假定你对 Java 或 Scala 有一定的了解，当然，如果你之前使用的是其他开发语言，你也应该能够跟随本教程进行学习。
+
+<a name="help-im-stuck"></a>
 
 ## 困难求助
 
 如果遇到困难，可以参考 [社区支持资源](https://flink.apache.org/zh/gettinghelp.html)。
 当然也可以在邮件列表提问，Flink 的 [用户邮件列表](https://flink.apache.org/zh/community.html#mailing-lists)  一直被评为所有Apache项目中最活跃的一个，这也是快速获得帮助的好方法。
+
+<a name="how-to-follow-along"></a>
 
 ## 怎样跟着教程练习
 
@@ -59,7 +67,7 @@ Flink 支持对状态和时间的细粒度控制，以此来实现复杂的事�
 一个准备好的 Flink Maven Archetype 能够快速创建一个包含了必要依赖的 Flink 程序骨架，基于此，你可以把精力集中在编写业务逻辑上即可。
 这些已包含的依赖包括 `flink-streaming-java`、`flink-walkthrough-common` 等，他们分别是 Flink 应用程序的核心依赖项和这个代码练习需要的数据生成器，当然还包括其他本代码练习所依赖的类。
 
-{% panel **说明:** 为简洁起见，本练习中的代码块中可能不包含完整的类路径。完整的类路径可以在文档底部 [链接](#完整的程序) 中找到。 %}
+{% panel **说明:** 为简洁起见，本练习中的代码块中可能不包含完整的类路径。完整的类路径可以在文档底部 [链接](#final-application) 中找到。 %}
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -125,6 +133,9 @@ Maven 将会创建一个名为 `frauddetection` 的文件夹，包含了所有�
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
+
+<a name="frauddetectionjobjava"></a>
+
 #### FraudDetectionJob.java
 
 {% highlight java %}
@@ -160,6 +171,8 @@ public class FraudDetectionJob {
 }
 {% endhighlight %}
 
+<a name="frauddetectorjava"></a>
+
 #### FraudDetector.java
 {% highlight java %}
 package spendreport;
@@ -193,6 +206,9 @@ public class FraudDetector extends KeyedProcessFunction<Long, Transaction, Alert
 </div>
 
 <div data-lang="scala" markdown="1">
+
+<a name="frauddetectionjobscala"></a>
+
 #### FraudDetectionJob.scala
 
 {% highlight scala %}
@@ -227,6 +243,8 @@ object FraudDetectionJob {
   }
 }
 {% endhighlight %}
+
+<a name="frauddetectorscala"></a>
 
 #### FraudDetector.scala
 
@@ -264,11 +282,15 @@ class FraudDetector extends KeyedProcessFunction[Long, Transaction, Alert] {
 </div>
 </div>
 
+<a name="breaking-down-the-code"></a>
+
 ## 代码分析
 
 让我们一步步地来分析一下这两个代码文件。`FraudDetectionJob` 类定义了程序的数据流，而 `FraudDetector` 类定义了欺诈交易检测的业务逻辑。
 
 下面我们开始讲解整个 Job 是如何组装到 `FraudDetectionJob` 类的 `main` 函数中的。
+
+<a name="the-execution-environment"></a>
 
 #### 执行环境
 
@@ -288,6 +310,8 @@ val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnv
 {% endhighlight %}
 </div>
 </div>
+
+<a name="creating-a-source"></a>
 
 #### 创建数据源
 
@@ -314,6 +338,7 @@ val transactions: DataStream[Transaction] = env
 </div>
 </div>
 
+<a name="partitioning-events--detecting-fraud"></a>
 
 #### 对事件分区 & 欺诈检测
 
@@ -344,6 +369,8 @@ val alerts: DataStream[Alert] = transactions
 </div>
 </div>
 
+<a name="outputting-results"></a>
+
 #### 输出结果
 
 sink 会将 `DataStream` 写出到外部系统，例如 Apache Kafka、Cassandra 或者 AWS Kinesis 等。
@@ -363,6 +390,8 @@ alerts.addSink(new AlertSink)
 </div>
 </div>
 
+<a name="executing-the-job"></a>
+
 #### 运行作业
 
 Flink 程序是懒加载的，并且只有在完全搭建好之后，才能够发布到集群上执行。
@@ -381,6 +410,8 @@ env.execute("Fraud Detection")
 {% endhighlight %}
 </div>
 </div>
+
+<a name="the-fraud-detector"></a>
 
 #### 欺诈检测器
 
@@ -441,6 +472,8 @@ class FraudDetector extends KeyedProcessFunction[Long, Transaction, Alert] {
 </div>
 </div>
 
+<a name="writing-a-real-application-v1"></a>
+
 ## 实现一个真正的应用程序
 
 我们先实现第一版报警程序，对于一个账户，如果出现小于 $1 美元的交易后紧跟着一个大于 $500 的交易，就输出一个报警信息。
@@ -448,14 +481,14 @@ class FraudDetector extends KeyedProcessFunction[Long, Transaction, Alert] {
 假设你的欺诈检测器所处理的交易数据如下：
 
 <p class="text-center">
-    <img alt="Transactions" width="80%" src="{{ site.baseurl }}/fig/fraud-transactions.svg"/>
+    <img alt="Transactions" width="80%" src="{% link /fig/fraud-transactions.svg %}"/>
 </p>
 
 交易 3 和交易 4 应该被标记为欺诈行为，因为交易 3 是一个 $0.09 的小额交易，而紧随着的交易 4 是一个 $510 的大额交易。
 另外，交易 7、8 和 交易 9 就不属于欺诈交易了，因为在交易 7 这个 $0.02 的小额交易之后，并没有跟随一个大额交易，而是一个金额适中的交易，这使得交易 7 到 交易 9 不属于欺诈行为。
 
 欺诈检测器需要在多个交易事件之间记住一些信息。仅当一个大额的交易紧随一个小额交易的情况发生时，这个大额交易才被认为是欺诈交易。
-在多个事件之间存储信息就需要使用到 [状态]({{ site.baseurl }}/zh/concepts/glossary.html#managed-state)，这也是我们选择使用 [KeyedProcessFunction]({{ site.baseurl }}/zh/dev/stream/operators/process_function.html) 的原因。
+在多个事件之间存储信息就需要使用到 [状态]({% link concepts/glossary.zh.md %}#managed-state)，这也是我们选择使用 [KeyedProcessFunction]({% link dev/stream/operators/process_function.zh.md %}) 的原因。
 它能够同时提供对状态和时间的细粒度操作，这使得我们能够在接下来的代码练习中实现更复杂的算法。
 
 最直接的实现方式是使用一个 boolean 型的标记状态来表示是否刚处理过一个小额交易。
@@ -468,7 +501,7 @@ Flink 会在同一个 `FraudDetector` 的并发实例中处理多个账户的交
 
 为了应对这个问题，Flink 提供了一套支持容错状态的原语，这些原语几乎与常规成员变量一样易于使用。
 
-Flink 中最基础的状态类型是 [ValueState]({{ site.baseurl }}/zh/dev/stream/state/state.html#using-managed-keyed-state)，这是一种能够为被其封装的变量添加容错能力的类型。
+Flink 中最基础的状态类型是 [ValueState]({% link dev/stream/state/state.zh.md %}#using-managed-keyed-state)，这是一种能够为被其封装的变量添加容错能力的类型。
 `ValueState` 是一种 _keyed state_，也就是说它只能被用于 _keyed context_ 提供的 operator 中，即所有能够紧随 `DataStream#keyBy` 之后被调用的operator。
 一个 operator 中的  _keyed state_ 的作用域默认是属于它所属的 key 的。
 这个例子中，key 就是当前正在处理的交易行为所属的信用卡账户（key 传入 keyBy() 函数调用），而 `FraudDetector` 维护了每个帐户的标记状态。
@@ -750,6 +783,8 @@ private def cleanUp(ctx: KeyedProcessFunction[Long, Transaction, Alert]#Context)
 
 这就是一个功能完备的，有状态的分布式流处理程序了。
 
+<a name="final-application"></a>
+
 ## 完整的程序
 
 <div class="codetabs" markdown="1">
@@ -930,6 +965,8 @@ class FraudDetector extends KeyedProcessFunction[Long, Transaction, Alert] {
 {% endhighlight %}
 </div>
 </div>
+
+<a name="expected-output"></a>
 
 ### 期望的结果
 

--- a/docs/try-flink/flink-operations-playground.md
+++ b/docs/try-flink/flink-operations-playground.md
@@ -50,16 +50,16 @@ operational tasks like upgrades and rescaling.
 ## Anatomy of this Playground
 
 This playground consists of a long living
-[Flink Session Cluster]({{ site.baseurl }}/concepts/glossary.html#flink-session-cluster) and a Kafka
+[Flink Session Cluster]({% link concepts/glossary.md %}#flink-session-cluster) and a Kafka
 Cluster.
 
 A Flink Cluster always consists of a 
-[JobManager]({{ site.baseurl }}/concepts/glossary.html#flink-jobmanager) and one or more 
-[Flink TaskManagers]({{ site.baseurl }}/concepts/glossary.html#flink-taskmanager). The JobManager 
-is responsible for handling [Job]({{ site.baseurl }}/concepts/glossary.html#flink-job) submissions, 
+[JobManager]({% link concepts/glossary.md %}#flink-jobmanager) and one or more 
+[Flink TaskManagers]({% link concepts/glossary.md %}#flink-taskmanager). The JobManager 
+is responsible for handling [Job]({% link concepts/glossary.md %}#flink-job) submissions, 
 the supervision of Jobs as well as resource management. The Flink TaskManagers are the worker 
 processes and are responsible for the execution of the actual 
-[Tasks]({{ site.baseurl }}/concepts/glossary.html#task) which make up a Flink Job. In this 
+[Tasks]({% link concepts/glossary.md %}#task) which make up a Flink Job. In this 
 playground you will start with a single TaskManager, but scale out to more TaskManagers later. 
 Additionally, this playground comes with a dedicated *client* container, which we use to submit the 
 Flink Job initially and to perform various operational tasks later on. The *client* container is not
@@ -67,18 +67,18 @@ needed by the Flink Cluster itself but only included for ease of use.
 
 The Kafka Cluster consists of a Zookeeper server and a Kafka Broker.
 
-<img src="{{ site.baseurl }}/fig/flink-docker-playground.svg" alt="Flink Docker Playground"
+<img src="{% link /fig/flink-docker-playground.svg %}" alt="Flink Docker Playground"
 class="offset" width="80%" />
 
 When the playground is started a Flink Job called *Flink Event Count* will be submitted to the 
 JobManager. Additionally, two Kafka Topics *input* and *output* are created.
 
-<img src="{{ site.baseurl }}/fig/click-event-count-example.svg" alt="Click Event Count Example"
+<img src="{% link /fig/click-event-count-example.svg %}" alt="Click Event Count Example"
 class="offset" width="80%" />
 
 The Job consumes `ClickEvent`s from the *input* topic, each with a `timestamp` and a `page`. The 
 events are then keyed by `page` and counted in 15 second
-[windows]({{ site.baseurl }}/dev/stream/operators/windows.html). The results are written to the 
+[windows]({% link dev/stream/operators/windows.md %}). The results are written to the 
 *output* topic. 
 
 There are six different pages and we generate 1000 click events per page and 15 seconds. Hence, the 
@@ -140,7 +140,7 @@ The most natural starting point to observe your Flink Cluster is the WebUI expos
 [http://localhost:8081](http://localhost:8081). If everything went well, you'll see that the cluster initially consists of 
 one TaskManager and executes a Job called *Click Event Count*.
 
-<img src="{{ site.baseurl }}/fig/playground-webui.png" alt="Playground Flink WebUI"
+<img src="{% link /fig/playground-webui.png %}" alt="Playground Flink WebUI"
 class="offset" width="100%" />
 
 The Flink WebUI contains a lot of useful and interesting information about your Flink Cluster and 
@@ -169,7 +169,7 @@ After the initial startup you should mainly see log messages for every checkpoin
 
 ### Flink CLI
 
-The [Flink CLI]({{ site.baseurl }}/ops/cli.html) can be used from within the client container. For
+The [Flink CLI]({% link ops/cli.md %}) can be used from within the client container. For
 example, to print the `help` message of the Flink CLI you can run
 {% highlight bash%}
 docker-compose run --no-deps client flink --help
@@ -177,7 +177,7 @@ docker-compose run --no-deps client flink --help
 
 ### Flink REST API
 
-The [Flink REST API]({{ site.baseurl }}/monitoring/rest_api.html#api) is exposed via
+The [Flink REST API]({% link monitoring/rest_api.md %}#api) is exposed via
 `localhost:8081` on the host or via `jobmanager:8081` from the client container, e.g. to list all
 currently running jobs, you can run:
 {% highlight bash%}
@@ -291,7 +291,7 @@ immediately resubmit it for recovery.
 When the Job gets restarted, its tasks remain in the `SCHEDULED` state, which is indicated by the 
 purple colored squares (see screenshot below).
 
-<img src="{{ site.baseurl }}/fig/playground-webui-failure.png" alt="Playground Flink WebUI" 
+<img src="{% link /fig/playground-webui-failure.png %}" alt="Playground Flink WebUI" 
 class="offset" width="100%" />
 
 <p style="border-radius: 5px; padding: 5px" class="bg-info">
@@ -316,14 +316,14 @@ docker-compose up -d taskmanager
 
 When the JobManager is notified about the new TaskManager, it schedules the tasks of the 
 recovering Job to the newly available TaskSlots. Upon restart, the tasks recover their state from
-the last successful [checkpoint]({{ site.baseurl }}/learn-flink/fault_tolerance.html) that was taken
+the last successful [checkpoint]({% link learn-flink/fault_tolerance.md %}) that was taken
 before the failure and switch to the `RUNNING` state.
 
 The Job will quickly process the full backlog of input events (accumulated during the outage) 
 from Kafka and produce output at a much higher rate (> 24 records/minute) until it reaches 
 the head of the stream. In the *output* you will see that all keys (`page`s) are present for all time 
 windows and that every count is exactly one thousand. Since we are using the 
-[FlinkKafkaProducer]({{ site.baseurl }}/dev/connectors/kafka.html#kafka-producers-and-fault-tolerance)
+[FlinkKafkaProducer]({% link dev/connectors/kafka.md %}#kafka-producers-and-fault-tolerance)
 in its "at-least-once" mode, there is a chance that you will see some duplicate output records.
 
 <p style="border-radius: 5px; padding: 5px" class="bg-info">
@@ -334,7 +334,7 @@ in its "at-least-once" mode, there is a chance that you will see some duplicate 
 ### Upgrading & Rescaling a Job
 
 Upgrading a Flink Job always involves two steps: First, the Flink Job is gracefully stopped with a
-[Savepoint]({{ site.baseurl }}/ops/state/savepoints.html). A Savepoint is a consistent snapshot of 
+[Savepoint]({% link ops/state/savepoints.md %}). A Savepoint is a consistent snapshot of 
 the complete application state at a well-defined, globally consistent point in time (similar to a 
 checkpoint). Second, the upgraded Flink Job is started from the Savepoint. In this context "upgrade" 
 can mean different things including the following:
@@ -530,7 +530,7 @@ rescaling: all windows are present with a count of exactly one thousand.
 
 ### Querying the Metrics of a Job
 
-The JobManager exposes system and user [metrics]({{ site.baseurl }}/monitoring/metrics.html)
+The JobManager exposes system and user [metrics]({% link monitoring/metrics.md %})
 via its REST API.
 
 The endpoint depends on the scope of these metrics. Metrics scoped to a Job can be listed via 
@@ -780,7 +780,7 @@ curl localhost:8081/jobs/<jod-id>
 }
 {% endhighlight %}
 
-Please consult the [REST API reference]({{ site.baseurl }}/monitoring/rest_api.html#api)
+Please consult the [REST API reference]({% link monitoring/rest_api.md %}#api)
 for a complete list of possible queries including how to query metrics of different scopes (e.g. 
 TaskManager metrics);
 
@@ -792,12 +792,12 @@ You might have noticed that the *Click Event Count* application was always start
 and `--event-time` program arguments. By omitting these in the command of the *client* container in the 
 `docker-compose.yaml`, you can change the behavior of the Job.
 
-* `--checkpointing` enables [checkpoint]({{ site.baseurl }}/learn-flink/fault_tolerance.html), 
+* `--checkpointing` enables [checkpoint]({% link learn-flink/fault_tolerance.md %}), 
 which is Flink's fault-tolerance mechanism. If you run without it and go through 
 [failure and recovery](#observing-failure--recovery), you should will see that data is actually 
 lost.
 
-* `--event-time` enables [event time semantics]({{ site.baseurl }}/dev/event_time.html) for your 
+* `--event-time` enables [event time semantics]({% link dev/event_time.md %}) for your 
 Job. When disabled, the Job will assign events to windows based on the wall-clock time instead of 
 the timestamp of the `ClickEvent`. Consequently, the number of events per window will not be exactly
 one thousand anymore. 
@@ -808,7 +808,7 @@ command of the *client* container in `docker-compose.yaml`.
 
 * `--backpressure` adds an additional operator into the middle of the job that causes severe backpressure 
 during even-numbered minutes (e.g., during 10:12, but not during 10:13). This can be observed by 
-inspecting various [network metrics]({{ site.baseurl }}/monitoring/metrics.html#default-shuffle-service) 
+inspecting various [network metrics]({% link monitoring/metrics.md %}#default-shuffle-service) 
 such as `outputQueueLength` and `outPoolUsage`, and/or by using the 
-[backpressure monitoring]({{ site.baseurl }}/monitoring/back_pressure.html#monitoring-back-pressure) 
+[backpressure monitoring]({% link monitoring/back_pressure.md %}#monitoring-back-pressure) 
 available in the WebUI.

--- a/docs/try-flink/flink-operations-playground.zh.md
+++ b/docs/try-flink/flink-operations-playground.zh.md
@@ -38,6 +38,7 @@ Apache Flink 可以以多种方式在不同的环境中部署，抛开这种多�
 
 * This will be replaced by the TOC
 {:toc}
+
 <a name="anatomy-of-this-playground"></a>
 
 ## 场景说明
@@ -76,6 +77,7 @@ class="offset" width="80%" />
 因此，针对特定 page，该 Flink job 应该能在每个窗口中输出 1000 个该 page 的点击数据。
 
 {% top %}
+
 <a name="starting-the-playground"></a>
 
 ## 环境搭建
@@ -120,11 +122,13 @@ operations-playground_zookeeper_1              /bin/sh -c /usr/sbin/sshd  ...   
 {% highlight bash %}
 docker-compose down -v
 {% endhighlight %}
+
 <a name="entering-the-playground"></a>
 
 ## 环境讲解
 
 在这个搭建好的环境中你可以尝试和验证很多事情，在下面的两个部分中我们将向你展示如何与 Flink 集群进行交互以及演示并讲解 Flink 的一些核心特性。
+
 <a name="flink-webui"></a>
 
 ### Flink WebUI 界面
@@ -137,6 +141,7 @@ docker-compose down -v
 class="offset" width="100%" />
 
 Flink WebUI 界面包含许多关于 Flink 集群以及运行在其上的 Jobs 的有用信息，比如：JobGraph、Metrics、Checkpointing Statistics、TaskManager Status 等等。 
+
 <a name="logs"></a>
 
 ### 日志
@@ -200,12 +205,14 @@ docker-compose exec kafka kafka-console-consumer.sh \
 {% endhighlight %}
 
 {%  top %}
+
 <a name="time-to-play"></a>
 
 ## 核心特性探索
 
 到目前为止，你已经学习了如何与 Flink 以及 Docker 容器进行交互，现在让我们看一些常用的操作命令。
 本节中的各部分命令不需要按任何特定的顺序执行，这些命令大部分都可以通过 [CLI](#flink-cli) 或 [RESTAPI](#flink-rest-api) 执行。
+
 <a name="listing-running-jobs"></a>
 
 ### 获取所有运行中的 Job
@@ -246,12 +253,14 @@ curl localhost:8081/jobs
 
 一旦 Job 提交，Flink 会默认为其生成一个 JobID，后续对该 Job 的
 所有操作（无论是通过 CLI 还是 REST API）都需要带上 JobID。
+
 <a name="observing-failure--recovery"></a>
 
 ### Job 失败与恢复
 
 在 Job (部分)失败的情况下，Flink 对事件处理依然能够提供精确一次的保障，
 在本节中你将会观察到并能够在某种程度上验证这种行为。 
+
 <a name="step-1-observing-the-output"></a>
 
 #### Step 1: 观察输出
@@ -266,6 +275,7 @@ curl localhost:8081/jobs
 docker-compose exec kafka kafka-console-consumer.sh \
   --bootstrap-server localhost:9092 --topic output
 {% endhighlight %}
+
 <a name="step-2-introducing-a-fault"></a>
 
 #### Step 2: 模拟失败
@@ -293,6 +303,7 @@ class="offset" width="100%" />
 不断循环的过程。
 
 与此同时，数据生成器 (data generator) 一直不断地往 *input* topic 中生成 `ClickEvent` 事件，在生产环境中也经常出现这种 Job 挂掉但源头还在不断产生数据的情况。
+
 <a name="step-3-recovery"></a>
 
 #### Step 3: 失败恢复
@@ -318,6 +329,7 @@ docker-compose up -d taskmanager
   <b>注意</b>：在大部分生产环境中都需要一个资源管理器 (Kubernetes、Yarn,、Mesos)对
   失败的 Job 进行自动重启。
 </p>
+
 <a name="upgrading--rescaling-a-job"></a>
 
 ### Job 升级与扩容
@@ -337,6 +349,7 @@ Savepoint 是整个应用程序状态的一次快照（类似于 checkpoint ）�
 docker-compose exec kafka kafka-console-consumer.sh \
   --bootstrap-server localhost:9092 --topic output
 {% endhighlight %}
+
 <a name="step-1-stopping-the-job"></a>
 
 #### Step 1: 停止 Job
@@ -408,6 +421,7 @@ curl -X POST localhost:8081/jobs/<job-id>/stop -d '{"drain": false}'
 {% endhighlight %}
 </div>
 </div>
+
 <a name="step-2a-restart-job-without-changes"></a>
 
 #### Step 2a: 重启 Job (不作任何变更)
@@ -464,6 +478,7 @@ curl -X POST http://localhost:8081/jars/<jar-id>/run \
 一旦该 Job 再次处于 `RUNNING` 状态，你将从 *output* Topic 中看到数据在快速输出，
 因为刚启动的 Job 正在处理停止期间积压的大量数据。另外，你还会看到在升级期间
 没有产生任何数据丢失：所有窗口都在输出 1000。
+
 <a name="step-2b-restart-job-with-a-different-parallelism-rescaling"></a>
 
 #### Step 2b: 重启 Job (修改并行度)
@@ -525,6 +540,7 @@ docker-compose scale taskmanager=2
 
 一旦 Job 再次运行起来，从 *output* Topic 的输出中你会看到在扩容期间数据依然没有丢失：
 所有窗口的计数都正好是 1000。
+
 <a name="querying-the-metrics-of-a-job"></a>
 
 ### 查询 Job 指标
@@ -780,6 +796,7 @@ curl localhost:8081/jobs/<jod-id>
 请查阅 [REST API 参考]({%link monitoring/rest_api.zh.md %}#api)，该参考上有完整的指标查询接口信息，包括如何查询不同种类的指标（例如 TaskManager 指标）。
 
 {%  top %}
+
 <a name="variants"></a>
 
 ## 延伸拓展

--- a/docs/try-flink/python_api.zh.md
+++ b/docs/try-flink/python_api.zh.md
@@ -26,10 +26,13 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
+<a name="python-table-api-tutorial"></a>
 
 ## Python Table API 教程
 
 详细信息请参考 [Python Table API 教程]({% link dev/python/table_api_tutorial.zh.md %})文档
+
+<a name="python-datastream-api-tutorial"></a>
 
 ## Python DataStream API 教程
 


### PR DESCRIPTION
## What is the purpose of the change

Change the link format

 from  `{{ site.baseurl }}/.../xxx.html`

to  `{% link .../xxx.md %}` 

in some doc directories.

## Brief change log

Change the link format in these directories:
- `docs/try-flink`
- `docs/flinkDev`
- `docs/internal`
- `docs/concepts`
- `docs/monitoring`
- `docs/learn-flink`

Please refer to the corresponding commits.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

The `docs/build_docs.sh` script can be executed normally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
