### PR TITLE
[FLINK-19265][FLINK-20049][core] Source API final adjustments

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitEnumerator.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 
 import java.io.IOException;
@@ -73,7 +72,7 @@ public class MockSplitEnumerator implements SplitEnumerator<MockSourceSplit, Lis
 			context.assignSplits(new SplitsAssignment<>(assignment));
 			splits.clear();
 			for (int i = 0; i < numReaders; i++) {
-				context.sendEventToSourceReader(i, new NoMoreSplitsEvent());
+				context.signalNoMoreSplits(i);
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitEnumerator.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,14 +47,13 @@ public class MockSplitEnumerator implements SplitEnumerator<MockSourceSplit, Lis
 	}
 
 	@Override
-	public void start() {
-
-	}
+	public void start() {}
 
 	@Override
-	public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+	public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {}
 
-	}
+	@Override
+	public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
 
 	@Override
 	public void addSplitsBack(List<MockSourceSplit> splits, int subtaskId) {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -21,7 +21,6 @@ package org.apache.flink.connector.file.src.impl;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.event.RequestSplitEvent;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.file.src.FileSourceSplit;
@@ -48,12 +47,12 @@ public final class FileSourceReader<T, SplitT extends FileSourceSplit>
 
 	@Override
 	public void start() {
-		requestSplit();
+		context.sendSplitRequest();
 	}
 
 	@Override
 	protected void onSplitFinished(Collection<String> finishedSplitIds) {
-		requestSplit();
+		context.sendSplitRequest();
 	}
 
 	@Override
@@ -64,10 +63,6 @@ public final class FileSourceReader<T, SplitT extends FileSourceSplit>
 	@Override
 	protected SplitT toSplitType(String splitId, FileSourceSplitState<SplitT> splitState) {
 		return splitState.toFileSourceSplit();
-	}
-
-	private void requestSplit() {
-		context.sendSourceEventToCoordinator(new RequestSplitEvent(context.getLocalHostName()));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.api.connector.source.event.RequestSplitEvent;
 import org.apache.flink.connector.file.src.FileSource;
 import org.apache.flink.connector.file.src.FileSourceSplit;
@@ -121,7 +120,7 @@ public class StaticFileSplitEnumerator implements SplitEnumerator<FileSourceSpli
 			LOG.info("Assigned split to subtask {} : {}", subtask, split);
 		}
 		else {
-			context.sendEventToSourceReader(subtask, new NoMoreSplitsEvent());
+			context.signalNoMoreSplits(subtask);
 			LOG.info("No more splits available for subtask {}", subtask);
 		}
 	}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.reader.SimpleStreamFormat;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
