### PR TITLE
[FLINK-20062][hive] ContinuousHiveSplitEnumerator should be lock-free

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -144,8 +144,8 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 
 	private void handleNewSplits(NewSplitsAndState<T> newSplitsAndState, Throwable error) {
 		if (error != null) {
-			LOG.error("Failed to enumerate files", error);
-			return;
+			// we need to failover because the worker thread is stateful
+			throw new FlinkHiveException("Failed to enumerate files", error);
 		}
 		this.currentReadOffset = newSplitsAndState.offset;
 		this.seenPartitionsSinceOffset = newSplitsAndState.seenPartitions;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -68,7 +68,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 	private T currentReadOffset;
 	// the partitions that have been processed for the current read offset
 	private Collection<List<String>> seenPartitionsSinceOffset;
-	private final NewPartitionMonitor<T> monitor;
+	private final PartitionMonitor<T> monitor;
 
 	public ContinuousHiveSplitEnumerator(
 			SplitEnumeratorContext<HiveSourceSplit> enumeratorContext,
@@ -87,7 +87,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 		this.discoveryInterval = discoveryInterval;
 		this.fetcherContext = fetcherContext;
 		readersAwaitingSplit = new LinkedHashMap<>();
-		monitor = new NewPartitionMonitor<>(
+		monitor = new PartitionMonitor<>(
 				currentReadOffset, seenPartitionsSinceOffset, tablePath, jobConf, fetcher, fetcherContext);
 	}
 
@@ -169,7 +169,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 		}
 	}
 
