### PR TITLE
[FLINK-19253][connectors/common] Synchronize setting the SplitFetcher isIdle flag

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -26,6 +26,8 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,9 +56,12 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	private final FetchTask<E, SplitT> fetchTask;
 	private volatile SplitFetcherTask runningTask = null;
 
+	private final Object lock = new Object();
+
 	/** Flag whether this fetcher has no work assigned at the moment.
 	 * Fetcher that have work (a split) assigned but are currently blocked (for example enqueueing
 	 * a fetch and hitting the element queue limit) are NOT considered idle. */
+	@GuardedBy("lock")
 	private volatile boolean isIdle;
 
 	SplitFetcher(
@@ -162,8 +167,10 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	}
 
 	public void enqueueTask(SplitFetcherTask task) {
-		isIdle = false;
-		taskQueue.offer(task);
+		synchronized (lock) {
+			taskQueue.offer(task);
+			isIdle = false;
+		}
 	}
 
 	public SplitReader<E, SplitT> getSplitReader() {
@@ -285,14 +292,21 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	}
 
 	private void checkAndSetIdle() {
-		final boolean nowIdle = assignedSplits.isEmpty() && taskQueue.isEmpty();
-		if (nowIdle) {
-			isIdle = true;
+		if (shouldIdle()) {
+			synchronized (lock) {
+				if (shouldIdle()) {
+					isIdle = true;
+				}
+			}
 
 			// because the method might get invoked past the point when the source reader last checked
 			// the elements queue, we need to notify availability in the case when we become idle
 			elementsQueue.notifyAvailable();
 		}
+	}
+
+	private boolean shouldIdle() {
+		return assignedSplits.isEmpty() && taskQueue.isEmpty();
 	}
 
 	//--------------------- Helper class ------------------

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -157,7 +157,6 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	 * @param splitsToAdd the splits to add.
 	 */
 	public void addSplits(List<SplitT> splitsToAdd) {
-		isIdle = false; // in case we were idle before
 		enqueueTask(new AddSplitsTask<>(splitReader, splitsToAdd, assignedSplits));
 		wakeUp(true);
 	}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -20,8 +20,10 @@ package org.apache.flink.connector.base.source.reader;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
 import org.apache.flink.connector.base.source.reader.mocks.PassThroughRecordEmitter;
@@ -45,7 +47,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -82,7 +87,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 				public void wakeUp() {}
 
 				@Override
-				public void close() throws Exception {}
+				public void close() {}
 			},
 			getConfig(),
 			null)) {
@@ -255,13 +260,13 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
 		final SourceReader<E, TestingSourceSplit> reader = new SingleThreadMultiplexSourceReaderBase<E, E, TestingSourceSplit, TestingSourceSplit>(
 			elementsQueue,
-			() -> new TestingSplitReader<E, TestingSourceSplit>(records),
-			new PassThroughRecordEmitter<E, TestingSourceSplit>(),
+			() -> new TestingSplitReader<>(records),
+			new PassThroughRecordEmitter<>(),
 			new Configuration(),
 			new TestingReaderContext()) {
 
 			@Override
-			public void notifyCheckpointComplete(long checkpointId) throws Exception {}
+			public void notifyCheckpointComplete(long checkpointId) {}
 
 			@Override
 			protected void onSplitFinished(Collection<String> finishedSplitIds) {}
@@ -285,5 +290,72 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 		reader.isAvailable().get();
 
 		return reader;
+	}
+
+	@Test
+	public void pollNextReturnMoreAvailableWhenAllSplitFetcherCloseWithLeftoverElementInQueue()
+		throws Exception {
+
+		FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
+			new FutureCompletingBlockingQueue<>();
+		MockSplitReader mockSplitReader =
+			new MockSplitReader(1, true);
+		BlockingShutdownSplitFetcherManager<int[], MockSourceSplit> splitFetcherManager =
+			new BlockingShutdownSplitFetcherManager<>(elementsQueue, () -> mockSplitReader);
+		final MockSourceReader sourceReader = new MockSourceReader(
+			elementsQueue,
+			splitFetcherManager,
+			getConfig(),
+			null);
+
+		// Create and add a split that only contains one record
+		final MockSourceSplit split = new MockSourceSplit(0, 0, 1);
+		sourceReader.addSplits(Collections.singletonList(split));
+		sourceReader.notifyNoMoreSplits();
+
+		// Add the last record to the split when the splitFetcherManager shutting down SplitFetchers
+		splitFetcherManager.getInShutdownSplitFetcherFuture().thenRun(() -> split.addRecord(1));
+		assertEquals(InputStatus.MORE_AVAILABLE,
+			sourceReader.pollNext(new TestingReaderOutput<>()));
+	}
+
+	/**
+	 * When maybeShutdownFinishedFetchers is invoke, BlockingShutdownSplitFetcherManager
+	 * will complete the inShutdownSplitFetcherFuture and ensures that all the split fetchers
+	 * are shutdown.
+	 */
+	static class BlockingShutdownSplitFetcherManager<E, SplitT extends SourceSplit>
+		extends SingleThreadFetcherManager<E, SplitT> {
+
+		private final CompletableFuture<Void> inShutdownSplitFetcherFuture;
+
+		public BlockingShutdownSplitFetcherManager(
+			FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+			Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
+			super(elementsQueue, splitReaderSupplier);
+			this.inShutdownSplitFetcherFuture = new CompletableFuture<>();
+		}
+
+		@Override
+		public boolean maybeShutdownFinishedFetchers() {
+			shutdownAllSplitFetcher();
+			return true;
+		}
+
+		public CompletableFuture<Void> getInShutdownSplitFetcherFuture() {
+			return inShutdownSplitFetcherFuture;
+		}
+
+		private void shutdownAllSplitFetcher() {
+			inShutdownSplitFetcherFuture.complete(null);
+			while (!super.maybeShutdownFinishedFetchers()) {
+				try {
+					// avoid tight loop
+					Thread.sleep(1);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+		}
 	}
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
@@ -41,6 +42,13 @@ public class MockSourceReader
 							Configuration config,
 							SourceReaderContext context) {
 		super(elementsQueue, splitFetcherSupplier, new MockRecordEmitter(), config, context);
+	}
+
+	public MockSourceReader(FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
+							SingleThreadFetcherManager<int[], MockSourceSplit> splitSplitFetcherManager,
+							Configuration config,
+							SourceReaderContext context) {
+		super(elementsQueue, splitSplitFetcherManager, new MockRecordEmitter(), config, context);
 	}
 
 	@Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, there exists a race condition on setting the SplitFetcher isIdle flag. 
It occurs when one thread executing the SplitFetcher#checkAndSetIdle method and the other thread adding split to the SplitFetcher with SplitFetcher#addSplits. i.e., the checkAndSetIdle first check if it should go to idle and set the isIdle flag. Between these two steps, another thread could call the addSplits, which put a new task into the taskQueue and set the isIdle flag to false. Then, the first thread set the isIdle flag to true.

This PR synchronize setting the isIdle flag.

## Brief change log

- Remove redundant on setting the idIdle flag
- Synchronize setting the isIdle flag


## Verifying this change
  - Add a Thread.sleep before setting the isIdle flag in SplitFetcher#checkAndSetIdle, run the testAddSplitToExistingFetcher 1000 times without hanging. Before the fix, it hangs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicabled)
