### PR TITLE
[hotfix][doc] Fix a concurrent issue in testing.md

### DIFF
--- a/docs/dev/stream/testing.md
+++ b/docs/dev/stream/testing.md
@@ -501,10 +501,10 @@ public class ExampleIntegrationTest {
     private static class CollectSink implements SinkFunction<Long> {
 
         // must be static
-        public static final List<Long> values = new ArrayList<>();
+        public static final List<Long> values = Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public synchronized void invoke(Long value) throws Exception {
+        public void invoke(Long value) throws Exception {
             values.add(value);
         }
     }
@@ -556,15 +556,13 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
 class CollectSink extends SinkFunction[Long] {
 
   override def invoke(value: Long): Unit = {
-    synchronized {
-      CollectSink.values.add(value)
-    }
+    CollectSink.values.add(value)
   }
 }
 
 object CollectSink {
     // must be static
-    val values: util.List[Long] = new util.ArrayList()
+    val values: util.List[Long] = Collections.synchronizedList(new util.ArrayList())
 }
 {% endhighlight %}
 </div>

--- a/docs/dev/stream/testing.zh.md
+++ b/docs/dev/stream/testing.zh.md
@@ -501,10 +501,10 @@ public class ExampleIntegrationTest {
     private static class CollectSink implements SinkFunction<Long> {
 
         // must be static
-        public static final List<Long> values = new ArrayList<>();
+        public static final List<Long> values = Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public synchronized void invoke(Long value) throws Exception {
+        public void invoke(Long value) throws Exception {
             values.add(value);
         }
     }
@@ -556,15 +556,13 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
 class CollectSink extends SinkFunction[Long] {
 
   override def invoke(value: Long): Unit = {
-    synchronized {
-      CollectSink.values.add(value)
-    }
+    CollectSink.values.add(value)
   }
 }
 
 object CollectSink {
     // must be static
-    val values: util.List[Long] = new util.ArrayList()
+    val values: util.List[Long] = Collections.synchronizedList(new util.ArrayList())
 }
 {% endhighlight %}
 </div>


### PR DESCRIPTION
## What is the purpose of the change

An example in `testing.md` uses `synchronized` keyword to protect a static variable, which will cause concurrent issues with multiple sink instances. 

## Brief change log

Use `Collections.synchronizedList()` to create a thread-safe list and remove the old `synchronized` keyword.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
