### PR TITLE
[FLINK-13733][connector/kafka] Make FlinkKafkaInternalProducerITCase more robust

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -26,19 +26,21 @@ import kafka.server.KafkaServer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for our own {@link FlinkKafkaInternalProducer}.
@@ -47,6 +49,7 @@ import static org.junit.Assert.assertEquals;
 public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 	protected String transactionalId;
 	protected Properties extraProperties;
+	private volatile Exception exceptionInCallback;
 
 	@BeforeClass
 	public static void prepare() throws Exception {
@@ -78,31 +81,33 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 	}
 
 	@Test(timeout = 30000L)
-	public void testHappyPath() throws IOException {
+	public void testHappyPath() throws Exception {
 		String topicName = "flink-kafka-producer-happy-path";
 
 		Producer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties);
 		try {
 			kafkaProducer.initTransactions();
 			kafkaProducer.beginTransaction();
-			kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"));
+			kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"), new ErrorCheckingCallback());
 			kafkaProducer.commitTransaction();
 		} finally {
 			kafkaProducer.close(Duration.ofSeconds(5));
 		}
+		assertNull("The message should have been successfully sent", exceptionInCallback);
 		assertRecord(topicName, "42", "42");
 		deleteTestTopic(topicName);
 	}
 
 	@Test(timeout = 30000L)
-	public void testResumeTransaction() throws IOException {
+	public void testResumeTransaction() throws Exception {
 		String topicName = "flink-kafka-producer-resume-transaction";
 		FlinkKafkaInternalProducer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties);
 		try {
 			kafkaProducer.initTransactions();
 			kafkaProducer.beginTransaction();
-			kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"));
+			kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"), new ErrorCheckingCallback());
 			kafkaProducer.flush();
+			assertNull("The message should have been successfully sent", exceptionInCallback);
 			long producerId = kafkaProducer.getProducerId();
 			short epoch = kafkaProducer.getEpoch();
 
@@ -205,15 +210,19 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 		FlinkKafkaInternalProducer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties);
 		kafkaProducer.initTransactions();
 		kafkaProducer.beginTransaction();
-		kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"));
+		kafkaProducer.send(new ProducerRecord<>(topicName, "42", "42"), new ErrorCheckingCallback());
 		kafkaProducer.close(Duration.ofSeconds(5));
+		assertNull("The message should have been successfully sent", exceptionInCallback);
 		return kafkaProducer;
 	}
 
 	private void assertRecord(String topicName, String expectedKey, String expectedValue) {
 		try (KafkaConsumer<String, String> kafkaConsumer = new KafkaConsumer<>(extraProperties)) {
 			kafkaConsumer.subscribe(Collections.singletonList(topicName));
-			ConsumerRecords<String, String> records = kafkaConsumer.poll(10000);
+			ConsumerRecords<String, String> records = ConsumerRecords.empty();
+			while (records.isEmpty()) {
+				records = kafkaConsumer.poll(10000);
+			}
 
 			ConsumerRecord<String, String> record = Iterables.getOnlyElement(records);
 			assertEquals(expectedKey, record.key());
@@ -242,6 +251,13 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 			toRestart.shutdown();
 			toRestart.awaitShutdown();
 			toRestart.startup();
+		}
+	}
+
+	private class ErrorCheckingCallback implements Callback {
+		@Override
+		public void onCompletion(RecordMetadata metadata, Exception exception) {
+			exceptionInCallback = exception;
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -80,7 +80,7 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 		extraProperties.put("isolation.level", "read_committed");
 	}
 
-	@Test(timeout = 30000L)
+	@Test(timeout = 60000L)
 	public void testHappyPath() throws Exception {
 		String topicName = "flink-kafka-producer-happy-path";
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds error checking and retry strategy for FlinkKafkaInternalProducerITCase to make it more robust.

## Brief change log
- Add error checking in `kafkaProducer.send()` callback.
- Add retry for `kafkaConsumer.poll()` if nothing is retrieved from Kafka brokers in `assertRecord()`.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
