### PR TITLE
[FLINK-10274][flink-core]Add `env.pid.dir` configuration to CoreOptions

### DIFF
--- a/docs/_includes/generated/environment_configuration.html
+++ b/docs/_includes/generated/environment_configuration.html
@@ -63,6 +63,12 @@
             <td>The maximum number of old log files to keep.</td>
         </tr>
         <tr>
+            <td><h5>env.pid.dir</h5></td>
+            <td style="word-wrap: break-word;">"/tmp"</td>
+            <td>String</td>
+            <td>Defines the directory where the flink-&lt;host&gt;-&lt;process&gt;.pid files are saved.</td>
+        </tr>
+        <tr>
             <td><h5>env.ssh.opts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -15,12 +15,6 @@
             <td>If configured, Flink will add this key to the resource profile of container request to Yarn. The value will be set to the value of external-resource.&lt;resource_name&gt;.amount.</td>
         </tr>
         <tr>
-            <td><h5>yarn.security.kerberos.additionalFileSystems</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>List&lt;String&gt;</td>
-            <td>A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.</td>
-        </tr>
-        <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
@@ -127,6 +121,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
             <td>A semicolon-separated list of provided lib directories. They should be pre-uploaded and world-readable. Flink will use them to exclude the local Flink jars(e.g. flink-dist, lib/, plugins/)uploading to accelerate the job submission process. Also YARN will cache them on the nodes so that they doesn't need to be downloaded every time for each application. An example could be hdfs://$namenode_address/path/of/flink/lib</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.security.kerberos.additionalFileSystems</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.</td>
         </tr>
         <tr>
             <td><h5>yarn.security.kerberos.localized-keytab-path</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -220,6 +220,17 @@ public class CoreOptions {
 
 	/**
 	 * This options is here only for documentation generation, it is only
+	 * evalu
+	 */
+	public static final ConfigOption<String> FLINK_APP_PID_DIR = ConfigOptions
+		.key("env.pid.dir")
+		.noDefaultValue()
+		.withDescription(
+			"Defines the directory where the flink-<host>-<process>.pid files are saved."
+				+ "(Defaults to the system tmp directory)");
+
+	/**
+	 * This options is here only for documentation generation, it is only
 	 * evaluated in the shell scripts.
 	 */
 	@SuppressWarnings("unused")

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -220,7 +220,7 @@ public class CoreOptions {
 
 	/**
 	 * The config parameter defining the directory for Flink PID file.
-	 * see: {@link bin/config.sh#KEY_ENV_PID_DIR} and {@link bin/config.sh#DEFAULT_ENV_PID_DIR}
+	 * see: {@code bin/config.sh#KEY_ENV_PID_DIR} and {@code bin/config.sh#DEFAULT_ENV_PID_DIR}
 	 */
 	public static final ConfigOption<String> FLINK_PID_DIR = ConfigOptions
 		.key("env.pid.dir")

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -220,7 +220,7 @@ public class CoreOptions {
 
 	/**
 	 * This options is here only for documentation generation, it is only
-	 * evalu
+	 * evaluated in the shell scripts.
 	 */
 	public static final ConfigOption<String> FLINK_APP_PID_DIR = ConfigOptions
 		.key("env.pid.dir")

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -219,15 +219,14 @@ public class CoreOptions {
 			" (Defaults to the log directory under Flink’s home)");
 
 	/**
-	 * This options is here only for documentation generation, it is only
-	 * evaluated in the shell scripts.
+	 * The config parameter defining the directory for Flink PID file.
+	 * see: {@link bin/config.sh#KEY_ENV_PID_DIR} and {@link bin/config.sh#DEFAULT_ENV_PID_DIR}
 	 */
-	public static final ConfigOption<String> FLINK_APP_PID_DIR = ConfigOptions
+	public static final ConfigOption<String> FLINK_PID_DIR = ConfigOptions
 		.key("env.pid.dir")
-		.noDefaultValue()
+		.defaultValue("/tmp")
 		.withDescription(
-			"Defines the directory where the flink-<host>-<process>.pid files are saved."
-				+ "(Defaults to the system tmp directory)");
+			"Defines the directory where the flink-<host>-<process>.pid files are saved.");
 
 	/**
 	 * This options is here only for documentation generation, it is only


### PR DESCRIPTION

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

This pull request Ensure that the documentation does not confuse developers. Because I cannot find the `env.pid.dir` configuration in the documentation, but the conf will used in the `conf.sh`.  And reminde the developer who want to override it where to modify.

## Brief change log

- add `env.pid.dir` configuration to Configuration page of Documentation.


## Verifying this change

This change is already covered by existing tests, such as Flink-docs test


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: don't know
  - The S3 file system connector: don't know

## Documentation

  - Does this pull request introduce a new feature?  no
