### PR TITLE
[FLINK-20050][runtime/operator] Fix methods that are only visible for…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -131,12 +131,14 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	// ---------------------
 
 	@VisibleForTesting
-	public OperatorCoordinator getInternalCoordinator() {
+	public OperatorCoordinator getInternalCoordinator() throws Exception {
+		waitForAllAsyncCallsFinish();
 		return coordinator.internalCoordinator;
 	}
 
 	@VisibleForTesting
-	QuiesceableContext getQuiesceableContext() {
+	QuiesceableContext getQuiesceableContext() throws Exception {
+		waitForAllAsyncCallsFinish();
 		return coordinator.internalQuiesceableContext;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -239,7 +239,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 		return (RecreateOnResetOperatorCoordinator) provider.create(context);
 	}
 
-	private TestingOperatorCoordinator getInternalCoordinator(RecreateOnResetOperatorCoordinator coordinator) {
+	private TestingOperatorCoordinator getInternalCoordinator(RecreateOnResetOperatorCoordinator coordinator) throws Exception {
 		return (TestingOperatorCoordinator) coordinator.getInternalCoordinator();
 	}
 


### PR DESCRIPTION
… testing in RecreateOnResetOperatorCoordinator, so that they work with fully asynchronous thread model.

## What is the purpose of the change
In #13574 we made `RecreateOnResetOperatorCoordinator` fully asynchronous. However, the methods that are visible only for testing were not changed accordingly, which caused the occasional test failures. This patch fixes these methods.


## Brief change log
7ccbb78b03b Fix the methods in `RecreateOnResetOperatorCoordinator` so they work with the fully asynchronous thread model.

## Verifying this change
Looped to run the tests for over 1000 times and did not see a failure. Prior to the fix, it fails within 3 runs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
