### PR TITLE
[FLINK-19448][connector/common] Synchronize fetchers.isEmpty status to SourceReaderBase using elementsQueue.notifyAvailable()

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -270,7 +270,9 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 			splitFetcherManager.checkErrors();
 			return InputStatus.END_OF_INPUT;
 		} else {
-			throw new IllegalStateException("Called 'finishedOrAvailableLater()' with shut-down fetchers but non-empty queue");
+			// We may fall in this method because of purely finished splits record. If all splits
+			// were finished meanwhile, we may end up here with no empty elementsQueue.
+			return InputStatus.MORE_AVAILABLE;
 		}
 	}
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -270,8 +270,8 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 			splitFetcherManager.checkErrors();
 			return InputStatus.END_OF_INPUT;
 		} else {
-			// We may fall in this method because of purely finished splits record. If all splits
-			// were finished meanwhile, we may end up here with no empty elementsQueue.
+			// We can reach this case if we just processed all data from the queue and finished a split,
+			// and concurrently the fetcher finished another split, whose data is then in the queue.
 			return InputStatus.MORE_AVAILABLE;
 		}
 	}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -133,7 +133,13 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 			elementsQueue,
 			splitReader,
 			errorHandler,
-			() -> fetchers.remove(fetcherId));
+			() -> {
+				fetchers.remove(fetcherId);
+				// We need this to synchronize status of fetchers to concurrent partners as
+				// ConcurrentHashMap's aggregate status methods including size, isEmpty, and
+				// containsValue are not designed for program control.
+				elementsQueue.notifyAvailable();
+			});
 		fetchers.put(fetcherId, splitFetcher);
 		return splitFetcher;
 	}


### PR DESCRIPTION
## What is the purpose of the change
Synchronize `fetchers.isEmpty` status to `SourceReaderBase` using `elementsQueue.notifyAvailable()`.

## Brief change log
* Add test case to fail empty queue assumption in `SourceReaderBase.finishedOrAvailableLater`.
* Correct empty queue assumption by returning `InputStatus.MORE_AVAILABLE` if not empty.
* Synchronize `fetchers.isEmpty` status to `SourceReaderBase` using `elementsQueue.notifyAvailable()`.

## Verifying this change
This change is already covered by existing tests, such as:
*  `CoordinatedSourceITCase.testEnumeratorReaderCommunication`.

This change added tests and can be verified as follows:
* `SourceReaderBaseTest.testMultipleSplitsWithSeparatedFinishedRecord`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
