### PR TITLE
[FLINK-19510][sink][filesystem] Support processing time in FileSink

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -136,6 +136,8 @@ public class FileSink<IN>
 
 		private static final long serialVersionUID = 1L;
 
+		public static final long DEFAULT_BUCKET_CHECK_INTERVAL = 60L * 1000L;
+
 		@SuppressWarnings("unchecked")
 		protected T self() {
 			return (T) this;
@@ -164,6 +166,8 @@ public class FileSink<IN>
 
 		private final Path basePath;
 
+		private long bucketCheckInterval;
+
 		private final Encoder<IN> encoder;
 
 		private final FileWriterBucketFactory<IN> bucketFactory;
@@ -180,6 +184,7 @@ public class FileSink<IN>
 				BucketAssigner<IN, String> bucketAssigner) {
 			this(
 					basePath,
+					DEFAULT_BUCKET_CHECK_INTERVAL,
 					encoder,
 					bucketAssigner,
 					DefaultRollingPolicy.builder().build(),
@@ -189,17 +194,24 @@ public class FileSink<IN>
 
 		protected RowFormatBuilder(
 				Path basePath,
+				long bucketCheckInterval,
 				Encoder<IN> encoder,
 				BucketAssigner<IN, String> assigner,
 				RollingPolicy<IN, String> policy,
 				FileWriterBucketFactory<IN> bucketFactory,
 				OutputFileConfig outputFileConfig) {
 			this.basePath = checkNotNull(basePath);
+			this.bucketCheckInterval = bucketCheckInterval;
 			this.encoder = checkNotNull(encoder);
 			this.bucketAssigner = checkNotNull(assigner);
 			this.rollingPolicy = checkNotNull(policy);
 			this.bucketFactory = checkNotNull(bucketFactory);
 			this.outputFileConfig = checkNotNull(outputFileConfig);
+		}
+
+		public T withBucketCheckInterval(final long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
 		public T withBucketAssigner(final BucketAssigner<IN, String> assigner) {
@@ -230,7 +242,9 @@ public class FileSink<IN>
 					bucketFactory,
 					createBucketWriter(),
 					rollingPolicy,
-					outputFileConfig);
+					outputFileConfig,
+					context.getProcessingTimeService(),
+					bucketCheckInterval);
 		}
 
 		@Override
@@ -287,6 +301,8 @@ public class FileSink<IN>
 
 		private final Path basePath;
 
+		private long bucketCheckInterval;
+
 		private final BulkWriter.Factory<IN> writerFactory;
 
 		private final FileWriterBucketFactory<IN> bucketFactory;
@@ -303,6 +319,7 @@ public class FileSink<IN>
 				BucketAssigner<IN, String> assigner) {
 			this(
 					basePath,
+					DEFAULT_BUCKET_CHECK_INTERVAL,
 					writerFactory,
 					assigner,
 					OnCheckpointRollingPolicy.build(),
@@ -312,17 +329,24 @@ public class FileSink<IN>
 
 		protected BulkFormatBuilder(
 				Path basePath,
+				long bucketCheckInterval,
 				BulkWriter.Factory<IN> writerFactory,
 				BucketAssigner<IN, String> assigner,
 				CheckpointRollingPolicy<IN, String> policy,
 				FileWriterBucketFactory<IN> bucketFactory,
 				OutputFileConfig outputFileConfig) {
 			this.basePath = checkNotNull(basePath);
+			this.bucketCheckInterval = bucketCheckInterval;
 			this.writerFactory = writerFactory;
 			this.bucketAssigner = checkNotNull(assigner);
 			this.rollingPolicy = checkNotNull(policy);
 			this.bucketFactory = checkNotNull(bucketFactory);
 			this.outputFileConfig = checkNotNull(outputFileConfig);
+		}
+
+		public T withBucketCheckInterval(final long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
 		public T withBucketAssigner(BucketAssigner<IN, String> assigner) {
@@ -348,6 +372,7 @@ public class FileSink<IN>
 							+ "after specifying a customized bucket factory");
 			return new BulkFormatBuilder<>(
 					basePath,
+					bucketCheckInterval,
 					writerFactory,
 					checkNotNull(assigner),
 					rollingPolicy,
@@ -368,7 +393,9 @@ public class FileSink<IN>
 					bucketFactory,
 					createBucketWriter(),
 					rollingPolicy,
-					outputFileConfig);
+					outputFileConfig,
+					context.getProcessingTimeService(),
+					bucketCheckInterval);
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.file.sink.writer;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
@@ -41,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -49,7 +51,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class FileWriter<IN>
-		implements SinkWriter<IN, FileSinkCommittable, FileWriterBucketState> {
+		implements SinkWriter<IN, FileSinkCommittable, FileWriterBucketState>,
+		Sink.ProcessingTimeService.ProcessingTimeCallback {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FileWriter.class);
 
@@ -64,6 +67,10 @@ public class FileWriter<IN>
 	private final BucketWriter<IN, String> bucketWriter;
 
 	private final RollingPolicy<IN, String> rollingPolicy;
+
+	private final Sink.ProcessingTimeService processingTimeService;
+
+	private final long bucketCheckInterval;
 
 	// --------------------------- runtime fields -----------------------------
 
@@ -92,7 +99,9 @@ public class FileWriter<IN>
 			final FileWriterBucketFactory<IN> bucketFactory,
 			final BucketWriter<IN, String> bucketWriter,
 			final RollingPolicy<IN, String> rollingPolicy,
-			final OutputFileConfig outputFileConfig) {
+			final OutputFileConfig outputFileConfig,
+			final Sink.ProcessingTimeService processingTimeService,
+			final long bucketCheckInterval) {
 
 		this.basePath = checkNotNull(basePath);
 		this.bucketAssigner = checkNotNull(bucketAssigner);
@@ -107,6 +116,15 @@ public class FileWriter<IN>
 
 		this.bucketStateSerializer = new FileWriterBucketStateSerializer(
 				bucketWriter.getProperties().getInProgressFileRecoverableSerializer());
+
+		this.processingTimeService = checkNotNull(processingTimeService);
+		checkArgument(
+				bucketCheckInterval > 0,
+				"Bucket checking interval for processing time should be positive.");
+		this.bucketCheckInterval = bucketCheckInterval;
+		processingTimeService.registerProcessingTimer(
+				processingTimeService.getCurrentProcessingTime() + bucketCheckInterval,
+				this);
 	}
 
 	/**
@@ -166,7 +184,7 @@ public class FileWriter<IN>
 
 		final String bucketId = bucketAssigner.getBucketId(element, bucketerContext);
 		final FileWriterBucket<IN> bucket = getOrCreateBucketForBucketId(bucketId);
-		bucket.write(element);
+		bucket.write(element, processingTimeService.getCurrentProcessingTime());
 	}
 
 	@Override
@@ -231,6 +249,17 @@ public class FileWriter<IN>
 			return basePath;
 		}
 		return new Path(basePath, bucketId);
+	}
+
+	@Override
+	public void onProcessingTime(long time) throws IOException {
+		for (FileWriterBucket<IN> bucket : activeBuckets.values()) {
+			bucket.onProcessingTime(time);
+		}
+
+		processingTimeService.registerProcessingTimer(
+				processingTimeService.getCurrentProcessingTime() + bucketCheckInterval,
+				this);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterBucketTest.java
@@ -73,7 +73,7 @@ public class FileWriterBucketTest {
 				path,
 				DEFAULT_ROLLING_POLICY,
 				OutputFileConfig.builder().build());
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
 		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(false);
 		FileWriterBucketState bucketState = bucket.snapshotState();
 
@@ -97,7 +97,7 @@ public class FileWriterBucketTest {
 				path,
 				ON_CHECKPOING_ROLLING_POLICY,
 				OutputFileConfig.builder().build());
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
 		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(false);
 		FileWriterBucketState bucketState = bucket.snapshotState();
 
@@ -121,9 +121,9 @@ public class FileWriterBucketTest {
 				path,
 				EACH_ELEMENT_ROLLING_POLICY,
 				OutputFileConfig.builder().build());
-		bucket.write("test-element");
-		bucket.write("test-element");
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
+		bucket.write("test-element", 0);
+		bucket.write("test-element", 0);
 		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(false);
 		FileWriterBucketState bucketState = bucket.snapshotState();
 
@@ -148,13 +148,13 @@ public class FileWriterBucketTest {
 				path,
 				DEFAULT_ROLLING_POLICY,
 				OutputFileConfig.builder().build());
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
 
 		bucket.prepareCommit(false);
 		bucket.snapshotState();
 
 		// One more checkpoint
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
 		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(false);
 		FileWriterBucketState bucketState = bucket.snapshotState();
 
@@ -178,7 +178,7 @@ public class FileWriterBucketTest {
 				path,
 				DEFAULT_ROLLING_POLICY,
 				OutputFileConfig.builder().build());
-		bucket.write("test-element");
+		bucket.write("test-element", 0);
 
 		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(true);
 
@@ -186,6 +186,39 @@ public class FileWriterBucketTest {
 		assertNull(
 				"The bucket should not have in-progress part after flushed",
 				bucket.getInProgressPart());
+	}
+
+	@Test
+	public void testRollingOnProcessingTime() throws IOException {
+		File outDir = TEMP_FOLDER.newFolder();
+		Path path = new Path(outDir.toURI());
+
+		RollingPolicy<String, String> onProcessingTimeRollingPolicy = DefaultRollingPolicy
+				.builder()
+				.withRolloverInterval(10)
+				.build();
+
+		TestRecoverableWriter recoverableWriter = getRecoverableWriter(path);
+		FileWriterBucket<String> bucket = createBucket(
+				recoverableWriter,
+				path,
+				onProcessingTimeRollingPolicy,
+				OutputFileConfig.builder().build());
+		bucket.write("test-element", 11);
+		bucket.write("test-element", 12);
+
+		bucket.onProcessingTime(20);
+		assertNotNull(
+				"The bucket should not roll since interval is not reached",
+				bucket.getInProgressPart());
+
+		bucket.write("test-element", 21);
+		bucket.onProcessingTime(30);
+		assertNull(
+				"The bucket should roll since interval is reached",
+				bucket.getInProgressPart());
+		List<FileSinkCommittable> fileSinkCommittables = bucket.prepareCommit(false);
+		compareNumberOfPendingAndInProgress(fileSinkCommittables, 1, 0);
 	}
 
 	// --------------------------- Checking Restore ---------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -19,7 +19,9 @@
 package org.apache.flink.connector.file.sink.writer;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
 import org.apache.flink.core.fs.FileSystem;
@@ -29,6 +31,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RowWiseBucketWriter;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -36,14 +39,17 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -180,6 +186,55 @@ public class FileWriterTest {
 		assertTrue(fileWriter.getActiveBuckets().isEmpty());
 	}
 
+	@Test
+	public void testOnProcessingTime() throws IOException {
+		File outDir = TEMP_FOLDER.newFolder();
+		Path path = new Path(outDir.toURI());
+
+		// Create the processing timer service starts from 10.
+		ManuallyTriggeredProcessingTimeService processingTimeService = new ManuallyTriggeredProcessingTimeService();
+		processingTimeService.advanceTo(10);
+
+		FileWriter<String> fileWriter = createWriter(
+				path,
+				DefaultRollingPolicy.builder().withRolloverInterval(10).build(),
+				new OutputFileConfig("part-", ""),
+				processingTimeService,
+				5);
+
+		// Test timer registered timer@15 on startup
+		fileWriter.write("test1", new ContextImpl());
+		processingTimeService.advanceTo(15);
+		fileWriter.write("test2", new ContextImpl());
+		processingTimeService.advanceTo(20);
+
+		FileWriterBucket<String> test1Bucket = fileWriter.getActiveBuckets().get("test1");
+		assertNull("The in-progress part of test1 should be rolled", test1Bucket.getInProgressPart());
+		assertEquals(1, test1Bucket.getPendingFiles().size());
+
+		FileWriterBucket<String> test2Bucket = fileWriter.getActiveBuckets().get("test2");
+		assertNotNull("The in-progress part of test2 should not be rolled", test2Bucket.getInProgressPart());
+		assertEquals(0, test2Bucket.getPendingFiles().size());
+
+		// Close, pre-commit & clear all the pending records.
+		processingTimeService.advanceTo(30);
+		fileWriter.prepareCommit(false);
+
+		// Test timer re-registration.
+		fileWriter.write("test1", new ContextImpl());
+		processingTimeService.advanceTo(35);
+		fileWriter.write("test2", new ContextImpl());
+		processingTimeService.advanceTo(40);
+
+		test1Bucket = fileWriter.getActiveBuckets().get("test1");
+		assertNull("The in-progress part of test1 should be rolled", test1Bucket.getInProgressPart());
+		assertEquals(1, test1Bucket.getPendingFiles().size());
+
+		test2Bucket = fileWriter.getActiveBuckets().get("test2");
+		assertNotNull("The in-progress part of test2 should not be rolled", test2Bucket.getInProgressPart());
+		assertEquals(0, test2Bucket.getPendingFiles().size());
+	}
+
 	// ------------------------------- Mock Classes --------------------------------
 
 	private static class ContextImpl implements SinkWriter.Context {
@@ -206,6 +261,51 @@ public class FileWriterTest {
 		}
 	}
 
+	private static class ManuallyTriggeredProcessingTimeService implements Sink.ProcessingTimeService {
+
+		private long now;
+
+		private Deque<Tuple2<Long, ProcessingTimeCallback>> timers = new ArrayDeque<>();
+
+		@Override
+		public long getCurrentProcessingTime() {
+			return now;
+		}
+
+		@Override
+		public void registerProcessingTimer(long time, ProcessingTimeCallback processingTimeCallback) {
+			if (time <= now) {
+				try {
+					processingTimeCallback.onProcessingTime(now);
+				} catch (IOException e) {
+					ExceptionUtils.rethrow(e);
+				}
+			} else {
+				timers.add(new Tuple2<>(time, processingTimeCallback));
+			}
+		}
+
+		public void advanceTo(long time) {
+			if (time > now) {
+				now = time;
+
+				int size = timers.size();
+				for (int i = 0; i < size; ++i) {
+					Tuple2<Long, ProcessingTimeCallback> timer = timers.poll();
+					if (now >= timer.f0) {
+						try {
+							timer.f1.onProcessingTime(now);
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+					} else {
+						timers.add(timer);
+					}
+				}
+			}
+		}
+	}
+
 	// ------------------------------- Utility Methods --------------------------------
 
 	private static FileWriter<String> createWriter(
@@ -220,7 +320,28 @@ public class FileWriterTest {
 						.get(basePath.toUri())
 						.createRecoverableWriter(), new SimpleStringEncoder<>()),
 				rollingPolicy,
-				outputFileConfig);
+				outputFileConfig,
+				new ManuallyTriggeredProcessingTimeService(),
+				10);
+	}
+
+	private static FileWriter<String> createWriter(
+			Path basePath,
+			RollingPolicy<String, String> rollingPolicy,
+			OutputFileConfig outputFileConfig,
+			Sink.ProcessingTimeService processingTimeService,
+			long bucketCheckInterval) throws IOException {
+		return new FileWriter<>(
+				basePath,
+				new FileSinkTestUtils.StringIdentityBucketAssigner(),
+				new DefaultFileWriterBucketFactory<>(),
+				new RowWiseBucketWriter<>(FileSystem
+						.get(basePath.toUri())
+						.createRecoverableWriter(), new SimpleStringEncoder<>()),
+				rollingPolicy,
+				outputFileConfig,
+				processingTimeService,
+				bucketCheckInterval);
 	}
 
 	private static FileWriter<String> restoreWriter(

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/Sink.java
@@ -98,6 +98,12 @@ public interface Sink<InputT, CommT, WriterStateT, GlobalCommT> extends Serializ
 	interface InitContext {
 
 		/**
+		 * Returns a {@link ProcessingTimeService} that can be used to
+		 * get the current time and register timers.
+		 */
+		ProcessingTimeService getProcessingTimeService();
+
+		/**
 		 * @return The id of task where the writer is.
 		 */
 		int getSubtaskId();
@@ -106,5 +112,37 @@ public interface Sink<InputT, CommT, WriterStateT, GlobalCommT> extends Serializ
 		 * @return The metric group this writer belongs to.
 		 */
 		MetricGroup metricGroup();
+	}
+
+	/**
+	 * A service that allows to get the current processing time and register timers that
+	 * will execute the given {@link ProcessingTimeCallback} when firing.
+	 */
+	interface ProcessingTimeService {
+
+		/** Returns the current processing time. */
+		long getCurrentProcessingTime();
+
+		/**
+		 * Invokes the given callback at the given timestamp.
+		 *
+		 * @param time Time when the callback is invoked at
+		 * @param processingTimerCallback The callback to be invoked.
+		 */
+		void registerProcessingTimer(long time, ProcessingTimeCallback processingTimerCallback);
+
+		/**
+		 * A callback that can be registered via {@link #registerProcessingTimer(long,
+		 * ProcessingTimeCallback)}.
+		 */
+		interface ProcessingTimeCallback {
+
+			/**
+			 * This method is invoked with the time which the callback register for.
+			 *
+			 * @param time The time this callback was registered for.
+			 */
+			void onProcessingTime(long time) throws IOException;
+		}
 	}
 }

