### PR TITLE
[FLINK-19912][json] Fix JSON format fails to serialize map value with…

### DIFF
--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -181,10 +181,30 @@ Format Options
       <td>Specify the input and output timestamp format. Currently supported values are <code>'SQL'</code> and <code>'ISO-8601'</code>:
       <ul>
         <li>Option <code>'SQL'</code> will parse input timestamp in "yyyy-MM-dd HH:mm:ss.s{precision}" format, e.g '2020-12-30 12:13:14.123' and output timestamp in the same format.</li>
-        <li>Option <code>'ISO-8601'</code>will parse input timestamp in "yyyy-MM-ddTHH:mm:ss.s{precision}" format, e.g '2020-12-30T12:13:14.123' and output timestamp in the same format.</li>
+        <li>Option <code>'ISO-8601'</code> will parse input timestamp in "yyyy-MM-ddTHH:mm:ss.s{precision}" format, e.g '2020-12-30T12:13:14.123' and output timestamp in the same format.</li>
       </ul>
       </td>
     </tr>
+    <tr>
+      <td><h5>canal-json.map-null-key.mode</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+      <td>String</td>
+      <td>Specify the handling mode when serializing null keys for map data. Currently supported values are <code>'FAIL'</code>, <code>'DROP'</code> and <code>'LITERAL'</code>:
+      <ul>
+        <li>Option <code>'FAIL'</code> will throw exception when encountering map value with null key.</li>
+        <li>Option <code>'DROP'</code> will drop null key entries for map data.</li>
+        <li>Option <code>'LITERAL'</code> will replace null key with string literal. The string literal is defined by <code>canal-json.map-null-key.literal</code> option.</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><h5>canal-json.map-null-key.literal</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>Specify string literal to replace null key when <code>'canal-json.map-null-key.mode'</code> is LITERAL.</td>
+    </tr>        
     <tr>
       <td><h5>canal-json.database.include</h5></td>
       <td>optional</td>

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -176,13 +176,33 @@ Format 参数
        <td>选填</td>
        <td style="word-wrap: break-word;"><code>'SQL'</code></td>
        <td>String</td>
-       <td>指定输入和输出时间戳格式。 当前支持的值是 <code>'SQL'</code> 和 <code>'ISO-8601'</code>:
+       <td>指定输入和输出时间戳格式。当前支持的值是 <code>'SQL'</code> 和 <code>'ISO-8601'</code>:
        <ul>
          <li>选项 <code>'SQL'</code> 将解析 "yyyy-MM-dd HH:mm:ss.s{precision}" 格式的输入时间戳，例如 '2020-12-30 12:13:14.123'，并以相同格式输出时间戳。</li>
          <li>选项 <code>'ISO-8601'</code> 将解析 "yyyy-MM-ddTHH:mm:ss.s{precision}" 格式的输入时间戳，例如 '2020-12-30T12:13:14.123'，并以相同的格式输出时间戳。</li>
        </ul>
        </td>
     </tr>
+    <tr>
+       <td><h5>canal-json.map-null-key.mode</h5></td>
+       <td>选填</td>
+       <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+       <td>String</td>
+       <td>指定处理 Map 中 key 值为空的方法. 当前支持的值有 <code>'FAIL'</code>, <code>'DROP'</code> 和 <code>'LITERAL'</code>:
+       <ul>
+         <li>Option <code>'FAIL'</code> 将抛出异常，如果遇到 Map 中 key 值为空的数据。</li>
+         <li>Option <code>'DROP'</code> 将丢弃 Map 中 key 值为空的数据项。</li> 
+         <li>Option <code>'LITERAL'</code> 将使用字符串常量来替换 Map 中的空 key 值。字符串常量的值由 <code>'canal-json.map-null-key.literal'</code> 定义。</li>
+       </ul>
+       </td>
+    </tr>
+    <tr>
+      <td><h5>canal-json.map-null-key.literal</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>当 <code>'canal-json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
+    </tr>       
     <tr>
       <td><h5>canal-json.database.include</h5></td>
       <td>optional</td>

