### PR TITLE
[FLINK-19989][python] Add collect operation in Python DataStream API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
@@ -302,13 +302,6 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
 	}
 
 	/**
-	 * Returns the field types of the row. The order matches the order of the field names.
-	 */
-	public TypeInformation<?>[] getFieldTypes() {
-		return types;
-	}
-
-	/**
 	 * Tests whether an other object describes the same, schema-equivalent row information.
 	 */
 	public boolean schemaEquals(Object obj) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfoBase.java
@@ -81,7 +81,11 @@ public abstract class TupleTypeInfoBase<T> extends CompositeType<T> {
 	public int getArity() {
 		return types.length;
 	}
-	
+
+	public TypeInformation<?>[] getFieldTypes() {
+		return types;
+	}
+
 	@Override
 	public int getTotalFields() {
 		return totalFields;

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -325,7 +325,7 @@ class RowTypeInfo(WrapperTypeInfo):
     TypeInformation for Row.
     """
 
-    def __init__(self, types: List[WrapperTypeInfo], field_names: List[str] = None):
+    def __init__(self, types: List[TypeInformation], field_names: List[str] = None):
         self.types = types
         self.field_names = field_names
         self.j_types_array = get_gateway().new_array(
@@ -358,7 +358,7 @@ class RowTypeInfo(WrapperTypeInfo):
     def get_field_index(self, field_name: str) -> int:
         return self._j_typeinfo.getFieldIndex(field_name)
 
-    def get_field_types(self) -> List[WrapperTypeInfo]:
+    def get_field_types(self) -> List[TypeInformation]:
         return self.types
 
     def __eq__(self, other) -> bool:
@@ -428,7 +428,7 @@ class TupleTypeInfo(WrapperTypeInfo):
     TypeInformation for Tuple.
     """
 
-    def __init__(self, types: List[WrapperTypeInfo]):
+    def __init__(self, types: List[TypeInformation]):
         self.types = types
         j_types_array = get_gateway().new_array(
             get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation, len(types))
@@ -442,7 +442,7 @@ class TupleTypeInfo(WrapperTypeInfo):
             .org.apache.flink.api.java.typeutils.TupleTypeInfo(j_types_array)
         super(TupleTypeInfo, self).__init__(j_typeinfo=j_typeinfo)
 
-    def get_field_types(self) -> List[WrapperTypeInfo]:
+    def get_field_types(self) -> List[TypeInformation]:
         return self.types
 
     def __eq__(self, other) -> bool:
@@ -558,7 +558,7 @@ class Types(object):
     PICKLED_BYTE_ARRAY = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
 
     @staticmethod
-    def ROW(types: List[WrapperTypeInfo]):
+    def ROW(types: List[TypeInformation]):
         """
         Returns type information for Row with fields of the given types. A row itself must not be
         null.
@@ -568,7 +568,7 @@ class Types(object):
         return RowTypeInfo(types)
 
     @staticmethod
-    def ROW_NAMED(names: List[str], types: List[WrapperTypeInfo]):
+    def ROW_NAMED(names: List[str], types: List[TypeInformation]):
         """
         Returns type information for Row with fields of the given types and with given names. A row
         must not be null.
@@ -579,7 +579,7 @@ class Types(object):
         return RowTypeInfo(types, names)
 
     @staticmethod
-    def TUPLE(types: List[WrapperTypeInfo]):
+    def TUPLE(types: List[TypeInformation]):
         """
         Returns type information for Tuple with fields of the given types. A Tuple itself must not
         be null.
@@ -617,7 +617,7 @@ class Types(object):
             raise TypeError("Invalid element type for a primitive array.")
 
     @staticmethod
-    def BASIC_ARRAY(element_type: TypeInformation) -> WrapperTypeInfo:
+    def BASIC_ARRAY(element_type: TypeInformation) -> TypeInformation:
         """
         Returns type information for arrays of boxed primitive type (such as Integer[]).
 
@@ -647,7 +647,7 @@ class Types(object):
                             str(element_type))
 
 
-def _from_java_type(j_type_info: JavaObject) -> WrapperTypeInfo:
+def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
     gateway = get_gateway()
     JBasicTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
 

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -598,8 +598,8 @@ class DataStream(object):
         """
         return DataStreamSink(self._j_data_stream.addSink(sink_func.get_java_function()))
 
-    def execute_and_collect(self, job_execution_name: str = None, limit: int = None,
-                            type_info: TypeInformation = None) -> Union['CloseableIterator', list]:
+    def execute_and_collect(self, job_execution_name: str = None, limit: int = None) \
+            -> Union['CloseableIterator', list]:
         """
         Triggers the distributed execution of the streaming dataflow and returns an iterator over
         the elements of the given DataStream.
@@ -612,18 +612,17 @@ class DataStream(object):
 
          :param job_execution_name: The name of the job execution.
          :param limit: The limit for the collected elements.
-         :param  type_info: The type info of the collected elements.
          """
         if job_execution_name is None and limit is None:
-            return CloseableIterator(self._j_data_stream.executeAndCollect(), type_info)
+            return CloseableIterator(self._j_data_stream.executeAndCollect(), self.get_type())
         elif job_execution_name is not None and limit is None:
             return CloseableIterator(self._j_data_stream.executeAndCollect(job_execution_name),
-                                     type_info)
+                                     self.get_type())
         if job_execution_name is None and limit is not None:
-            return list(map(lambda data: convert_to_python_obj(data, type_info),
+            return list(map(lambda data: convert_to_python_obj(data, self.get_type()),
                             self._j_data_stream.executeAndCollect(limit)))
         else:
-            return list(map(lambda data: convert_to_python_obj(data, type_info),
+            return list(map(lambda data: convert_to_python_obj(data, self.get_type()),
                             self._j_data_stream.executeAndCollect(job_execution_name, limit)))
 
     def print(self, sink_identifier: str = None) -> 'DataStreamSink':

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -124,7 +124,7 @@ class DataStream(object):
         self._j_data_stream.setMaxParallelism(max_parallelism)
         return self
 
-    def get_type(self) -> WrapperTypeInfo:
+    def get_type(self) -> TypeInformation:
         """
         Gets the type of the stream.
 
@@ -213,7 +213,7 @@ class DataStream(object):
         self._j_data_stream.slotSharingGroup(slot_sharing_group)
         return self
 
-    def map(self, func: Union[Callable, MapFunction], output_type: WrapperTypeInfo = None) \
+    def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
             -> 'DataStream':
         """
         Applies a Map transformation on a DataStream. The transformation calls a MapFunction for
@@ -605,14 +605,14 @@ class DataStream(object):
         the elements of the given DataStream.
 
         The DataStream application is executed in the regular distributed manner on the target
-         environment, and the events from the stream are polled back to this application process and
-         thread through Flink's REST API.
+        environment, and the events from the stream are polled back to this application process and
+        thread through Flink's REST API.
 
-         The returned iterator must be closed to free all cluster resources.
+        The returned iterator must be closed to free all cluster resources.
 
-         :param job_execution_name: The name of the job execution.
-         :param limit: The limit for the collected elements.
-         """
+        :param job_execution_name: The name of the job execution.
+        :param limit: The limit for the collected elements.
+        """
         if job_execution_name is None and limit is None:
             return CloseableIterator(self._j_data_stream.executeAndCollect(), self.get_type())
         elif job_execution_name is not None and limit is None:
@@ -787,7 +787,7 @@ class KeyedStream(DataStream):
         self._original_data_type_info = original_data_type_info
         self._origin_stream = origin_stream
 
-    def map(self, func: Union[Callable, MapFunction], output_type: WrapperTypeInfo = None) \
+    def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
             -> 'DataStream':
         return self._values().map(func, output_type)
 

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import datetime
 import decimal
 import os
 import uuid
@@ -319,6 +320,89 @@ class DataStreamTests(PyFlinkTestCase):
         expected = ['deeefg,4', 'bdc,2', 'ab,1', 'cfgs,3']
         results.sort()
         expected.sort()
+        self.assertEqual(expected, results)
+
+    def test_execute_and_collect(self):
+        collection = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
+                       bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
+                       datetime.time(hour=12, minute=0, second=0,
+                                     microsecond=123000),
+                       datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [1, 2, 3],
+                       decimal.Decimal('1000000000000000000.05'),
+                       decimal.Decimal('1000000000000000000.0599999999999'
+                                       '9999899999999999')),
+                      (2, None, 2, True, 23878, 652516352, 9.87, 2.98936,
+                       bytearray(b'flink'), 'pyflink', datetime.date(2015, 10, 14),
+                       datetime.time(hour=11, minute=2, second=2,
+                                     microsecond=234500),
+                       datetime.datetime(2020, 4, 15, 8, 2, 6, 235000), [2, 4, 6],
+                       decimal.Decimal('2000000000000000000.74'),
+                       decimal.Decimal('2000000000000000000.061111111111111'
+                                       '11111111111111'))]
+        ds = self.env.from_collection(collection)
+
+        expected = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
+                     bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
+                     datetime.time(hour=12, minute=0, second=0,
+                                   microsecond=123000),
+                     datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [1, 2, 3],
+                     decimal.Decimal('1000000000000000000.05'),
+                     decimal.Decimal('1000000000000000000.0599999999999'
+                                     '9999899999999999')),
+                    (2, None, 2, True, 23878, 652516352, 9.87, 2.98936,
+                     bytearray(b'flink'), 'pyflink', datetime.date(2015, 10, 14),
+                     datetime.time(hour=11, minute=2, second=2,
+                                   microsecond=234500),
+                     datetime.datetime(2020, 4, 15, 8, 2, 6, 235000), [2, 4, 6],
+                     decimal.Decimal('2000000000000000000.74'),
+                     decimal.Decimal('2000000000000000000.061111111111111'
+                                     '11111111111111'))]
+
+        with ds.execute_and_collect() as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=2)
+        results = []
+        for i in result:
+            results.append(i)
+        self.assertEqual(expected, results)
+
+        type_info = Types.ROW(
+            [Types.LONG(), Types.LONG(), Types.SHORT(), Types.BOOLEAN(), Types.SHORT(), Types.INT(),
+             Types.FLOAT(), Types.DOUBLE(), Types.PICKLED_BYTE_ARRAY(), Types.STRING(),
+             Types.SQL_DATE(), Types.SQL_TIME(), Types.SQL_TIMESTAMP(),
+             Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(), Types.BIG_DEC()])
+
+        ds = self.env.from_collection(collection=collection, type_info=type_info)
+
+        expected = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
+                     bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
+                     datetime.time(hour=12, minute=0, second=0),
+                     datetime.datetime(2018, 3, 11, 3, 0, 0, 123000), [1, 2, 3],
+                     decimal.Decimal('1000000000000000000.05'),
+                     decimal.Decimal('1000000000000000000.0599999999999'
+                                     '9999899999999999')),
+                    (2, None, 2, True, 23878, 652516352, 9.87, 2.98936,
+                     bytearray(b'flink'), 'pyflink', datetime.date(2015, 10, 14),
+                     datetime.time(hour=11, minute=2, second=2),
+                     datetime.datetime(2020, 4, 15, 8, 2, 6, 235000), [2, 4, 6],
+                     decimal.Decimal('2000000000000000000.74'),
+                     decimal.Decimal('2000000000000000000.061111111111111'
+                                     '11111111111111'))]
+
+        with ds.execute_and_collect(type_info=type_info) as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=2, type_info=type_info)
+        results = []
+        for i in result:
+            results.append(i)
         self.assertEqual(expected, results)
 
     def test_key_by_map(self):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -354,6 +354,38 @@ class DataStreamTests(PyFlinkTestCase):
             results.append(i)
         self.assertEqual(expected, results)
 
+        collection = [['pyflink', 'datastream'], ['execute', 'collect']]
+        ds = self.env.from_collection(collection)
+
+        expected = [['pyflink', 'datastream'], ['execute', 'collect']]
+
+        with ds.execute_and_collect() as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=2)
+        results = []
+        for i in result:
+            results.append(i)
+        self.assertEqual(expected, results)
+
+        ds = self.env.from_collection(collection=collection,
+                                      type_info=Types.BASIC_ARRAY(Types.STRING()))
+
+        with ds.execute_and_collect() as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=2)
+        results = []
+        for i in result:
+            results.append(i)
+        self.assertEqual(expected, results)
+
         collection = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
                        bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
                        datetime.time(hour=12, minute=0, second=0,

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -323,6 +323,37 @@ class DataStreamTests(PyFlinkTestCase):
         self.assertEqual(expected, results)
 
     def test_execute_and_collect(self):
+        collection = ['pyflink', 'datastream', 'execute', 'collect']
+        ds = self.env.from_collection(collection)
+
+        expected = ['pyflink', 'datastream', 'execute', 'collect']
+
+        with ds.execute_and_collect() as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=4)
+        results = []
+        for i in result:
+            results.append(i)
+        self.assertEqual(expected, results)
+
+        ds = self.env.from_collection(collection=collection, type_info=Types.STRING())
+
+        with ds.execute_and_collect() as result:
+            results = []
+            for i in result:
+                results.append(i)
+            self.assertEqual(expected, results)
+
+        result = ds.execute_and_collect(limit=4)
+        results = []
+        for i in result:
+            results.append(i)
+        self.assertEqual(expected, results)
+
         collection = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
                        bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
                        datetime.time(hour=12, minute=0, second=0,
@@ -370,13 +401,11 @@ class DataStreamTests(PyFlinkTestCase):
             results.append(i)
         self.assertEqual(expected, results)
 
-        type_info = Types.ROW(
-            [Types.LONG(), Types.LONG(), Types.SHORT(), Types.BOOLEAN(), Types.SHORT(), Types.INT(),
-             Types.FLOAT(), Types.DOUBLE(), Types.PICKLED_BYTE_ARRAY(), Types.STRING(),
-             Types.SQL_DATE(), Types.SQL_TIME(), Types.SQL_TIMESTAMP(),
-             Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(), Types.BIG_DEC()])
-
-        ds = self.env.from_collection(collection=collection, type_info=type_info)
+        ds = self.env.from_collection(collection=collection, type_info=Types.ROW([
+            Types.LONG(), Types.LONG(), Types.SHORT(), Types.BOOLEAN(), Types.SHORT(),
+            Types.INT(), Types.FLOAT(), Types.DOUBLE(), Types.PICKLED_BYTE_ARRAY(),
+            Types.STRING(), Types.SQL_DATE(), Types.SQL_TIME(), Types.SQL_TIMESTAMP(),
+            Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(), Types.BIG_DEC()]))
 
         expected = [(1, None, 1, True, 32767, -2147483648, 1.23, 1.98932,
                      bytearray(b'flink'), 'pyflink', datetime.date(2014, 9, 13),
@@ -393,13 +422,13 @@ class DataStreamTests(PyFlinkTestCase):
                      decimal.Decimal('2000000000000000000.061111111111111'
                                      '11111111111111'))]
 
-        with ds.execute_and_collect(type_info=type_info) as result:
+        with ds.execute_and_collect() as result:
             results = []
             for i in result:
                 results.append(i)
             self.assertEqual(expected, results)
 
-        result = ds.execute_and_collect(limit=2, type_info=type_info)
+        result = ds.execute_and_collect(limit=2)
         results = []
         for i in result:
             results.append(i)

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -270,7 +270,8 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
                                       type_info=Types.ROW(
                                           [Types.LONG(), Types.LONG(), Types.SHORT(),
                                            Types.BOOLEAN(), Types.SHORT(), Types.INT(),
-                                           Types.FLOAT(), Types.DOUBLE(), Types.BYTE(),
+                                           Types.FLOAT(), Types.DOUBLE(),
+                                           Types.PICKLED_BYTE_ARRAY(),
                                            Types.STRING(), Types.SQL_DATE(), Types.SQL_TIME(),
                                            Types.SQL_TIMESTAMP(),
                                            Types.BASIC_ARRAY(Types.LONG()), Types.BIG_DEC(),
@@ -280,11 +281,11 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         results = self.test_sink.get_results(False)
         # if user specifies data types of input data, the collected result should be in row format.
         expected = [
-            '1,null,1,true,32767,-2147483648,1.23,1.98932,null,pyflink,2014-09-13,12:00:00,'
-            '2018-03-11 03:00:00.123,[1, 2, 3],1000000000000000000.05,'
+            '1,null,1,true,32767,-2147483648,1.23,1.98932,[102, 108, 105, 110, 107],pyflink,'
+            '2014-09-13,12:00:00,2018-03-11 03:00:00.123,[1, 2, 3],1000000000000000000.05,'
             '1000000000000000000.05999999999999999899999999999',
-            '2,null,2,true,-21658,557549056,9.87,2.98936,null,pyflink,2015-10-14,11:02:02,'
-            '2020-04-15 08:02:06.235,[2, 4, 6],2000000000000000000.74,'
+            '2,null,2,true,-21658,557549056,9.87,2.98936,[102, 108, 105, 110, 107],pyflink,'
+            '2015-10-14,11:02:02,2020-04-15 08:02:06.235,[2, 4, 6],2000000000000000000.74,'
             '2000000000000000000.06111111111111111111111111111']
         results.sort()
         expected.sort()

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -20,8 +20,8 @@ import datetime
 import pickle
 
 from pyflink.common import typeinfo
-from pyflink.common.typeinfo import WrapperTypeInfo, RowTypeInfo, Types, BasicArrayTypeInfo, \
-    PrimitiveArrayTypeInfo
+from pyflink.common.typeinfo import WrapperTypeInfo, RowTypeInfo, TupleTypeInfo, Types, \
+    BasicArrayTypeInfo, PrimitiveArrayTypeInfo
 from pyflink.java_gateway import get_gateway
 
 
@@ -32,7 +32,7 @@ def convert_to_python_obj(data, type_info):
         gateway = get_gateway()
         pickle_bytes = gateway.jvm.PythonBridgeUtils. \
             getPickledBytesFromJavaObject(data, type_info.get_java_type_info())
-        if hasattr(type_info, 'types'):
+        if isinstance(type_info, RowTypeInfo) or isinstance(type_info, TupleTypeInfo):
             field_data = zip(list(pickle_bytes[1:]), type_info.get_field_types())
             fields = []
             for data, field_type in field_data:

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -1,0 +1,75 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import ast
+import datetime
+import pickle
+
+from pyflink.common import typeinfo
+from pyflink.common.typeinfo import WrapperTypeInfo, RowTypeInfo, Types, BasicArrayTypeInfo, \
+    PrimitiveArrayTypeInfo
+from pyflink.java_gateway import get_gateway
+
+
+def convert_to_python_obj(data, type_info):
+    if type_info is None:
+        return pickle.loads(data)
+    else:
+        gateway = get_gateway()
+        pickle_bytes = gateway.jvm.PythonBridgeUtils. \
+            getPickledBytesFromJavaObject(data, type_info.get_java_type_info())
+        pickle_bytes = list(pickle_bytes[1:])
+        field_data = zip(pickle_bytes, type_info.types)
+        fields = []
+        for data, field_type in field_data:
+            if len(data) == 0:
+                fields.append(None)
+            else:
+                fields.append(java_to_python_converter(data, field_type))
+        return tuple(fields)
+
+
+def java_to_python_converter(data, field_type: WrapperTypeInfo):
+    if isinstance(field_type, RowTypeInfo):
+        data = zip(list(data[1:]), field_type.get_field_types())
+        fields = []
+        for d, d_type in data:
+            fields.append(java_to_python_converter(d, d_type))
+        return tuple(fields)
+    else:
+        data = pickle.loads(data)
+        if field_type == Types.SQL_TIME():
+            seconds, microseconds = divmod(data, 10 ** 6)
+            minutes, seconds = divmod(seconds, 60)
+            hours, minutes = divmod(minutes, 60)
+            return datetime.time(hours, minutes, seconds, microseconds)
+        elif field_type == Types.SQL_DATE():
+            return field_type.from_internal_type(data)
+        elif field_type == Types.SQL_TIMESTAMP():
+            return field_type.from_internal_type(int(data.timestamp() * 10 ** 6))
+        elif field_type == Types.FLOAT():
+            return field_type.from_internal_type(ast.literal_eval(data))
+        elif BasicArrayTypeInfo.is_basic_array_type_info(field_type) or \
+                PrimitiveArrayTypeInfo.is_primitive_array_type_info(field_type):
+            element_type = typeinfo._from_java_type(
+                field_type.get_java_type_info().getComponentInfo())
+            elements = []
+            for element_bytes in data:
+                elements.append(java_to_python_converter(element_bytes, element_type))
+            return elements
+        else:
+            return field_type.from_internal_type(data)

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -20,7 +20,7 @@ import datetime
 import pickle
 
 from pyflink.common import typeinfo
-from pyflink.common.typeinfo import WrapperTypeInfo, RowTypeInfo, TupleTypeInfo, Types, \
+from pyflink.common.typeinfo import RowTypeInfo, TupleTypeInfo, Types, \
     BasicArrayTypeInfo, PrimitiveArrayTypeInfo
 from pyflink.java_gateway import get_gateway
 
@@ -45,7 +45,7 @@ def convert_to_python_obj(data, type_info):
             return pickled_bytes_to_python_converter(pickle_bytes, type_info)
 
 
-def pickled_bytes_to_python_converter(data, field_type: WrapperTypeInfo):
+def pickled_bytes_to_python_converter(data, field_type):
     if isinstance(field_type, RowTypeInfo):
         data = zip(list(data[1:]), field_type.get_field_types())
         fields = []

--- a/flink-python/pyflink/table/table_result.py
+++ b/flink-python/pyflink/table/table_result.py
@@ -26,7 +26,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table.result_kind import ResultKind
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import _from_java_type
-from pyflink.table.utils import java_to_python_converter
+from pyflink.table.utils import pickled_bytes_to_python_converter
 
 __all__ = ['TableResult']
 
@@ -247,7 +247,7 @@ class CloseableIterator(object):
             if len(data) == 0:
                 fields.append(None)
             else:
-                fields.append(java_to_python_converter(data, field_type))
+                fields.append(pickled_bytes_to_python_converter(data, field_type))
         result_row = Row(*fields)
         result_row.set_row_kind(row_kind)
         return result_row


### PR DESCRIPTION
## What is the purpose of the change

*`DataStream.executeAndCollect()` has already been supported in FLINK-19508. `DataStream` should also support `executeAndCollect` interface in the Python DataStream API.*

## Brief change log

  - *`DataStream` adds `execute_and_collec` to trigger the distributed execution of the streaming dataflow and returns an iterator over the elements of the given DataStream.*

## Verifying this change

  - *`DataStreamTests`adds `test_execute_and_collect` test method to verify whether adding `execute_and_collec` method could trigger the distributed execution of the streaming dataflow and returns an iterator over the elements of the given DataStream.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)