--- a/flink-end-to-end-tests/flink-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-file-sink-test/pom.xml
@@ -27,8 +27,8 @@ under the License.
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>flink-streaming-file-sink-test</artifactId>
-	<name>Flink : E2E Tests : Streaming file sink</name>
+	<artifactId>flink-file-sink-test</artifactId>
+	<name>Flink : E2E Tests : File sink</name>
 
 	<dependencies>
 		<dependency>
@@ -36,6 +36,12 @@ under the License.
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -46,16 +52,16 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>StreamingFileSinkSinkTestProgram</id>
+						<id>FileSinkTestProgram</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<finalName>StreamingFileSinkProgram</finalName>
+							<finalName>FileSinkProgram</finalName>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>StreamingFileSinkProgram</mainClass>
+									<mainClass>FileSinkProgram</mainClass>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/FileSinkProgram.java
@@ -24,11 +24,13 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
@@ -40,7 +42,7 @@ import java.io.PrintStream;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Test program for the {@link StreamingFileSink}.
+ * Test program for the {@link StreamingFileSink} and {@link FileSink}.
  *
  * <p>Uses a source that steadily emits a deterministic set of records over 60 seconds,
  * after which it idles and waits for job cancellation. Every record has a unique index that is
@@ -50,12 +52,13 @@ import java.util.concurrent.TimeUnit;
  * Adding all committed part files together, and numerically sorting the contents, should
  * result in a complete sequence from 0 (inclusive) to 60000 (exclusive).
  */
