### PR TITLE
[FLINK-19903][Table SQL / API] Metadata fields for filesystem csv format

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroFileSystemFormatFactory.java
@@ -37,8 +37,10 @@ import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -97,6 +99,16 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
                 context.getPushedDownLimit(),
                 selectFieldToProjectField,
                 selectFieldToFormatField);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // TODO: implement
     }
 
     /**
@@ -160,6 +172,7 @@ public class AvroFileSystemFormatFactory implements FileSystemFormatFactory {
                             fieldNames,
                             fieldTypes,
                             selectFields,
+                            0,
                             partitionKeys,
                             currentSplit.getPath(),
                             defaultPartValue);

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
@@ -89,5 +89,127 @@ public class CsvFilesystemBatchITCase {
                     "select * from nonPartitionedTable",
                     Arrays.asList(Row.of("x5", 5, 1, 1), Row.of("x5", 5, 2, 2)));
         }
+
+        @Test
+        public void testFilenamePathMetadata() throws Exception {
+            String path = new URI(resultPath()).getPath();
+            new File(path).mkdirs();
+            File file1 = new File(path, "test_file1");
+            file1.createNewFile();
+            FileUtils.writeFileUtf8(file1, "x8,8,1,1\n" + "x8,8,3,3");
+            File file2 = new File(path, "test_file2");
+            file2.createNewFile();
+            FileUtils.writeFileUtf8(file2, "x8,8,2,2");
+
+            check(
+                    "select x,y,a,b,`flink.fs.path` from withMetadataTable",
+                    Arrays.asList(
+                            // TODO: should path have a leading file:/ or not?
+                            Row.of("x8,8,1,1,file:" + file1.getPath()),
+                            Row.of("x8,8,2,2,file:" + file2.getPath()),
+                            Row.of("x8,8,3,3,file:" + file1.getPath())));
+
+            check(
+                    "select x,y,a,b,`flink.fs.path` from withMetadataTable2",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,file:" + file1.getPath()),
+                            Row.of("x8,8,2,2,file:" + file2.getPath()),
+                            Row.of("x8,8,3,3,file:" + file1.getPath())));
+
+            check(
+                    "select x,y,a,b,`flink.fs.path` from withMetadataTable3",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,file:" + file1.getPath()),
+                            Row.of("x8,8,2,2,file:" + file2.getPath()),
+                            Row.of("x8,8,3,3,file:" + file1.getPath())));
+            check(
+                    "select x,y,a,b,`flink.fs.path` from withMetadataTable5",
+                    Arrays.asList(
+                            // TODO: should path have a leading file:/ or not?
+                            Row.of("x8,8,1,1,file:" + file1.getPath()),
+                            Row.of("x8,8,2,2,file:" + file2.getPath()),
+                            Row.of("x8,8,3,3,file:" + file1.getPath())));
+        }
+
+        @Test
+        public void testBasenameMetadata() throws Exception {
+            String path = new URI(resultPath()).getPath();
+            new File(path).mkdirs();
+            File file1 = new File(path, "test_file1");
+            file1.createNewFile();
+            FileUtils.writeFileUtf8(file1, "x8,8,1,1\n" + "x8,8,3,3");
+            File file2 = new File(path, "test_file2");
+            file2.createNewFile();
+            FileUtils.writeFileUtf8(file2, "x8,8,2,2");
+
+            check(
+                    "select x,y,a,b,`flink.fs.basename` from withMetadataTable",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,test_file1"),
+                            Row.of("x8,8,2,2,test_file2"),
+                            Row.of("x8,8,3,3,test_file1")));
+            check(
+                    "select x,y,a,b,`flink.fs.basename` from withMetadataTable2",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,test_file1"),
+                            Row.of("x8,8,2,2,test_file2"),
+                            Row.of("x8,8,3,3,test_file1")));
+            check(
+                    "select x,y,a,b,`flink.fs.basename` from withMetadataTable4",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,test_file1"),
+                            Row.of("x8,8,2,2,test_file2"),
+                            Row.of("x8,8,3,3,test_file1")));
+            check(
+                    "select x,y,a,b,`flink.fs.basename` from withMetadataTable5",
+                    Arrays.asList(
+                            Row.of("x8,8,1,1,test_file1"),
+                            Row.of("x8,8,2,2,test_file2"),
+                            Row.of("x8,8,3,3,test_file1")));
+        }
+
+        @Test
+        public void testMetadata() throws Exception {
+            String path = new URI(resultPath()).getPath();
+            new File(path).mkdirs();
+            File file1 = new File(path, "test_file1");
+            file1.createNewFile();
+            FileUtils.writeFileUtf8(file1, "x1,2,3,4\n" + "x9,10,11,12");
+            File file2 = new File(path, "test_file2");
+            file2.createNewFile();
+            FileUtils.writeFileUtf8(file2, "x5,6,7,8");
+
+            //  x  y  a b
+            // x1  2  3 4
+            check(
+                    "select x,`flink.fs.path`,a,`flink.fs.basename`,y from withMetadataTable", // we
+                    // drop field b
+                    Arrays.asList(
+                            // TODO: should path have a leading file:/ or not?
+                            Row.of("x1,file:" + file1.getAbsolutePath() + ",3,test_file1,2"),
+                            Row.of("x5,file:" + file2.getAbsolutePath() + ",7,test_file2,6"),
+                            Row.of("x9,file:" + file1.getAbsolutePath() + ",11,test_file1,10")));
+
+            check(
+                    "select x,`flink.fs.path`,b,a,`flink.fs.basename`,y from withMetadataTable",
+                    Arrays.asList(
+                            Row.of("x1,file:" + file1.getAbsolutePath() + ",4,3,test_file1,2"),
+                            Row.of("x5,file:" + file2.getAbsolutePath() + ",8,7,test_file2,6"),
+                            Row.of("x9,file:" + file1.getAbsolutePath() + ",12,11,test_file1,10")));
+
+            check(
+                    "select x,`flink.fs.path`,b,a,bname,y from withMetadataTable6",
+                    Arrays.asList(
+                            Row.of("x1,file:" + file1.getAbsolutePath() + ",4,3,test_file1,2"),
+                            Row.of("x5,file:" + file2.getAbsolutePath() + ",8,7,test_file2,6"),
+                            Row.of("x9,file:" + file1.getAbsolutePath() + ",12,11,test_file1,10")));
+
+            check(
+                    "select x,`flink.fs.path`,b,a,bname,y from withMetadataTable7",
+                    Arrays.asList(
+                            Row.of("x1,file:" + file1.getAbsolutePath() + ",4,3,test_file1,2"),
+                            Row.of("x5,file:" + file2.getAbsolutePath() + ",8,7,test_file2,6"),
+                            Row.of("x9,file:" + file1.getAbsolutePath() + ",12,11,test_file1,10")));
+        }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FileSystemFormatFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FileSystemFormatFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.DataType;
@@ -41,7 +42,7 @@ import java.util.stream.Collectors;
  */
 @Deprecated
 @Internal
