### PR TITLE
[FLINK-20008] Close LeaderElectionDriver outside of lock in DefaultLeaderElectionService.stop()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -60,7 +60,6 @@ public class DefaultLeaderElectionService implements LeaderElectionService, Lead
 	@GuardedBy("lock")
 	private volatile boolean running;
 
-	@GuardedBy("lock")
 	private LeaderElectionDriver leaderElectionDriver;
 
 	public DefaultLeaderElectionService(LeaderElectionDriverFactory leaderElectionDriverFactory) {
@@ -100,8 +99,9 @@ public class DefaultLeaderElectionService implements LeaderElectionService, Lead
 			}
 			running = false;
 			clearConfirmedLeaderInformation();
-			leaderElectionDriver.close();
 		}
+
+		leaderElectionDriver.close();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class TestingLeaderElectionDriver implements LeaderElectionDriver {
 
+	private final Object lock = new Object();
+
 	private final AtomicBoolean isLeader = new AtomicBoolean(false);
 	private final LeaderElectionEventHandler leaderElectionEventHandler;
 	private final FatalErrorHandler fatalErrorHandler;
@@ -56,7 +58,9 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
 
 	@Override
 	public void close() throws Exception {
-		// noop
+		synchronized (lock) {
+			// noop
+		}
 	}
 
 	public LeaderInformation getLeaderInformation() {
@@ -64,13 +68,17 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
 	}
 
 	public void isLeader() {
-		isLeader.set(true);
-		leaderElectionEventHandler.onGrantLeadership();
+		synchronized (lock) {
+			isLeader.set(true);
+			leaderElectionEventHandler.onGrantLeadership();
+		}
 	}
 
 	public void notLeader() {
-		isLeader.set(false);
-		leaderElectionEventHandler.onRevokeLeadership();
+		synchronized (lock) {
+			isLeader.set(false);
+			leaderElectionEventHandler.onRevokeLeadership();
+		}
 	}
 
 	public void leaderInformationChanged(LeaderInformation newLeader) {


### PR DESCRIPTION
## What is the purpose of the change

59f19e8:
In order to avoid deadlocks in LeaderElectionDrivers which call onGrantLeadership and revokeLeadership
under an internal lock, we must not close the LeaderElectionDriver under the DefaultLeaderElectionService.lock.

f233b9c:
In order to avoid seeing LeaderContender callbacks after the DefaultLeaderElectionService
has been shut down, they need to be executed under the lock of the service. This entails
that the user of this class should not close the service under the same lock as the
callback can acquire.

052df91:
This commit moves the closing of the leaderRetrievalDriver used by the DefaultLeaderRetrievalService
out of the lock scope. This ensures that if the LeaderRetrievalDriver triggers callbacks while holding a lock,
then we won't deadlock.

Moreover, this commit moves the LeaderRetrievalListener callback back under the lock scope in order to avoid
callbacks after the DefaultLeaderRetrievalService has been closed.

cc @wangyang0918 

## Verifying this change

- Added `DefaultLeaderElectionServiceTest.testServiceShutDownWithSynchronizedDriver`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
