### PR TITLE
[FLINK-19979][e2e] Add sanity check after bash e2e tests for no leftovers

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -55,6 +55,8 @@ if [ ! -z "$TF_BUILD" ] ; then
 		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/compressed-archive-dir"
 	}
 	on_exit run_on_exit
+else
+	echo "WARNING: It is not recommended to run this script outside of a CI environment, because some tests may modify system files"
 fi
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -116,19 +116,8 @@ function stop_kafka_cluster {
   fi
   $KAFKA_DIR/bin/zookeeper-server-stop.sh
 
-  # Terminate Kafka process if it still exists
-  PIDS=$(jps -vl | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}'|| echo "")
-
-  if [ ! -z "$PIDS" ]; then
-    kill -s TERM $PIDS || true
-  fi
-
-  # Terminate QuorumPeerMain process if it still exists
-  PIDS=$(jps -vl | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}'|| echo "")
-
-  if [ ! -z "$PIDS" ]; then
-    kill -s TERM $PIDS || true
-  fi
+  kill_all 'kafka'
+  kill_all 'QuorumPeer'
 }
 
 function create_kafka_topic {
@@ -207,6 +196,7 @@ function get_and_verify_schema_subjects_exist {
 
 function stop_confluent_schema_registry {
     $CONFLUENT_DIR/bin/schema-registry-stop
+    kill_all 'SchemaRegistry'
 }
 
 function debug_error {

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -37,6 +37,8 @@ function run_test {
     printf "Running '${description}'\n"
     printf "==============================================================================\n"
 
+    local num_ports_before=$(get_num_ports)
+
     # used to randomize created directories
     export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
     echo "TEST_DATA_DIR: $TEST_DATA_DIR"
@@ -58,7 +60,7 @@ function run_test {
     exit_code="$?"
     # remove trap for test execution
     trap - ERR
-    post_test_validation ${exit_code} "$description" "$skip_check_exceptions"
+    post_test_validation ${exit_code} "$description" "$skip_check_exceptions" "$num_ports_before"
 }
 
 # Validates the test result and exit code after its execution.
@@ -66,6 +68,7 @@ function post_test_validation {
     local exit_code="$1"
     local description="$2"
     local skip_check_exceptions="$3"
+    local num_ports_before="$4"
 
     local time_elapsed=$(end_timer)
 
@@ -97,6 +100,7 @@ function post_test_validation {
     if [[ ${exit_code} == 0 ]]; then
         cleanup
         log_environment_info
+        ensure_clean_environment ${num_ports_before} || exit $?
     else
         log_environment_info
         # make logs available if ARTIFACTS_DIR is set
@@ -110,10 +114,40 @@ function post_test_validation {
     fi
 }
 
+# returns the number of allocated ports
+function get_num_ports {
+    # "ps --ppid 2 -p 2 --deselect" shows all non-kernel processes
+    # "ps --ppid $$" shows all children of this bash process
+    # "ps -o pid= -o comm=" removes the header line
+    echo $(sudo netstat -tulpn | wc -l)
+}
+
+# Ensure that the number of running processes has not increased (no leftover daemons,
+# potentially affecting subsequent tests due to allocated ports etc.)
+function ensure_clean_environment {
+    local num_ports_before=$1
+    local num_ports_after=$(get_num_ports)
+    if [ "$num_ports_before" -ne "$num_ports_after" ]; then
+        printf "\n==============================================================================\n"
+        echo "FATAL: This test has left ports allocated."
+        echo "Allocated ports before the test: $num_ports_before and after: $num_ports_after. Stopping test execution."
+        printf "\n==============================================================================\n"
+        exit 1
+    fi
+
+    if [ $(jps | wc -l) -ne 1 ]; then
+        printf "\n==============================================================================\n"
+        echo "FATAL: This test has left JVMs running. Stopping test execution."
+        printf "\n==============================================================================\n"
+        exit 1
+    fi
+}
+
+
 function log_environment_info {
     echo "##[group]Environment Information"
-    echo "Jps"
-    jps
+    echo "Running JVMs"
+    jps -v
 
     echo "Disk information"
     df -hH

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -132,6 +132,8 @@ function ensure_clean_environment {
         echo "FATAL: This test has left ports allocated."
         echo "Allocated ports before the test: $num_ports_before and after: $num_ports_after. Stopping test execution."
         printf "\n==============================================================================\n"
+        echo "Printing pstree for debugging:"
+        sudo pstree -p
         exit 1
     fi
 

--- a/tools/azure-pipelines/e2e_uploading_watchdog.sh
+++ b/tools/azure-pipelines/e2e_uploading_watchdog.sh
@@ -61,12 +61,27 @@ function log_upload_watchdog {
 	done
 }
 
+
+function stop_watchdog {
+  # pkill (the child processes) and the watchdog shell itself. This is necessary to prevent the
+  # sleep inside the watchdog to become a daemon process, which inherits the file descriptors and
+  # potentially prevents parent processes from noticing that this script is done.
+  # Kill silently. If a watchdog has "triggered", it won't exist anymore.
+  ( pkill -P $1 2>&1 ) > /dev/null
+  ( kill $1 2>&1 ) > /dev/null
+}
+
 warning_watchdog &
+warning_wd_pid=$!
 log_upload_watchdog &
+log_upload_wd_pid=$!
 
 # ts from moreutils prepends the time to each line
-( $COMMAND & PID=$! ; wait $PID ) | ts | tee $OUTPUT_FILE
+eval $COMMAND 2>&1 | ts | tee $OUTPUT_FILE
 TEST_EXIT_CODE=${PIPESTATUS[0]}
+
+stop_watchdog $warning_wd_pid
+stop_watchdog $log_upload_wd_pid
 
 # properly forward exit code
 exit $TEST_EXIT_CODE


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to increase the robustness of the e2e tests overall.


## Brief change log

- Check of leftover JVMs after a e2e test, and fails if there's one
- Check for "more ports open than before", and fail if there are more open
- increase robustness of process stopping: wait until a process has finished, potentially shooting it with a sigkill
- increase robustness of `run_with_timeout`. It used to leave a dangling `sleep` in the system


## Verifying this change

I ran this change through 3 CI runs, to make sure all the tests adhere to the stricter requirements of "no leftover stuff".

I will also manually test the watchdog again (proper killing and reporting).