@@ -81,7 +80,7 @@ public class FileSourceHeavyThroughputTest {
 		final FileSource<byte[]> source = FileSource.forRecordStreamFormat(new ArrayReaderFormat(), path).build();
 		final SourceReader<byte[], FileSourceSplit> reader = source.createReader(new NoOpReaderContext());
 		reader.addSplits(Collections.singletonList(split));
-		reader.handleSourceEvents(new NoMoreSplitsEvent());
+		reader.notifyNoMoreSplits();
 
 		final ReaderOutput<byte[]> out = new NoOpReaderOutput<>();
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceHeavyThroughputTest.java
@@ -206,6 +206,9 @@ public class FileSourceHeavyThroughputTest {
 		}
 
 		@Override
+		public void sendSplitRequest() {}
+
+		@Override
 		public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -94,13 +94,25 @@ public interface SourceReader<T, SplitT extends SourceSplit>
 	void addSplits(List<SplitT> splits);
 
 	/**
+	 * This method is called when the reader is notified that it will not
+	 * receive any further splits.
+	 *
+	 * <p>It is triggered when the enumerator calls {@link SplitEnumeratorContext#signalNoMoreSplits(int)}
+	 * with the reader's parallel subtask.
+	 */
+	void notifyNoMoreSplits();
+
+	/**
 	 * Handle a custom source event sent by the {@link SplitEnumerator}.
 	 * This method is called when the enumerator sends an event via
 	 * {@link SplitEnumeratorContext#sendEventToSourceReader(int, SourceEvent)}.
 	 *
+	 * <p>This method has a default implementation that does nothing, because
+	 * most sources do not require any custom events.
+	 *
 	 * @param sourceEvent the event sent by the {@link SplitEnumerator}.
 	 */
-	void handleSourceEvents(SourceEvent sourceEvent);
+	default void handleSourceEvents(SourceEvent sourceEvent) {}
 
 	/**
 	 * We have an empty default implementation here because most source readers do not have

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReaderContext.java
@@ -50,6 +50,13 @@ public interface SourceReaderContext {
 	int getIndexOfSubtask();
 
 	/**
+	 * Sends a split request to the source's {@link SplitEnumerator}.
+	 * This will result in a call to the {@link SplitEnumerator#handleSplitRequest(int, String)} method,
+	 * with this reader's parallel subtask id and the hostname where this reader runs.
+	 */
+	void sendSplitRequest();
+
+	/**
 	 * Send a source event to the source coordinator.
 	 *
 	 * @param sourceEvent the source event to coordinator.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
@@ -21,6 +21,8 @@ package org.apache.flink.api.connector.source;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.state.CheckpointListener;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -41,12 +43,14 @@ public interface SplitEnumerator<SplitT extends SourceSplit, CheckpointT>
 	void start();
 
 	/**
-	 * Handles the source event from the source reader.
+	 * Handles the request for a split. This method is called when the reader with the given subtask
+	 * id calls the {@link SourceReaderContext#sendSplitRequest()} method.
 	 *
 	 * @param subtaskId the subtask id of the source reader who sent the source event.
-	 * @param sourceEvent the source event from the source reader.
+	 * @param requesterHostname Optional, the hostname where the requesting task is running.
+	 *                          This can be used to make split assignments locality-aware.
 	 */
-	void handleSourceEvent(int subtaskId, SourceEvent sourceEvent);
+	void handleSplitRequest(int subtaskId, @Nullable String requesterHostname);
 
 	/**
 	 * Add a split back to the split enumerator. It will only happen when a {@link SourceReader} fails
@@ -87,4 +91,18 @@ public interface SplitEnumerator<SplitT extends SourceSplit, CheckpointT>
 	 */
 	@Override
 	default void notifyCheckpointComplete(long checkpointId) throws Exception {}
+
+	/**
+	 * Handles a custom source event from the source reader.
+	 *
+	 * <p>This method has a default implementation that does nothing, because it is only
+	 * required to be implemented by some sources, which have a custom event protocol between
+	 * reader and enumerator. The common events for reader registration and split requests
+	 * are not dispatched to this method, but rather invoke the {@link #addReader(int)} and
+	 * {@link #handleSplitRequest(int, String)} methods.
+	 *
+	 * @param subtaskId the subtask id of the source reader who sent the source event.
+	 * @param sourceEvent the source event from the source reader.
+	 */
+	default void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -84,6 +84,14 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 	}
 
 	/**
+	 * Signals a subtask that it will not receive any further split.
+	 *
+	 * @param subtask The index of the operator's parallel subtask that shall be
+	 *                signaled it will not receive any further split.
+	 */
+	void signalNoMoreSplits(int subtask);
+
+	/**
 	 * Invoke the callable and handover the return value to the handler which will be executed
 	 * by the source coordinator. When this method is invoked multiple times, The <code>Coallble</code>s
 	 * may be executed in a thread pool concurrently.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.api.connector.source.lib.util;
 
-import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.connector.source.event.RequestSplitEvent;
-import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -56,11 +55,7 @@ public class IteratorSourceEnumerator<SplitT extends IteratorSourceSplit<?, ?>> 
 	public void close() {}
 
 	@Override
-	public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
-		if (!(sourceEvent instanceof RequestSplitEvent)) {
-			throw new FlinkRuntimeException("Unrecognized event: " + sourceEvent);
-		}
-
+	public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
 		final SplitT nextSplit = remainingSplits.poll();
 		if (nextSplit != null) {
 			context.assignSplit(nextSplit, subtaskId);

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
@@ -21,7 +21,6 @@ package org.apache.flink.api.connector.source.lib.util;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.api.connector.source.event.RequestSplitEvent;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -66,7 +65,7 @@ public class IteratorSourceEnumerator<SplitT extends IteratorSourceSplit<?, ?>> 
 		if (nextSplit != null) {
 			context.assignSplit(nextSplit, subtaskId);
 		} else {
-			context.sendEventToSourceReader(subtaskId, new NoMoreSplitsEvent());
+			context.signalNoMoreSplits(subtaskId);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
@@ -19,13 +19,10 @@
 package org.apache.flink.api.connector.source.lib.util;
 
 import org.apache.flink.api.connector.source.ReaderOutput;
-import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.event.NoMoreSplitsEvent;
 import org.apache.flink.api.connector.source.event.RequestSplitEvent;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
@@ -122,6 +119,16 @@ public class IteratorSourceReader<E, IterT extends Iterator<E>, SplitT extends I
 	}
 
 	@Override
+	public void notifyNoMoreSplits() {
+		// if we get this after we already had a split, we must have requested more than
+		// one split, which is not expected here.
+		checkState(remainingSplits == null, "Unexpected response, requested more than one split.");
+
+		// non-null queue signals splits were assigned, in this case no splits
+		remainingSplits = new ArrayDeque<>();
+	}
+
+	@Override
 	public List<SplitT> snapshotState(long checkpointId) {
 		final ArrayList<SplitT> allSplits = new ArrayList<>(1 + remainingSplits.size());
 		if (iterator != null) {
@@ -131,16 +138,6 @@ public class IteratorSourceReader<E, IterT extends Iterator<E>, SplitT extends I
 		}
 		allSplits.addAll(remainingSplits);
 		return allSplits;
-	}
-
-	@Override
-	public void handleSourceEvents(SourceEvent sourceEvent) {
-		if (sourceEvent instanceof NoMoreSplitsEvent) {
-			// non-null queue signals splits were assigned, in this case no splits
-			remainingSplits = new ArrayDeque<>();
-		} else {
-			throw new FlinkRuntimeException("Unexpected event: " + sourceEvent);
-		}
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
@@ -21,7 +21,6 @@ package org.apache.flink.api.connector.source.lib.util;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.event.RequestSplitEvent;
 import org.apache.flink.core.io.InputStatus;
 
 import javax.annotation.Nullable;
@@ -83,7 +82,7 @@ public class IteratorSourceReader<E, IterT extends Iterator<E>, SplitT extends I
 	public void start() {
 		// request a split only if we did not get one during restore
 		if (iterator == null) {
-			context.sendSourceEventToCoordinator(new RequestSplitEvent());
+			context.sendSplitRequest();
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -108,12 +108,10 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 	}
 
 	@Override
-	public void handleSourceEvents(SourceEvent sourceEvent) {
-		if (sourceEvent instanceof MockNoMoreSplitsEvent) {
-			waitingForMoreSplits = false;
-			markAvailable();
-		}
-		receivedSourceEvents.add(sourceEvent);
+	public void notifyNoMoreSplits() {
+		waitingForMoreSplits = false;
+		markAvailable();
+		receivedSourceEvents.add(new MockNoMoreSplitsEvent());
 	}
 
 	@Override

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumerator.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,6 +71,9 @@ public class MockSplitEnumerator implements SplitEnumerator<MockSourceSplit, Set
 	public void start() {
 		this.started = true;
 	}
+
+	@Override
+	public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
 
 	@Override
 	public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/TestingReaderContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/TestingReaderContext.java
@@ -69,6 +69,9 @@ public class TestingReaderContext implements SourceReaderContext {
 	}
 
 	@Override
+	public void sendSplitRequest() {}
+
+	@Override
 	public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {
 		sentEvents.add(sourceEvent);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -30,7 +30,9 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
+import org.apache.flink.runtime.source.event.RequestSplitEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
+import org.apache.flink.util.FlinkException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,10 +136,14 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 		coordinatorExecutor.execute(() -> {
 			try {
 				LOG.debug("Handling event from subtask {} of source {}: {}", subtask, operatorName, event);
-				if (event instanceof SourceEventWrapper) {
+				if (event instanceof RequestSplitEvent) {
+					enumerator.handleSplitRequest(subtask, ((RequestSplitEvent) event).hostName());
+				} else if (event instanceof SourceEventWrapper) {
 					enumerator.handleSourceEvent(subtask, ((SourceEventWrapper) event).getSourceEvent());
 				} else if (event instanceof ReaderRegistrationEvent) {
 					handleReaderRegistrationEvent((ReaderRegistrationEvent) event);
+				} else {
+					throw new FlinkException("Unrecognized Operator Event: " + event);
 				}
 			} catch (Exception e) {
 				LOG.error("Failing the job due to exception when handling operator event {} from subtask {} " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/NoMoreSplitsEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/NoMoreSplitsEvent.java
@@ -16,16 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.connector.source.event;
+package org.apache.flink.runtime.source.event;
 
-import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 
 /**
  * A source event sent from the SplitEnumerator to the SourceReader to indicate that no more
  * splits will be assigned to the source reader anymore. So once the SplitReader finishes
  * reading the currently assigned splits, they can exit.
  */
