### PR TITLE
[FLINK-19863][tests] check hbase has been ready before use it

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/main/java/org/apache/flink/tests/util/hbase/LocalStandaloneHBaseResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/main/java/org/apache/flink/tests/util/hbase/LocalStandaloneHBaseResource.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +47,8 @@ public class LocalStandaloneHBaseResource implements HBaseResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneHBaseResource.class);
 
+	private static final int MAX_RETRIES = 3;
+	private static final int RETRY_INTERVAL_SECONDS = 30;
 	private final TemporaryFolder tmp = new TemporaryFolder();
 
 	private final DownloadCache downloadCache = DownloadCache.get();
@@ -68,7 +71,7 @@ public class LocalStandaloneHBaseResource implements HBaseResource {
 		tmp.create();
 		downloadCache.before();
 
-		this.hbaseDir = tmp.newFolder("hbase").toPath().toAbsolutePath();
+		this.hbaseDir = tmp.newFolder("hbase-" + hbaseVersion).toPath().toAbsolutePath();
 		setupHBaseDist();
 		setupHBaseCluster();
 	}
@@ -92,62 +95,98 @@ public class LocalStandaloneHBaseResource implements HBaseResource {
 	}
 
 	private void setupHBaseCluster() throws IOException {
-		LOG.info("Starting HBase cluster");
-		AutoClosableProcess.runBlocking(
-			hbaseDir.resolve(Paths.get("bin", "start-hbase.sh")).toString());
-
-		while (!isHBaseRunning()) {
-			try {
-				LOG.info("Waiting for HBase to start");
-				Thread.sleep(500L);
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				break;
-			}
-		}
+		LOG.info("Starting HBase cluster...");
+		runHBaseProcessWithRetry("start-hbase.sh", () -> !isHMasterRunning());
+		LOG.info("Start HBase cluster success");
 	}
 
 	@Override
 	public void afterTestSuccess() {
-		try {
-			LOG.info("Stopping HBase Cluster");
-			AutoClosableProcess.runBlocking(
-				hbaseDir.resolve(Paths.get("bin", "hbase-daemon.sh")).toString(),
-				"stop",
-				"master");
-
-			while (isHBaseRunning()) {
-				try {
-					LOG.info("Waiting for HBase to stop");
-					Thread.sleep(500L);
-				} catch (InterruptedException e) {
-					Thread.currentThread().interrupt();
-					break;
-				}
-			}
-
-		} catch (IOException ioe) {
-			LOG.warn("Error while shutting down hbase.", ioe);
-		}
+		shutdownResource();
 		downloadCache.afterTestSuccess();
 		tmp.delete();
 	}
 
-	private static boolean isHBaseRunning() {
+	private void shutdownResource() {
+		LOG.info("Stopping HBase Cluster...");
+		try {
+			runHBaseProcessWithRetry("stop-hbase.sh", () -> isHMasterAlive());
+		} catch (IOException ioe) {
+			LOG.warn("Error when shutting down HBase Cluster.", ioe);
+		}
+		LOG.info("Stop HBase Cluster success");
+	}
+
+	private void runHBaseProcessWithRetry(String command, Supplier<Boolean> processStatusChecker) throws IOException {
+		LOG.info("Execute {} for HBase Cluster", command);
+
+		for (int i = 1; i <= MAX_RETRIES; i++) {
+			try {
+				AutoClosableProcess.runBlocking(
+						hbaseDir.resolve(Paths.get("bin", command)).toString());
+			} catch (IOException ioe) {
+				LOG.warn("Get exception when execute {} ", command, ioe);
+			}
+
+			int waitSecond = 0;
+			while (processStatusChecker.get()) {
+				try {
+					LOG.info("Waiting for HBase {} works", command);
+					Thread.sleep(1000L);
+				} catch (InterruptedException e) {
+					LOG.warn("sleep interrupted", e);
+				}
+				waitSecond++;
+				if (waitSecond > RETRY_INTERVAL_SECONDS) {
+					break;
+				}
+			}
+
+			if (waitSecond < RETRY_INTERVAL_SECONDS) {
+				break;
+			} else {
+				if (i == MAX_RETRIES) {
+					LOG.error("Execute {} failed, retry times {}", command, i);
+					throw new IllegalArgumentException(String.format(
+							"Execute %s failed aftert retry %s times", command, i));
+				} else {
+					LOG.warn("Execute {} failed, retry times {}", command, i);
+				}
+			}
+		}
+	}
+
+	private boolean isHMasterRunning() {
 		try {
 			final AtomicBoolean atomicHMasterStarted = new AtomicBoolean(false);
-			queryHMasterStatus(line -> atomicHMasterStarted.compareAndSet(false, line.contains("HMaster")));
+			queryHBaseStatus(line ->
+					atomicHMasterStarted.compareAndSet(false, line.contains("hbase:namespace")));
 			return atomicHMasterStarted.get();
 		} catch (IOException ioe) {
 			return false;
 		}
 	}
 
-	private static void queryHMasterStatus(final Consumer<String> stdoutProcessor) throws IOException {
+	private void queryHBaseStatus(final Consumer<String> stdoutProcessor) throws IOException {
+		executeHBaseShell("scan 'hbase:meta'", stdoutProcessor);
+	}
+
+	private boolean isHMasterAlive() {
+		try {
+			final AtomicBoolean atomicHMasterStarted = new AtomicBoolean(false);
+			queryHBaseProcess(line ->
+					atomicHMasterStarted.compareAndSet(false, line.contains("HMaster")));
+			return atomicHMasterStarted.get();
+		} catch (IOException ioe) {
+			return false;
+		}
+	}
+
+	private void queryHBaseProcess(final Consumer<String> stdoutProcessor) throws IOException {
 		AutoClosableProcess
-			.create("jps")
-			.setStdoutProcessor(stdoutProcessor)
-			.runBlocking();
+				.create("jps")
+				.setStdoutProcessor(stdoutProcessor)
+				.runBlocking();
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

* This pull request to fix the unstable test SQLClientHBaseITCase.testHBase failed with "java.io.IOException: Process failed due to timeout", the fail reason may be we only check the `HMaster` status before use it, we should check it by using hbase shell to scan meta table. 


## Brief change log

  - using hbase shell to check the hbase cluster has been ready
 - using different directory for hbase1 E2E test and hbase2 E2E test

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
