### PR TITLE
[FLINK-20037][Table SQL / API]update comment problem in fromValues(AbstractDataType<?> rowType, Obj…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -183,7 +183,7 @@ public interface TableEnvironment {
 	 * <pre>{@code
 	 *  root
 	 *  |-- id: DECIMAL(10, 2)
-	 *  |-- f1: STRING
+	 *  |-- name: STRING
 	 * }</pre>
 	 *
 	 * <p>For more examples see {@link #fromValues(Object...)}.


### PR DESCRIPTION
I find a comment problem  in fromValues(AbstractDataType<?> rowType, Object... values) method of TableEnvironment, i think second column name is "name" not "f1". this is my first issue, if there is a problem, please understand
<p>Examples:
	 * <pre>{@code
	 *  tEnv.fromValues(
	 *      DataTypes.ROW(
	 *          DataTypes.FIELD("id", DataTypes.DECIMAL(10, 2)),
	 *          DataTypes.FIELD("name", DataTypes.STRING())
	 *      ),
	 *      row(1, "ABC"),
	 *      row(2L, "ABCDE")
	 *  )
	 * }</pre>
	 * will produce a Table with a schema as follows:
	 * <pre>{@code
	 *  root
	 *  |-- id: DECIMAL(10, 2)
	 *  |-- f1: STRING
	 * }</pre>
	 *
	 * <p>For more examples see {@link #fromValues(Object...)}.
	 *
	 * @param rowType Expected row type for the values.
	 * @param values Expressions for constructing rows of the VALUES table.
	 * @see #fromValues(Object...)
	 */
	default Table fromValues(AbstractDataType<?> rowType, Object... values) {
		// It is necessary here to implement TableEnvironment#fromValues(Object...) for BatchTableEnvImpl.
		// In scala varargs are translated to Seq. Due to the type erasure Seq<Expression> and Seq<Object>
		// are the same. It is not a problem in java as varargs in java are translated to an array.
		return fromValues(rowType, Arrays.asList(values));
	}