### PR TITLE
[hotfix][hbase] Add missed ITCase in hbase2 connector

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -395,7 +395,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
-		// regiter HBase table testTable1 which contains test data
+		// register HBase table testTable1 which contains test data
 		String table1DDL = createHBaseTableDDL(TEST_TABLE_1, true);
 		tEnv.executeSql(table1DDL);
 

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -247,6 +247,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		TestBaseUtils.compareResultAsText(results, expected);
 	}
 
+	@Test
 	public void testTableSourceWithTableAPI() throws Exception {
 		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
@@ -397,7 +398,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
-		// regiter HBase table testTable1 which contains test data
+		// register HBase table testTable1 which contains test data
 		String table1DDL = createHBaseTableDDL(TEST_TABLE_1, true);
 		tEnv.executeSql(table1DDL);
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request  add the missed `@Test` in hbase2 connector, I think this test is missed in FLINK-18795


## Brief change log

  - add the missed `@Test`
  - fix typo

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