-public class NoMoreSplitsEvent implements SourceEvent {
+public class NoMoreSplitsEvent implements OperatorEvent {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/RequestSplitEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/RequestSplitEvent.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.connector.source.event;
+package org.apache.flink.runtime.source.event;
 
-import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 
 import javax.annotation.Nullable;
 
@@ -30,7 +30,7 @@ import java.util.Objects;
  * <p>This event optionally carries the hostname of the location where the reader runs, to support
  * locality-aware work assignment.
  */
-public final class RequestSplitEvent implements SourceEvent {
+public final class RequestSplitEvent implements OperatorEvent {
 
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -277,6 +278,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 			}
 		} else if (event instanceof SourceEventWrapper) {
 			sourceReader.handleSourceEvents(((SourceEventWrapper) event).getSourceEvent());
+		} else if (event instanceof NoMoreSplitsEvent) {
+			sourceReader.notifyNoMoreSplits();
 		} else {
 			throw new IllegalStateException("Received unexpected operator event " + event);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
+import org.apache.flink.runtime.source.event.RequestSplitEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -162,6 +163,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 			@Override
 			public int getIndexOfSubtask() {
 				return getRuntimeContext().getIndexOfThisSubtask();
+			}
+
+			@Override
+			public void sendSplitRequest() {
+				operatorEventGateway.sendEventToCoordinator(new RequestSplitEvent(getLocalHostName()));
 			}
 
 			@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.connector.source.ReaderOutput;
-import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -293,7 +292,7 @@ public class SourceOperatorEventTimeTest {
 		public void addSplits(List<MockSourceSplit> splits) {}
 
 		@Override
-		public void handleSourceEvents(SourceEvent sourceEvent) {}
+		public void notifyNoMoreSplits() {}
 
 		@Override
 		public void close() {}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -328,8 +328,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 			}
 
 			@Override
-			public void handleSourceEvents(SourceEvent sourceEvent) {
-			}
+			public void notifyNoMoreSplits() {}
 
 			@Override
 			public void close() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -35,7 +35,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -71,6 +70,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -367,8 +367,7 @@ public class UnalignedCheckpointITCase extends TestLogger {
 			}
 
 			@Override
-			public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
-			}
+			public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
 
 			@Override
 			public void addSplitsBack(List<LongSplit> splits, int subtaskId) {


### PR DESCRIPTION
## Purpose / Brief change log

This adds convenience methods for the common actions around split requesting, rather than requiring every source to implement the event handling themselves.

  1. To simplify split requests, this adds `SplitReaderContext.sendSplitRequest()` and `SplitEnumerator.handleSplitRequest()`.
  2. To simplify dealing with a finite amount of bounded splits (all batch use cases), this add `SplitEnumeratorContext.signalNoMoreSplits()` and `SourceReader.notifyNoMoreSplits()`.
  3. The PR removes the `RequestSplitEvent` and `NoMoreSplitsEvent`.

## Verifying this change

This change is API rework and covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no** (only API extensions)
  - If yes, how is the feature documented? **JavaDocs**