--- a/docs/dev/table/connectors/formats/debezium.md
+++ b/docs/dev/table/connectors/formats/debezium.md
@@ -201,6 +201,27 @@ Format Options
        </ul>
        </td>
     </tr>
+    <tr>
+      <td><h5>debezium-json.map-null-key.mode</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+      <td>String</td>
+      <td>Specify the handling mode when serializing null keys for map data. Currently supported values are <code>'FAIL'</code>, <code>'DROP'</code> and <code>'LITERAL'</code>:
+      <ul>
+        <li>Option <code>'FAIL'</code> will throw exception when encountering map with null key.</li>
+        <li>Option <code>'DROP'</code> will drop null key entries for map data.</li>
+        <li>Option <code>'LITERAL'</code> will replace null key with string literal. The string literal is defined by <code>debezium-json.map-null-key.literal</code> option.</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><h5>debezium-json.map-null-key.literal</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>Specify string literal to replace null key when <code>'debezium-json.map-null-key.mode'</code> is LITERAL.</td>
+    </tr>        
+    <tr>       
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/debezium.zh.md
+++ b/docs/dev/table/connectors/formats/debezium.zh.md
@@ -199,6 +199,26 @@ Format 参数
       </ul>
       </td>
     </tr>
+    <tr>
+       <td><h5>debezium-json.map-null-key.mode</h5></td>
+       <td>选填</td>
+       <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+       <td>String</td>
+       <td>指定处理 Map 中 key 值为空的方法. 当前支持的值有 <code>'FAIL'</code>, <code>'DROP'</code> 和 <code>'LITERAL'</code>:
+       <ul>
+         <li>Option <code>'FAIL'</code> 将抛出异常，如果遇到 Map 中 key 值为空的数据。</li>
+         <li>Option <code>'DROP'</code> 将丢弃 Map 中 key 值为空的数据项。</li> 
+         <li>Option <code>'LITERAL'</code> 将使用字符串常量来替换 Map 中的空 key 值。字符串常量的值由 <code>'debezium-json.map-null-key.literal'</code> 定义。</li>
+       </ul>
+       </td>
+    </tr>
+    <tr>
+      <td><h5>debezium-json.map-null-key.literal</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>当 <code>'debezium-json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
+    </tr>             
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/json.md
+++ b/docs/dev/table/connectors/formats/json.md
@@ -117,6 +117,26 @@ Format Options
       </ul>
       </td>
     </tr>
+    <tr>
+      <td><h5>json.map-null-key.mode</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+      <td>String</td>
+      <td>Specify the handling mode when serializing null keys for map data. Currently supported values are <code>'FAIL'</code>, <code>'DROP'</code> and <code>'LITERAL'</code>:
+      <ul>
+        <li>Option <code>'FAIL'</code> will throw exception when encountering map with null key.</li>
+        <li>Option <code>'DROP'</code> will drop null key entries for map data.</li>
+        <li>Option <code>'LITERAL'</code> will replace null key with string literal. The string literal is defined by <code>json.map-null-key.literal</code> option.</li>
+      </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><h5>json.map-null-key.literal</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>Specify string literal to replace null key when <code>'json.map-null-key.mode'</code> is LITERAL.</td>
+    </tr>     
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/json.zh.md
+++ b/docs/dev/table/connectors/formats/json.zh.md
@@ -116,6 +116,26 @@ Format 参数
       </ul>
       </td>
     </tr>