-	private static class NewPartitionMonitor<T extends Comparable<T>> implements Callable<NewSplitsAndState<T>> {
+	private static class PartitionMonitor<T extends Comparable<T>> implements Callable<NewSplitsAndState<T>> {
 
 		// keep these locally so that we don't need to share state with main thread
 		private T currentReadOffset;
@@ -180,7 +180,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 		private final ContinuousPartitionFetcher<Partition, T> fetcher;
 		private final HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext;
 
-		NewPartitionMonitor(
+		private PartitionMonitor(
 				T currentReadOffset,
 				Collection<List<String>> seenPartitionsSinceOffset,
 				ObjectPath tablePath,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -48,8 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.Callable;
 
 /**
  * A continuously monitoring {@link SplitEnumerator} for hive source.
@@ -63,17 +62,13 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 	private final FileSplitAssigner splitAssigner;
 	private final long discoveryInterval;
 
-	private final JobConf jobConf;
-	private final ObjectPath tablePath;
-
-	private final ContinuousPartitionFetcher<Partition, T> fetcher;
 	private final HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext;
 
-	private final ReadWriteLock stateLock = new ReentrantReadWriteLock();
 	// the maximum partition read offset seen so far
-	private volatile T currentReadOffset;
+	private T currentReadOffset;
 	// the partitions that have been processed for the current read offset
-	private final Set<List<String>> seenPartitionsSinceOffset;
+	private Collection<List<String>> seenPartitionsSinceOffset;
+	private final NewPartitionMonitor<T> monitor;
 
 	public ContinuousHiveSplitEnumerator(
 			SplitEnumeratorContext<HiveSourceSplit> enumeratorContext,
@@ -87,14 +82,13 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 			HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext) {
 		this.enumeratorContext = enumeratorContext;
 		this.currentReadOffset = currentReadOffset;
-		this.seenPartitionsSinceOffset = new HashSet<>(seenPartitionsSinceOffset);
+		this.seenPartitionsSinceOffset = new ArrayList<>(seenPartitionsSinceOffset);
 		this.splitAssigner = splitAssigner;
 		this.discoveryInterval = discoveryInterval;
-		this.jobConf = jobConf;
-		this.tablePath = tablePath;
-		this.fetcher = fetcher;
 		this.fetcherContext = fetcherContext;
 		readersAwaitingSplit = new LinkedHashMap<>();
+		monitor = new NewPartitionMonitor<>(
+				currentReadOffset, seenPartitionsSinceOffset, tablePath, jobConf, fetcher, fetcherContext);
 	}
 
 	@Override
@@ -102,7 +96,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 		try {
 			fetcherContext.open();
 			enumeratorContext.callAsync(
-					this::monitorAndGetSplits,
+					monitor,
 					this::handleNewSplits,
 					discoveryInterval,
 					discoveryInterval);
@@ -125,12 +119,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 	@Override
 	public void addSplitsBack(List<HiveSourceSplit> splits, int subtaskId) {
 		LOG.debug("Continuous Hive Source Enumerator adds splits back: {}", splits);
-		stateLock.writeLock().lock();
-		try {
-			splitAssigner.addSplits(new ArrayList<>(splits));
-		} finally {
-			stateLock.writeLock().unlock();
-		}
+		splitAssigner.addSplits(new ArrayList<>(splits));
 	}
 
 	@Override
@@ -140,13 +129,8 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 
 	@Override
 	public PendingSplitsCheckpoint<HiveSourceSplit> snapshotState() throws Exception {
-		stateLock.readLock().lock();
-		try {
-			Collection<HiveSourceSplit> remainingSplits = (Collection<HiveSourceSplit>) (Collection<?>) splitAssigner.remainingSplits();
-			return new ContinuousHivePendingSplitsCheckpoint(remainingSplits, currentReadOffset, seenPartitionsSinceOffset);
-		} finally {
-			stateLock.readLock().unlock();
-		}
+		Collection<HiveSourceSplit> remainingSplits = (Collection<HiveSourceSplit>) (Collection<?>) splitAssigner.remainingSplits();
+		return new ContinuousHivePendingSplitsCheckpoint(remainingSplits, currentReadOffset, seenPartitionsSinceOffset);
 	}
 
 	@Override
@@ -158,12 +142,64 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 		}
 	}
 
-	private Void monitorAndGetSplits() throws Exception {
-		stateLock.writeLock().lock();
-		try {
+	private void handleNewSplits(NewSplitsAndState<T> newSplitsAndState, Throwable error) {
+		if (error != null) {
+			LOG.error("Failed to enumerate files", error);
+			return;
+		}
+		this.currentReadOffset = newSplitsAndState.offset;
+		this.seenPartitionsSinceOffset = newSplitsAndState.seenPartitions;
+		splitAssigner.addSplits(new ArrayList<>(newSplitsAndState.newSplits));
+		assignSplits();
+	}
+
+	private void assignSplits() {
+		final Iterator<Map.Entry<Integer, String>> awaitingReader = readersAwaitingSplit.entrySet().iterator();
+		while (awaitingReader.hasNext()) {
+			final Map.Entry<Integer, String> nextAwaiting = awaitingReader.next();
+			final String hostname = nextAwaiting.getValue();
+			final int awaitingSubtask = nextAwaiting.getKey();
+			final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+			if (nextSplit.isPresent()) {
+				enumeratorContext.assignSplit((HiveSourceSplit) nextSplit.get(), awaitingSubtask);
+				awaitingReader.remove();
+			} else {
+				break;
+			}
+		}
+	}
+
+	private static class NewPartitionMonitor<T extends Comparable<T>> implements Callable<NewSplitsAndState<T>> {
+
+		// keep these locally so that we don't need to share state with main thread
+		private T currentReadOffset;
+		private final Set<List<String>> seenPartitionsSinceOffset;
+
+		private final ObjectPath tablePath;
+		private final JobConf jobConf;
+		private final ContinuousPartitionFetcher<Partition, T> fetcher;
+		private final HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext;
+
+		NewPartitionMonitor(
+				T currentReadOffset,
+				Collection<List<String>> seenPartitionsSinceOffset,
+				ObjectPath tablePath,
+				JobConf jobConf,
+				ContinuousPartitionFetcher<Partition, T> fetcher,
+				HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext) {
+			this.currentReadOffset = currentReadOffset;
+			this.seenPartitionsSinceOffset = new HashSet<>(seenPartitionsSinceOffset);
+			this.tablePath = tablePath;
+			this.jobConf = jobConf;
+			this.fetcher = fetcher;
+			this.fetcherContext = fetcherContext;
+		}
+
+		@Override
+		public NewSplitsAndState<T> call() throws Exception {
 			List<Tuple2<Partition, T>> partitions = fetcher.fetchPartitions(fetcherContext, currentReadOffset);
 			if (partitions.isEmpty()) {
-				return null;
+				return new NewSplitsAndState<>(Collections.emptyList(), currentReadOffset, seenPartitionsSinceOffset);
 			}
 
 			partitions.sort(Comparator.comparing(o -> o.f1));
@@ -189,44 +225,26 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>> implements S
 				}
 			}
 			currentReadOffset = maxOffset;
-			splitAssigner.addSplits(new ArrayList<>(newSplits));
 			if (!nextSeen.isEmpty()) {
 				seenPartitionsSinceOffset.clear();
 				seenPartitionsSinceOffset.addAll(nextSeen);
 			}
-			return null;
-		} finally {
-			stateLock.writeLock().unlock();
+			return new NewSplitsAndState<>(newSplits, currentReadOffset, seenPartitionsSinceOffset);
 		}
 	}
 
-	private void handleNewSplits(Void v, Throwable error) {
-		if (error != null) {
-			LOG.error("Failed to enumerate files", error);
-			return;
-		}
-		assignSplits();
-	}
+	/**
+	 * The result passed from monitor thread to main thread.
+	 */
+	private static class NewSplitsAndState<T extends Comparable<T>> {
+		private final T offset;
+		private final Collection<List<String>> seenPartitions;
+		private final Collection<HiveSourceSplit> newSplits;
 
-	private void assignSplits() {
-		final Iterator<Map.Entry<Integer, String>> awaitingReader = readersAwaitingSplit.entrySet().iterator();
-
-		stateLock.writeLock().lock();
-		try {
-			while (awaitingReader.hasNext()) {
-				final Map.Entry<Integer, String> nextAwaiting = awaitingReader.next();
-				final String hostname = nextAwaiting.getValue();
-				final int awaitingSubtask = nextAwaiting.getKey();
-				final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
-				if (nextSplit.isPresent()) {
-					enumeratorContext.assignSplit((HiveSourceSplit) nextSplit.get(), awaitingSubtask);
-					awaitingReader.remove();
-				} else {
-					break;
-				}
-			}
-		} finally {
-			stateLock.writeLock().unlock();
+		private NewSplitsAndState(Collection<HiveSourceSplit> newSplits, T offset, Collection<List<String>> seenPartitions) {
+			this.newSplits = newSplits;
+			this.offset = offset;
+			this.seenPartitions = new ArrayList<>(seenPartitions);
 		}
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make `ContinuousHiveSplitEnumerator` lock-free.


## Brief change log

  - Implement a callable for the monitor thread which keeps local state. Each time the monitor is run, it returns state and new splits to main thread. Main thread can therefore update its own state.


## Verifying this change

Existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
