### PR TITLE
[FLINK-19983][network] Remove wrong state checking in SortMergeSubpartitionReader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -134,10 +134,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 			ctx.channel().close();
 		}
 
-		for (NetworkSequenceViewReader reader : allReaders.values()) {
-			releaseViewReader(reader);
-		}
-		allReaders.clear();
+		releaseAllResources();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -317,7 +317,6 @@ public class SortMergeResultPartition extends ResultPartition {
 				availabilityListener,
 				resultFile);
 			readers.add(reader);
-			availabilityListener.notifyDataAvailable();
 
 			return reader;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -138,7 +138,9 @@ public class SortMergeSubpartitionReader implements ResultSubpartitionView, Buff
 
 	@Override
 	public void recycle(MemorySegment segment) {
-		readBuffers.add(segment);
+		if (!isReleased) {
+			readBuffers.add(segment);
+		}
 
 		// notify data available if the reader is unavailable currently
 		if (!isReleased && readBuffers.size() == NUM_READ_BUFFERS) {
@@ -154,6 +156,9 @@ public class SortMergeSubpartitionReader implements ResultSubpartitionView, Buff
 	@Override
 	public void releaseAllResources() {
 		isReleased = true;
+
+		buffersRead.clear();
+		readBuffers.clear();
 
 		IOUtils.closeQuietly(fileReader);
 		partition.releaseReader(this);


### PR DESCRIPTION
## What is the purpose of the change

Remove wrong state checking in SortMergeSubpartitionReader.

## Brief change log

  - Remove wrong state checking in SortMergeSubpartitionReader.

## Verifying this change

This change is already covered by existing tests, such as ShuffleCompressionITCase#testDataCompressionForSortMergeBlockingShuffle.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