+    <tr>
+       <td><h5>json.map-null-key.mode</h5></td>
+       <td>选填</td>
+       <td style="word-wrap: break-word;"><code>'FAIL'</code></td>
+       <td>String</td>
+       <td>指定处理 Map 中 key 值为空的方法. 当前支持的值有 <code>'FAIL'</code>, <code>'DROP'</code> 和 <code>'LITERAL'</code>:
+       <ul>
+         <li>Option <code>'FAIL'</code> 将抛出异常，如果遇到 Map 中 key 值为空的数据。</li>
+         <li>Option <code>'DROP'</code> 将丢弃 Map 中 key 值为空的数据项。</li> 
+         <li>Option <code>'LITERAL'</code> 将使用字符串常量来替换 Map 中的空 key 值。字符串常量的值由 <code>'json.map-null-key.literal'</code> 定义。</li>
+       </ul>
+       </td>
+    </tr>
+    <tr>
+      <td><h5>json.map-null-key.literal</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">'null'</td>
+      <td>String</td>
+      <td>当 <code>'json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
+    </tr>        
     </tbody>
 </table>
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -43,8 +42,11 @@ import java.util.Set;
 
 import static org.apache.flink.formats.json.JsonOptions.FAIL_ON_MISSING_FIELD;
 import static org.apache.flink.formats.json.JsonOptions.IGNORE_PARSE_ERRORS;
+import static org.apache.flink.formats.json.JsonOptions.MAP_NULL_KEY_LITERAL;
+import static org.apache.flink.formats.json.JsonOptions.MAP_NULL_KEY_MODE;
 import static org.apache.flink.formats.json.JsonOptions.TIMESTAMP_FORMAT;
-import static org.apache.flink.formats.json.JsonOptions.TIMESTAMP_FORMAT_ENUM;
+import static org.apache.flink.formats.json.JsonOptions.validateDecodingFormatOptions;
+import static org.apache.flink.formats.json.JsonOptions.validateEncodingFormatOptions;
 
 /**
  * Table format factory for providing configured instances of JSON to RowData
@@ -61,7 +63,7 @@ public class JsonFormatFactory implements
 			DynamicTableFactory.Context context,
 			ReadableConfig formatOptions) {
 		FactoryUtil.validateFactoryOptions(this, formatOptions);
-		validateFormatOptions(formatOptions);
+		validateDecodingFormatOptions(formatOptions);
 
 		final boolean failOnMissingField = formatOptions.get(FAIL_ON_MISSING_FIELD);
 		final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
@@ -96,8 +98,11 @@ public class JsonFormatFactory implements
 			DynamicTableFactory.Context context,
 			ReadableConfig formatOptions) {
 		FactoryUtil.validateFactoryOptions(this, formatOptions);
+		validateEncodingFormatOptions(formatOptions);
 
 		TimestampFormat timestampOption = JsonOptions.getTimestampFormat(formatOptions);
+		JsonOptions.MapNullKeyMode mapNullKeyMode = JsonOptions.getMapNullKeyMode(formatOptions);
+		String mapNullKeyLiteral = formatOptions.get(MAP_NULL_KEY_LITERAL);
 
 		return new EncodingFormat<SerializationSchema<RowData>>() {
 			@Override
@@ -105,7 +110,11 @@ public class JsonFormatFactory implements
 					DynamicTableSink.Context context,
 					DataType consumedDataType) {
 				final RowType rowType = (RowType) consumedDataType.getLogicalType();
-				return new JsonRowDataSerializationSchema(rowType, timestampOption);
+				return new JsonRowDataSerializationSchema(
+						rowType,
+						timestampOption,
+						mapNullKeyMode,
+						mapNullKeyLiteral);
 			}
 
 			@Override
@@ -131,26 +140,8 @@ public class JsonFormatFactory implements
 		options.add(FAIL_ON_MISSING_FIELD);
 		options.add(IGNORE_PARSE_ERRORS);
 		options.add(TIMESTAMP_FORMAT);
+		options.add(MAP_NULL_KEY_MODE);
+		options.add(MAP_NULL_KEY_LITERAL);
 		return options;
-	}
-
-	// ------------------------------------------------------------------------
-	//  Validation
-	// ------------------------------------------------------------------------
-
-	static void validateFormatOptions(ReadableConfig tableOptions) {
-		boolean failOnMissingField = tableOptions.get(FAIL_ON_MISSING_FIELD);
-		boolean ignoreParseErrors = tableOptions.get(IGNORE_PARSE_ERRORS);
-		String timestampFormat = tableOptions.get(TIMESTAMP_FORMAT);
-		if (ignoreParseErrors && failOnMissingField) {
-			throw new ValidationException(FAIL_ON_MISSING_FIELD.key()
-					+ " and "
-					+ IGNORE_PARSE_ERRORS.key()
-					+ " shouldn't both be true.");
-		}
-		if (!TIMESTAMP_FORMAT_ENUM.contains(timestampFormat)){
-			throw new ValidationException(String.format("Unsupported value '%s' for %s. Supported values are [SQL, ISO-8601].",
-				timestampFormat, TIMESTAMP_FORMAT.key()));
-		}
 	}
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json.canal;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.formats.json.JsonOptions;
+
+/**
+ * Option utils for canal-json format.
+ */
+public class CanalJsonOptions {
+
+	public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS = JsonOptions.IGNORE_PARSE_ERRORS;
+
+	public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
+
+	public static final ConfigOption<String> DATABASE_INCLUDE = ConfigOptions
+		.key("database.include")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Only read changelog rows which match the specific database (by comparing the \"database\" meta field in the record).");
+
+	public static final ConfigOption<String> TABLE_INCLUDE = ConfigOptions
+		.key("table.include")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Only read changelog rows which match the specific table (by comparing the \"table\" meta field in the record).");
+
+	// --------------------------------------------------------------------------------------------
+	// Validation
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Validator for canal decoding format.
+	 */
+	public static void validateDecodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateDecodingFormatOptions(tableOptions);
+	}
+
+	/**
+	 * Validator for canal encoding format.
+	 */
+	public static void validateEncodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateEncodingFormatOptions(tableOptions);
+	}
+
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.json.canal;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
@@ -54,10 +55,16 @@ public class CanalJsonSerializationSchema implements SerializationSchema<RowData
 	 */
 	private final JsonRowDataSerializationSchema jsonSerializer;
 
