### PR TITLE
[FLINK-20035][tests] Use random port for rest endpoint in BlockingShuffleITCase and ShuffleCompressionITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.MiniClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -39,6 +40,7 @@ public class JobGraphRunningUtil {
 			int numTaskManagers,
 			int numSlotsPerTaskManager) throws Exception {
 		configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
+		configuration.setString(RestOptions.BIND_ADDRESS, "0");
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)


### PR DESCRIPTION
## What is the purpose of the change

Use random port for rest endpoint in BlockingShuffleITCase and ShuffleCompressionITCase to make the cases more stable.

## Brief change log

  - Use random port for rest endpoint in BlockingShuffleITCase and ShuffleCompressionITCase to make the cases more stable.


## Verifying this change

This change is already covered by existing tests, such as BlockingShuffleITCase and ShuffleCompressionITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
