### PR TITLE
Fixed typo `spits` -> `splits` in Source.java docs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/Source.java
@@ -43,7 +43,7 @@ public interface Source<T, SplitT extends SourceSplit, EnumChkT> extends Seriali
 	Boundedness getBoundedness();
 
 	/**
-	 * Creates a new reader to read data from the spits it gets assigned.
+	 * Creates a new reader to read data from the splits it gets assigned.
 	 * The reader starts fresh and does not have any state to resume.
 	 *
 	 * @param readerContext The {@link SourceReaderContext context} for the source reader.


### PR DESCRIPTION
Read the documentation contribution guide and it says no JIRA ticket is required for trivial documentation changes such as typos.