### PR TITLE
[FLINK-20055] [runtime/config] - hide sensitive datadog API key from logs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -45,7 +45,7 @@ public final class GlobalConfiguration {
 
 	// the keys whose values should be hidden
 	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret",
-		"fs.azure.account.key", "metrics.reporter.dghttp.apikey"};
+		"fs.azure.account.key", "apikey"};
 
 	// the hidden content to be displayed
 	public static final String HIDDEN_CONTENT = "******";

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -44,7 +44,7 @@ public final class GlobalConfiguration {
 	public static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
 	// the keys whose values should be hidden
-	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret", 
+	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret",
 		"fs.azure.account.key", "metrics.reporter.dghttp.apikey"};
 
 	// the hidden content to be displayed

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -44,7 +44,8 @@ public final class GlobalConfiguration {
 	public static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
 	// the keys whose values should be hidden
-	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret", "fs.azure.account.key"};
+	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret", 
+		"fs.azure.account.key", "metrics.reporter.dghttp.apikey"};
 
 	// the hidden content to be displayed
 	public static final String HIDDEN_CONTENT = "******";

--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -44,8 +44,7 @@ public final class GlobalConfiguration {
 	public static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
 	// the keys whose values should be hidden
-	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret",
-		"fs.azure.account.key", "apikey"};
+	private static final String[] SENSITIVE_KEYS = new String[] {"password", "secret", "fs.azure.account.key", "apikey"};
 
 	// the hidden content to be displayed
 	public static final String HIDDEN_CONTENT = "******";

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -130,5 +130,6 @@ public class GlobalConfigurationTest extends TestLogger {
 		assertTrue(GlobalConfiguration.isSensitive("Secret"));
 		assertTrue(GlobalConfiguration.isSensitive("fs.azure.account.key.storageaccount123456.core.windows.net"));
 		assertFalse(GlobalConfiguration.isSensitive("Hello"));
+		assertTrue(GlobalConfiguration.isSensitive("metrics.reporter.dghttp.apikey"));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Add new entry to list of SENSITIVE configuration parameters, so that the Datadog API key is not leaked into logs.*

## Brief change log

  - *added `metrics.reporter.dghttp.apikey` to list of sensitive keys*

## Verifying this change

*This change added a new test and can be verified by starting a Flink cluster with config key `metrics.reporter.dghttp.apikey: XYZ` and observing in the log file that the sensitive value is not printed.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**