### PR TITLE
[FLINK-19697] Make the Committer/GlobalCommitter retry-able

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/util/SinkUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/util/SinkUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.util;
+
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Utility class for {@link org.apache.flink.api.connector.sink.Sink}'s runtime operators.
+ */
+public class SinkUtils {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(SinkUtils.class);
+
+	/**
+	 * Commit a list of committables until all of them are committed successfully if retryInterval > 0.
+	 * or return a list of uncommitted committables.
+	 *
+	 * @param committables A list of committables
+	 * @param committer A function used to commit the committables.
+	 * @param output Used to send the committed committables.
+	 * @param retryInterval Commit retry interval.
+	 *
+	 * @return A list of uncommitted committables.
+	 */
+	public static <CommT> List<CommT> commit(
+			List<CommT> committables,
+			Function<List<CommT>, List<CommT>> committer,
+			@Nullable Output<StreamRecord<CommT>> output,
+			long retryInterval) throws InterruptedException {
+
+		final List<CommT> readyCommittables = new ArrayList<>(committables);
+		final List<CommT> neededToRetryCommittables = new ArrayList<>();
+		boolean retry;
+		do {
+			retry = false;
+			readyCommittables.addAll(neededToRetryCommittables);
+			neededToRetryCommittables.clear();
+			neededToRetryCommittables.addAll(committer.apply(Collections.unmodifiableList(
+					readyCommittables)));
+			if (!neededToRetryCommittables.isEmpty()) {
+				LOG.info(
+						"{} of {} committables needed to retry",
+						neededToRetryCommittables.size(),
+						readyCommittables.size());
+				readyCommittables.removeAll(neededToRetryCommittables);
+			}
+			if (output != null) {
+				for (CommT committable : readyCommittables) {
+					output.collect(new StreamRecord<>(committable));
+				}
+			}
+			readyCommittables.clear();
+			if (!neededToRetryCommittables.isEmpty() && retryInterval > 0) {
+				retry = true;
+				Thread.sleep(retryInterval);
+			}
+		} while (retry);
+
+		return neededToRetryCommittables;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -302,13 +302,22 @@ public class TestSink implements Sink<Integer, String, String, String> {
 	}
 
 	/**
-	 * A {@link Committer} that always re-commits the committables data it received.
+	 * A {@link Committer} that re-commits the committables if the variable 'retry' is true.
 	 */
-	static class AlwaysRetryCommitter extends DefaultCommitter implements Committer<String> {
+	static class RetryCommitter extends DefaultCommitter implements Committer<String> {
 
-		@Override
+		private boolean retry = true;
+
 		public List<String> commit(List<String> committables) {
-			return committables;
+			if (retry) {
+				return committables;
+			} else {
+				return super.commit(committables);
+			}
+		}
+
+		public void setRetry(boolean retry) {
+			this.retry = retry;
 		}
 	}
 
@@ -363,28 +372,22 @@ public class TestSink implements Sink<Integer, String, String, String> {
 	}
 
 	/**
-	 * A {@link GlobalCommitter} that always re-commits global committables it received.
+	 * A {@link GlobalCommitter} that re-commits the committables if the variable 'retry' is true.
 	 */
-	static class AlwaysRetryGlobalCommitter extends DefaultGlobalCommitter {
+	static class RetryGlobalCommitter extends DefaultGlobalCommitter {
 
-		@Override
-		public List<String> filterRecoveredCommittables(List<String> globalCommittables) {
-			return Collections.emptyList();
-		}
+		private boolean retry = true;
 
-		@Override
-		public String combine(List<String> committables) {
-			return String.join("|", committables);
-		}
-
-		@Override
-		public void endOfInput() {
-
-		}
-
-		@Override
 		public List<String> commit(List<String> committables) {
-			return committables;
+			if (retry) {
+				return committables;
+			} else {
+				return super.commit(committables);
+			}
+		}
+
+		public void setRetry(boolean retry) {
+			this.retry = retry;
 		}
 	}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make the Committer/GlobalCommitter retry-able.


## Brief change log

  - *Introduce SinkUtils::commit for retry-commit*
  - *Make the AbstractStreamingCommitterOperator recommit the committables when commit fails*
  - *Make the BatchGlobalCommitterOperator recommit the committables when commit fails*
  - *Make the BatchCommitterOperator recommit the committables when commit fails*


## Verifying this change

*(example:)*
  - *StreamingCommitterOperatorTest*
  - *BatchCommitterOperatorTest*
  - *BatchGlobalCommitterOperatorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