-public enum StreamingFileSinkProgram {
+public enum FileSinkProgram {
 	;
 
 	public static void main(final String[] args) throws Exception {
 		final ParameterTool params = ParameterTool.fromArgs(args);
 		final String outputPath = params.getRequired("outputPath");
+		final String sinkToTest = params.getRequired("sinkToTest");
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
@@ -63,23 +66,36 @@ public enum StreamingFileSinkProgram {
 		env.enableCheckpointing(5000L);
 		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, Time.of(10L, TimeUnit.SECONDS)));
 
-		final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
-			.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
-				PrintStream out = new PrintStream(stream);
-				out.println(element.f1);
-			})
-			.withBucketAssigner(new KeyBucketAssigner())
-			.withRollingPolicy(OnCheckpointRollingPolicy.build())
-			.build();
-
 		// generate data, shuffle, sink
-		env.addSource(new Generator(10, 10, 60))
-			.keyBy(0)
-			.addSink(sink);
+		DataStream<Tuple2<Integer, Integer>> source = env.addSource(new Generator(10, 10, 60));
+
+		if (sinkToTest.equalsIgnoreCase("StreamingFileSink")) {
+			final StreamingFileSink<Tuple2<Integer, Integer>> sink = StreamingFileSink
+					.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
+						PrintStream out = new PrintStream(stream);
+						out.println(element.f1);
+					})
+					.withBucketAssigner(new KeyBucketAssigner())
+					.withRollingPolicy(OnCheckpointRollingPolicy.build())
+					.build();
+
+			source.keyBy(0).addSink(sink);
+		} else if (sinkToTest.equalsIgnoreCase("FileSink")){
+			FileSink<Tuple2<Integer, Integer>> sink = FileSink
+					.forRowFormat(new Path(outputPath), (Encoder<Tuple2<Integer, Integer>>) (element, stream) -> {
+						PrintStream out = new PrintStream(stream);
+						out.println(element.f1);
+					})
+					.withBucketAssigner(new KeyBucketAssigner())
+					.withRollingPolicy(OnCheckpointRollingPolicy.build())
+					.build();
+			source.keyBy(0).sinkTo(sink);
+		} else {
+			throw new UnsupportedOperationException("Unsupported sink type: " + sinkToTest);
+		}
 
 		env.execute("StreamingFileSinkProgram");
 	}
