### PR TITLE
[FLINK-19945][Connectors / FileSystem]Support sink parallelism config…

### DIFF
--- a/docs/dev/table/connectors/filesystem.md
+++ b/docs/dev/table/connectors/filesystem.md
@@ -274,7 +274,7 @@ public class HourPartTimeExtractor implements PartitionTimeExtractor {
 The partition commit policy defines what action is taken when partitions are committed. 
 
 - The first is metastore, only hive table supports metastore policy, file system manages partitions through directory structure.
-- The second is the success file, which will write an empty file in the directory corresponding to the partition.
+- The second is the success file, which will write an empty file in the directory corresponding to the partition. 
 
 <table class="table table-bordered">
   <thead>
@@ -334,6 +334,35 @@ public class AnalysisCommitPolicy implements PartitionCommitPolicy {
 }
 
 {% endhighlight %}
+</div>
+</div>
+
+### Sink Parallelism
+
+The parallelism of writing files into external file system can be configured by corresponding table option. By default, the parallelism is configured to being the same as the parallelism of its last upstream chained operator.
+
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+        <th class="text-left" style="width: 20%">Key</th>
+        <th class="text-left" style="width: 15%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 55%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><h5>sink.parallelism</h5></td>
+        <td style="word-wrap: break-word;">(none)</td>
+        <td>Integer</td>
+        <td>Parallelism of writing files into external file system. The value should greater than zero otherwise exception will be thrown.</td>
+    </tr>
+    
+  </tbody>
+</table>
+
+
 </div>
 </div>
 

--- a/docs/dev/table/connectors/filesystem.zh.md
+++ b/docs/dev/table/connectors/filesystem.zh.md
@@ -337,6 +337,35 @@ public class AnalysisCommitPolicy implements PartitionCommitPolicy {
 </div>
 </div>
 
+### Sink Parallelism
+
+The parallelism of writing files into external file system can be configured by corresponding table option. By default, the parallelism is configured to being the same as the parallelism of its last upstream chained operator.
+
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+        <th class="text-left" style="width: 20%">Key</th>
+        <th class="text-left" style="width: 15%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 55%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><h5>sink.parallelism</h5></td>
+        <td style="word-wrap: break-word;">(none)</td>
+        <td>Integer</td>
+        <td>Parallelism of writing files into external file system. The value should greater than zero otherwise exception will be thrown.</td>
+    </tr>
+    
+  </tbody>
+</table>
+
+
+</div>
+</div>
+
 ## Full Example
 
 The below shows how the file system connector can be used to write a streaming query to write data from Kafka into a file system and runs a batch query to read that data back out. 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -262,6 +262,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
 		}
 
 		long bucketCheckInterval = conf.get(SINK_ROLLING_POLICY_CHECK_INTERVAL).toMillis();
+		//todo HIVE sink parallelism support
+		int parallelism = dataStream.getParallelism();
 
 		DataStream<PartitionCommitInfo> writerStream;
 		if (autoCompaction) {
@@ -277,10 +279,11 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
 					fsFactory(),
 					path,
 					createCompactReaderFactory(sd, tableProps),
-					compactionSize);
+					compactionSize,
+					parallelism);
 		} else {
 			writerStream = StreamingSink.writer(
-					dataStream, bucketCheckInterval, builder);
+					dataStream, bucketCheckInterval, builder, parallelism);
 		}
 
 		return StreamingSink.sink(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.filesystem;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.table.factories.FactoryUtil;
 
 import java.time.Duration;
 
@@ -215,4 +216,6 @@ public class FileSystemOptions {
 					.memoryType()
 					.noDefaultValue()
 					.withDescription("The compaction target file size, the default value is the rolling file size.");
+
+	public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -109,6 +109,7 @@ public class FileSystemTableFactory implements
 		options.add(FileSystemOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
 		options.add(FileSystemOptions.AUTO_COMPACTION);
 		options.add(FileSystemOptions.COMPACTION_FILE_SIZE);
+		options.add(FileSystemOptions.SINK_PARALLELISM);
 		return options;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingSink.java
@@ -63,14 +63,15 @@ public class StreamingSink {
 			DataStream<T> inputStream,
 			long bucketCheckInterval,
 			StreamingFileSink.BucketsBuilder<T, String, ? extends
-					StreamingFileSink.BucketsBuilder<T, String, ?>> bucketsBuilder) {
+					StreamingFileSink.BucketsBuilder<T, String, ?>> bucketsBuilder,
+			int parallelism) {
 		StreamingFileWriter<T> fileWriter = new StreamingFileWriter<>(
 				bucketCheckInterval,
 				bucketsBuilder);
 		return inputStream.transform(
 				StreamingFileWriter.class.getSimpleName(),
 				TypeInformation.of(PartitionCommitInfo.class),
-				fileWriter).setParallelism(inputStream.getParallelism());
+				fileWriter).setParallelism(parallelism);
 	}
 
 	/**
@@ -85,7 +86,8 @@ public class StreamingSink {
 			FileSystemFactory fsFactory,
 			Path path,
 			CompactReader.Factory<T> readFactory,
-			long targetFileSize) {
+			long targetFileSize,
+			int parallelism) {
 		CompactFileWriter<T> writer = new CompactFileWriter<>(bucketCheckInterval, bucketsBuilder);
 
 		SupplierWithException<FileSystem, IOException> fsSupplier =
@@ -99,7 +101,7 @@ public class StreamingSink {
 						"streaming-writer",
 						TypeInformation.of(CoordinatorInput.class),
 						writer)
-				.setParallelism(inputStream.getParallelism())
+				.setParallelism(parallelism)
 				.transform(
 						"compact-coordinator",
 						TypeInformation.of(CoordinatorOutput.class),

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSinkTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSinkTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test for {@link FileSystemTableSink}.
+ */
+public class FileSystemTableSinkTest {
+
+	private static final TableSchema TEST_SCHEMA = TableSchema.builder()
+		.field("f0", DataTypes.STRING())
+		.field("f1", DataTypes.BIGINT())
+		.field("f2", DataTypes.BIGINT())
+		.build();
+
+	@Test
+	public void testFileSystemTableSinkWithParallelismInStreaming() {
+
+		int parallelism = 2;
+
+		DescriptorProperties descriptor = new DescriptorProperties();
+		descriptor.putString(FactoryUtil.CONNECTOR.key(), "filesystem");
+		descriptor.putString("path", "/tmp");
+		descriptor.putString("format", "testcsv");
+		descriptor.putString("sink.parallelism", String.valueOf(parallelism));
+
+		final DynamicTableSink tableSink = createSink(descriptor);
+		Assert.assertTrue(tableSink instanceof FileSystemTableSink);
+
+		final DynamicTableSink.SinkRuntimeProvider provider = tableSink.getSinkRuntimeProvider
+			(new MockSinkContext(false));
+		Assert.assertTrue(provider instanceof DataStreamSinkProvider);
+
+		final DataStreamSinkProvider dataStreamSinkProvider = (DataStreamSinkProvider) provider;
+		final DataStreamSink<?> dataStreamSink = dataStreamSinkProvider.consumeDataStream(createInputDataStream());
+		final List<Transformation<?>> inputs = dataStreamSink.getTransformation().getInputs();
+		Assert.assertTrue(inputs.get(0).getParallelism() == parallelism);
+	}
+
+	@Test
+	public void testFileSystemTableSinkWithParallelismInBatch() {
+
+		int parallelism = 2;
+
+		DescriptorProperties descriptor = new DescriptorProperties();
+		descriptor.putString(FactoryUtil.CONNECTOR.key(), "filesystem");
+		descriptor.putString("path", "/tmp");
+		descriptor.putString("format", "testcsv");
+		descriptor.putString("sink.parallelism", String.valueOf(parallelism));
+
+		final DynamicTableSink tableSink = createSink(descriptor);
+		Assert.assertTrue(tableSink instanceof FileSystemTableSink);
+
+		final DynamicTableSink.SinkRuntimeProvider provider = tableSink.getSinkRuntimeProvider
+			(new MockSinkContext(true));
+		Assert.assertTrue(provider instanceof DataStreamSinkProvider);
+
+		final DataStreamSinkProvider dataStreamSinkProvider = (DataStreamSinkProvider) provider;
+		final DataStreamSink<?> dataStreamSink = dataStreamSinkProvider.consumeDataStream(createInputDataStream());
+		Assert.assertTrue(dataStreamSink.getTransformation().getParallelism() == parallelism);
+	}
+
+	private static DataStream<RowData> createInputDataStream() {
+		final MockTransformation<RowData> mockTransformation = MockTransformation.createMockTransformation();
+		final DummyStreamExecutionEnvironment mockEnv = new DummyStreamExecutionEnvironment();
+
+		return new DataStream<>(mockEnv, mockTransformation);
+	}
+
+	private static DynamicTableSink createSink(DescriptorProperties properties) {
+		return FactoryUtil.createTableSink(
+			null,
+			ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
+			new CatalogTableImpl(TEST_SCHEMA, properties.asMap(), ""),
+			new Configuration(),
+			Thread.currentThread().getContextClassLoader(),
+			false);
+	}
+
+	private static class MockSinkContext implements DynamicTableSink.Context {
+
+		private final boolean bounded;
+
+		public MockSinkContext(boolean bounded) {
+			this.bounded = bounded;
+		}
+
+		@Override
+		public boolean isBounded() {
+			return bounded;
+		}
+
+		@Override
+		public TypeInformation<?> createTypeInformation(DataType consumedDataType) {
+			return null;
+		}
+
+		@Override
+		public DynamicTableSink.DataStructureConverter createDataStructureConverter(DataType consumedDataType) {
+			return null;
+		}
+	}
+
+	private static class MockTransformation<T> extends Transformation<T> {
+
+		public static MockTransformation<RowData> createMockTransformation() {
+			final InternalTypeInfo<RowData> typeInfo = InternalTypeInfo.of(TEST_SCHEMA.toPhysicalRowDataType().getLogicalType());
+			return new MockTransformation<RowData>(typeInfo);
+		}
+
+		public MockTransformation(TypeInformation<T> typeInfo) {
+			super("MockTransform", typeInfo, 1);
+		}
+
+		@Override
+		public List<Transformation<?>> getTransitivePredecessors() {
+			return null;
+		}
+
+		@Override
+		public List<Transformation<?>> getInputs() {
+			return Collections.emptyList();
+		}
+	}
+
+	private static class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
+
+		@Override
+		public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
…uration to FileSystem connector

## What is the purpose of the change

give user access to configuring the sink parallelism of FileSystem.


## Brief change log

-  add SINK_PARALLELISM into optionalOptions of `FileSystemTableFactory`
-  configure parallelism of writing file transformation both in streaming and batch in `FileSystemTableSink`
-  update docs, introducing sink.parallelism

## Verifying this change
This change added tests and can be verified as follows:
- `FileSystemTableSinkTest` ensure the configured parallelism is applied
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( docs)
