### PR TITLE
[FLINK-20088][kinesis] Fix issue encountered when Polling consumer using timestamp with empty shard

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
@@ -48,8 +48,6 @@ public class PollingRecordPublisher implements RecordPublisher {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
 
-	private static final SequenceNumber TIMESTAMP_SENTINEL_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
-
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
 	private final KinesisProxyInterface kinesisProxy;
@@ -122,7 +120,7 @@ public class PollingRecordPublisher implements RecordPublisher {
 		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
 		// This is because we have not yet received any real sequence numbers on this shard.
 		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
-		if (TIMESTAMP_SENTINEL_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
+		if (SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().equals(latestSequenceNumber)) {
 			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
 			return nextStartingPosition;
 		} else {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisher.java
@@ -34,8 +34,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 
 /**
  * A {@link RecordPublisher} that will read records from Kinesis and forward them to the subscriber.
@@ -45,6 +47,8 @@ import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.
 public class PollingRecordPublisher implements RecordPublisher {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PollingRecordPublisher.class);
+
+	private static final SequenceNumber TIMESTAMP_SENTINEL_SEQUENCE_NUMBER = SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get();
 
 	private final PollingRecordPublisherMetricsReporter metricsReporter;
 
@@ -106,11 +110,24 @@ public class PollingRecordPublisher implements RecordPublisher {
 		GetRecordsResult result = getRecords(nextShardItr, maxNumberOfRecords);
 
 		RecordBatch recordBatch = new RecordBatch(result.getRecords(), subscribedShard, result.getMillisBehindLatest());
-		SequenceNumber latestSeequenceNumber = consumer.accept(recordBatch);
+		SequenceNumber latestSequenceNumber = consumer.accept(recordBatch);
 
-		nextStartingPosition = StartingPosition.continueFromSequenceNumber(latestSeequenceNumber);
+		nextStartingPosition = getNextStartingPosition(latestSequenceNumber);
 		nextShardItr = result.getNextShardIterator();
 		return nextShardItr == null ? COMPLETE : INCOMPLETE;
+	}
+
+	private StartingPosition getNextStartingPosition(final SequenceNumber latestSequenceNumber) {
+		// When consuming from a timestamp sentinel/AT_TIMESTAMP ShardIteratorType.
+		// If the first RecordBatch is empty, then the latestSequenceNumber would be the timestamp sentinel.
+		// This is because we have not yet received any real sequence numbers on this shard.
+		// In this condition we should retry from the previous starting position (AT_TIMESTAMP).
+		if (TIMESTAMP_SENTINEL_SEQUENCE_NUMBER.equals(latestSequenceNumber)) {
+			Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
+			return nextStartingPosition;
+		} else {
+			return StartingPosition.continueFromSequenceNumber(latestSequenceNumber);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

The consumer fails when a Kinesis Polling record publisher uses a timestamp sentinel starting position and the first record batch is empty. This is because the consumer tries to recalculate the start position from the timestamp sentinel, this operation is not supported.

## Brief change log

This is fixed by reusing the existing timestamp starting position in this condition when polling consumer encounters empty batch with timestamp starting position.

## Verifying this change

This change added a unit test and can be verified as follows:
- Running tests in `ShardConsumerTest`

This has been manually verified on Flink cluster consuming from a Kinesis Stream.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