-	public CanalJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat) {
+	public CanalJsonSerializationSchema(
+			RowType rowType,
+			TimestampFormat timestampFormat,
+			JsonOptions.MapNullKeyMode mapNullKeyMode,
+			String mapNullKeyLiteral) {
 		jsonSerializer = new JsonRowDataSerializationSchema(
 			createJsonRowType(fromLogicalToDataType(rowType)),
-			timestampFormat);
+			timestampFormat,
+			mapNullKeyMode,
+			mapNullKeyLiteral);
 	}
 
 	@Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonOptions.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json.debezium;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.formats.json.JsonOptions;
+import org.apache.flink.table.api.ValidationException;
+
+import static org.apache.flink.formats.json.debezium.DebeziumJsonFormatFactory.IDENTIFIER;
+
+/**
+ * Option utils for debezium-json format.
+ */
+public class DebeziumJsonOptions {
+
+	public static final ConfigOption<Boolean> SCHEMA_INCLUDE = ConfigOptions
+		.key("schema-include")
+		.booleanType()
+		.defaultValue(false)
+		.withDescription("When setting up a Debezium Kafka Connect, users can enable " +
+			"a Kafka configuration 'value.converter.schemas.enable' to include schema in the message. " +
+			"This option indicates the Debezium JSON data include the schema in the message or not. " +
+			"Default is false.");
+
+	public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS = JsonOptions.IGNORE_PARSE_ERRORS;
+
+	public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
+
+	// --------------------------------------------------------------------------------------------
+	// Validation
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Validator for debezium decoding format.
+	 */
+	public static void validateDecodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateDecodingFormatOptions(tableOptions);
+	}
+
+	/**
+	 * Validator for debezium encoding format.
+	 */
+	public static void validateEncodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateEncodingFormatOptions(tableOptions);
+
+		// validator for {@link SCHEMA_INCLUDE}
+		if (tableOptions.get(SCHEMA_INCLUDE)) {
+			throw new ValidationException(String.format(
+				"Debezium JSON serialization doesn't support '%s.%s' option been set to true.",
+				IDENTIFIER,
+				SCHEMA_INCLUDE.key()
+			));
+		}
+	}
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.json.debezium;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
@@ -49,10 +50,16 @@ public class DebeziumJsonSerializationSchema implements SerializationSchema<RowD
 
 	private transient GenericRowData genericRowData;
 