-
 
 	/**
 	 * Use first field for buckets.

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<module>flink-confluent-schema-registry</module>
 		<module>flink-stream-state-ttl-test</module>
 		<module>flink-sql-client-test</module>
-		<module>flink-streaming-file-sink-test</module>
+		<module>flink-file-sink-test</module>
 		<module>flink-state-evolution-test</module>
 		<module>flink-rocksdb-state-memory-control-test</module>
 		<module>flink-end-to-end-tests-common</module>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -185,8 +185,11 @@ run_test "Batch SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_sq
 run_test "Streaming SQL end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh old" "skip_check_exceptions"
 run_test "Streaming SQL end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh blink" "skip_check_exceptions"
 
-run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh" "skip_check_exceptions"
-run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3" "skip_check_exceptions"
+run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local StreamingFileSink" "skip_check_exceptions"
+run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh s3 StreamingFileSink" "skip_check_exceptions"
+run_test "New File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local FileSink" "skip_check_exceptions"
+run_test "New File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh s3 FileSink" "skip_check_exceptions"
+
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 
 run_test "Netty shuffle direct memory consumption end-to-end test" "$END_TO_END_DIR/test-scripts/test_netty_shuffle_memory_control.sh"

--- a/flink-end-to-end-tests/test-scripts/test_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_file_sink.sh
@@ -18,8 +18,9 @@
 ################################################################################
 
 OUT_TYPE="${1:-local}" # other type: s3
+SINK_TO_TEST="${2:-"StreamingFileSink"}"
 
-S3_PREFIX=temp/test_streaming_file_sink-$(uuidgen)
+S3_PREFIX=temp/test_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
 S3_OUTPUT_PATH="s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
 source "$(dirname "$0")"/common.sh
@@ -60,7 +61,7 @@ if [ "${OUT_TYPE}" == "s3" ]; then
   on_exit out_cleanup
 fi
 
-TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-streaming-file-sink-test/target/StreamingFileSinkProgram.jar"
+TEST_PROGRAM_JAR="${END_TO_END_DIR}/flink-file-sink-test/target/FileSinkProgram.jar"
 
 ###################################
 # Get all lines in part files and sort them numerically.
@@ -135,7 +136,7 @@ function wait_for_complete_result {
     done
 }
 
-function run_streaming_file_sink_test {
+function run_file_sink_test {
   start_cluster
 
   "${FLINK_DIR}/bin/taskmanager.sh" start
@@ -143,7 +144,8 @@ function run_streaming_file_sink_test {
   "${FLINK_DIR}/bin/taskmanager.sh" start
 
   echo "Submitting job."
-  CLIENT_OUTPUT=$("$FLINK_DIR/bin/flink" run -d "${TEST_PROGRAM_JAR}" --outputPath "${JOB_OUTPUT_PATH}")
+  CLIENT_OUTPUT=$("$FLINK_DIR/bin/flink" run -d "${TEST_PROGRAM_JAR}" --outputPath "${JOB_OUTPUT_PATH}" \
+    --sinkToTest "${SINK_TO_TEST}")
   JOB_ID=$(echo "${CLIENT_OUTPUT}" | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
   if [[ -z $JOB_ID ]]; then
@@ -187,4 +189,4 @@ function run_streaming_file_sink_test {
 }
 
 # usual runtime is ~6 minutes
-run_test_with_timeout 900 run_streaming_file_sink_test
+run_test_with_timeout 900 run_file_sink_test

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperatorFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 /**
  * Base {@link OneInputStreamOperatorFactory} for subclasses of {@link AbstractSinkWriterOperator}.
@@ -36,10 +37,10 @@ abstract class AbstractSinkWriterOperatorFactory<InputT, CommT> extends Abstract
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T extends StreamOperator<CommT>> T createStreamOperator(StreamOperatorParameters<CommT> parameters) {
-		final AbstractSinkWriterOperator<InputT, CommT> writerOperator = createWriterOperator();
+		final AbstractSinkWriterOperator<InputT, CommT> writerOperator = createWriterOperator(this.processingTimeService);
 		writerOperator.setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
 		return (T) writerOperator;
 	}
 
-	abstract AbstractSinkWriterOperator<InputT, CommT> createWriterOperator();
+	abstract AbstractSinkWriterOperator<InputT, CommT> createWriterOperator(ProcessingTimeService processingTimeService);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.CollectionUtil;
 
 import java.util.List;
@@ -59,8 +60,10 @@ final class StatefulSinkWriterOperator<InputT, CommT, WriterStateT> extends Abst
 	private ListState<WriterStateT> writerState;
 
 	StatefulSinkWriterOperator(
+			final ProcessingTimeService processingTimeService,
 			final Sink<InputT, CommT, WriterStateT, ?> sink,
 			final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer) {
+		super(processingTimeService);
 		this.sink = sink;
 		this.writerStateSimpleVersionedSerializer = writerStateSimpleVersionedSerializer;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 /**
  * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
@@ -39,8 +40,8 @@ public final class StatefulSinkWriterOperatorFactory<InputT, CommT, WriterStateT
 	}
 
 	@Override
-	AbstractSinkWriterOperator<InputT, CommT> createWriterOperator() {
-		return new StatefulSinkWriterOperator<>(sink, sink.getWriterStateSerializer().get());
+	AbstractSinkWriterOperator<InputT, CommT> createWriterOperator(ProcessingTimeService processingTimeService) {
+		return new StatefulSinkWriterOperator<>(processingTimeService, sink, sink.getWriterStateSerializer().get());
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperator.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -38,7 +39,8 @@ final class StatelessSinkWriterOperator<InputT, CommT> extends AbstractSinkWrite
 	/** Used to create the stateless {@link SinkWriter}. */
 	private final Sink<InputT, CommT, ?, ?> sink;
 
