### PR TITLE
[FLINK-20076][runtime][test] Fixed DispatcherTest.testOnRemovedJobGraphDoesNotCleanUpHAFiles

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -742,9 +742,13 @@ public class DispatcherTest extends TestLogger {
 	@Test
 	public void testOnRemovedJobGraphDoesNotCleanUpHAFiles() throws Exception {
 		final CompletableFuture<JobID> removeJobGraphFuture = new CompletableFuture<>();
+		final CompletableFuture<JobID> releaseJobGraphFuture = new CompletableFuture<>();
+
 		final TestingJobGraphStore testingJobGraphStore = TestingJobGraphStore.newBuilder()
 			.setRemoveJobGraphConsumer(removeJobGraphFuture::complete)
+			.setReleaseJobGraphConsumer(releaseJobGraphFuture::complete)
 			.build();
+		testingJobGraphStore.start(null);
 
 		dispatcher = new TestingDispatcherBuilder()
 			.setInitialJobGraphs(Collections.singleton(jobGraph))
@@ -755,6 +759,8 @@ public class DispatcherTest extends TestLogger {
 		final CompletableFuture<Void> processFuture = dispatcher.onRemovedJobGraph(jobGraph.getJobID());
 
 		processFuture.join();
+
+		assertThat(releaseJobGraphFuture.get(), is(jobGraph.getJobID()));
 
 		try {
 			removeJobGraphFuture.get(10L, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## What is the purpose of the change

Fixing a test to reflect the actual purpose of it: We missed starting the JobGraphStore which caused an exception and prevented us from testing the actual behavior even though the test succeeded.

## Brief change log

* the `JobGraphStore.start` method call was added
* Additionally, I added a check to verify that the JobGraph got released. This way, we make sure that the `removeJobGraphFuture` times out after the relevant cleanup code was executed.

## Verifying this change

* Running the test itself and checking the logs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
