### PR TITLE
[FLINK-20031] Keep the uid of SinkWriter same as the SinkTransformation

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
@@ -88,7 +88,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				sourceNode,
 				IntSerializer.class,
 				writerNode,
-				"Writer",
+				String.format("Sink Writer: %s", NAME),
+				UID,
 				StatelessSinkWriterOperatorFactory.class,
 				PARALLELISM,
 				-1);
@@ -111,7 +112,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				writerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				committerNode,
-				"Committer",
+				String.format("Sink Committer: %s", NAME),
+				String.format("Sink Committer: %s", UID),
 				committerClass,
 				runtimeExecutionMode == RuntimeExecutionMode.STREAMING ? PARALLELISM : 1,
 				runtimeExecutionMode == RuntimeExecutionMode.STREAMING ? -1 : 1);
@@ -135,7 +137,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				committerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				globalCommitterNode,
-				"Global Committer",
+				String.format("Sink Global Committer: %s", NAME),
+				String.format("Sink Global Committer: %s", UID),
 				globalCommitterClass,
 				1,
 				1);
@@ -158,7 +161,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				writerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				globalCommitterNode,
-				"Global Committer",
+				String.format("Sink Global Committer: %s", NAME),
+				String.format("Sink Global Committer: %s", UID),
 				globalCommitterClass,
 				1,
 				1);
@@ -208,7 +212,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 			StreamNode src,
 			Class<?> srcOutTypeInfo,
 			StreamNode dest,
-			String midName,
+			String name,
+			String uid,
 			Class<?> expectedOperatorFactory,
 			int expectedParallelism,
 			int expectedMaxParallelism) {
@@ -224,13 +229,12 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 		assertThat(dest.getTypeSerializersIn()[0], instanceOf(srcOutTypeInfo));
 
 		//verify dest node
-		assertThat(dest.getOperatorName(), equalTo(String.format("Sink %s: %s", midName, NAME)));
+		assertThat(dest.getOperatorName(), equalTo(name));
+		assertThat(dest.getTransformationUID(), equalTo(uid));
+
 		assertThat(
 				dest.getOperatorFactory(),
 				instanceOf(expectedOperatorFactory));
-		assertThat(
-				dest.getTransformationUID(),
-				equalTo(String.format("Sink %s: %s", midName, UID)));
 		assertThat(dest.getParallelism(), equalTo(expectedParallelism));
 		assertThat(dest.getMaxParallelism(), equalTo(expectedMaxParallelism));
 		assertThat(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In this case that we want to migrate the StreamingFileSink to the new sink api we might need to let user set the SinkWriter's uid same as the StreamingFileSink's. So that SinkWriter operator has the opportunity to reuse the old state. (This is just a option.)
For this we need to let SinkWriter operator's uid is the same as the SinkTransformation.


## Brief change log

  - *Set the sink operator's uid the same as the SinkTransformation*


## Verifying this change

This change added tests and can be verified as follows:

  - *SinkTransformationTranslatorTest test the writer's uid and name*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