-	StatelessSinkWriterOperator(final Sink<InputT, CommT, ?, ?> sink) {
+	StatelessSinkWriterOperator(final ProcessingTimeService processingTimeService, final Sink<InputT, CommT, ?, ?> sink) {
+		super(processingTimeService);
 		this.sink = sink;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatelessSinkWriterOperatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 /**
  * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
@@ -38,8 +39,8 @@ public final class StatelessSinkWriterOperatorFactory<InputT, CommT> extends Abs
 	}
 
 	@Override
-	AbstractSinkWriterOperator<InputT, CommT> createWriterOperator() {
-		return new StatelessSinkWriterOperator<>(sink);
+	AbstractSinkWriterOperator<InputT, CommT> createWriterOperator(ProcessingTimeService processingTimeService) {
+		return new StatelessSinkWriterOperator<>(processingTimeService, sink);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorTest.java
@@ -88,7 +88,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				sourceNode,
 				IntSerializer.class,
 				writerNode,
-				"Writer",
+				String.format("Sink Writer: %s", NAME),
+				UID,
 				StatelessSinkWriterOperatorFactory.class,
 				PARALLELISM,
 				-1);
@@ -111,7 +112,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				writerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				committerNode,
-				"Committer",
+				String.format("Sink Committer: %s", NAME),
+				String.format("Sink Committer: %s", UID),
 				committerClass,
 				runtimeExecutionMode == RuntimeExecutionMode.STREAMING ? PARALLELISM : 1,
 				runtimeExecutionMode == RuntimeExecutionMode.STREAMING ? -1 : 1);
@@ -135,7 +137,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				committerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				globalCommitterNode,
-				"Global Committer",
+				String.format("Sink Global Committer: %s", NAME),
+				String.format("Sink Global Committer: %s", UID),
 				globalCommitterClass,
 				1,
 				1);
@@ -158,7 +161,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 				writerNode,
 				SimpleVersionedSerializerTypeSerializerProxy.class,
 				globalCommitterNode,
-				"Global Committer",
+				String.format("Sink Global Committer: %s", NAME),
+				String.format("Sink Global Committer: %s", UID),
 				globalCommitterClass,
 				1,
 				1);
@@ -208,7 +212,8 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 			StreamNode src,
 			Class<?> srcOutTypeInfo,
 			StreamNode dest,
-			String midName,
+			String name,
+			String uid,
 			Class<?> expectedOperatorFactory,
 			int expectedParallelism,
 			int expectedMaxParallelism) {
@@ -224,13 +229,12 @@ public class SinkTransformationTranslatorTest extends TestLogger {
 		assertThat(dest.getTypeSerializersIn()[0], instanceOf(srcOutTypeInfo));
 
 		//verify dest node
-		assertThat(dest.getOperatorName(), equalTo(String.format("Sink %s: %s", midName, NAME)));
+		assertThat(dest.getOperatorName(), equalTo(name));
+		assertThat(dest.getTransformationUID(), equalTo(uid));
+
 		assertThat(
 				dest.getOperatorFactory(),
 				instanceOf(expectedOperatorFactory));
-		assertThat(
-				dest.getTransformationUID(),
-				equalTo(String.format("Sink %s: %s", midName, UID)));
 		assertThat(dest.getParallelism(), equalTo(expectedParallelism));
 		assertThat(dest.getMaxParallelism(), equalTo(expectedMaxParallelism));
 		assertThat(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -28,11 +29,13 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -40,7 +43,8 @@ import static org.junit.Assert.assertThat;
  */
 public abstract class SinkWriterOperatorTestBase extends TestLogger {
 
-	protected abstract AbstractSinkWriterOperatorFactory<Integer, String> createWriterOperator(TestSink sink);
+	protected abstract AbstractSinkWriterOperatorFactory<Integer, String> createWriterOperator(
+			TestSink sink);
 
 	@Test
 	public void nonBufferingWriterEmitsWithoutFlush() throws Exception {
@@ -49,7 +53,7 @@ public abstract class SinkWriterOperatorTestBase extends TestLogger {
 		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
 				createTestHarness(TestSink
 						.newBuilder()
-						.setWriter(new NonBufferingSinkWriter())
+						.setWriter(new TestSink.DefaultSinkWriter())
 						.withWriterState()
 						.build());
 		testHarness.open();
@@ -76,7 +80,7 @@ public abstract class SinkWriterOperatorTestBase extends TestLogger {
 		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
 				createTestHarness(TestSink
 						.newBuilder()
-						.setWriter(new NonBufferingSinkWriter())
+						.setWriter(new TestSink.DefaultSinkWriter())
 						.withWriterState()
 						.build());
 		testHarness.open();
@@ -146,17 +150,41 @@ public abstract class SinkWriterOperatorTestBase extends TestLogger {
 						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
-	/**
-	 * A {@link SinkWriter} that returns all committables from {@link #prepareCommit(boolean)} without
-	 * waiting for {@code flush} to be {@code true}.
-	 */
-	static class NonBufferingSinkWriter extends TestSink.DefaultSinkWriter {
-		@Override
-		public List<String> prepareCommit(boolean flush) {
-			List<String> result = elements;
-			elements = new ArrayList<>();
-			return result;
-		}
+	@Test
+	public void processingTimeBufferingSinkWriter() throws Exception {
+		final long initialTime = 0;
+
+		final OneInputStreamOperatorTestHarness<Integer, String> testHarness =
+				createTestHarness(TestSink
+						.newBuilder()
+						.setWriter(new TimeBasedBufferingSinkWriter())
+						.withWriterState()
+						.build());
+		testHarness.open();
+
+		testHarness.setProcessingTime(0L);
+
+		testHarness.processElement(1, initialTime + 1);
+		testHarness.processElement(2, initialTime + 2);
+
+		testHarness.prepareSnapshotPreBarrier(1L);
+
+		assertThat(testHarness.getOutput().size(), equalTo(0));
+
+		testHarness.getProcessingTimeService().setCurrentTime(2001);
+
+		testHarness.prepareSnapshotPreBarrier(1L);
+		testHarness.endInput();
+
+		assertThat(
+				testHarness.getOutput(),
+				contains(
+						new StreamRecord<>(Tuple3
+								.of(1, initialTime + 1, Long.MIN_VALUE)
+								.toString()),
+						new StreamRecord<>(Tuple3
+								.of(2, initialTime + 2, Long.MIN_VALUE)
+								.toString())));
 	}
 
 	/**
@@ -172,6 +200,33 @@ public abstract class SinkWriterOperatorTestBase extends TestLogger {
 			List<String> result = elements;
 			elements = new ArrayList<>();
 			return result;
+		}
+	}
+
+	/**
+	 * A {@link SinkWriter} that buffers the committables and send the cached committables per second.
+	 */
+	static class TimeBasedBufferingSinkWriter extends TestSink.DefaultSinkWriter implements Sink.ProcessingTimeService.ProcessingTimeCallback {
+
+		private final List<String> cachedCommittables = new ArrayList<>();
+
+		@Override
+		public void write(Integer element, Context context) {
+			cachedCommittables.add(Tuple3
+					.of(element, context.timestamp(), context.currentWatermark())
+					.toString());
+		}
+
+		void setProcessingTimerService(Sink.ProcessingTimeService processingTimerService) {
+			super.setProcessingTimerService(processingTimerService);
+			this.processingTimerService.registerProcessingTimer(1000, this);
+		}
+
+		@Override
+		public void onProcessingTime(long time) throws IOException {
+			elements.addAll(cachedCommittables);
+			cachedCommittables.clear();
+			this.processingTimerService.registerProcessingTimer(time + 1000, this);
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -81,8 +81,11 @@ public class TestSink implements Sink<Integer, String, String, String> {
 	}
 
 	@Override
-	public SinkWriter<Integer, String, String> createWriter(InitContext context, List<String> states) {
+	public SinkWriter<Integer, String, String> createWriter(
+			InitContext context,
+			List<String> states) {
 		writer.restoredFrom(states);
+		writer.setProcessingTimerService(context.getProcessingTimeService());
 		return writer;
 	}
 
@@ -206,6 +209,8 @@ public class TestSink implements Sink<Integer, String, String, String> {
 
 		protected List<String> elements;
 
+		protected ProcessingTimeService processingTimerService;
+
 		DefaultSinkWriter() {
 			this.elements = new ArrayList<>();
 		}
@@ -235,6 +240,10 @@ public class TestSink implements Sink<Integer, String, String, String> {
 
 		void restoredFrom(List<String> states) {
 
+		}
+
+		void setProcessingTimerService(ProcessingTimeService processingTimerService) {
+			this.processingTimerService = processingTimerService;
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR supports the processing time in the new `FileSink`.

## Brief change log

- 5a0a0170d51820864557f287f8a7847d9fce8069 adds the support for the processing time in the new `FileSink`.

## Verifying this change

This change added tests and can be verified as follows:

  - Added UT to test the behavior of `FIleWriterBucket` and `FileWriter` when dealing with processing time.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
