### PR TITLE
[FLINK-19384][core] Add common permissive exception signatures to all methods of Source.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
@@ -21,7 +21,6 @@ package org.apache.flink.api.connector.source;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
-import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -49,16 +48,22 @@ public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Seriali
 	 *
 	 * @param readerContext The {@link SourceReaderContext context} for the source reader.
 	 * @return A new SourceReader.
+	 *
+	 * @throws Exception The implementor is free to forward all exceptions directly.
+	 *                   Exceptions thrown from this method cause task failure/recovery.
 	 */
-	SourceReader<T, SplitT> createReader(SourceReaderContext readerContext);
+	SourceReader<T, SplitT> createReader(SourceReaderContext readerContext) throws Exception;
 
 	/**
 	 * Creates a new SplitEnumerator for this source, starting a new input.
 	 *
 	 * @param enumContext The {@link SplitEnumeratorContext context} for the split enumerator.
 	 * @return A new SplitEnumerator.
+	 *
+	 * @throws Exception The implementor is free to forward all exceptions directly.
+	 * 	 *                   Exceptions thrown from this method cause JobManager failure/recovery.
 	 */
-	SplitEnumerator<SplitT, EnumChkT> createEnumerator(SplitEnumeratorContext<SplitT> enumContext);
+	SplitEnumerator<SplitT, EnumChkT> createEnumerator(SplitEnumeratorContext<SplitT> enumContext) throws Exception;
 
 	/**
 	 * Restores an enumerator from a checkpoint.
@@ -66,10 +71,13 @@ public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Seriali
 	 * @param enumContext The {@link SplitEnumeratorContext context} for the restored split enumerator.
 	 * @param checkpoint The checkpoint to restore the SplitEnumerator from.
 	 * @return A SplitEnumerator restored from the given checkpoint.
+	 *
+	 * @throws Exception The implementor is free to forward all exceptions directly.
+	 * 	 *                   Exceptions thrown from this method cause JobManager failure/recovery.
 	 */
 	SplitEnumerator<SplitT, EnumChkT> restoreEnumerator(
 			SplitEnumeratorContext<SplitT> enumContext,
-			EnumChkT checkpoint) throws IOException;
+			EnumChkT checkpoint) throws Exception;
 
 	// ------------------------------------------------------------------------
 	//  serializers for the metadata

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -61,19 +61,40 @@ public interface SourceReader<T, SplitT extends SourceSplit> extends AutoCloseab
 	List<SplitT> snapshotState();
 
 	/**
+	 * Returns a future that signals that data is available from the reader.
+	 *
+	 * <p>Once the future completes, the runtime will keep calling the {@link #pollNext(ReaderOutput)}
+	 * method until that methods returns a status other than {@link InputStatus#MORE_AVAILABLE}.
+	 * After that the, the runtime will again call this method to obtain the next future.
+	 * Once that completes, it will again call {@link #pollNext(ReaderOutput)} and so on.
+	 *
+	 * <p>The contract is the following: If the reader has data available, then all
+	 * futures previously returned by this method must eventually complete. Otherwise
+	 * the source might stall indefinitely.
+	 *
+	 * <p>It is not a problem to have occasional "false positives", meaning to complete
+	 * a future even if no data is available. However, one should not use an "always complete"
+	 * future in cases no data is available, because that will result in busy waiting loops
+	 * calling {@code pollNext(...)} even though no data is available.
+	 *
 	 * @return a future that will be completed once there is a record available to poll.
 	 */
 	CompletableFuture<Void> isAvailable();
 
 	/**
 	 * Adds a list of splits for this reader to read.
+	 * This method is called when the enumerator assigns a split via
+	 * {@link SplitEnumeratorContext#assignSplit(SourceSplit, int)} or
+	 * {@link SplitEnumeratorContext#assignSplits(SplitsAssignment)}.
 	 *
 	 * @param splits The splits assigned by the split enumerator.
 	 */
 	void addSplits(List<SplitT> splits);
 
 	/**
-	 * Handle a source event sent by the {@link SplitEnumerator}.
+	 * Handle a custom source event sent by the {@link SplitEnumerator}.
+	 * This method is called when the enumerator sends an event via
+	 * {@link SplitEnumeratorContext#sendEventToSourceReader(int, SourceEvent)}.
 	 *
 	 * @param sourceEvent the event sent by the {@link SplitEnumerator}.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -203,6 +203,6 @@ public interface OperatorCoordinator extends AutoCloseable {
 		/**
 		 * Creates the {@code OperatorCoordinator}, using the given context.
 		 */
