### PR TITLE
[FLINK-20069][build] Fix docs_404_check

### DIFF
--- a/tools/ci/docs.sh
+++ b/tools/ci/docs.sh
@@ -17,16 +17,22 @@
 # limitations under the License.
 ################################################################################
 
+gem update --system
+gem install bundler -v 1.17.2
+
 CACHE_DIR=$HOME/gem_cache ./docs/build_docs.sh -p &
 
-for i in `seq 1 30`;
+for i in `seq 1 90`;
 do
 	echo "Waiting for server..."
 	curl -Is http://localhost:4000 --fail
 	if [ $? -eq 0 ]; then
-		break
+		./docs/check_links.sh
+		EXIT_CODE=$?
+		exit $EXIT_CODE
 	fi
 	sleep 10
 done
 
-./docs/check_links.sh
+echo "Jekyll server wasn't started within 15 minutes"
+exit 1


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the docs_404_check*

## Verifying this change

Verified in my personal azure pipeline that it takes effect: 
Failed if there are broken links in the documentation: https://dev.azure.com/dianfu/Flink/_build/results?buildId=237&view=logs&j=64eb2d20-7d61-5c6d-9ae0-2f5940b1051d&t=36ef8439-438c-5ac6-2742-d7c6b595805a
Succeed based on #14009 which fixed the broken links: https://dev.azure.com/dianfu/Flink/_build/results?buildId=236&view=logs&j=64eb2d20-7d61-5c6d-9ae0-2f5940b1051d&t=36ef8439-438c-5ac6-2742-d7c6b595805a 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicableno)