-	public DebeziumJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat) {
+	public DebeziumJsonSerializationSchema(
+			RowType rowType,
+			TimestampFormat timestampFormat,
+			JsonOptions.MapNullKeyMode mapNullKeyMode,
+			String mapNullKeyLiteral) {
 		jsonSerializer = new JsonRowDataSerializationSchema(
-			createJsonRowType(fromLogicalToDataType(rowType)),
-			timestampFormat);
+				createJsonRowType(fromLogicalToDataType(rowType)),
+				timestampFormat,
+				mapNullKeyMode,
+				mapNullKeyLiteral);
 	}
 
 	@Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonOptions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json.maxwell;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.formats.json.JsonOptions;
+
+/**
+ * Option utils for maxwell-json format.
+ */
+public class MaxwellJsonOptions {
+
+	public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS = JsonOptions.IGNORE_PARSE_ERRORS;
+
+	public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
+
+	public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL = JsonOptions.MAP_NULL_KEY_LITERAL;
+
+	// --------------------------------------------------------------------------------------------
+	// Validation
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Validator for maxwell decoding format.
+	 */
+	public static void validateDecodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateDecodingFormatOptions(tableOptions);
+	}
+
+	/**
+	 * Validator for maxwell encoding format.
+	 */
+	public static void validateEncodingFormatOptions(ReadableConfig tableOptions) {
+		JsonOptions.validateEncodingFormatOptions(tableOptions);
+	}
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.json.maxwell;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
@@ -51,10 +52,16 @@ public class MaxwellJsonSerializationSchema implements SerializationSchema<RowDa
 
 	private transient GenericRowData reuse;
 
-	public MaxwellJsonSerializationSchema(RowType rowType, TimestampFormat timestampFormat) {
+	public MaxwellJsonSerializationSchema(
+			RowType rowType,
+			TimestampFormat timestampFormat,
+			JsonOptions.MapNullKeyMode mapNullKeyMode,
+			String mapNullKeyLiteral) {
 		this.jsonSerializer = new JsonRowDataSerializationSchema(
-			createJsonRowType(fromLogicalToDataType(rowType)),
-			timestampFormat);
+				createJsonRowType(fromLogicalToDataType(rowType)),
+				timestampFormat,
+				mapNullKeyMode,
+				mapNullKeyLiteral);
 		this.timestampFormat = timestampFormat;
 	}
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -110,6 +110,25 @@ public class JsonFormatFactoryTest extends TestLogger {
 		thrown.expect(containsCause(new ValidationException("Unsupported value 'iso-8601' for timestamp-format.standard. Supported values are [SQL, ISO-8601].")));
 		testSchemaDeserializationSchema(tableOptions);
 	}
