### PR TITLE
[FLINK-20019][core] Support all conversion classes in Row.equals/hashCode

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/types/RowTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RowTest.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 
 public class RowTest {
 	@Test
@@ -66,7 +66,7 @@ public class RowTest {
 
 		Row copy = Row.copy(row);
 		assertEquals(row, copy);
-		assertTrue(row != copy);
+		assertNotSame(row, copy);
 	}
 
 	@Test
@@ -112,12 +112,12 @@ public class RowTest {
 	}
 
 	@Test
-	public void testDeepEquals() {
+	public void testDeepEqualsAndHashCode() {
 		final Map<String, byte[]> originalMap = new HashMap<>();
 		originalMap.put("k1", new byte[]{1, 2, 3});
 		originalMap.put("k2", new byte[]{3, 4, 6});
 
-		final Row originalRow = Row.of(
+		final Row originalRow = Row.ofKind(
 				RowKind.INSERT,
 				true,
 				new Integer[]{1, null, 3},
@@ -127,11 +127,12 @@ public class RowTest {
 				new int[][]{{1, 2, 3}, {}, {4, 5}},
 				1.44
 		);
-		assertTrue(Row.deepEquals(originalRow, originalRow));
+		assertEquals(originalRow, originalRow);
+		assertEquals(originalRow.hashCode(), originalRow.hashCode());
 
 		{
 			// no diff
-			final Row row = Row.of(
+			final Row row = Row.ofKind(
 					RowKind.INSERT,
 					true,
 					new Integer[]{1, null, 3},
@@ -141,7 +142,8 @@ public class RowTest {
 					new int[][]{{1, 2, 3}, {}, {4, 5}},
 					1.44
 			);
-			assertTrue(Row.deepEquals(row, originalRow));
+			assertEquals(row, originalRow);
+			assertEquals(row.hashCode(), originalRow.hashCode());
 		}
 
 		{
@@ -149,7 +151,7 @@ public class RowTest {
 			map.put("k1", new byte[]{1, 2, 3});
 			map.put("k2", new byte[]{3, 4, 6});
 
-			final Row row = Row.of(
+			final Row row = Row.ofKind(
 					RowKind.INSERT,
 					true,
 					new Integer[]{1, null, 3, 99}, // diff here
@@ -159,7 +161,8 @@ public class RowTest {
 					new int[][]{{1, 2, 3}, {}, {4, 5}},
 					1.44
 			);
-			assertFalse(Row.deepEquals(row, originalRow));
+			assertNotEquals(row, originalRow);
+			assertNotEquals(row.hashCode(), originalRow.hashCode());
 		}
 
 		{
@@ -167,7 +170,7 @@ public class RowTest {
 			map.put("k1", new byte[]{1, 2, 2}); // diff here
 			map.put("k2", new byte[]{3, 4, 6});
 
-			final Row row = Row.of(
+			final Row row = Row.ofKind(
 					RowKind.INSERT,
 					true,
 					new Integer[]{1, null, 3},
@@ -177,7 +180,8 @@ public class RowTest {
 					new int[][]{{1, 2, 3}, {}, {4, 5}},
 					1.44
 			);
-			assertFalse(Row.deepEquals(row, originalRow));
+			assertNotEquals(row, originalRow);
+			assertNotEquals(row.hashCode(), originalRow.hashCode());
 		}
 
 		{
@@ -185,7 +189,7 @@ public class RowTest {
 			map.put("k1", new byte[]{1, 2, 3});
 			map.put("k2", new byte[]{3, 4, 6});
 
-			final Row row = Row.of(
+			final Row row = Row.ofKind(
 					RowKind.INSERT,
 					true,
 					new Integer[]{1, null, 3},
@@ -195,7 +199,8 @@ public class RowTest {
 					new Integer[][]{{1, 2, 3}, {}, {4, 5}}, // diff here
 					1.44
 			);
-			assertFalse(Row.deepEquals(row, originalRow));
+			assertNotEquals(row, originalRow);
+			assertNotEquals(row.hashCode(), originalRow.hashCode());
 		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableTestMatchers.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableTestMatchers.java
@@ -34,21 +34,6 @@ import java.util.List;
 @Internal
 public final class TableTestMatchers {
 
-	public static Matcher<Row> deepEqualTo(Row row) {
-		return new BaseMatcher<Row>() {
-
-			@Override
-			public void describeTo(Description description) {
-				description.appendValue(row);
-			}
-
-			@Override
-			public boolean matches(Object item) {
-				return Row.deepEquals(row, (Row) item);
-			}
-		};
-	}
-
 	public static Matcher<List<Row>> deepEqualTo(List<Row> rows, boolean ignoreOrder) {
 		return new BaseMatcher<List<Row>>() {
 


### PR DESCRIPTION
## What is the purpose of the change

The Row.equals/hashCode cannot handle arrays in nested structures (e.g. Map, List) well. Since those methods are used for a variety of use cases. We should support all conversion classes of the table ecosystem in all combinations. Initial work for this has been done recently. But it would be good to finalize this for 1.12 as a preparation for FLIP-136.

## Brief change log

- Implement a deepHashCode for the `Row` class  
- Make `RowUtils.deepEquals` and `RowUtils.deepHashCode` the default for `Row`

## Verifying this change

This change is already covered by existing tests and additionally tested in `RowTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