-public interface FileSystemFormatFactory extends Factory {
+public interface FileSystemFormatFactory extends Factory, SupportsReadingMetadata {
 
     /** Create {@link InputFormat} reader. */
     InputFormat<RowData, ?> createReader(ReaderContext context);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -235,10 +235,11 @@ public class PartitionPathUtils {
             String[] fieldNames,
             DataType[] fieldTypes,
             int[] selectFields,
+            int metadataArity,
             List<String> partitionKeys,
             Path path,
             String defaultPartValue) {
-        GenericRowData record = new GenericRowData(selectFields.length);
+        GenericRowData record = new GenericRowData(selectFields.length + metadataArity);
         LinkedHashMap<String, String> partSpec =
                 PartitionPathUtils.extractPartitionSpecFromPath(path);
         for (int i = 0; i < selectFields.length; i++) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -95,6 +95,118 @@ trait FileSystemITCaseBase {
          |)
        """.stripMargin
     )
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable (
+         | x string,
+         | y int,
+         | a int,
+         | b bigint
+         | ,`flink.fs.basename` VARCHAR METADATA VIRTUAL
+         | ,`flink.fs.path` VARCHAR METADATA VIRTUAL
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable2 (
+         | x string,
+         | y int,
+         | a int,
+         | b bigint
+         | ,`flink.fs.path` VARCHAR METADATA VIRTUAL
+         | ,`flink.fs.basename` VARCHAR METADATA VIRTUAL
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable3 (
+         | x string,
+         | y int,
+         | a int,
+         | b bigint
+         | ,`flink.fs.path` VARCHAR METADATA VIRTUAL
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable4 (
+         | x string,
+         | y int,
+         | a int,
+         | b bigint
+         | ,`flink.fs.basename` VARCHAR METADATA VIRTUAL
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable5 (
+         | x string,
+         | `flink.fs.basename` VARCHAR METADATA VIRTUAL,
+         | y int,
+         | a int,
+         | `flink.fs.path` VARCHAR METADATA VIRTUAL,
+         | b bigint
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable6 (
+         | x string,
+         | `bname` VARCHAR METADATA FROM 'flink.fs.basename',
+         | y int,
+         | a int,
+         | `flink.fs.path` VARCHAR METADATA VIRTUAL,
+         | b bigint
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
+
+    tableEnv.executeSql(
+      s"""
+         |create table withMetadataTable7 (
+         | x string,
+         | `flink.fs.path` VARCHAR METADATA VIRTUAL,
+         | y int,
+         | a int,
+         | `bname` VARCHAR METADATA FROM 'flink.fs.basename',
+         | b bigint
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
+         |  ${formatProperties().mkString(",\n")}
+         |)
+      """.stripMargin
+    )
   }
 
   @Test

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
@@ -244,6 +244,7 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
                             fieldNames,
                             fieldTypes,
                             projectFields,
+                            0,
                             partitionKeys,
                             currentSplit.getPath(),
                             defaultPartValue);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.DynamicTableFactory;
@@ -69,6 +70,7 @@ import java.util.stream.Stream;
 /** File system table source. */
 public class FileSystemTableSource extends AbstractFileSystemTable
         implements ScanTableSource,
+                SupportsReadingMetadata,
                 SupportsProjectionPushDown,
                 SupportsLimitPushDown,
                 SupportsPartitionPushDown,
@@ -325,5 +327,16 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                                 .toArray(DataTypes.Field[]::new))
                 .bridgedTo(RowData.class)
                 .notNull();
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        // TODO delegate to the format
+        return this.formatFactory.listReadableMetadata();
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        this.formatFactory.applyReadableMetadata(metadataKeys, producedDataType);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/TestCsvFileSystemFormatFactory.java
@@ -40,7 +40,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_FIELD_DELIMITER;
@@ -117,6 +120,16 @@ public class TestCsvFileSystemFormatFactory
                 return ChangelogMode.insertOnly();
             }
         };
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // TODO: implement
     }
 
     private static class CsvBulkWriter implements BulkWriter<RowData> {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

https://issues.apache.org/jira/browse/FLINK-19903

## What is the purpose of the change

This pull request add metadata fields to the Table SQL Filesystem connector when format=csv.

* `flink.fs.path` field represents the full path to the file that produced the record
* `flink.fs.basename` field represent the last portion of `flink.fs.path`

## Brief change log

- `FileSystemTableSource` now implements `SupportsReadingMetadata`, and delegates to the `FileSystemFormatFactory` implementation
- `FileSystemFormatFactory` now inherits from `SupportReadingMetadata`, so all classes implementing the interface had changed to include at least a dummy implementation returning no metadata
- `CsvFileSystemFormatFactory` implements `flinks.fs.path` and `flink.fs.basename`
- `PartitionPathUtils.fillPartitionValueForRecord` modified to account for the extra metadata fields
-  fixed bug on `PushProjectionIntoTableSourceScanRule.onMatch` that forced the metadata fields n the `CREATE TABLE xx(... yyy VARCHAR METADATA VIRTUAL,...)` to be declared in a particular order


## Verifying this change

This change added tests and can be verified as follows:
- Added test that checks that `flink.fs.path` in 3 different tables (one with both metadata fields, one with the same metadata fields in reverse order, an one with one that particular metadata field)
- Added test that check `flink.fs.basename` in the same way as the one above.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know, I don't think so. 
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
