### PR TITLE
[FLINK-19964][network] Avoid proactively pulling segments in destroyed LocalBufferPool.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -141,6 +141,18 @@ public class LocalBufferPoolTest extends TestLogger {
 	}
 
 	@Test
+	public void testSetNumAfterDestroyDoesNotProactivelyFetchSegments() {
+		localBufferPool.setNumBuffers(2);
+		assertEquals(2L, localBufferPool.getNumBuffers());
+		assertEquals(1L, localBufferPool.getNumberOfAvailableMemorySegments());
+
+		localBufferPool.lazyDestroy();
+		localBufferPool.setNumBuffers(3);
+		assertEquals(3L, localBufferPool.getNumBuffers());
+		assertEquals(0L, localBufferPool.getNumberOfAvailableMemorySegments());
+	}
+
+	@Test
 	public void testRecycleAfterDestroy() {
 		localBufferPool.setNumBuffers(numBuffers);
 


### PR DESCRIPTION



<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The following segment leak is closed:
* Two LocalBufferPools are concurrently destroyed.
* The second LocalBufferPool still gets buffer assigned while the first one is destroyed in NetworkBufferPool (always has been like this).
* With the change in FLINK-16972, the second LocalBufferPool proactively acquires one of the assigned buffers.
* Since it already has been destroyed this buffer is never returned to the NetworkBufferPool and simply vanishes from heap.

## Brief change log

* Check in LocalBufferPool#setNumBuffers if pool is already destroyed and stop pro-active acquisition.

## Verifying this change

Added a new unit test. The issue was detected by various ITCases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
