### PR TITLE
[FLINK-20063][connector files] FileSourceReader request only a split if it doesn't have one already

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -236,6 +236,17 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 		splitFetcherManager.close(options.sourceReaderCloseTimeout);
 	}
 
+	/**
+	 * Gets the number of splits the reads has currently assigned.
+	 *
+	 * <p>These are the splits that have been added via {@link #addSplits(List)} and have not
+	 * yet been finished by returning them from the {@link SplitReader#fetch()} as part of
+	 * {@link RecordsWithSplitIds#finishedSplits()}.
+	 */
+	public int getNumberOfCurrentlyAssignedSplits() {
+		return splitStates.size();
+	}
+
 	// -------------------- Abstract method to allow different implementations ------------------
 	/**
 	 * Handles the finished splits to clean the state if needed.

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -21,8 +21,6 @@ package org.apache.flink.connector.base.source.reader;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
-import org.apache.flink.api.connector.source.mocks.TestingReaderContext;
-import org.apache.flink.api.connector.source.mocks.TestingReaderOutput;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
@@ -34,6 +32,8 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
 
 import org.junit.Rule;

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -85,6 +85,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -47,7 +47,10 @@ public final class FileSourceReader<T, SplitT extends FileSourceSplit>
 
 	@Override
 	public void start() {
-		context.sendSplitRequest();
+		// we request a split only if we did not get splits during the checkpoint restore
+		if (getNumberOfCurrentlyAssignedSplits() == 0) {
+			context.sendSplitRequest();
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileSourceReaderTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/FileSourceReaderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.impl;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.reader.TextLineFormat;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for the {@link FileSourceReader}.
+ */
+public class FileSourceReaderTest {
+
+	@ClassRule
+	public static final TemporaryFolder TMP_DIR = new TemporaryFolder();
+
+	@Test
+	public void testRequestSplitWhenNoSplitRestored() throws Exception {
+		final TestingReaderContext context = new TestingReaderContext();
+		final FileSourceReader<String, FileSourceSplit> reader = createReader(context);
+
+		reader.start();
+		reader.close();
+
+		assertEquals(1, context.getNumSplitRequests());
+	}
+
+	@Test
+	public void testNoSplitRequestWhenSplitRestored() throws Exception {
+		final TestingReaderContext context = new TestingReaderContext();
+		final FileSourceReader<String, FileSourceSplit> reader = createReader(context);
+
+		reader.addSplits(Collections.singletonList(createTestFileSplit()));
+		reader.start();
+		reader.close();
+
+		assertEquals(0, context.getNumSplitRequests());
+	}
+
+	private static FileSourceReader<String, FileSourceSplit> createReader(TestingReaderContext context) {
+		return new FileSourceReader<>(
+				context,
+				new StreamFormatAdapter<>(new TextLineFormat()),
+				new Configuration());
+	}
+
+	private static FileSourceSplit createTestFileSplit() throws IOException {
+		return new FileSourceSplit(
+			"test-id",
+			Path.fromLocalFile(TMP_DIR.newFile()),
+			0L,
+			0L);
+	}
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.connector.source.mocks;
+package org.apache.flink.connector.testutils.source.reader;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReaderContext;
@@ -37,6 +37,8 @@ public class TestingReaderContext implements SourceReaderContext {
 	private final Configuration config;
 
 	private final ArrayList<SourceEvent> sentEvents = new ArrayList<>();
+
+	private int numSplitRequests;
 
 	public TestingReaderContext() {
 		this(new Configuration());
@@ -69,7 +71,9 @@ public class TestingReaderContext implements SourceReaderContext {
 	}
 
 	@Override
-	public void sendSplitRequest() {}
+	public void sendSplitRequest() {
+		numSplitRequests++;
+	}
 
 	@Override
 	public void sendSourceEventToCoordinator(SourceEvent sourceEvent) {
@@ -77,6 +81,10 @@ public class TestingReaderContext implements SourceReaderContext {
 	}
 
 	// ------------------------------------------------------------------------
+
+	public int getNumSplitRequests() {
+		return numSplitRequests;
+	}
 
 	public List<SourceEvent> getSentEvents() {
 		return new ArrayList<>(sentEvents);

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderOutput.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderOutput.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.api.connector.source.mocks;
+package org.apache.flink.connector.testutils.source.reader;
 
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.ReaderOutput;


### PR DESCRIPTION
## What is the purpose of the change

Fixes a bug where the FileSourceReader reader increases its split backlog size by one, causing problems for balanced split assignments.

With this change, the reader only requests a split when it did not yet have one from a checkpoint restore.

## Verifying this change

Adds the unit test `FileSourceReaderTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
