### PR TITLE
[FLINK-19934][Connector] Add a new API: SplitEnumeratorContext.runInC…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -112,4 +112,20 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 	 * @param period the period between two invocations of the callable.
 	 */
 	<T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler, long initialDelay, long period);
+
+	/**
+	 * Invoke the given runnable in the source coordinator thread.
+	 *
+	 * <p>This can be useful when the enumerator needs to execute some action (like assignSplits) triggered
+	 * by some external events. E.g., Watermark from another source advanced and this source now be able to
+	 * assign splits to awaiting readers. The trigger can be initiated from the coordinator thread of
+	 * the other source. Instead of using lock for thread safety, this API allows to run such externally
+	 * triggered action in the coordinator thread. Hence, we can ensure all enumerator actions are serialized
+	 * in the single coordinator thread.
+	 *
+	 * <p>It is important that the runnable does not block.
+	 *
+	 * @param runnable a runnable to execute
+	 */
+	void runInCoordinatorThread(Runnable runnable);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -197,6 +197,11 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 	}
 
 	@Override
+	public void runInCoordinatorThread(Runnable runnable) {
+		coordinatorExecutor.execute(runnable);
+	}
+
+	@Override
 	public void close() throws InterruptedException {
 		notifier.close();
 		coordinatorExecutor.shutdown();


### PR DESCRIPTION
…oordinatorThread(Runnable)

## What is the purpose of the change

This PR adds a new API in SplitEnumeratorContext so that enumerator can run all actions in the source coordinator thread.

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
