### PR TITLE
[FLINK-20081][connector/common][source] Fix the executor notifier to let the handler run in main thread when handling exception from the callable.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -100,6 +100,8 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 	 * the states that will be a part of the {@link SplitEnumerator#snapshotState()}. Otherwise the
 	 * there might be unexpected behavior.
 	 *
+	 * <p>Note that an exception thrown from the handler would result in failing the job.
+	 *
 	 * @param callable a callable to call.
 	 * @param handler a handler that handles the return value of or the exception thrown from the callable.
 	 */
@@ -113,6 +115,8 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 	 * <p>It is important to make sure that the callable does not modify any shared state, especially
 	 * the states that will be a part of the {@link SplitEnumerator#snapshotState()}. Otherwise the
 	 * there might be unexpected behavior.
+	 *
+	 * <p>Note that an exception thrown from the handler would result in failing the job.
 	 *
 	 * @param callable the callable to call.
 	 * @param handler a handler that handles the return value of or the exception thrown from the callable.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/ExecutorNotifier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/ExecutorNotifier.java
@@ -83,8 +83,7 @@ public class ExecutorNotifier implements AutoCloseable {
 				T result = callable.call();
 				executorToNotify.execute(() -> handler.accept(result, null));
 			} catch (Throwable t) {
-				LOG.error("Unexpected exception {}", t);
-				handler.accept(null, t);
+				executorToNotify.execute(() -> handler.accept(null, t));
 			}
 		});
 	}
@@ -133,7 +132,7 @@ public class ExecutorNotifier implements AutoCloseable {
 				T result = callable.call();
 				executorToNotify.execute(() -> handler.accept(result, null));
 			} catch (Throwable t) {
-				handler.accept(null, t);
+				executorToNotify.execute(() -> handler.accept(null, t));
 			}
 		}, initialDelayMs, periodMs, TimeUnit.MILLISECONDS);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -149,7 +149,8 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 		SourceCoordinatorContext<MockSourceSplit> restoredContext;
 		SplitAssignmentTracker<MockSourceSplit> restoredTracker = new SplitAssignmentTracker<>();
 		SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
-				new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(TEST_OPERATOR_ID.toHexString());
+				new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+					TEST_OPERATOR_ID.toHexString(), operatorCoordinatorContext);
 		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
 				DataInputStream in = new DataInputStream(bais)) {
 			restoredContext = new SourceCoordinatorContext<>(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -57,7 +57,8 @@ public abstract class SourceCoordinatorTestBase {
 		splitSplitAssignmentTracker = new SplitAssignmentTracker<>();
 		String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
 		SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
-				new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(coordinatorThreadName);
+				new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+					coordinatorThreadName, operatorCoordinatorContext);
 		coordinatorExecutor = Executors.newSingleThreadExecutor(coordinatorThreadFactory);
 		context = new SourceCoordinatorContext<>(
 				coordinatorExecutor,


### PR DESCRIPTION
## What is the purpose of the change
This patch fixes the following two issues:
1. Currently the `ExecutorNotifier` runs the `handler` in the worker thread if there is an exception thrown from the `callable`. This breaks the threading model and prevents an exception from bubbling up to fail the job.
2. When an exception bubbles up from the `SourceCoordinator`, the `UncaughtExceptionHandler` will call `System.exit(-17)` and kill the JM. This is too much. Instead, we should just fail the job to trigger a failover.

## Brief change log
- Let the the `handler` always run in the main thread in `ExecutorNotifier`
- Fail the job instead of killing the JM in the `UncaughtExceptionHandler` in the `SourceCoordinator` executor.

## Verifying this change
The following unit tests have been added to verify the change.
- ExecutorNotifierTest.testExceptionInHandlerWhenHandlingException()
- SourceCoordinatorProviderTest.testCallAsyncExceptionFailsJob()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
