### PR TITLE
[hotfix][docs]The default value of sink.partition-commit.success-file.name shoule be _SUCCESS.

### DIFF
--- a/docs/dev/table/connectors/filesystem.md
+++ b/docs/dev/table/connectors/filesystem.md
@@ -334,7 +334,7 @@ The partition commit policy defines what action is taken when partitions are com
     </tr>
     <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>
-        <td style="word-wrap: break-word;">(none)</td>
+        <td style="word-wrap: break-word;">_SUCCESS</td>
         <td>String</td>
         <td>The file name for success-file partition commit policy, default is '_SUCCESS'.</td>
     </tr>

--- a/docs/dev/table/connectors/filesystem.zh.md
+++ b/docs/dev/table/connectors/filesystem.zh.md
@@ -334,7 +334,7 @@ The partition commit policy defines what action is taken when partitions are com
     </tr>
     <tr>
         <td><h5>sink.partition-commit.success-file.name</h5></td>
-        <td style="word-wrap: break-word;">(none)</td>
+        <td style="word-wrap: break-word;">_SUCCESS</td>
         <td>String</td>
         <td>The file name for success-file partition commit policy, default is '_SUCCESS'.</td>
     </tr>


### PR DESCRIPTION

## What is the purpose of the change

*The default value of sink.partition-commit.success-file.name shoule be _SUCCESS.*


## Brief change log

*(for example:)*
  - *The default value of sink.partition-commit.success-file.name shoule be _SUCCESS.*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)no
