### PR TITLE
[FLINK-20047][coordination] DefaultLeaderRetrievalService should only notify the LeaderRetrievalListener when leader truly changed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalService.java
@@ -136,9 +136,10 @@ public class DefaultLeaderRetrievalService implements LeaderRetrievalService, Le
 
 					lastLeaderAddress = newLeaderAddress;
 					lastLeaderSessionID = newLeaderSessionID;
-				}
 
-				leaderListener.notifyLeaderAddress(newLeaderAddress, newLeaderSessionID);
+					// Notify the listener only when the leader is truly changed.
+					leaderListener.notifyLeaderAddress(newLeaderAddress, newLeaderSessionID);
+				}
 			} else {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("Ignoring notification since the {} has already been closed.", leaderRetrievalDriver);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalEventHandler.java
@@ -36,6 +36,8 @@ public interface LeaderRetrievalEventHandler {
 	 *
 	 * @param leaderInformation the new leader information to notify {@link LeaderRetrievalService}. It could be
 	 * {@link LeaderInformation#empty()} if the leader address does not exist in the external storage.
+	 * Duplicated leader change events could happen, so the implementation should check whether the passed leader
+	 * information is truly changed with last stored leader information.
 	 */
 	void notifyLeaderAddress(LeaderInformation leaderInformation);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingRetrievalBase.java
@@ -108,6 +108,10 @@ public class TestingRetrievalBase {
 		this.leader = leaderInformation;
 	}
 
+	public int getLeaderEventQueueSize() {
+		return leaderEventQueue.size();
+	}
+
 	/**
 	 * Please use {@link #waitForError} before get the error.
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalServiceTest.java
@@ -107,6 +107,25 @@ public class DefaultLeaderRetrievalServiceTest extends TestLogger {
 		}};
 	}
 
+	@Test
+	public void testNotifyLeaderAddressOnlyWhenLeaderTrulyChanged() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final LeaderInformation newLeader = LeaderInformation.known(UUID.randomUUID(), TEST_URL);
+				testingLeaderRetrievalDriver.onUpdate(newLeader);
+				assertThat(testingListener.getLeaderEventQueueSize(), is(1));
+
+				// Same leader information should not be notified twice.
+				testingLeaderRetrievalDriver.onUpdate(newLeader);
+				assertThat(testingListener.getLeaderEventQueueSize(), is(1));
+
+				// Leader truly changed.
+				testingLeaderRetrievalDriver.onUpdate(LeaderInformation.known(UUID.randomUUID(), TEST_URL + 1));
+				assertThat(testingListener.getLeaderEventQueueSize(), is(2));
+			});
+		}};
+	}
+
 	private class Context {
 		private final TestingLeaderRetrievalDriver.TestingLeaderRetrievalDriverFactory leaderRetrievalDriverFactory =
 			new TestingLeaderRetrievalDriver.TestingLeaderRetrievalDriverFactory();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, in `DefaultLeaderRetrievalService` we are notifying the `LeaderRetrievalListener` even though the leader is not truly changed. In Kubernetes HA service, we could get lots of leader information notification events with same leader. Because the ConfigMap is updated periodically. We should filter out these useless events and do not notify the `LeaderRetrievalListener`.


## Brief change log

* DefaultLeaderRetrievalService should only notify the LeaderRetrievalListener when leader truly changed


## Verifying this change

* Add a new unit test `testNotifyLeaderAddressOnlyWhenLeaderTrulyChanged`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