+
+	@Test
+	public void testInvalidOptionForMapNullKeyMode() {
+		final Map<String, String> tableOptions = getModifyOptions(
+			options -> options.put("json.map-null-key.mode", "invalid"));
+
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException("Unsupported value 'invalid' for option map-null-key.mode. Supported values are [LITERAL, FAIL, DROP].")));
+		testSchemaSerializationSchema(tableOptions);
+	}
+
+	@Test
+	public void testLowerCaseOptionForMapNullKeyMode() {
+		final Map<String, String> tableOptions = getModifyOptions(
+			options -> options.put("json.map-null-key.mode", "fail"));
+
+		testSchemaDeserializationSchema(tableOptions);
+	}
+
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
@@ -137,8 +156,11 @@ public class JsonFormatFactoryTest extends TestLogger {
 	}
 
 	private void testSchemaSerializationSchema(Map<String, String> options) {
-		final JsonRowDataSerializationSchema expectedSer = new JsonRowDataSerializationSchema(ROW_TYPE,
-			TimestampFormat.ISO_8601);
+		final JsonRowDataSerializationSchema expectedSer = new JsonRowDataSerializationSchema(
+				ROW_TYPE,
+				TimestampFormat.ISO_8601,
+				JsonOptions.MapNullKeyMode.LITERAL,
+				"null");
 
 		final DynamicTableSink actualSink = createTableSink(options);
 		assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
@@ -174,6 +196,8 @@ public class JsonFormatFactoryTest extends TestLogger {
 		options.put("json.fail-on-missing-field", "false");
 		options.put("json.ignore-parse-errors", "true");
 		options.put("json.timestamp-format.standard", "ISO-8601");
+		options.put("json.map-null-key.mode", "LITERAL");
+		options.put("json.map-null-key.literal", "null");
 		return options;
 	}
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.json.canal;
 
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -154,7 +155,9 @@ public class CanalJsonSerDeSchemaTest {
 		// test Serialization
 		CanalJsonSerializationSchema serializationSchema = new CanalJsonSerializationSchema(
 			SCHEMA,
-			TimestampFormat.ISO_8601);
+			TimestampFormat.ISO_8601,
+			JsonOptions.MapNullKeyMode.LITERAL,
+			"null");
 		serializationSchema.open(null);
 
 		List<String> result = new ArrayList<>();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.json.debezium;
 
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.formats.json.debezium.DebeziumJsonDecodingFormat.ReadableMetadata;
 import org.apache.flink.table.api.DataTypes;
@@ -247,7 +248,10 @@ public class DebeziumJsonSerDeSchemaTest {
 
 		DebeziumJsonSerializationSchema serializationSchema = new DebeziumJsonSerializationSchema(
 			(RowType) PHYSICAL_DATA_TYPE.getLogicalType(),
-			TimestampFormat.SQL);
+			TimestampFormat.SQL,
+			JsonOptions.MapNullKeyMode.LITERAL,
+			"null");
+
 		serializationSchema.open(null);
 		actual = new ArrayList<>();
 		for (RowData rowData : collector.list) {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.json.maxwell;
 
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -133,7 +134,9 @@ public class MaxwellJsonSerDerTest {
 
 		MaxwellJsonSerializationSchema serializationSchema = new MaxwellJsonSerializationSchema(
 			SCHEMA,
-			TimestampFormat.SQL);
+			TimestampFormat.SQL,
+			JsonOptions.MapNullKeyMode.LITERAL,
+			"null");
 		serializationSchema.open(null);
 		List<String> result = new ArrayList<>();
 		for (RowData rowData : collector.list) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
@@ -118,7 +118,7 @@ public final class GenericMapData implements MapData {
 		int result = 0;
 		for (Object key : map.keySet()) {
 			// only include key because values can contain byte[]
-			result += 31 * key.hashCode();
+			result += 31 *  Objects.hashCode(key);
 		}
 		return result;
 	}


### PR DESCRIPTION
… null keys

## What is the purpose of the change

Fix JSON format fails to serialize map value with null keys

## Brief change log

1.  Add map-null-key.mode and map-null-key.literal
    to `JsonRowDeserializationSchema`, `MaxwellJsonSerializationSchema` , `DebeziumJsonSerializationSchema` and `CanalJsonSerializationSchema`.
2. Add decoding format options validator and encoding format options validator to `CanalJsonFormatFactory`, `DebeziumJsonFormatFactory` and `MaxwellJsonFormatFactory`.
3.  Fix `GenericMapData`  hash code NPE when map value with null keys .
4. Update documents for `Canal`,  `Debezium` and `Json`.
     `Maxwell` document is missing, creating issue [FLINK-20034](https://issues.apache.org/jira/browse/FLINK-20034) to track it.

## Verifying this change

This change added tests and can be verified as follows:
1.  JsonRowDataSerDeSchemaTest#testSerializationMapNullKey  ensure options is correct when serializing.
2. JsonFormatFactoryTest#testInvalidOptionForMapNullKeyMode ensure options validate correctly.
3. JsonFormatFactoryTest#testLowerCaseOptionForMapNullKeyMode ensure options are case insensitive.
4. Other Format validator tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no / don't know)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no / don't know)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
