### PR TITLE
[FLINK-20045][tests] Let TestingLeaderEelctionEventHandler wait until being initialized

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Consumer;
 
 /**
  * {@link LeaderElectionEventHandler} implementation which provides some convenience functions for testing
@@ -28,41 +33,64 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase impleme
 
 	private final LeaderInformation leaderInformation;
 
-	private LeaderInformation confirmedLeaderInformation = LeaderInformation.empty();
+	private final OneShotLatch initializationLatch;
 
-	private LeaderElectionDriver leaderElectionDriver = null;
+	@Nullable
+	private LeaderElectionDriver initializedLeaderElectionDriver = null;
+
+	private LeaderInformation confirmedLeaderInformation = LeaderInformation.empty();
 
 	public TestingLeaderElectionEventHandler(LeaderInformation leaderInformation) {
 		this.leaderInformation = leaderInformation;
+		this.initializationLatch = new OneShotLatch();
 	}
 
 	public void init(LeaderElectionDriver leaderElectionDriver) {
-		this.leaderElectionDriver = leaderElectionDriver;
+		Preconditions.checkState(initializedLeaderElectionDriver == null);
+		this.initializedLeaderElectionDriver = leaderElectionDriver;
+		initializationLatch.trigger();
 	}
 
 	@Override
 	public void onGrantLeadership() {
-		if (leaderElectionDriver == null) {
-			throw new FlinkRuntimeException("init() should be called first.");
-		}
-		confirmedLeaderInformation = leaderInformation;
-		leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
-		leaderEventQueue.offer(confirmedLeaderInformation);
+		waitForInitialization(
+			leaderElectionDriver -> {
+				confirmedLeaderInformation = leaderInformation;
+				leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
+				leaderEventQueue.offer(confirmedLeaderInformation);
+			});
 	}
 
 	@Override
 	public void onRevokeLeadership() {
-		confirmedLeaderInformation = LeaderInformation.empty();
-		leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
-		leaderEventQueue.offer(confirmedLeaderInformation);
+		waitForInitialization(
+			(leaderElectionDriver) -> {
+				confirmedLeaderInformation = LeaderInformation.empty();
+				leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
+				leaderEventQueue.offer(confirmedLeaderInformation);
+			});
 	}
 
 	@Override
 	public void onLeaderInformationChange(LeaderInformation leaderInformation) {
-		if (confirmedLeaderInformation.getLeaderSessionID() != null &&
-			!this.confirmedLeaderInformation.equals(leaderInformation)) {
-			leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
+		waitForInitialization(
+			leaderElectionDriver -> {
+				if (confirmedLeaderInformation.getLeaderSessionID() != null &&
+					!this.confirmedLeaderInformation.equals(leaderInformation)) {
+					leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
+				}
+			});
+	}
+
+	private void waitForInitialization(Consumer<? super LeaderElectionDriver> operation) {
+		try {
+			initializationLatch.await();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
+
+		Preconditions.checkState(initializedLeaderElectionDriver != null);
+		operation.accept(initializedLeaderElectionDriver);
 	}
 
 	public LeaderInformation getConfirmedLeaderInformation() {


### PR DESCRIPTION
## What is the purpose of the change

The commit changes hte behaviour of the TestingLeaderElectionEventHandler so that it waits
on being initialized before executing callbacks.

cc @wangyang0918 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no**/ don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
