### PR TITLE
[FLINK-19340][table-runtime-blink] Support NestedRowData in RowDataSerializer#copy

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.memory.AbstractPagedOutputView;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.NestedRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -122,6 +123,8 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 		}
 		if (from instanceof BinaryRowData) {
 			return ((BinaryRowData) from).copy();
+		} else if (from instanceof NestedRowData) {
+			return ((NestedRowData) from).copy();
 		} else {
 			return copyRowData(from, new GenericRowData(from.getArity()));
 		}
@@ -138,6 +141,10 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 			return reuse instanceof BinaryRowData
 				? ((BinaryRowData) from).copy((BinaryRowData) reuse)
 				: ((BinaryRowData) from).copy();
+		} else if (from instanceof NestedRowData) {
+			return reuse instanceof NestedRowData
+				? ((NestedRowData) from).copy(reuse)
+				: ((NestedRowData) from).copy();
 		} else {
 			return copyRowData(from, reuse);
 		}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -259,7 +259,7 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 		if (should.getArity() != is.getArity()) {
 			return false;
 		}
-		if (checkClass && should.getClass() != is.getClass()) {
+		if (checkClass && (should.getClass() != is.getClass() || !should.equals(is))) {
 			return false;
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/RowDataSerializerTest.java
@@ -22,13 +22,16 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryArrayData;
 import org.apache.flink.table.data.binary.BinaryMapData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryArrayWriter;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.IntType;
@@ -86,7 +89,8 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 				testRowDataSerializer(),
 				testLargeRowDataSerializer(),
 				testRowDataSerializerWithComplexTypes(),
-				testRowDataSerializerWithKryo());
+				testRowDataSerializerWithKryo(),
+				testRowDataSerializerWithNestedRow());
 	}
 
 	private static Object[] testRowDataSerializer() {
@@ -178,6 +182,40 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 		return new Object[] {serializer, new GenericRowData[]{row}};
 	}
 
+	private static Object[] testRowDataSerializerWithNestedRow() {
+		final DataType nestedDataType = DataTypes.ROW(
+			DataTypes.FIELD("ri", DataTypes.INT()),
+			DataTypes.FIELD("rs", DataTypes.STRING()),
+			DataTypes.FIELD("rb", DataTypes.BIGINT())
+		);
+
+		final DataType outerDataType = DataTypes.ROW(
+			DataTypes.FIELD("i", DataTypes.INT()),
+			DataTypes.FIELD(
+				"r",
+				nestedDataType
+			),
+			DataTypes.FIELD("s", DataTypes.STRING())
+		);
+
+		final TypeSerializer<RowData> nestedSerializer = InternalSerializers.create(nestedDataType.getLogicalType());
+		final RowDataSerializer outerSerializer = (RowDataSerializer) InternalSerializers.<RowData>create(outerDataType.getLogicalType());
+
+		final GenericRowData outerRow1 = GenericRowData.of(
+			12,
+			GenericRowData.of(34, StringData.fromString("56"), 78L),
+			StringData.fromString("910"));
+		final RowData nestedRow1 = outerSerializer.toBinaryRow(outerRow1).getRow(1, 3);
+
+		final GenericRowData outerRow2 = GenericRowData.of(
+			12,
+			GenericRowData.of(null, StringData.fromString("56"), 78L),
+			null);
+		final RowData nestedRow2 = outerSerializer.toBinaryRow(outerRow2).getRow(1, 3);
+
+		return new Object[] {nestedSerializer, new RowData[]{nestedRow1, nestedRow2}};
+	}
+
 	// ----------------------------------------------------------------------------------------------
 
 	private static BinaryArrayData createArray(int... ints) {
@@ -205,44 +243,77 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 	}
 
 	private static boolean deepEqualsRowData(
-		RowData should, RowData is, RowDataSerializer serializer1, RowDataSerializer serializer2) {
+			RowData should,
+			RowData is,
+			RowDataSerializer serializer1,
+			RowDataSerializer serializer2) {
+		return deepEqualsRowData(should, is, serializer1, serializer2, false);
+	}
+
+	private static boolean deepEqualsRowData(
+			RowData should,
+			RowData is,
+			RowDataSerializer serializer1,
+			RowDataSerializer serializer2,
+			boolean checkClass) {
 		if (should.getArity() != is.getArity()) {
 			return false;
 		}
+		if (checkClass && should.getClass() != is.getClass()) {
+			return false;
+		}
+
 		BinaryRowData row1 = serializer1.toBinaryRow(should);
 		BinaryRowData row2 = serializer2.toBinaryRow(is);
 
 		return Objects.equals(row1, row2);
 	}
 
-	private void checkDeepEquals(RowData should, RowData is) {
-		boolean equals = deepEqualsRowData(should, is,
-				(RowDataSerializer) serializer.duplicate(), (RowDataSerializer) serializer.duplicate());
+	private void checkDeepEquals(RowData should, RowData is, boolean checkClass) {
+		boolean equals = deepEqualsRowData(
+			should,
+			is,
+			(RowDataSerializer) serializer.duplicate(),
+			(RowDataSerializer) serializer.duplicate(),
+			checkClass);
 		Assert.assertTrue(equals);
 	}
 
 	@Test
 	public void testCopy() {
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(row));
+			checkDeepEquals(
+				row,
+				serializer.copy(row),
+				true);
 		}
 
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(row, new GenericRowData(row.getArity())));
+			checkDeepEquals(
+				row,
+				serializer.copy(row, new GenericRowData(row.getArity())),
+				true);
 		}
 
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(serializer.toBinaryRow(row),
-					new GenericRowData(row.getArity())));
+			checkDeepEquals(
+				row,
+				serializer.copy(serializer.toBinaryRow(row), new GenericRowData(row.getArity())),
+				false);
 		}
 
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(serializer.toBinaryRow(row)));
+			checkDeepEquals(
+				row,
+				serializer.copy(serializer.toBinaryRow(row)),
+				false);
 		}
 
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(serializer.toBinaryRow(row),
-					new BinaryRowData(row.getArity())));
+			checkDeepEquals(
+				row,
+				serializer.copy(serializer.toBinaryRow(row), new BinaryRowData(row.getArity())),
+				false);
 		}
 	}
 
@@ -256,7 +327,10 @@ public class RowDataSerializerTest extends SerializerTestInstance<RowData> {
 	public void testWrongCopyReuse() {
 		thrown.expect(IllegalArgumentException.class);
 		for (RowData row : testData) {
-			checkDeepEquals(row, serializer.copy(row, new GenericRowData(row.getArity() + 1)));
+			checkDeepEquals(
+				row,
+				serializer.copy(row, new GenericRowData(row.getArity() + 1)),
+				false);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

The `RowDataSerializer.copy()` method did not consider `NestedRowData` which led to
inconsistent `MapState` when using a heap state backend. This caused `AggregateITCase.testListAggWithDistinct`
to be unstable when performing a distinct using map views.

## Brief change log

- Fix RowDataSerializer#copy

## Verifying this change

This change added tests and can be verified as follows:

- Run AggregateITCase.testListAggWithDistinct ~2000 times with HEAP and all modes ON
- Dedicated RowDataSerializerTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
