### PR TITLE
[FLINK-20033] Ensure that stopping a JobMaster will suspend the running job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -955,10 +955,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		if (jobManagerJobMetricGroup != null) {
 			jobManagerJobMetricGroup.close();
 		}
-
-		if (jobStatusListener != null) {
-			jobStatusListener.stop();
-		}
 	}
 
 	private void clearSchedulerFields() {
@@ -1212,23 +1208,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private class JobManagerJobStatusListener implements JobStatusListener {
 
-		private volatile boolean running = true;
-
 		@Override
 		public void jobStatusChanges(
 				final JobID jobId,
 				final JobStatus newJobStatus,
 				final long timestamp,
 				final Throwable error) {
-
-			if (running) {
-				// run in rpc thread to avoid concurrency
-				runAsync(() -> jobStatusChanged(newJobStatus, timestamp, error));
-			}
-		}
-
-		private void stop() {
-			running = false;
+			jobStatusChanged(newJobStatus, timestamp, error);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1969,6 +1969,58 @@ public class JobMasterTest extends TestLogger {
 		);
 	}
 
+	/**
+	 * Tests that the job gets suspended when the JobMaster stops. See FLINK-20033.
+	 */
+	@Test
+	public void testJobSuspensionWhenJobMasterStops() throws Exception {
+		final JobMasterBuilder.TestingOnCompletionActions onCompletionActions = new JobMasterBuilder.TestingOnCompletionActions();
+
+		final JobMaster jobMaster = createJobMaster(
+			configuration,
+			JobGraphTestUtils.createSingleVertexJobGraph(),
+			haServices,
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices,
+			onCompletionActions);
+
+		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+
+		try {
+			// wait for the start of the JobMaster
+			startFuture.get();
+
+			final CompletableFuture<TaskDeploymentDescriptor> tddFuture = new CompletableFuture<>();
+			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.setSubmitTaskConsumer((taskDeploymentDescriptor, jobMasterId) -> {
+					tddFuture.complete(taskDeploymentDescriptor);
+					return CompletableFuture.completedFuture(Acknowledge.get());
+				})
+				.createTestingTaskExecutorGateway();
+			final LocalUnresolvedTaskManagerLocation taskManagerLocation = new LocalUnresolvedTaskManagerLocation();
+			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+			registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway, taskManagerLocation);
+
+			// wait for deployment
+			tddFuture.get();
+
+			// trigger termination of JobMaster and also the job
+			jobMaster.close();
+
+			try {
+				final ArchivedExecutionGraph archivedExecutionGraph = onCompletionActions
+					.getJobReachedGloballyTerminalStateFuture()
+					.get(50, TimeUnit.MILLISECONDS);
+				fail(String.format("Job must not reach the globally terminal state %s when stopping the JobMaster.", archivedExecutionGraph.getState()));
+			} catch (TimeoutException expected) {
+				// expected
+			}
+		} finally {
+			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+		}
+	}
+
 	private void runJobFailureWhenTaskExecutorTerminatesTest(
 			HeartbeatServices heartbeatServices,
 			BiConsumer<LocalUnresolvedTaskManagerLocation, JobMasterGateway> jobReachedRunningState,


### PR DESCRIPTION
## What is the purpose of the change

79d31ae Since the ExecutionGraph can only be modified using the JobMaster's main thread, we no longer
need to trigger a jobStatusChanged async message when the JobManagerJobStatusListener.jobStatusChanges
callback is triggered. This ensures that job status changes will directly be reported.

693e390 This commit adds a test which ensures that stopping a JobMaster will suspend the running job.

## Verifying this change

- Added `JobMasterTest.testJobSuspensionWhenJobMasterStops`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
