### PR TITLE
[FLINK-20013][network] BoundedBlockingSubpartition may leak network buffer if task is failed or canceled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -199,6 +200,10 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 			isReleased = true;
 			isFinished = true; // for fail fast writes
 
+			if (currentBuffer != null) {
+				currentBuffer.close();
+				currentBuffer = null;
+			}
 			checkReaderReferencesAndDispose();
 		}
 	}
@@ -243,6 +248,11 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 		if (readers.isEmpty()) {
 			data.close();
 		}
+	}
+
+	@VisibleForTesting
+	public BufferConsumer getCurrentBuffer() {
+		return currentBuffer;
 	}
 
 	// ---------------------------- statistics --------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import org.junit.AfterClass;
@@ -43,6 +44,9 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -115,6 +119,34 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 		bbspr.releaseAllResources();
 
 		assertTrue(reader.closed);
+	}
+
+	@Test
+	public void testRecycleCurrentBufferOnFailure() throws Exception {
+		final ResultPartition resultPartition = createPartition(ResultPartitionType.BLOCKING, fileChannelManager);
+		final BoundedBlockingSubpartition subpartition = new BoundedBlockingSubpartition(
+				0,
+				resultPartition,
+				new FailingBoundedData(),
+				!sslEnabled && type == BoundedBlockingSubpartitionType.FILE);
+		final BufferConsumer consumer = BufferBuilderTestUtils.createFilledFinishedBufferConsumer(100);
+
+		try {
+			try {
+				subpartition.add(consumer);
+				subpartition.createReadView(new NoOpBufferAvailablityListener());
+				fail("should fail with an exception");
+			} catch (Exception ignored) {
+				// expected
+			}
+
+			assertNotNull(subpartition.getCurrentBuffer());
+			assertFalse(subpartition.getCurrentBuffer().isRecycled());
+		} finally {
+			subpartition.release();
+
+			assertNull(subpartition.getCurrentBuffer());
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionTest.java
@@ -140,10 +140,14 @@ public class BoundedBlockingSubpartitionTest extends SubpartitionTestBase {
 				// expected
 			}
 
+			assertFalse(consumer.isRecycled());
+
 			assertNotNull(subpartition.getCurrentBuffer());
 			assertFalse(subpartition.getCurrentBuffer().isRecycled());
 		} finally {
 			subpartition.release();
+
+			assertTrue(consumer.isRecycled());
 
 			assertNull(subpartition.getCurrentBuffer());
 		}


### PR DESCRIPTION
## What is the purpose of the change

*`BoundedBlockingSubpartition` may leak network buffer if task is failed or canceled. `BoundedBlockingSubpartition` needs to add the close of current buffer to recycle the current BufferConsumer when task is failed or canceled.*

## Brief change log

  - *`BoundedBlockingSubpartition#close()` adds the close of the current BufferConsumer for recycle to avoid network buffer leakage.*

## Verifying this change

  - *`BoundedBlockingSubpartitionTest` adds `testRecycleCurrentBufferOnFailure` test method to verify the test case whether to recycle the current BufferConsumer when task is failed or canceled.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)