### PR TITLE
 [FLINK-19314][coordination] Add DeclarativeSlotPoolBridge 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -97,10 +97,10 @@ public class ClusterOptions {
 	public static final ConfigOption<Boolean> ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT = ConfigOptions
 		.key("cluster.declarative-resource-management.enabled")
 		.booleanType()
-		.defaultValue(false)
+		.defaultValue(true)
 		.withDescription("Defines whether the cluster uses declarative resource management.");
 
 	public static boolean isDeclarativeResourceManagementEnabled(Configuration configuration) {
-		return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT) || System.getProperties().containsKey("flink.tests.enable-declarative");
+		return configuration.get(ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT) && !System.getProperties().containsKey("flink.tests.disable-declarative");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -82,6 +82,7 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPayload;
@@ -739,6 +740,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	@Override
 	public void notifyAllocationFailure(AllocationID allocationID, Exception cause) {
 		internalFailAllocation(null, allocationID, cause);
+	}
+
+	@Override
+	public void notifyNotEnoughResourcesAvailable(Collection<ResourceRequirement> acquiredResources) {
+		slotPool.notifyNotEnoughResourcesAvailable(acquiredResources);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -584,15 +584,15 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			final Exception cause) {
 
 		if (registeredTaskManagers.containsKey(taskManagerId)) {
-			internalFailAllocation(allocationId, cause);
+			internalFailAllocation(taskManagerId, allocationId, cause);
 		} else {
 			log.warn("Cannot fail slot " + allocationId + " because the TaskManager " +
 			taskManagerId + " is unknown.");
 		}
 	}
 
-	private void internalFailAllocation(AllocationID allocationId, Exception cause) {
-		final Optional<ResourceID> resourceIdOptional = slotPool.failAllocation(allocationId, cause);
+	private void internalFailAllocation(@Nullable ResourceID resourceId, AllocationID allocationId, Exception cause) {
+		final Optional<ResourceID> resourceIdOptional = slotPool.failAllocation(resourceId, allocationId, cause);
 		resourceIdOptional.ifPresent(taskManagerId -> {
 			if (!partitionTracker.isTrackingPartitionsFor(taskManagerId)) {
 				releaseEmptyTaskManager(taskManagerId);
@@ -738,7 +738,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	@Override
 	public void notifyAllocationFailure(AllocationID allocationID, Exception cause) {
-		internalFailAllocation(allocationID, cause);
+		internalFailAllocation(null, allocationID, cause);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPayload;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -264,6 +265,13 @@ public interface JobMasterGateway extends
 	 * @param cause the reason that the allocation failed
 	 */
 	void notifyAllocationFailure(AllocationID allocationID, Exception cause);
+
+	/**
+	 * Notifies that not enough resources are available to fulfill the resource requirements of a job.
+	 *
+	 * @param acquiredResources the resources that have been acquired for the job
+	 */
+	void notifyNotEnoughResourcesAvailable(Collection<ResourceRequirement> acquiredResources);
 
 	/**
 	 * Update the aggregate and return the new value.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -1,0 +1,658 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.clock.Clock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * {@link SlotPool} implementation which uses the {@link DeclarativeSlotPool} to allocate slots.
+ */
+public class DeclarativeSlotPoolBridge implements SlotPool {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSlotPoolBridge.class);
+
+	private final JobID jobId;
+
+	private final Map<SlotRequestId, PendingRequest> pendingRequests;
+	private final Map<SlotRequestId, AllocationID> fulfilledRequests;
+	private final DeclarativeSlotPool declarativeSlotPool;
+	private final Set<ResourceID> registeredTaskManagers;
+
+	@Nullable
+	private ComponentMainThreadExecutor componentMainThreadExecutor;
+
+	@Nullable
+	private String jobManagerAddress;
+
+	@Nullable
+	private JobMasterId jobMasterId;
+
+	private DeclareResourceRequirementServiceConnectionManager declareResourceRequirementServiceConnectionManager;
+
+	private final Clock clock;
+	private final Time rpcTimeout;
+	private final Time idleSlotTimeout;
+	private final Time batchSlotTimeout;
+	private boolean isBatchSlotRequestTimeoutCheckDisabled;
+
+	public DeclarativeSlotPoolBridge(
+			JobID jobId,
+			DeclarativeSlotPoolFactory declarativeSlotPoolFactory,
+			Clock clock,
+			Time rpcTimeout,
+			Time idleSlotTimeout,
+			Time batchSlotTimeout) {
+		this.jobId = Preconditions.checkNotNull(jobId);
+		this.clock = Preconditions.checkNotNull(clock);
+		this.rpcTimeout = Preconditions.checkNotNull(rpcTimeout);
+		this.idleSlotTimeout = Preconditions.checkNotNull(idleSlotTimeout);
+		this.batchSlotTimeout = Preconditions.checkNotNull(batchSlotTimeout);
+		this.isBatchSlotRequestTimeoutCheckDisabled = false;
+
+		this.pendingRequests = new LinkedHashMap<>();
+		this.fulfilledRequests = new HashMap<>();
+		this.registeredTaskManagers = new HashSet<>();
+		this.declareResourceRequirementServiceConnectionManager = NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
+		this.declarativeSlotPool = declarativeSlotPoolFactory.create(
+				this::declareResourceRequirements,
+				this::newSlotsAreAvailable,
+				idleSlotTimeout,
+				rpcTimeout);
+	}
+
+	@Override
+	public void start(JobMasterId jobMasterId, String newJobManagerAddress, ComponentMainThreadExecutor jmMainThreadScheduledExecutor) throws Exception {
+		this.componentMainThreadExecutor = Preconditions.checkNotNull(jmMainThreadScheduledExecutor);
+		this.jobManagerAddress = Preconditions.checkNotNull(newJobManagerAddress);
+		this.jobMasterId = Preconditions.checkNotNull(jobMasterId);
+		this.declareResourceRequirementServiceConnectionManager = DefaultDeclareResourceRequirementServiceConnectionManager.create(componentMainThreadExecutor);
+
+		componentMainThreadExecutor.schedule(this::checkIdleSlotTimeout, idleSlotTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		componentMainThreadExecutor.schedule(this::checkBatchSlotTimeout, batchSlotTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public void suspend() {
+		assertRunningInMainThread();
+		LOG.info("Suspending slot pool.");
+
+		cancelPendingRequests(request -> true, new FlinkException("Suspending slot pool."));
+		clearState();
+	}
+
+	@Override
+	public void close() {
+		LOG.info("Closing slot pool.");
+		final FlinkException cause = new FlinkException("Closing slot pool");
+		cancelPendingRequests(request -> true, cause);
+		releaseAllTaskManagers(new FlinkException("Closing slot pool."));
+		clearState();
+	}
+
+	private void cancelPendingRequests(Predicate<PendingRequest> requestPredicate, FlinkException cancelCause) {
+		ResourceCounter decreasedResourceRequirements = ResourceCounter.empty();
+
+		// need a copy since failing a request could trigger another request to be issued
+		final Iterable<PendingRequest> pendingRequestsToFail = new ArrayList<>(pendingRequests.values());
+		pendingRequests.clear();
+
+		for (PendingRequest pendingRequest : pendingRequestsToFail) {
+			if (requestPredicate.test(pendingRequest)) {
+				pendingRequest.failRequest(cancelCause);
+				decreasedResourceRequirements = decreasedResourceRequirements.add(pendingRequest.getResourceProfile(), 1);
+			} else {
+				pendingRequests.put(pendingRequest.getSlotRequestId(), pendingRequest);
+			}
+		}
+
+		if (!decreasedResourceRequirements.isEmpty()) {
+			declarativeSlotPool.decreaseResourceRequirementsBy(decreasedResourceRequirements);
+		}
+	}
+
+	private void clearState() {
+		declareResourceRequirementServiceConnectionManager.close();
+		declareResourceRequirementServiceConnectionManager = NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
+		registeredTaskManagers.clear();
+		jobManagerAddress = null;
+		jobMasterId = null;
+	}
+
+	@Override
+	public void connectToResourceManager(ResourceManagerGateway resourceManagerGateway) {
+		assertRunningInMainThread();
+		Preconditions.checkNotNull(resourceManagerGateway);
+
+		declareResourceRequirementServiceConnectionManager.connect(resourceRequirements -> resourceManagerGateway.declareRequiredResources(jobMasterId, resourceRequirements, rpcTimeout));
+		declareResourceRequirements(declarativeSlotPool.getResourceRequirements());
+	}
+
+	@Override
+	public void disconnectResourceManager() {
+		assertRunningInMainThread();
+		this.declareResourceRequirementServiceConnectionManager.disconnect();
+	}
+
+	@Override
+	public boolean registerTaskManager(ResourceID resourceID) {
+		assertRunningInMainThread();
+
+		LOG.debug("Register new TaskExecutor {}.", resourceID);
+		return registeredTaskManagers.add(resourceID);
+	}
+
+	@Override
+	public boolean releaseTaskManager(ResourceID resourceId, Exception cause) {
+		assertRunningInMainThread();
+
+		if (registeredTaskManagers.remove(resourceId)) {
+			internalReleaseTaskManager(resourceId, cause);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private void releaseAllTaskManagers(FlinkException cause) {
+		for (ResourceID registeredTaskManager : registeredTaskManagers) {
+			internalReleaseTaskManager(registeredTaskManager, cause);
+		}
+
+		registeredTaskManagers.clear();
+	}
+
+	private void internalReleaseTaskManager(ResourceID resourceId, Exception cause) {
+		ResourceCounter previouslyFulfilledRequirement = declarativeSlotPool.releaseSlots(resourceId, cause);
+		declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
+	}
+
+	@Override
+	public Collection<SlotOffer> offerSlots(TaskManagerLocation taskManagerLocation, TaskManagerGateway taskManagerGateway, Collection<SlotOffer> offers) {
+		assertRunningInMainThread();
+		Preconditions.checkNotNull(taskManagerGateway);
+		Preconditions.checkNotNull(offers);
+
+		if (!registeredTaskManagers.contains(taskManagerLocation.getResourceID())) {
+			return Collections.emptyList();
+		}
+
+		return declarativeSlotPool.offerSlots(offers, taskManagerLocation, taskManagerGateway, clock.relativeTimeMillis());
+	}
+
+	@VisibleForTesting
+	void newSlotsAreAvailable(Collection<? extends PhysicalSlot> newSlots) {
+		final Collection<PendingRequestSlotMatching> matchingsToFulfill = new ArrayList<>();
+
+		for (PhysicalSlot newSlot : newSlots) {
+			final Optional<PendingRequest> matchingPendingRequest = findMatchingPendingRequest(newSlot);
+
+			matchingPendingRequest.ifPresent(pendingRequest -> {
+				Preconditions.checkNotNull(pendingRequests.remove(pendingRequest.getSlotRequestId()), "Cannot fulfill a non existing pending slot request.");
+				reserveFreeSlot(pendingRequest.getSlotRequestId(), newSlot.getAllocationId(), pendingRequest.resourceProfile);
+
+				matchingsToFulfill.add(PendingRequestSlotMatching.createFor(pendingRequest, newSlot));
+			});
+		}
+
+		// we have to first reserve all matching slots before fulfilling the requests
+		// otherwise it can happen that the SchedulerImpl reserves one of the new slots
+		// for a request which has been triggered by fulfilling a pending request
+		for (PendingRequestSlotMatching pendingRequestSlotMatching : matchingsToFulfill) {
+			pendingRequestSlotMatching.fulfillPendingRequest();
+		}
+	}
+
+	private void reserveFreeSlot(SlotRequestId slotRequestId, AllocationID allocationId, ResourceProfile resourceProfile) {
+		LOG.debug("Reserve slot {} for slot request id {}", allocationId, slotRequestId);
+		declarativeSlotPool.reserveFreeSlot(allocationId, resourceProfile);
+		fulfilledRequests.put(slotRequestId, allocationId);
+	}
+
+	private Optional<PendingRequest> findMatchingPendingRequest(PhysicalSlot slot) {
+		final ResourceProfile resourceProfile = slot.getResourceProfile();
+
+		for (PendingRequest pendingRequest : pendingRequests.values()) {
+			if (resourceProfile.isMatching(pendingRequest.getResourceProfile())) {
+				LOG.debug("Matched slot {} to pending request {}.", slot, pendingRequest);
+				return Optional.of(pendingRequest);
+			}
+		}
+		LOG.debug("Could not match slot {} to any pending request.", slot);
+
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<PhysicalSlot> allocateAvailableSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull AllocationID allocationID, @Nonnull ResourceProfile requirementProfile) {
+		assertRunningInMainThread();
+		Preconditions.checkNotNull(requirementProfile, "The requiredSlotProfile must not be null.");
+
+		LOG.debug("Reserving free slot {} for slot request id {} and profile {}.", allocationID, slotRequestId, requirementProfile);
+
+		return Optional.of(reserveFreeSlotForResource(slotRequestId, allocationID, requirementProfile));
+	}
+
+	private PhysicalSlot reserveFreeSlotForResource(SlotRequestId slotRequestId, AllocationID allocationId, ResourceProfile requiredSlotProfile) {
+		declarativeSlotPool.increaseResourceRequirementsBy(ResourceCounter.withResource(requiredSlotProfile, 1));
+		final PhysicalSlot physicalSlot = declarativeSlotPool.reserveFreeSlot(allocationId, requiredSlotProfile);
+		fulfilledRequests.put(slotRequestId, allocationId);
+
+		return physicalSlot;
+	}
+
+	@Override
+	@Nonnull
+	public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile, @Nullable Time timeout) {
+		assertRunningInMainThread();
+
+		LOG.debug("Request new allocated slot with slot request id {} and resource profile {}", slotRequestId, resourceProfile);
+
+		final PendingRequest pendingRequest = PendingRequest.createNormalRequest(slotRequestId, resourceProfile);
+
+		return internalRequestNewSlot(pendingRequest, timeout);
+	}
+
+	@Override
+	@Nonnull
+	public CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+		assertRunningInMainThread();
+
+		LOG.debug("Request new allocated batch slot with slot request id {} and resource profile {}", slotRequestId, resourceProfile);
+
+		final PendingRequest pendingRequest = PendingRequest.createBatchRequest(slotRequestId, resourceProfile);
+
+		return internalRequestNewSlot(pendingRequest, null);
+	}
+
+	private CompletableFuture<PhysicalSlot> internalRequestNewSlot(PendingRequest pendingRequest, @Nullable Time timeout) {
+		internalRequestNewAllocatedSlot(pendingRequest);
+
+		if (timeout == null) {
+			return pendingRequest.getSlotFuture();
+		} else {
+			return FutureUtils
+				.orTimeout(
+					pendingRequest.getSlotFuture(),
+					timeout.toMilliseconds(),
+					TimeUnit.MILLISECONDS,
+					componentMainThreadExecutor)
+				.whenComplete((physicalSlot, throwable) -> {
+					if (throwable instanceof TimeoutException) {
+						timeoutPendingSlotRequest(pendingRequest.getSlotRequestId());
+					}
+				});
+		}
+	}
+
+	private void timeoutPendingSlotRequest(SlotRequestId slotRequestId) {
+		releaseSlot(slotRequestId, new TimeoutException("Pending slot request timed out in slot pool."));
+	}
+
+	private void internalRequestNewAllocatedSlot(PendingRequest pendingRequest) {
+		pendingRequests.put(pendingRequest.getSlotRequestId(), pendingRequest);
+
+		declarativeSlotPool.increaseResourceRequirementsBy(ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
+	}
+
+	private void declareResourceRequirements(Collection<ResourceRequirement> resourceRequirements) {
+		assertRunningInMainThread();
+
+		LOG.debug("Declare new resource requirements for job {}: {}.", jobId, resourceRequirements);
+
+		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(ResourceRequirements.create(jobId, jobManagerAddress, resourceRequirements));
+	}
+
+	@Override
+	public Optional<ResourceID> failAllocation(AllocationID allocationID, Exception cause) {
+		throw new UnsupportedOperationException("Please call failAllocation(ResourceID, AllocationID, Exception)");
+	}
+
+	@Override
+	public Optional<ResourceID> failAllocation(@Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
+		assertRunningInMainThread();
+
+		Preconditions.checkNotNull(allocationID);
+		Preconditions.checkNotNull(resourceId, "This slot pool only supports failAllocation calls coming from the TaskExecutor.");
+
+		ResourceCounter previouslyFulfilledRequirements = declarativeSlotPool.releaseSlot(allocationID, cause);
+		if (!previouslyFulfilledRequirements.isEmpty()) {
+			declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirements);
+		}
+
+		if (declarativeSlotPool.containsSlots(resourceId)) {
+			return Optional.empty();
+		} else {
+			return Optional.of(resourceId);
+		}
+	}
+
+	@Override
+	public void releaseSlot(@Nonnull SlotRequestId slotRequestId, @Nullable Throwable cause) {
+		LOG.debug("Release slot with slot request id {}", slotRequestId);
+		assertRunningInMainThread();
+
+		final PendingRequest pendingRequest = pendingRequests.remove(slotRequestId);
+
+		if (pendingRequest != null) {
+			declarativeSlotPool.decreaseResourceRequirementsBy(ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
+			pendingRequest.failRequest(new FlinkException(
+					String.format("Pending slot request with %s has been released.", pendingRequest.getSlotRequestId()),
+					cause));
+		} else {
+			final AllocationID allocationId = fulfilledRequests.remove(slotRequestId);
+
+			if (allocationId != null) {
+				ResourceCounter previouslyFulfilledRequirement = declarativeSlotPool.freeReservedSlot(allocationId, cause, clock.relativeTimeMillis());
+				if (!previouslyFulfilledRequirement.isEmpty()) {
+					declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
+				}
+			} else {
+				LOG.debug("Could not find slot which has fulfilled slot request {}. Ignoring the release operation.", slotRequestId);
+			}
+		}
+	}
+
+	@Override
+	public void notifyNotEnoughResourcesAvailable(Collection<ResourceRequirement> acquiredResources) {
+		assertRunningInMainThread();
+
+		failPendingRequests();
+	}
+
+	private void failPendingRequests() {
+		if (!pendingRequests.isEmpty()) {
+			final NoResourceAvailableException cause = new NoResourceAvailableException("Could not acquire the minimum required resources.");
+
+			cancelPendingRequests(
+				request -> !isBatchSlotRequestTimeoutCheckDisabled || !request.isBatchRequest(), cause
+			);
+		}
+	}
+
+	@Override
+	public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
+		assertRunningInMainThread();
+		Preconditions.checkNotNull(taskManagerId);
+
+		final Collection<? extends SlotInfo> allocatedSlotsInformation = declarativeSlotPool.getAllSlotsInformation();
+
+		final Collection<AllocatedSlotInfo> allocatedSlotInfos = new ArrayList<>();
+
+		for (SlotInfo slotInfo : allocatedSlotsInformation) {
+			if (slotInfo.getTaskManagerLocation().getResourceID().equals(taskManagerId)) {
+				allocatedSlotInfos.add(new AllocatedSlotInfo(
+						slotInfo.getPhysicalSlotNumber(),
+						slotInfo.getAllocationId()));
+			}
+		}
+
+		return new AllocatedSlotReport(jobId, allocatedSlotInfos);
+	}
+
+	@Override
+	public Collection<SlotInfo> getAllocatedSlotsInformation() {
+		assertRunningInMainThread();
+
+		final Collection<? extends SlotInfo> allSlotsInformation = declarativeSlotPool.getAllSlotsInformation();
+		final Set<AllocationID> freeSlots = declarativeSlotPool.getFreeSlotsInformation().stream()
+				.map(SlotInfoWithUtilization::getAllocationId)
+				.collect(Collectors.toSet());
+
+		return allSlotsInformation.stream()
+				.filter(slotInfo -> !freeSlots.contains(slotInfo.getAllocationId()))
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	@Nonnull
+	public Collection<SlotInfoWithUtilization> getAvailableSlotsInformation() {
+		assertRunningInMainThread();
+
+		return declarativeSlotPool.getFreeSlotsInformation();
+	}
+
+	@Override
+	public void disableBatchSlotRequestTimeoutCheck() {
+		isBatchSlotRequestTimeoutCheckDisabled = true;
+	}
+
+	private void assertRunningInMainThread() {
+		if (componentMainThreadExecutor != null) {
+			componentMainThreadExecutor.assertRunningInMainThread();
+		} else {
+			throw new IllegalStateException("The FutureSlotPool has not been started yet.");
+		}
+	}
+
+	private void checkIdleSlotTimeout() {
+		declarativeSlotPool.releaseIdleSlots(clock.relativeTimeMillis());
+
+		if (componentMainThreadExecutor != null) {
+			componentMainThreadExecutor.schedule(this::checkIdleSlotTimeout, idleSlotTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	private void checkBatchSlotTimeout() {
+		if (isBatchSlotRequestTimeoutCheckDisabled) {
+			return;
+		}
+
+		final Collection<PendingRequest> pendingBatchRequests = getPendingBatchRequests();
+
+		if (!pendingBatchRequests.isEmpty()) {
+			final Set<ResourceProfile> allResourceProfiles = getResourceProfilesFromAllSlots();
+
+			final Map<Boolean, List<PendingRequest>> fulfillableAndUnfulfillableRequests = pendingBatchRequests
+					.stream()
+					.collect(Collectors.partitioningBy(canBeFulfilledWithAnySlot(allResourceProfiles)));
+
+			final List<PendingRequest> fulfillableRequests = fulfillableAndUnfulfillableRequests.get(true);
+			final List<PendingRequest> unfulfillableRequests = fulfillableAndUnfulfillableRequests.get(false);
+
+			final long currentTimestamp = clock.relativeTimeMillis();
+
+			for (PendingRequest fulfillableRequest : fulfillableRequests) {
+				fulfillableRequest.markFulfillable();
+			}
+
+			for (PendingRequest unfulfillableRequest : unfulfillableRequests) {
+				unfulfillableRequest.markUnfulfillable(currentTimestamp);
+
+				if (unfulfillableRequest.getUnfulfillableSince() + batchSlotTimeout.toMilliseconds() <= currentTimestamp) {
+					timeoutPendingSlotRequest(unfulfillableRequest.getSlotRequestId());
+				}
+			}
+		}
+
+		if (componentMainThreadExecutor != null) {
+			componentMainThreadExecutor.schedule(this::checkBatchSlotTimeout, batchSlotTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		}
+	}
+
+	private Set<ResourceProfile> getResourceProfilesFromAllSlots() {
+		return Stream
+				.concat(
+						getAvailableSlotsInformation().stream(),
+						getAllocatedSlotsInformation().stream())
+				.map(SlotInfo::getResourceProfile)
+				.collect(Collectors.toSet());
+	}
+
+	private Collection<PendingRequest> getPendingBatchRequests() {
+		return pendingRequests.values().stream()
+				.filter(PendingRequest::isBatchRequest)
+				.collect(Collectors.toList());
+	}
+
+	private static Predicate<PendingRequest> canBeFulfilledWithAnySlot(Set<ResourceProfile> allocatedResourceProfiles) {
+		return pendingRequest -> {
+			for (ResourceProfile allocatedResourceProfile : allocatedResourceProfiles) {
+				if (allocatedResourceProfile.isMatching(pendingRequest.getResourceProfile())) {
+					return true;
+				}
+			}
+
+			return false;
+		};
+	}
+
+	private static final class PendingRequest {
+
+		private final SlotRequestId slotRequestId;
+
+		private final ResourceProfile resourceProfile;
+
+		private final CompletableFuture<PhysicalSlot> slotFuture;
+
+		private final boolean isBatchRequest;
+
+		private long unfulfillableSince;
+
+		private PendingRequest(SlotRequestId slotRequestId, ResourceProfile resourceProfile, boolean isBatchRequest) {
+			this.slotRequestId = slotRequestId;
+			this.resourceProfile = resourceProfile;
+			this.isBatchRequest = isBatchRequest;
+			this.slotFuture = new CompletableFuture<>();
+			this.unfulfillableSince = Long.MAX_VALUE;
+		}
+
+		static PendingRequest createBatchRequest(SlotRequestId slotRequestId, ResourceProfile resourceProfile) {
+			return new PendingRequest(
+					slotRequestId,
+					resourceProfile,
+					true);
+		}
+
+		static PendingRequest createNormalRequest(SlotRequestId slotRequestId, ResourceProfile resourceProfile) {
+			return new PendingRequest(
+					slotRequestId,
+					resourceProfile,
+					false);
+		}
+
+		SlotRequestId getSlotRequestId() {
+			return slotRequestId;
+		}
+
+		ResourceProfile getResourceProfile() {
+			return resourceProfile;
+		}
+
+		CompletableFuture<PhysicalSlot> getSlotFuture() {
+			return slotFuture;
+		}
+
+		void failRequest(Exception cause) {
+			slotFuture.completeExceptionally(cause);
+		}
+
+		public boolean isBatchRequest() {
+			return isBatchRequest;
+		}
+
+		public void markFulfillable() {
+			this.unfulfillableSince = Long.MAX_VALUE;
+		}
+
+		public void markUnfulfillable(long currentTimestamp) {
+			this.unfulfillableSince = currentTimestamp;
+		}
+
+		public long getUnfulfillableSince() {
+			return unfulfillableSince;
+		}
+
+		public boolean fulfill(PhysicalSlot slot) {
+			return slotFuture.complete(slot);
+		}
+
+		@Override
+		public String toString() {
+			return "PendingRequest{" +
+					"slotRequestId=" + slotRequestId +
+					", resourceProfile=" + resourceProfile +
+					", isBatchRequest=" + isBatchRequest +
+					", unfulfillableSince=" + unfulfillableSince +
+					'}';
+		}
+	}
+
+	private static final class PendingRequestSlotMatching {
+		private final PendingRequest pendingRequest;
+		private final PhysicalSlot matchedSlot;
+
+		private PendingRequestSlotMatching(PendingRequest pendingRequest, PhysicalSlot matchedSlot) {
+			this.pendingRequest = pendingRequest;
+			this.matchedSlot = matchedSlot;
+		}
+
+		public static PendingRequestSlotMatching createFor(PendingRequest pendingRequest, PhysicalSlot newSlot) {
+			return new PendingRequestSlotMatching(pendingRequest, newSlot);
+		}
+
+		public void fulfillPendingRequest() {
+			Preconditions.checkState(pendingRequest.fulfill(matchedSlot), "Pending requests must be fulfillable.");
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.clock.Clock;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Factory for {@link DeclarativeSlotPoolBridge}.
+ */
+public class DeclarativeSlotPoolBridgeFactory extends AbstractSlotPoolFactory {
+
+	public DeclarativeSlotPoolBridgeFactory(@Nonnull Clock clock, @Nonnull Time rpcTimeout, @Nonnull Time slotIdleTimeout, @Nonnull Time batchSlotTimeout) {
+		super(clock, rpcTimeout, slotIdleTimeout, batchSlotTimeout);
+	}
+
+	@Nonnull
+	@Override
+	public SlotPool createSlotPool(@Nonnull JobID jobId) {
+		return new DeclarativeSlotPoolBridge(
+			jobId,
+			new DefaultDeclarativeSlotPoolFactory(),
+			clock,
+			rpcTimeout,
+			slotIdleTimeout,
+			batchSlotTimeout
+		);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * Factory for a {@link DeclarativeSlotPool}.
+ */
+public interface DeclarativeSlotPoolFactory {
+	DeclarativeSlotPool create(
+		Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
+		Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
+		Time idleSlotTimeout,
+		Time rpcTimeout);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * Factory for {@link DefaultDeclarativeSlotPool}.
+ */
+public class DefaultDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFactory {
+
+	@Override
+	public DeclarativeSlotPool create(
+			Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
+			Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
+			Time idleSlotTimeout,
+			Time rpcTimeout) {
+		return new DefaultDeclarativeSlotPool(
+			new DefaultAllocatedSlotPool(),
+			notifyNewResourceRequirements,
+			notifyNewSlots,
+			idleSlotTimeout,
+			rpcTimeout);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImpl.java
@@ -82,7 +82,8 @@ public class PhysicalSlotProviderImpl implements PhysicalSlotProvider {
 		return selectedAvailableSlot.flatMap(
 			slotInfoAndLocality -> slotPool.allocateAvailableSlot(
 				slotRequestId,
-				slotInfoAndLocality.getSlotInfo().getAllocationId())
+				slotInfoAndLocality.getSlotInfo().getAllocationId(),
+				slotProfile.getPhysicalSlotResourceProfile())
 		);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -226,7 +226,8 @@ public class SchedulerImpl implements Scheduler {
 		return selectedAvailableSlot.flatMap(slotInfoAndLocality -> {
 			Optional<PhysicalSlot> optionalAllocatedSlot = slotPool.allocateAvailableSlot(
 				slotRequestId,
-				slotInfoAndLocality.getSlotInfo().getAllocationId());
+				slotInfoAndLocality.getSlotInfo().getAllocationId(),
+				slotProfile.getPhysicalSlotResourceProfile());
 
 			return optionalAllocatedSlot.map(
 				allocatedSlot -> new SlotAndLocality(allocatedSlot, slotInfoAndLocality.getLocality()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -124,6 +124,10 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	 */
 	Optional<ResourceID> failAllocation(AllocationID allocationID, Exception cause);
 
+	default Optional<ResourceID> failAllocation(@Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
+		return failAllocation(allocationID, cause);
+	}
+
 	// ------------------------------------------------------------------------
 	//  allocating and disposing slots
 	// ------------------------------------------------------------------------
@@ -146,16 +150,18 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	Collection<SlotInfo> getAllocatedSlotsInformation();
 
 	/**
-	 * Allocates the available slot with the given allocation id under the given request id. This method returns
-	 * {@code null} if no slot with the given allocation id is available.
+	 * Allocates the available slot with the given allocation id under the given request id for the given requirement profile.
+	 * The slot must be able to fulfill the requirement profile, otherwise an {@link IllegalStateException} will be thrown.
 	 *
 	 * @param slotRequestId identifying the requested slot
 	 * @param allocationID the allocation id of the requested available slot
-	 * @return the previously available slot with the given allocation id or {@code null} if no such slot existed.
+	 * @param requirementProfile resource profile of the requirement for which to allocate the slot
+	 * @return the previously available slot with the given allocation id, if a slot with this allocation id exists
 	 */
 	Optional<PhysicalSlot> allocateAvailableSlot(
 		@Nonnull SlotRequestId slotRequestId,
-		@Nonnull AllocationID allocationID);
+		@Nonnull AllocationID allocationID,
+		@Nonnull ResourceProfile requirementProfile);
 
 	/**
 	 * Request the allocation of a new slot from the resource manager. This method will not return a slot from the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -192,6 +193,13 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
 		@Nonnull SlotRequestId slotRequestId,
 		@Nonnull ResourceProfile resourceProfile);
+
+	/**
+	 * Notifies that not enough resources are available to fulfill the resource requirements.
+	 *
+	 * @param acquiredResources the resources that have been acquired
+	 */
+	default void notifyNotEnoughResourcesAvailable(Collection<ResourceRequirement> acquiredResources) {}
 
 	/**
 	 * Disables batch slot request timeout check. Invoked when someone else wants to

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolFactory.java
@@ -42,7 +42,13 @@ public interface SlotPoolFactory {
 		final Time batchSlotTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 
 		if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
-			throw new UnsupportedOperationException("Declarative slot pool is not yet implemented.");
+
+			return new DeclarativeSlotPoolBridgeFactory(
+				SystemClock.getInstance(),
+				rpcTimeout,
+				slotIdleTimeout,
+				batchSlotTimeout
+			);
 		} else {
 			return new DefaultSlotPoolFactory(
 				SystemClock.getInstance(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -409,7 +409,8 @@ public class SlotPoolImpl implements SlotPool {
 	@Override
 	public Optional<PhysicalSlot> allocateAvailableSlot(
 		@Nonnull SlotRequestId slotRequestId,
-		@Nonnull AllocationID allocationID) {
+		@Nonnull AllocationID allocationID,
+		@Nonnull ResourceProfile requirementProfile) {
 
 		componentMainThreadExecutor.assertRunningInMainThread();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1219,6 +1219,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		@Override
 		public void notifyNotEnoughResourcesAvailable(JobID jobId, Collection<ResourceRequirement> acquiredResources) {
 			validateRunsInMainThread();
+
+			JobManagerRegistration jobManagerRegistration = jobManagerRegistrations.get(jobId);
+			if (jobManagerRegistration != null) {
+				jobManagerRegistration.getJobManagerGateway().notifyNotEnoughResourcesAvailable(acquiredResources);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -219,6 +219,15 @@ class JobScopedResourceTracker {
 			this.resourceProfile = resourceProfile;
 			this.numExcessResources = numExcessResources;
 		}
+
+		@Override
+		public String toString() {
+			return "ExcessResource{" +
+				"numExcessResources=" + numExcessResources +
+				", requirementProfile=" + requirementProfile +
+				", resourceProfile=" + resourceProfile +
+				'}';
+		}
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -652,7 +652,7 @@ public class JobMasterTest extends TestLogger {
 		}
 
 		@Override
-		public Optional<PhysicalSlot> allocateAvailableSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull AllocationID allocationID) {
+		public Optional<PhysicalSlot> allocateAvailableSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull AllocationID allocationID, @Nonnull ResourceProfile requirementProfile) {
 			throw new UnsupportedOperationException("TestingSlotPool does not support this operation.");
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeTest.createAllocatedSlot;
+import static org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeTest.createDeclarativeSlotPoolBridge;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link DeclarativeSlotPoolBridge}.
+ */
+public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger {
+
+	private static final JobMasterId jobMasterId = JobMasterId.generate();
+	private final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+	private RequirementListener requirementListener;
+	private DeclarativeSlotPoolBridge declarativeSlotPoolBridge;
+
+	@Before
+	public void setup() throws Exception {
+		requirementListener = new RequirementListener();
+
+		final TestingDeclarativeSlotPoolBuilder slotPoolBuilder = TestingDeclarativeSlotPool.builder()
+			.setIncreaseResourceRequirementsByConsumer(requirementListener::increaseRequirements)
+			.setDecreaseResourceRequirementsByConsumer(requirementListener::decreaseRequirements)
+			.setReserveFreeSlotFunction((allocationId, resourceProfile) -> createAllocatedSlot(allocationId))
+			.setFreeReservedSlotFunction((allocationID, throwable, aLong) -> ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1))
+			.setReleaseSlotFunction((allocationID, e) -> ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1));
+
+		final DeclarativeSlotPoolBridgeTest.TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory = new DeclarativeSlotPoolBridgeTest.TestingDeclarativeSlotPoolFactory(slotPoolBuilder);
+		declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory);
+	}
+
+	@After
+	public void teardown() throws Exception {
+		if (declarativeSlotPoolBridge != null) {
+			declarativeSlotPoolBridge.close();
+		}
+	}
+
+	@Test
+	public void testRequirementsIncreasedOnNewAllocation() throws Exception {
+		declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+		// requesting the allocation of a new slot should increase the requirements
+		declarativeSlotPoolBridge.requestNewAllocatedSlot(new SlotRequestId(), ResourceProfile.UNKNOWN, Time.minutes(5));
+		assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(1));
+	}
+
+	@Test
+	public void testRequirementsDecreasedOnAllocationTimeout() throws Exception {
+		final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		try {
+			ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(scheduledExecutorService);
+			declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+			// requesting the allocation of a new slot increases the requirements
+			final CompletableFuture<PhysicalSlot> allocationFuture = CompletableFuture.supplyAsync(
+					() -> declarativeSlotPoolBridge.requestNewAllocatedSlot(new SlotRequestId(), ResourceProfile.UNKNOWN, Time.milliseconds(5)),
+					mainThreadExecutor)
+				.get();
+
+			// waiting for the timeout
+			assertThat(allocationFuture, FlinkMatchers.futureWillCompleteExceptionally(Duration.ofMinutes(1)));
+
+			// when the allocation fails the requirements should be reduced (it is the users responsibility to retry)
+			CompletableFuture.runAsync(
+					() -> assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(0)),
+					mainThreadExecutor)
+				.join();
+		} finally {
+			scheduledExecutorService.shutdown();
+		}
+	}
+
+	@Test
+	public void testRequirementsUnchangedOnNewSlotsNotification() throws Exception {
+		declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+		// notifications about new slots should not affect requirements
+		final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
+		declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(newSlot));
+		assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(0));
+	}
+
+	@Test
+	public void testRequirementsIncreasedOnSlotReservation() throws Exception {
+		declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+		final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
+		declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(newSlot));
+
+		// allocating (==reserving) an available (==free) slot should increase the requirements
+		final SlotRequestId slotRequestId = new SlotRequestId();
+		declarativeSlotPoolBridge.allocateAvailableSlot(slotRequestId, newSlot.getAllocationId(), ResourceProfile.UNKNOWN);
+		assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(1));
+	}
+
+	@Test
+	public void testRequirementsDecreasedOnSlotFreeing() throws Exception {
+		declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+		final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
+		declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(newSlot));
+
+		final SlotRequestId slotRequestId = new SlotRequestId();
+		declarativeSlotPoolBridge.allocateAvailableSlot(slotRequestId, newSlot.getAllocationId(), ResourceProfile.UNKNOWN);
+
+		// releasing (==freeing) a [reserved] slot should decrease the requirements
+		declarativeSlotPoolBridge.releaseSlot(slotRequestId, new RuntimeException("Test exception"));
+		assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(0));
+	}
+
+	@Test
+	public void testRequirementsDecreasedOnSlotAllocationFailure() throws Exception {
+		declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+		final PhysicalSlot newSlot = createAllocatedSlot(new AllocationID());
+		declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(newSlot));
+
+		declarativeSlotPoolBridge.allocateAvailableSlot(new SlotRequestId(), newSlot.getAllocationId(), ResourceProfile.UNKNOWN);
+
+		// releasing (==freeing) a [reserved] slot should decrease the requirements
+		declarativeSlotPoolBridge.failAllocation(newSlot.getTaskManagerLocation().getResourceID(), newSlot.getAllocationId(), new RuntimeException("Test exception"));
+		assertThat(requirementListener.getRequirements().getResourceCount(ResourceProfile.UNKNOWN), is(0));
+	}
+
+	private static final class RequirementListener {
+
+		private ResourceCounter requirements = ResourceCounter.empty();
+
+		private void increaseRequirements(ResourceCounter requirements) {
+			this.requirements = this.requirements.add(requirements);
+		}
+
+		private void decreaseRequirements(ResourceCounter requirements) {
+			this.requirements = this.requirements.subtract(requirements);
+		}
+
+		public ResourceCounter getRequirements() {
+			return requirements;
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.SystemClock;
+
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link DeclarativeSlotPoolBridge}.
+ */
+public class DeclarativeSlotPoolBridgeTest extends TestLogger {
+
+	private static final Time rpcTimeout = Time.seconds(20);
+	private static final JobID jobId = new JobID();
+	private static final JobMasterId jobMasterId = JobMasterId.generate();
+	private final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+	@Test
+	public void testSlotOffer() throws Exception {
+		final SlotRequestId slotRequestId = new SlotRequestId();
+		final AllocationID expectedAllocationId = new AllocationID();
+		final PhysicalSlot allocatedSlot = createAllocatedSlot(expectedAllocationId);
+
+		final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory = new TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPool.builder());
+		try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory)) {
+
+			declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+			CompletableFuture<PhysicalSlot> slotAllocationFuture = declarativeSlotPoolBridge.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, null);
+
+			declarativeSlotPoolBridge.newSlotsAreAvailable(Collections.singleton(allocatedSlot));
+
+			slotAllocationFuture.join();
+		}
+	}
+
+	@Test
+	public void testNotEnoughResourcesAvailableFailsPendingRequests() throws Exception {
+		final SlotRequestId slotRequestId = new SlotRequestId();
+
+		final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory = new TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPool.builder());
+		try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory)) {
+
+			declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+			CompletableFuture<PhysicalSlot> slotAllocationFuture = CompletableFuture
+					.supplyAsync(() -> declarativeSlotPoolBridge.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, Time.minutes(5)), mainThreadExecutor)
+					.get();
+
+			mainThreadExecutor.execute(() -> declarativeSlotPoolBridge.notifyNotEnoughResourcesAvailable(Collections.emptyList()));
+
+			assertThat(
+				slotAllocationFuture,
+				FlinkMatchers.futureWillCompleteExceptionally(
+					NoResourceAvailableException.class,
+					Duration.ofSeconds(10)));
+		}
+	}
+
+	@Test
+	public void testReleasingAllocatedSlot() throws Exception {
+		final CompletableFuture<AllocationID> releaseSlotFuture = new CompletableFuture<>();
+		final AllocationID expectedAllocationId = new AllocationID();
+		final PhysicalSlot allocatedSlot = createAllocatedSlot(expectedAllocationId);
+
+		final TestingDeclarativeSlotPoolBuilder builder = TestingDeclarativeSlotPool
+				.builder()
+				.setReserveFreeSlotFunction((allocationId, resourceProfile) -> {
+					assertThat(allocationId, is(expectedAllocationId));
+					return allocatedSlot;
+				})
+				.setFreeReservedSlotFunction((allocationID, throwable, aLong) -> {
+					releaseSlotFuture.complete(allocationID);
+					return ResourceCounter.empty();
+				});
+
+		final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory = new TestingDeclarativeSlotPoolFactory(builder);
+		try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory)) {
+			declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+			final SlotRequestId slotRequestId = new SlotRequestId();
+
+			declarativeSlotPoolBridge.allocateAvailableSlot(slotRequestId, expectedAllocationId, allocatedSlot.getResourceProfile());
+			declarativeSlotPoolBridge.releaseSlot(slotRequestId, null);
+
+			assertThat(releaseSlotFuture.join(), is(expectedAllocationId));
+		}
+	}
+
+	@Test
+	public void testNoConcurrentModificationWhenSuspendingAndReleasingSlot() throws Exception {
+		try (DeclarativeSlotPoolBridge declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(new DefaultDeclarativeSlotPoolFactory())) {
+
+			declarativeSlotPoolBridge.start(jobMasterId, "localhost", mainThreadExecutor);
+
+			final List<SlotRequestId> slotRequestIds = Arrays.asList(new SlotRequestId(), new SlotRequestId());
+
+			final List<CompletableFuture<PhysicalSlot>> slotFutures = slotRequestIds.stream()
+					.map(slotRequestId -> {
+						final CompletableFuture<PhysicalSlot> slotFuture = declarativeSlotPoolBridge.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, rpcTimeout);
+						slotFuture.whenComplete((physicalSlot, throwable) -> {
+							if (throwable != null) {
+								declarativeSlotPoolBridge.releaseSlot(slotRequestId, throwable);
+							}
+						});
+						return slotFuture;
+					})
+					.collect(Collectors.toList());
+
+			declarativeSlotPoolBridge.suspend();
+
+			try {
+				FutureUtils.waitForAll(slotFutures).get();
+				fail("The slot futures should be completed exceptionally.");
+			} catch (ExecutionException expected) {
+				// expected
+			}
+		}
+	}
+
+	@Nonnull
+	static DeclarativeSlotPoolBridge createDeclarativeSlotPoolBridge(DeclarativeSlotPoolFactory declarativeSlotPoolFactory) {
+		return new DeclarativeSlotPoolBridge(
+				jobId,
+				declarativeSlotPoolFactory,
+				SystemClock.getInstance(),
+				rpcTimeout,
+				Time.seconds(20),
+				Time.seconds(20)
+		);
+	}
+
+	static PhysicalSlot createAllocatedSlot(AllocationID allocationID) {
+		return new AllocatedSlot(
+				allocationID,
+				new LocalTaskManagerLocation(),
+				0,
+				ResourceProfile.ANY,
+				new RpcTaskManagerGateway(new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(), JobMasterId.generate()));
+	}
+
+	static final class TestingDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFactory {
+
+		final TestingDeclarativeSlotPoolBuilder builder;
+
+		public TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPoolBuilder builder) {
+			this.builder = builder;
+		}
+
+		@Override
+		public DeclarativeSlotPool create(Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements, Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots, Time idleSlotTimeout, Time rpcTimeout) {
+			return builder.build();
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -431,7 +431,7 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
 	}
 
 	@Nonnull
-	private static Collection<SlotOffer> offerSlots(DeclarativeSlotPool slotPool, Collection<SlotOffer> slotOffers) {
+	static Collection<SlotOffer> offerSlots(DeclarativeSlotPool slotPool, Collection<SlotOffer> slotOffers) {
 		return slotPool.offerSlots(slotOffers, new LocalTaskManagerLocation(), createTaskManagerGateway(null), 0);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImplTest.java
@@ -193,7 +193,8 @@ public class SlotPoolImplTest extends TestLogger {
 
 			Optional<PhysicalSlot> physicalSlot = slotPool.allocateAvailableSlot(
 				new SlotRequestId(),
-				allocationId);
+				allocationId,
+				ResourceProfile.ANY);
 
 			assertTrue(physicalSlot.isPresent());
 			assertEquals(0, slotPool.getAvailableSlots().size());
@@ -617,9 +618,9 @@ public class SlotPoolImplTest extends TestLogger {
 			final List<AllocationID> firstTaskManagersSlots = registerAndOfferSlots(firstTaskManagerLocation, slotPool, 4);
 			final List<AllocationID> secondTaskManagersSlots = registerAndOfferSlots(secondTaskManagerLocation, slotPool, 4);
 
-			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(0));
-			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(1));
-			slotPool.allocateAvailableSlot(new SlotRequestId(), secondTaskManagersSlots.get(3));
+			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(0), ResourceProfile.ANY);
+			slotPool.allocateAvailableSlot(new SlotRequestId(), firstTaskManagersSlots.get(1), ResourceProfile.ANY);
+			slotPool.allocateAvailableSlot(new SlotRequestId(), secondTaskManagersSlots.get(3), ResourceProfile.ANY);
 
 			final Collection<SlotInfoWithUtilization> availableSlotsInformation = slotPool.getAvailableSlotsInformation();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.function.QuadFunction;
+import org.apache.flink.util.function.TriFunction;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Testing {@link DeclarativeSlotPool} implementation.
+ */
+final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
+
+	private final Consumer<ResourceCounter> increaseResourceRequirementsByConsumer;
+
+	private final Consumer<ResourceCounter> decreaseResourceRequirementsByConsumer;
+
+	private final Supplier<Collection<ResourceRequirement>> getResourceRequirementsSupplier;
+
+	private final QuadFunction<Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long, Collection<SlotOffer>> offerSlotsFunction;
+
+	private final Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier;
+
+	private final Supplier<Collection<? extends SlotInfo>> getAllSlotsInformationSupplier;
+
+	private final BiFunction<ResourceID, Exception, ResourceCounter> releaseSlotsFunction;
+
+	private final BiFunction<AllocationID, Exception, ResourceCounter> releaseSlotFunction;
+
+	private final BiFunction<AllocationID, ResourceProfile, PhysicalSlot> reserveFreeSlotFunction;
+
+	private final TriFunction<AllocationID, Throwable, Long, ResourceCounter> freeReservedSlotFunction;
+
+	private final Function<ResourceID, Boolean> containsSlotsFunction;
+
+	private final LongConsumer releaseIdleSlotsConsumer;
+
+	TestingDeclarativeSlotPool(
+			Consumer<ResourceCounter> increaseResourceRequirementsByConsumer,
+			Consumer<ResourceCounter> decreaseResourceRequirementsByConsumer,
+			Supplier<Collection<ResourceRequirement>> getResourceRequirementsSupplier,
+			QuadFunction<Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long, Collection<SlotOffer>> offerSlotsFunction,
+			Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier,
+			Supplier<Collection<? extends SlotInfo>> getAllSlotsInformationSupplier,
+			BiFunction<ResourceID, Exception, ResourceCounter> releaseSlotsFunction,
+			BiFunction<AllocationID, Exception, ResourceCounter> releaseSlotFunction,
+			BiFunction<AllocationID, ResourceProfile, PhysicalSlot> reserveFreeSlotFunction,
+			TriFunction<AllocationID, Throwable, Long, ResourceCounter> freeReservedSlotFunction,
+			Function<ResourceID, Boolean> containsSlotsFunction,
+			LongConsumer releaseIdleSlotsConsumer) {
+		this.increaseResourceRequirementsByConsumer = increaseResourceRequirementsByConsumer;
+		this.decreaseResourceRequirementsByConsumer = decreaseResourceRequirementsByConsumer;
+		this.getResourceRequirementsSupplier = getResourceRequirementsSupplier;
+		this.offerSlotsFunction = offerSlotsFunction;
+		this.getFreeSlotsInformationSupplier = getFreeSlotsInformationSupplier;
+		this.getAllSlotsInformationSupplier = getAllSlotsInformationSupplier;
+		this.releaseSlotsFunction = releaseSlotsFunction;
+		this.releaseSlotFunction = releaseSlotFunction;
+		this.reserveFreeSlotFunction = reserveFreeSlotFunction;
+		this.freeReservedSlotFunction = freeReservedSlotFunction;
+		this.containsSlotsFunction = containsSlotsFunction;
+		this.releaseIdleSlotsConsumer = releaseIdleSlotsConsumer;
+	}
+
+	@Override
+	public void increaseResourceRequirementsBy(ResourceCounter increment) {
+		increaseResourceRequirementsByConsumer.accept(increment);
+	}
+
+	@Override
+	public void decreaseResourceRequirementsBy(ResourceCounter decrement) {
+		decreaseResourceRequirementsByConsumer.accept(decrement);
+	}
+
+	@Override
+	public Collection<ResourceRequirement> getResourceRequirements() {
+		return getResourceRequirementsSupplier.get();
+	}
+
+	@Override
+	public Collection<SlotOffer> offerSlots(
+			Collection<? extends SlotOffer> offers,
+			TaskManagerLocation taskManagerLocation,
+			TaskManagerGateway taskManagerGateway,
+			long currentTime) {
+		return offerSlotsFunction.apply(
+				offers,
+				taskManagerLocation,
+				taskManagerGateway,
+				currentTime);
+	}
+
+	@Override
+	public Collection<SlotInfoWithUtilization> getFreeSlotsInformation() {
+		return getFreeSlotsInformationSupplier.get();
+	}
+
+	@Override
+	public Collection<? extends SlotInfo> getAllSlotsInformation() {
+		return getAllSlotsInformationSupplier.get();
+	}
+
+	@Override
+	public ResourceCounter releaseSlots(ResourceID owner, Exception cause) {
+		return releaseSlotsFunction.apply(owner, cause);
+	}
+
+	@Override
+	public ResourceCounter releaseSlot(AllocationID allocationId, Exception cause) {
+		return releaseSlotFunction.apply(allocationId, cause);
+	}
+
+	@Override
+	public PhysicalSlot reserveFreeSlot(
+			AllocationID allocationId,
+			ResourceProfile requiredSlotProfile) {
+		return reserveFreeSlotFunction.apply(allocationId, requiredSlotProfile);
+	}
+
+	@Override
+	public ResourceCounter freeReservedSlot(
+			AllocationID allocationId,
+			@Nullable Throwable cause,
+			long currentTime) {
+		return freeReservedSlotFunction.apply(allocationId, cause, currentTime);
+	}
+
+	@Override
+	public boolean containsSlots(ResourceID owner) {
+		return containsSlotsFunction.apply(owner);
+	}
+
+	@Override
+	public void releaseIdleSlots(long currentTimeMillis) {
+		releaseIdleSlotsConsumer.accept(currentTimeMillis);
+	}
+
+	public static TestingDeclarativeSlotPoolBuilder builder() {
+		return new TestingDeclarativeSlotPoolBuilder();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.function.QuadFunction;
+import org.apache.flink.util.function.TriFunction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.Supplier;
+
+/**
+ * Builder for {@link TestingDeclarativeSlotPool}.
+ */
+public class TestingDeclarativeSlotPoolBuilder {
+
+	private Consumer<ResourceCounter> increaseResourceRequirementsByConsumer = ignored -> {};
+	private Consumer<ResourceCounter> decreaseResourceRequirementsByConsumer = ignored -> {};
+	private Supplier<Collection<ResourceRequirement>> getResourceRequirementsSupplier = Collections::emptyList;
+	private QuadFunction<Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long, Collection<SlotOffer>> offerSlotsFunction = (ignoredA, ignoredB, ignoredC, ignoredD) -> Collections.emptyList();
+	private Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier = Collections::emptyList;
+	private Supplier<Collection<? extends SlotInfo>> getAllSlotsInformationSupplier = Collections::emptyList;
+	private BiFunction<ResourceID, Exception, ResourceCounter> releaseSlotsFunction = (ignoredA, ignoredB) -> ResourceCounter.empty();
+	private BiFunction<AllocationID, Exception, ResourceCounter> releaseSlotFunction = (ignoredA, ignoredB) -> ResourceCounter.empty();
+	private BiFunction<AllocationID, ResourceProfile, PhysicalSlot> reserveFreeSlotFunction = (ignoredA, ignoredB) -> null;
+	private TriFunction<AllocationID, Throwable, Long, ResourceCounter> freeReservedSlotFunction = (ignoredA, ignoredB, ignoredC) -> ResourceCounter.empty();
+	private Function<ResourceID, Boolean> containsSlotsFunction = ignored -> false;
+	private LongConsumer returnIdleSlotsConsumer = ignored -> {};
+
+	public TestingDeclarativeSlotPoolBuilder setIncreaseResourceRequirementsByConsumer(Consumer<ResourceCounter> increaseResourceRequirementsByConsumer) {
+		this.increaseResourceRequirementsByConsumer = increaseResourceRequirementsByConsumer;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setDecreaseResourceRequirementsByConsumer(Consumer<ResourceCounter> decreaseResourceRequirementsByConsumer) {
+		this.decreaseResourceRequirementsByConsumer = decreaseResourceRequirementsByConsumer;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setGetResourceRequirementsSupplier(Supplier<Collection<ResourceRequirement>> getResourceRequirementsSupplier) {
+		this.getResourceRequirementsSupplier = getResourceRequirementsSupplier;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setOfferSlotsFunction(QuadFunction<Collection<? extends SlotOffer>, TaskManagerLocation, TaskManagerGateway, Long, Collection<SlotOffer>> offerSlotsFunction) {
+		this.offerSlotsFunction = offerSlotsFunction;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setGetFreeSlotsInformationSupplier(Supplier<Collection<SlotInfoWithUtilization>> getFreeSlotsInformationSupplier) {
+		this.getFreeSlotsInformationSupplier = getFreeSlotsInformationSupplier;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setGetAllSlotsInformationSupplier(Supplier<Collection<? extends SlotInfo>> getAllSlotsInformationSupplier) {
+		this.getAllSlotsInformationSupplier = getAllSlotsInformationSupplier;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setReleaseSlotsFunction(BiFunction<ResourceID, Exception, ResourceCounter> failSlotsConsumer) {
+		this.releaseSlotsFunction = failSlotsConsumer;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setReleaseSlotFunction(BiFunction<AllocationID, Exception, ResourceCounter> failSlotConsumer) {
+		this.releaseSlotFunction = failSlotConsumer;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setReserveFreeSlotFunction(BiFunction<AllocationID, ResourceProfile, PhysicalSlot> allocateFreeSlotForResourceFunction) {
+		this.reserveFreeSlotFunction = allocateFreeSlotForResourceFunction;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setFreeReservedSlotFunction(TriFunction<AllocationID, Throwable, Long, ResourceCounter> freeReservedSlotFunction) {
+		this.freeReservedSlotFunction = freeReservedSlotFunction;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setContainsSlotsFunction(Function<ResourceID, Boolean> containsSlotsFunction) {
+		this.containsSlotsFunction = containsSlotsFunction;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPoolBuilder setReturnIdleSlotsConsumer(LongConsumer returnIdleSlotsConsumer) {
+		this.returnIdleSlotsConsumer = returnIdleSlotsConsumer;
+		return this;
+	}
+
+	public TestingDeclarativeSlotPool build() {
+		return new TestingDeclarativeSlotPool(
+				increaseResourceRequirementsByConsumer,
+				decreaseResourceRequirementsByConsumer,
+				getResourceRequirementsSupplier,
+				offerSlotsFunction,
+				getFreeSlotsInformationSupplier,
+				getAllSlotsInformationSupplier,
+				releaseSlotsFunction,
+				releaseSlotFunction,
+				reserveFreeSlotFunction,
+				freeReservedSlotFunction,
+				containsSlotsFunction,
+				returnIdleSlotsConsumer);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPayload;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -162,6 +163,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	@Nonnull
 	private final BiFunction<OperatorID, SerializedValue<CoordinationRequest>, CompletableFuture<CoordinationResponse>> deliverCoordinationRequestFunction;
 
+	private final Consumer<Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer;
+
 	public TestingJobMasterGateway(
 			@Nonnull String address,
 			@Nonnull String hostname,
@@ -191,7 +194,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 			@Nonnull Function<Tuple4<JobID, JobVertexID, KeyGroupRange, String>, CompletableFuture<Acknowledge>> notifyKvStateUnregisteredFunction,
 			@Nonnull TriFunction<String, Object, byte[], CompletableFuture<Object>> updateAggregateFunction,
 			@Nonnull TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventSender,
-			@Nonnull BiFunction<OperatorID, SerializedValue<CoordinationRequest>, CompletableFuture<CoordinationResponse>> deliverCoordinationRequestFunction) {
+			@Nonnull BiFunction<OperatorID, SerializedValue<CoordinationRequest>, CompletableFuture<CoordinationResponse>> deliverCoordinationRequestFunction,
+			@Nonnull Consumer<Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
 		this.address = address;
 		this.hostname = hostname;
 		this.cancelFunction = cancelFunction;
@@ -221,6 +225,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 		this.updateAggregateFunction = updateAggregateFunction;
 		this.operatorEventSender = operatorEventSender;
 		this.deliverCoordinationRequestFunction = deliverCoordinationRequestFunction;
+		this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
 	}
 
 	@Override
@@ -316,6 +321,11 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	@Override
 	public void notifyAllocationFailure(AllocationID allocationID, Exception cause) {
 		notifyAllocationFailureConsumer.accept(allocationID, cause);
+	}
+
+	@Override
+	public void notifyNotEnoughResourcesAvailable(Collection<ResourceRequirement> acquiredResources) {
+		notifyNotEnoughResourcesConsumer.accept(acquiredResources);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
+import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorToJobManagerHeartbeatPayload;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
@@ -105,6 +106,7 @@ public class TestingJobMasterGatewayBuilder {
 	private TriFunction<String, Object, byte[], CompletableFuture<Object>> updateAggregateFunction = (a, b, c) -> CompletableFuture.completedFuture(new Object());
 	private TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventSender = (a, b, c) -> CompletableFuture.completedFuture(Acknowledge.get());
 	private BiFunction<OperatorID, SerializedValue<CoordinationRequest>, CompletableFuture<CoordinationResponse>> deliverCoordinationRequestFunction = (a, b) -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
+	private Consumer<Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer = ignored -> {};
 
 	public TestingJobMasterGatewayBuilder setAddress(String address) {
 		this.address = address;
@@ -206,6 +208,11 @@ public class TestingJobMasterGatewayBuilder {
 		return this;
 	}
 
+	public TestingJobMasterGatewayBuilder setNotifyNotEnoughResourcesConsumer(Consumer<Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
+		this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
+		return this;
+	}
+
 	public TestingJobMasterGatewayBuilder setAcknowledgeCheckpointConsumer(Consumer<Tuple5<JobID, ExecutionAttemptID, Long, CheckpointMetrics, TaskStateSnapshot>> acknowledgeCheckpointConsumer) {
 		this.acknowledgeCheckpointConsumer = acknowledgeCheckpointConsumer;
 		return this;
@@ -281,6 +288,7 @@ public class TestingJobMasterGatewayBuilder {
 			notifyKvStateUnregisteredFunction,
 			updateAggregateFunction,
 			operatorEventSender,
-			deliverCoordinationRequestFunction);
+			deliverCoordinationRequestFunction,
+			notifyNotEnoughResourcesConsumer);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -113,12 +113,6 @@ public class MiniClusterITCase extends TestLogger {
 		} catch (JobExecutionException e) {
 			assertTrue(findThrowableWithMessage(e, "Job execution failed.").isPresent());
 			assertTrue(findThrowable(e, NoResourceAvailableException.class).isPresent());
-
-			//TODO: remove the legacy scheduler message check once legacy scheduler is removed
-			final String legacySchedulerErrorMessage = "Slots required: 2, slots allocated: 1";
-			final String ngSchedulerErrorMessage = "Could not allocate the required slot within slot request timeout";
-			assertTrue(findThrowableWithMessage(e, legacySchedulerErrorMessage).isPresent() ||
-				findThrowableWithMessage(e, ngSchedulerErrorMessage).isPresent());
 		}
 	}
 
@@ -130,12 +124,6 @@ public class MiniClusterITCase extends TestLogger {
 		} catch (JobExecutionException e) {
 			assertTrue(findThrowableWithMessage(e, "Job execution failed.").isPresent());
 			assertTrue(findThrowable(e, NoResourceAvailableException.class).isPresent());
-
-			//TODO: remove the legacy scheduler message check once legacy scheduler is removed
-			final String legacySchedulerErrorMessage = "Could not allocate enough slots";
-			final String ngSchedulerErrorMessage = "Could not allocate the required slot within slot request timeout";
-			assertTrue(findThrowableWithMessage(e, legacySchedulerErrorMessage).isPresent() ||
-				findThrowableWithMessage(e, ngSchedulerErrorMessage).isPresent());
 		}
 	}
 

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -103,6 +103,8 @@ jobs:
         module: tests
       misc:
         module: misc
+      legacy_slot_management:
+        module: legacy_slot_management
   steps:
   # if on Azure, free up disk space
   - script: ./tools/azure-pipelines/free_disk_space.sh

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -27,6 +27,7 @@ STAGE_KAFKA_GELLY="kafka/gelly"
 STAGE_TESTS="tests"
 STAGE_MISC="misc"
 STAGE_CLEANUP="cleanup"
+STAGE_LEGACY_SLOT_MANAGEMENT="legacy_slot_management"
 
 MODULES_CORE="\
 flink-annotations,\
@@ -122,6 +123,8 @@ flink-connectors/flink-sql-connector-kafka,"
 MODULES_TESTS="\
 flink-tests"
 
+MODULES_LEGACY_SLOT_MANAGEMENT=${MODULES_CORE},${MODULES_TESTS}
+
 # we can only build the Scala Shell when building for Scala 2.11
 if [[ $PROFILE == *"scala-2.11"* ]]; then
     MODULES_CORE="$MODULES_CORE,flink-scala-shell"
@@ -158,6 +161,9 @@ function get_compile_modules_for_stage() {
             # compile everything for PyFlink.
             echo ""
         ;;
+        (${STAGE_LEGACY_SLOT_MANAGEMENT})
+            echo "-pl $MODULES_LEGACY_SLOT_MANAGEMENT -am"
+        ;;
     esac
 }
 
@@ -176,6 +182,7 @@ function get_test_modules_for_stage() {
     local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
     local modules_misc="$negated_core,$negated_libraries,$negated_blink_planner,$negated_connectors,$negated_kafka_gelly,$negated_tests"
+    local modules_legacy_slot_management=$MODULES_LEGACY_SLOT_MANAGEMENT
 
     case ${stage} in
         (${STAGE_CORE})
@@ -199,5 +206,8 @@ function get_test_modules_for_stage() {
         (${STAGE_MISC})
             echo "-pl $modules_misc"
         ;;
+        (${STAGE_LEGACY_SLOT_MANAGEMENT})
+            echo "-pl $modules_legacy_slot_management"
+        ::
     esac
 }

--- a/tools/ci/test_controller.sh
+++ b/tools/ci/test_controller.sh
@@ -105,6 +105,9 @@ if [ $STAGE == $STAGE_PYTHON ]; then
 	EXIT_CODE=$?
 else
 	MVN_TEST_OPTIONS="-Dflink.tests.with-openssl"
+	if [ $STAGE = $STAGE_LEGACY_SLOT_MANAGEMENT ]; then
+		MVN_TEST_OPTIONS="$MVN_TEST_OPTIONS -Dflink.tests.disable-declarative"
+	fi
 	MVN_TEST_MODULES=$(get_test_modules_for_stage ${STAGE})
 
 	run_with_watchdog "run_mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE $MVN_TEST_MODULES verify" $CALLBACK_ON_TIMEOUT


### PR DESCRIPTION
Based on #13722.

This PR adds the final bit declarative resource management: the `DeclarativeSlotPoolBridge` which acts as a glue between the declarative resource management and current SlotRequest-based scheduler.

The bridge essentially maps every incoming slot request, be it for a new or an existing slot, to a requirement increase, and every slot release/free to a requirement reduction.
When allocating a new slot the bridge returns a slot future. Whenever a new slot is offered to the JobMaster the bridge tries to fulfill any non-completed slot futures with the new slots.