-		OperatorCoordinator create(Context context);
+		OperatorCoordinator create(Context context) throws Exception;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -298,7 +298,7 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 	public static OperatorCoordinatorHolder create(
 			SerializedValue<OperatorCoordinator.Provider> serializedProvider,
 			ExecutionJobVertex jobVertex,
-			ClassLoader classLoader) throws IOException, ClassNotFoundException {
+			ClassLoader classLoader) throws Exception {
 
 		try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(classLoader)) {
 			final OperatorCoordinator.Provider provider = serializedProvider.deserializeValue(classLoader);
@@ -327,7 +327,7 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 			final BiFunction<SerializedValue<OperatorEvent>, Integer, CompletableFuture<Acknowledge>> eventSender,
 			final String operatorName,
 			final int operatorParallelism,
-			final int operatorMaxParallelism) {
+			final int operatorMaxParallelism) throws Exception {
 
 		final OperatorEventValve valve = new OperatorEventValve(eventSender);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 
 import javax.annotation.Nullable;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -39,7 +40,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
 	private RecreateOnResetOperatorCoordinator(
 			QuiesceableContext context,
-			Provider provider) {
+			Provider provider) throws Exception {
 		this.quiesceableContext = context;
 		this.provider = provider;
 		this.coordinator = provider.getCoordinator(context);
@@ -107,7 +108,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
 	// ---------------------
 
-	public static abstract class Provider implements OperatorCoordinator.Provider {
+	public abstract static class Provider implements OperatorCoordinator.Provider {
 		private static final long serialVersionUID = 3002837631612629071L;
 		private final OperatorID operatorID;
 
@@ -121,12 +122,12 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 		}
 
 		@Override
-		public OperatorCoordinator create(Context context) {
+		public OperatorCoordinator create(Context context) throws Exception {
 			QuiesceableContext quiesceableContext = new QuiesceableContext(context);
 			return new RecreateOnResetOperatorCoordinator(quiesceableContext, this);
 		}
 
-		protected abstract OperatorCoordinator getCoordinator(OperatorCoordinator.Context context);
+		protected abstract OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) throws Exception;
 	}
 
 	// ----------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -89,7 +89,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 			String operatorName,
 			ExecutorService coordinatorExecutor,
 			Source<?, SplitT, EnumChkT> source,
-			SourceCoordinatorContext<SplitT> context) {
+			SourceCoordinatorContext<SplitT> context) throws Exception {
 		this.operatorName = operatorName;
 		this.coordinatorExecutor = coordinatorExecutor;
 		this.source = source;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -64,7 +64,7 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit> extends Recre
 	}
 
 	@Override
-	public OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) {
+	public OperatorCoordinator getCoordinator(OperatorCoordinator.Context context) throws Exception  {
 		final String coordinatorThreadName = "SourceCoordinator-" + operatorName;
 		CoordinatorExecutorThreadFactory coordinatorThreadFactory =
 				new CoordinatorExecutorThreadFactory(coordinatorThreadName);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -90,7 +91,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 
 	private RecreateOnResetOperatorCoordinator createCoordinator(
 			TestingCoordinatorProvider provider,
-			OperatorCoordinator.Context context) {
+			OperatorCoordinator.Context context) throws Exception {
 		return (RecreateOnResetOperatorCoordinator) provider.create(context);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
@@ -55,7 +55,7 @@ public class SourceCoordinatorProviderTest {
 	}
 
 	@Test
-	public void testCreate() {
+	public void testCreate() throws Exception {
 		OperatorCoordinator coordinator =
 				provider.create(new MockOperatorCoordinatorContext(OPERATOR_ID, NUM_SPLITS));
 		assertTrue(coordinator instanceof RecreateOnResetOperatorCoordinator);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -52,7 +52,7 @@ public abstract class SourceCoordinatorTestBase {
 	protected MockSplitEnumerator enumerator;
 
 	@Before
-	public void setup() {
+	public void setup() throws Exception {
 		operatorCoordinatorContext = new MockOperatorCoordinatorContext(TEST_OPERATOR_ID, NUM_SUBTASKS);
 		splitSplitAssignmentTracker = new SplitAssignmentTracker<>();
 		String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
@@ -80,9 +80,10 @@ public abstract class SourceCoordinatorTestBase {
 
 	// --------------------------
 
-	protected SourceCoordinator getNewSourceCoordinator() {
+	protected SourceCoordinator getNewSourceCoordinator() throws Exception {
 		Source<Integer, MockSourceSplit, Set<MockSourceSplit>> mockSource =
 				new MockSource(Boundedness.BOUNDED, NUM_SUBTASKS * 2);
+
 		return new SourceCoordinator<>(OPERATOR_NAME, coordinatorExecutor, mockSource, context);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -47,11 +47,11 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.FunctionWithException;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -79,7 +79,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 	/** The factory for the source reader. This is a workaround, because currently the SourceReader
 	 * must be lazily initialized, which is mainly because the metrics groups that the reader relies on is
 	 * lazily initialized. */
-	private final Function<SourceReaderContext, SourceReader<OUT, SplitT>> readerFactory;
+	private final FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception> readerFactory;
 
 	/** The serializer for the splits, applied to the split types before storing them in the reader state. */
 	private final SimpleVersionedSerializer<SplitT> splitSerializer;
@@ -119,7 +119,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 	private TimestampsAndWatermarks<OUT> eventTimeLogic;
 
 	public SourceOperator(
-			Function<SourceReaderContext, SourceReader<OUT, SplitT>> readerFactory,
+			FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception> readerFactory,
 			OperatorEventGateway operatorEventGateway,
 			SimpleVersionedSerializer<SplitT> splitSerializer,
 			WatermarkStrategy<OUT> watermarkStrategy,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -32,8 +32,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.source.coordinator.SourceCoordinatorProvider;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
-
-import java.util.function.Function;
+import org.apache.flink.util.function.FunctionWithException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -137,7 +136,7 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
 	 */
 	@SuppressWarnings("unchecked")
 	private static <T, SplitT extends SourceSplit> SourceOperator<T, SplitT> instantiateSourceOperator(
-			Function<SourceReaderContext, SourceReader<T, ?>> readerFactory,
+			FunctionWithException<SourceReaderContext, SourceReader<T, ?>, Exception> readerFactory,
 			OperatorEventGateway eventGateway,
 			SimpleVersionedSerializer<?> splitSerializer,
 			WatermarkStrategy<T> watermarkStrategy,
@@ -147,8 +146,9 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
 			boolean emitProgressiveWatermarks) {
 
 		// jumping through generics hoops: cast the generics away to then cast them back more strictly typed
-		final Function<SourceReaderContext, SourceReader<T, SplitT>> typedReaderFactory =
-				(Function<SourceReaderContext, SourceReader<T, SplitT>>) (Function<?, ?>) readerFactory;
+		final FunctionWithException<SourceReaderContext, SourceReader<T, SplitT>, Exception> typedReaderFactory =
+				(FunctionWithException<SourceReaderContext, SourceReader<T, SplitT>, Exception>)
+				(FunctionWithException<?, ?, ?>) readerFactory;
 
 		final SimpleVersionedSerializer<SplitT> typedSplitSerializer = (SimpleVersionedSerializer<SplitT>) splitSerializer;
 


### PR DESCRIPTION
## What is the purpose of the change

This makes the exception signatures consistent within the class and with the exception philisophy in other API classes, like transformation functions: Allow users to simply throw or forward any type of checked exceptions.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** - Changes exception signatures on `@PublicEvolving` classes.
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
