### PR TITLE
[FLINK-20054][formats] Fix ParquetInputFormat 3 level List handling

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetMapInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetMapInputFormatTest.java
@@ -30,6 +30,8 @@ import org.apache.parquet.schema.MessageType;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,21 +45,27 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Test cases for reading Map from Parquet files.
  */
-public class ParquetMapInputFormatTest {
+@RunWith(Parameterized.class)
+public class ParquetMapInputFormatTest extends TestUtil {
 	private static final AvroSchemaConverter SCHEMA_CONVERTER = new AvroSchemaConverter();
 
 	@ClassRule
 	public static TemporaryFolder tempRoot = new TemporaryFolder();
 
+	public ParquetMapInputFormatTest(boolean useLegacyMode) {
+		super(useLegacyMode);
+	}
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testReadMapFromNestedRecord() throws IOException {
 		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.NESTED_SCHEMA, Collections.singletonList(nested.f1));
-		MessageType nestedType = SCHEMA_CONVERTER.convert(TestUtil.NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), getConfiguration());
+		MessageType nestedType = getSchemaConverter().convert(NESTED_SCHEMA);
 
 		ParquetMapInputFormat inputFormat = new ParquetMapInputFormat(path, nestedType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -84,12 +92,13 @@ public class ParquetMapInputFormatTest {
 	@SuppressWarnings("unchecked")
 	public void testProjectedReadMapFromNestedRecord() throws IOException {
 		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.NESTED_SCHEMA, Collections.singletonList(nested.f1));
-		MessageType nestedType = SCHEMA_CONVERTER.convert(TestUtil.NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), getConfiguration());
+		MessageType nestedType = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetMapInputFormat inputFormat = new ParquetMapInputFormat(path, nestedType);
 
 		inputFormat.selectFields(Collections.singletonList("nestedMap").toArray(new String[0]));
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetPojoInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetPojoInputFormatTest.java
@@ -33,6 +33,8 @@ import org.apache.parquet.schema.MessageType;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,17 +45,23 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test cases for reading Pojo from Parquet files.
  */
-public class ParquetPojoInputFormatTest {
+@RunWith(Parameterized.class)
+public class ParquetPojoInputFormatTest extends TestUtil {
 	private static final AvroSchemaConverter SCHEMA_CONVERTER = new AvroSchemaConverter();
 
 	@ClassRule
 	public static TemporaryFolder tempRoot = new TemporaryFolder();
 
+	public ParquetPojoInputFormatTest(boolean useLegacyMode) {
+		super(useLegacyMode);
+	}
+
 	@Test
 	public void testReadPojoFromSimpleRecord() throws IOException {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = TestUtil.getSimpleRecordTestData();
-		MessageType messageType = SCHEMA_CONVERTER.convert(TestUtil.SIMPLE_SCHEMA);
-		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.SIMPLE_SCHEMA, Collections.singletonList(simple.f1));
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = getSimpleRecordTestData();
+		MessageType messageType = getSchemaConverter().convert(SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), SIMPLE_SCHEMA,
+			Collections.singletonList(simple.f1), getConfiguration());
 
 		ParquetPojoInputFormat<PojoSimpleRecord> inputFormat = new ParquetPojoInputFormat<>(
 			path, messageType, (PojoTypeInfo<PojoSimpleRecord>) Types.POJO(PojoSimpleRecord.class));
@@ -72,12 +80,13 @@ public class ParquetPojoInputFormatTest {
 	@Test
 	public void testProjectedReadPojoFromSimpleRecord() throws IOException, NoSuchFieldError {
 		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = TestUtil.getSimpleRecordTestData();
-		MessageType messageType = SCHEMA_CONVERTER.convert(TestUtil.SIMPLE_SCHEMA);
-		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.SIMPLE_SCHEMA, Collections.singletonList(simple.f1));
+		MessageType messageType = getSchemaConverter().convert(SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), SIMPLE_SCHEMA,
+			Collections.singletonList(simple.f1), getConfiguration());
 
 		ParquetPojoInputFormat<PojoSimpleRecord> inputFormat = new ParquetPojoInputFormat<>(
 			path, messageType, (PojoTypeInfo<PojoSimpleRecord>) Types.POJO(PojoSimpleRecord.class));
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetRowInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetRowInputFormatTest.java
@@ -29,12 +29,12 @@ import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.schema.MessageType;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
@@ -52,28 +52,25 @@ import static org.junit.Assert.assertTrue;
 /**
  * Simple test case for reading {@link org.apache.flink.types.Row} from Parquet files.
  */
-public class ParquetRowInputFormatTest {
-	private static AvroSchemaConverter schemaConverter;
-
-	static {
-		// Use the conf to generate 3 level LIST schema
-		Configuration conf = new Configuration();
-		conf.setBoolean("parquet.avro.write-old-list-structure", false);
-		schemaConverter = new AvroSchemaConverter(conf);
-	}
+@RunWith(Parameterized.class)
+public class ParquetRowInputFormatTest extends TestUtil {
 
 	@ClassRule
 	public static TemporaryFolder tempRoot = new TemporaryFolder();
 
+	public ParquetRowInputFormatTest(boolean useLegacyMode) {
+		super(useLegacyMode);
+	}
+
 	@Test
 	public void testReadRowFromSimpleRecord() throws IOException {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = TestUtil.getSimpleRecordTestData();
-		Path path = TestUtil.createTempParquetFile(
-			tempRoot.getRoot(), TestUtil.SIMPLE_SCHEMA, Arrays.asList(simple.f1, simple.f1));
-		MessageType simpleType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = getSimpleRecordTestData();
+		Path path = createTempParquetFile(
+			tempRoot.getRoot(), SIMPLE_SCHEMA, Arrays.asList(simple.f1, simple.f1), getConfiguration());
+		MessageType simpleType = getSchemaConverter().convert(SIMPLE_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, simpleType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -103,13 +100,16 @@ public class ParquetRowInputFormatTest {
 
 		File tempFolder = tempRoot.newFolder();
 		// created a parquet file with 10 row groups. Each row group has 100 records
-		TestUtil.createTempParquetFile(tempFolder, TestUtil.SIMPLE_SCHEMA, records);
-		TestUtil.createTempParquetFile(tempFolder, TestUtil.SIMPLE_SCHEMA, records);
-		TestUtil.createTempParquetFile(tempFolder, TestUtil.SIMPLE_SCHEMA, records);
-		MessageType simpleType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+		createTempParquetFile(tempFolder, SIMPLE_SCHEMA,
+			records, getConfiguration());
+		createTempParquetFile(tempFolder, SIMPLE_SCHEMA,
+			records, getConfiguration());
+		createTempParquetFile(tempFolder, SIMPLE_SCHEMA,
+			records, getConfiguration());
+		MessageType simpleType = getSchemaConverter().convert(SIMPLE_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(new Path(tempFolder.getPath()), simpleType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(3);
 		assertEquals(3, splits.length);
@@ -141,11 +141,12 @@ public class ParquetRowInputFormatTest {
 		}
 
 		// created a parquet file with 10 row groups. Each row group has 100 records
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.SIMPLE_SCHEMA, records);
-		MessageType simpleType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.newFolder(), SIMPLE_SCHEMA,
+			records, getConfiguration());
+		MessageType simpleType = getSchemaConverter().convert(SIMPLE_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, simpleType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -248,11 +249,12 @@ public class ParquetRowInputFormatTest {
 		}
 
 		// created a parquet file with 10 row groups. Each row group has 100 records
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.SIMPLE_SCHEMA, records);
-		MessageType simpleType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.newFolder(), SIMPLE_SCHEMA,
+			records, getConfiguration());
+		MessageType simpleType = getSchemaConverter().convert(SIMPLE_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, simpleType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -348,12 +350,13 @@ public class ParquetRowInputFormatTest {
 
 	@Test
 	public void testReadRowFromNestedRecord() throws IOException {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.NESTED_SCHEMA, Collections.singletonList(nested.f1));
-		MessageType nestedType = schemaConverter.convert(TestUtil.NESTED_SCHEMA);
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = getNestedRecordTestData();
+		Path path = createTempParquetFile(tempRoot.newFolder(), NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), getConfiguration());
+		MessageType nestedType = getSchemaConverter().convert(NESTED_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, nestedType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = inputFormat.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -373,12 +376,13 @@ public class ParquetRowInputFormatTest {
 
 	@Test
 	public void testProjectedRowFromNestedRecord() throws Exception {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.NESTED_SCHEMA, Collections.singletonList(nested.f1));
-		MessageType nestedType = schemaConverter.convert(TestUtil.NESTED_SCHEMA);
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = getNestedRecordTestData();
+		Path path = createTempParquetFile(tempRoot.newFolder(), NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), getConfiguration());
+		MessageType nestedType = getSchemaConverter().convert(NESTED_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, nestedType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		inputFormat.selectFields(new String[]{"bar", "nestedMap"});
 
@@ -395,27 +399,29 @@ public class ParquetRowInputFormatTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidProjectionOfNestedRecord() throws Exception {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.NESTED_SCHEMA, Collections.singletonList(nested.f1));
-		MessageType nestedType = schemaConverter.convert(TestUtil.NESTED_SCHEMA);
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = getNestedRecordTestData();
+		Path path = createTempParquetFile(tempRoot.newFolder(), NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), getConfiguration());
+		MessageType nestedType = getSchemaConverter().convert(NESTED_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, nestedType);
-		inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		inputFormat.setRuntimeContext(getMockRuntimeContext());
 
 		inputFormat.selectFields(new String[]{"bar", "celona"});
 	}
 
 	@Test
 	public void testSerialization() throws Exception {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = TestUtil.getSimpleRecordTestData();
-		Path path = TestUtil.createTempParquetFile(tempRoot.newFolder(), TestUtil.SIMPLE_SCHEMA, Collections.singletonList(simple.f1));
-		MessageType simpleType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> simple = getSimpleRecordTestData();
+		Path path = createTempParquetFile(tempRoot.newFolder(), SIMPLE_SCHEMA,
+			Collections.singletonList(simple.f1), getConfiguration());
+		MessageType simpleType = getSchemaConverter().convert(SIMPLE_SCHEMA);
 
 		ParquetRowInputFormat inputFormat = new ParquetRowInputFormat(path, simpleType);
 		byte[] bytes = InstantiationUtil.serializeObject(inputFormat);
 		ParquetRowInputFormat copy = InstantiationUtil.deserializeObject(bytes, getClass().getClassLoader());
 
-		copy.setRuntimeContext(TestUtil.getMockRuntimeContext());
+		copy.setRuntimeContext(getMockRuntimeContext());
 
 		FileInputSplit[] splits = copy.createInputSplits(1);
 		assertEquals(1, splits.length);
@@ -425,5 +431,4 @@ public class ParquetRowInputFormatTest {
 		assertNotNull(row);
 		assertEquals(simple.f2, row);
 	}
-
 }

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.apache.flink.types.Row;
 
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.schema.MessageType;
 import org.junit.BeforeClass;
@@ -111,7 +112,7 @@ public class ParquetTableSourceITCase extends MultipleProgramsTestBase {
 	 */
 	private static Path createTestParquetFile(int numberOfRows) throws Exception {
 		List<IndexedRecord> records = TestUtil.createRecordList(numberOfRows);
-		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.NESTED_SCHEMA, records);
+		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.NESTED_SCHEMA, records, new Configuration());
 		return path;
 	}
 }

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.expressions.PlannerResolvedFieldReference;
 import org.apache.flink.types.Row;
 
 import org.apache.avro.specific.SpecificRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -64,7 +65,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test cases for {@link ParquetTableSource}.
  */
-public class ParquetTableSourceTest extends TestUtil {
+public class ParquetTableSourceTest {
 	private static final AvroSchemaConverter SCHEMA_CONVERTER = new AvroSchemaConverter();
 	private static Path testPath;
 
@@ -88,7 +89,7 @@ public class ParquetTableSourceTest extends TestUtil {
 		assertNotNull(returnType);
 		assertTrue(returnType instanceof RowTypeInfo);
 		RowTypeInfo rowType = (RowTypeInfo) returnType;
-		assertEquals(NESTED_ROW_TYPE, rowType);
+		assertEquals(TestUtil.NESTED_ROW_TYPE, rowType);
 	}
 
 	@Test
@@ -102,7 +103,7 @@ public class ParquetTableSourceTest extends TestUtil {
 		TableSchema schema = parquetTableSource.getTableSchema();
 		assertNotNull(schema);
 
-		RowTypeInfo expectedSchema = (RowTypeInfo) NESTED_ROW_TYPE;
+		RowTypeInfo expectedSchema = (RowTypeInfo) TestUtil.NESTED_ROW_TYPE;
 		assertArrayEquals(expectedSchema.getFieldNames(), schema.getFieldNames());
 		assertArrayEquals(expectedSchema.getFieldTypes(), schema.getFieldTypes());
 	}
@@ -121,8 +122,8 @@ public class ParquetTableSourceTest extends TestUtil {
 		// ensure that table source description differs
 		assertNotEquals(parquetTableSource.explainSource(), projected.explainSource());
 
-		String[] fieldNames = ((RowTypeInfo) NESTED_ROW_TYPE).getFieldNames();
-		TypeInformation[] fieldTypes =  ((RowTypeInfo) NESTED_ROW_TYPE).getFieldTypes();
+		String[] fieldNames = ((RowTypeInfo) TestUtil.NESTED_ROW_TYPE).getFieldNames();
+		TypeInformation[] fieldTypes =  ((RowTypeInfo) TestUtil.NESTED_ROW_TYPE).getFieldTypes();
 		assertEquals(
 			Types.ROW_NAMED(
 				new String[] {fieldNames[2], fieldNames[4], fieldNames[6]},
@@ -186,7 +187,7 @@ public class ParquetTableSourceTest extends TestUtil {
 		assertEquals(parquetTableSource.getTableSchema(), filtered.getTableSchema());
 
 		// ensure return type is identical
-		assertEquals(NESTED_ROW_TYPE, filtered.getReturnType());
+		assertEquals(TestUtil.NESTED_ROW_TYPE, filtered.getReturnType());
 
 		// ensure source description is not the same
 		assertNotEquals(parquetTableSource.explainSource(), filtered.explainSource());
@@ -217,14 +218,14 @@ public class ParquetTableSourceTest extends TestUtil {
 	}
 
 	private static Path createTestParquetFile() throws Exception {
-		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = getNestedRecordTestData();
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
-			Collections.singletonList(nested.f1));
+		Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> nested = TestUtil.getNestedRecordTestData();
+		Path path = TestUtil.createTempParquetFile(tempRoot.getRoot(), TestUtil.NESTED_SCHEMA,
+			Collections.singletonList(nested.f1), new Configuration());
 		return path;
 	}
 
 	private ParquetTableSource createNestedTestParquetTableSource(Path path) throws Exception {
-		MessageType nestedSchema = SCHEMA_CONVERTER.convert(NESTED_SCHEMA);
+		MessageType nestedSchema = SCHEMA_CONVERTER.convert(TestUtil.NESTED_SCHEMA);
 		ParquetTableSource parquetTableSource = ParquetTableSource.builder()
 			.path(path.getPath())
 			.forParquetSchema(nestedSchema)

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetRecordReaderTest.java
@@ -32,12 +32,13 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.ParquetReadOptions;
-import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.schema.MessageType;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,9 +55,14 @@ import static org.junit.Assert.assertTrue;
 /**
  * Simple test case for reading parquet records.
  */
+@RunWith(Parameterized.class)
 public class ParquetRecordReaderTest extends TestUtil {
 
 	private final Configuration testConfig = new Configuration();
+
+	public ParquetRecordReaderTest(boolean useLegacyMode) {
+		super(useLegacyMode);
+	}
 
 	@Test
 	public void testReadSimpleGroup() throws IOException {
@@ -66,8 +72,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("foo", 32L)
 			.set("arr", array).build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), SIMPLE_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), SIMPLE_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(SIMPLE_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -99,8 +106,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			records.add(record);
 		}
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), SIMPLE_SCHEMA, records);
-		MessageType readSchema = (new AvroSchemaConverter()).convert(SIMPLE_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(),
+			SIMPLE_SCHEMA, records, getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(SIMPLE_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -134,8 +142,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("bar", barRecord)
 			.build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -165,8 +174,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("spamMap", map.build())
 			.build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -207,8 +217,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("strArray", arrayString)
 			.build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -248,8 +259,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("nestedMap", map.build())
 			.set("foo", 34L).build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =
@@ -288,8 +300,9 @@ public class ParquetRecordReaderTest extends TestUtil {
 			.set("nestedArray", list.build())
 			.set("foo", 34L).build();
 
-		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA, Collections.singletonList(record));
-		MessageType readSchema = (new AvroSchemaConverter()).convert(NESTED_SCHEMA);
+		Path path = createTempParquetFile(tempRoot.getRoot(), NESTED_SCHEMA,
+			Collections.singletonList(record), getConfiguration());
+		MessageType readSchema = getSchemaConverter().convert(NESTED_SCHEMA);
 		ParquetRecordReader<Row> rowReader = new ParquetRecordReader<>(new RowReadSupport(), readSchema);
 
 		InputFile inputFile =

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Simple test case for conversion between Parquet schema and Flink date types.
  */
-public class ParquetSchemaConverterTest extends TestUtil {
+public class ParquetSchemaConverterTest {
 
 	private final Type[] simpleStandardTypes = {
 		org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.OPTIONAL)
@@ -73,11 +73,12 @@ public class ParquetSchemaConverterTest extends TestUtil {
 			.named("value"))
 			.named("nestedMap"),
 		org.apache.parquet.schema.Types.optionalGroup().addField(org.apache.parquet.schema.Types.repeatedGroup()
-			.addField(org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED)
-				.as(OriginalType.UTF8).named("type"))
-			.addField(org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
-				.as(OriginalType.INT_64).named("value"))
-			.named("element")).as(OriginalType.LIST)
+			.addField(org.apache.parquet.schema.Types.requiredGroup()
+				.addField(org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.REQUIRED)
+					.as(OriginalType.UTF8).named("type"))
+				.addField(org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
+					.as(OriginalType.INT_64).named("value"))
+				.named("element")).named("list")).as(OriginalType.LIST)
 			.named("nestedArray")
 	};
 
@@ -85,25 +86,25 @@ public class ParquetSchemaConverterTest extends TestUtil {
 	public void testSimpleSchemaConversion() {
 		MessageType simpleType = new MessageType("simple", simpleStandardTypes);
 		RowTypeInfo rowTypeInfo = (RowTypeInfo) ParquetSchemaConverter.fromParquetType(simpleType);
-		assertEquals(SIMPLE_ROW_TYPE, rowTypeInfo);
+		assertEquals(TestUtil.SIMPLE_ROW_TYPE, rowTypeInfo);
 	}
 
 	@Test
 	public void testNestedSchemaConversion() {
 		MessageType nestedTypes = new MessageType("nested", this.nestedTypes);
 		RowTypeInfo rowTypeInfo = (RowTypeInfo) ParquetSchemaConverter.fromParquetType(nestedTypes);
-		assertEquals(NESTED_ROW_TYPE, rowTypeInfo);
+		assertEquals(TestUtil.NESTED_ROW_TYPE, rowTypeInfo);
 	}
 
 	@Test
 	public void testSimpleRowTypeConversion() {
-		MessageType simpleSchema = ParquetSchemaConverter.toParquetType(SIMPLE_ROW_TYPE, true);
+		MessageType simpleSchema = ParquetSchemaConverter.toParquetType(TestUtil.SIMPLE_ROW_TYPE, false);
 		assertEquals(Arrays.asList(simpleStandardTypes), simpleSchema.getFields());
 	}
 
 	@Test
 	public void testNestedRowTypeConversion() {
-		MessageType nestedSchema = ParquetSchemaConverter.toParquetType(NESTED_ROW_TYPE, true);
+		MessageType nestedSchema = ParquetSchemaConverter.toParquetType(TestUtil.NESTED_ROW_TYPE, false);
 		assertEquals(Arrays.asList(nestedTypes), nestedSchema.getFields());
 	}
 }


### PR DESCRIPTION
# What is the purpose of the change
Fix the 3 level List handling in ParquetInputFormat

## Brief change log
1) Add the 3 level List schema conversion logic in ParquetSchemaConverter.
2) Update the ParquetRowInputFormatTest to generate 3 level List for end to end test.

## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as ParquetRowInputFormatTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
