### PR TITLE
[FLINK-20093] Create a download page for all optional sql client components

### DIFF
--- a/docs/_data/sql-connectors.yml
+++ b/docs/_data/sql-connectors.yml
@@ -1,3 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License
+
+# INSTRUCTIONS:
+#
+# In order to add a new connector/format add a new entry to this file.
+# You need specify a name that will be used in e.g. the description of the connector/format and
+# a category (either "format" or "connector"). The category determines which table will the entry
+# end up in on the Download page. The "maven" parameter describes the name of the maven module. The
+# three parameters are required.
+#
+# If you specify "built-in=true" the corresponding table on the connector/format will not contain
+# a link, but just a "Built-in" entry. If the built-in is set to true you do not need to provide the
+# sql-url.
+#
+# If a connector comes with different versions for the external system, you can put those under a
+# "versions" property. Each entry in the "versions" section should have a "version", which
+# determines name for the version and "maven" and "sql-url" entries for that particular version.
+# If you use the "versions" property, "maven" and "sql-url" should not be present in the top level
+# section of the connector. (Multiple versions are supported only for the connector for now. If you
+# need multiple versions support for formats, please update downloads.md)
+#
+# NOTE: You can use liquid variables in "sql-url" and "maven" properties.
+
 avro:
     name: Avro
     maven: flink-sql-avro

--- a/docs/_data/sql-connectors.yml
+++ b/docs/_data/sql-connectors.yml
@@ -1,0 +1,86 @@
+avro:
+    name: Avro
+    maven: flink-sql-avro
+    category: format
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro/{{site.version}}/flink-sql-avro-{{site.version}}.jar
+
+avro-confluent:
+    name: Avro Schema Registry
+    maven: flink-avro-confluent-registry
+    category: format
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/{{site.version}}/flink-sql-avro-confluent-registry-{{site.version}}.jar
+
+orc:
+    name: ORC
+    maven: flink-orc{{site.scala_version_suffix}}
+    category: format
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-orc{{site.scala_version_suffix}}/{{site.version}}/flink-sql-orc{{site.scala_version_suffix}}-{{site.version}}.jar
+
+parquet:
+    name: Parquet
+    maven: flink-parquet{{site.scala_version_suffix}}
+    category: format
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-parquet{{site.scala_version_suffix}}/{{site.version}}/flink-sql-parquet{{site.scala_version_suffix}}-{{site.version}}.jar
+
+debezium:
+    name: Debezium
+    maven: flink-json
+    category: format
+    built-in: true
+
+canal:
+    name: Canal
+    maven: flink-json
+    category: format
+    built-in: true
+
+csv:
+    name: CSV
+    maven: flink-csv
+    category: format
+    built-in: true
+
+json:
+    name: Json
+    maven: flink-json
+    category: format
+    built-in: true
+
+elastic:
+    name: Elasticsearch
+    category: connector
+    versions:
+        - version: 6.x
+          maven: flink-connector-elasticsearch6{{site.scala_version_suffix}}
+          sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar
+        - version: 7.x and later versions
+          maven: flink-connector-elasticsearch7{{site.scala_version_suffix}}
+          sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch7{{site.scala_version_suffix}}-{{site.version}}.jar
+
+hbase:
+    name: HBase
+    category: connector
+    versions:
+        - version: 1.4.x
+          maven: flink-connector-hbase{{site.scala_version_suffix}}
+          sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar
+
+jdbc:
+    name: JDBC
+    category: connector
+    maven: flink-connector-jdbc{{site.scala_version_suffix}}
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc{{site.scala_version_suffix}}/{{site.version}}/flink-connector-jdbc{{site.scala_version_suffix}}-{{site.version}}.jar
+
+kafka:
+    name: Kafka
+    category: connector
+    versions:
+        - version: universal
+          maven: flink-connector-kafka{{site.scala_version_suffix}}
+          sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar
+
+kinesis:
+    name: Kinesis
+    category: connector
+    maven: flink-connector-kinesis{{ site.scala_version_suffix }}
+

--- a/docs/_includes/sql-connector-download-table.html
+++ b/docs/_includes/sql-connector-download-table.html
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 <p>In order to use the {{ include.connector.name }} {{ include.connector.category }} the following
 dependencies are required for both projects using a build automation tool (such as Maven or SBT)
 and SQL Client with SQL JAR bundles.</p>

--- a/docs/_includes/sql-connector-download-table.html
+++ b/docs/_includes/sql-connector-download-table.html
@@ -1,0 +1,65 @@
+<p>In order to use the {{ include.connector.name }} {{ include.connector.category }} the following
+dependencies are required for both projects using a build automation tool (such as Maven or SBT)
+and SQL Client with SQL JAR bundles.</p>
+
+
+{% comment %}
+	The 'liquify' filter makes it possible to include liquid variables such as e.g. site.version.
+{% endcomment %}
+
+{% if include.connector.versions == nil %}
+<table>
+	<thead>
+	<tr>
+		<th style="text-align: left">Maven dependency</th>
+		<th style="text-align: left">SQL Client JAR</th>
+	</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td style="text-align: left"><code class="highlighter-rouge">{{ include.connector.maven | liquify }}</code></td>
+		{% if include.connector.built-in %}
+			<td style="text-align: left">Built-in</td>
+		{% elsif site.is_stable %}
+			{% if include.connector.sql-url != nil %}
+				<td style="text-align: left"><a href="{{ include.connector.sql-url | liquify }}">Download</a></td>
+			{% else %}
+				<td style="text-align: left">There is no sql jar available yet.</td>
+			{% endif %}
+		{% else %}
+			<td style="text-align: left">Only available for stable releases.</td>
+		{% endif %}
+	</tr>
+	</tbody>
+</table>
+{% else %}
+<table>
+	<thead>
+	<tr>
+		<th style="text-align: left">{{ include.connector.name }} version</th>
+		<th style="text-align: left">Maven dependency</th>
+		<th style="text-align: left">SQL Client JAR</th>
+	</tr>
+	</thead>
+	<tbody>
+	{% for version in include.connector.versions %}
+	<tr>
+		<td style="text-align: left">{{ version.version | liquify }}</td>
+		<td style="text-align: left"><code class="highlighter-rouge">{{ version.maven | liquify }}</code></td>
+		{% if include.connector.built-in %}
+		<td style="text-align: left">Built-in</td>
+		{% elsif include.connector.no-sql-jar %}
+		{% elsif site.is_stable %}
+			{% if version.sql-url != nil %}
+				<td style="text-align: left"><a href="{{ version.sql-url | liquify }}">Download</a></td>
+			{% else %}
+				<td style="text-align: left">There is no sql jar available yet.</td>
+			{% endif %}
+		{% else %}
+		<td style="text-align: left">Only available for stable releases.</td>
+		{% endif %}
+	</tr>
+	{% endfor %}
+	</tbody>
+</table>
+{% endif %}

--- a/docs/_plugins/liquify.rb
+++ b/docs/_plugins/liquify.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  module LiquifyFilter
+    def liquify(input)
+      Liquid::Template.parse(input).render(@context)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::LiquifyFilter)

--- a/docs/_plugins/liquify.rb
+++ b/docs/_plugins/liquify.rb
@@ -1,3 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# *A Jekyll filter that can parse Liquid in Liquid variables
+#
+# Usage:
+# e.g. Welcome to {{ page.title | liquify }}!
+
 module Jekyll
   module LiquifyFilter
     def liquify(input)

--- a/docs/dev/table/connectors/downloads.md
+++ b/docs/dev/table/connectors/downloads.md
@@ -41,10 +41,11 @@ The page contains links to optional sql-client connectors and formats that are n
     <tbody>
 {% for entry in site.data.sql-connectors %}
     {% for connector in entry %}
-      {% if connector.category == "format" and connector.built-in != true and connector.sql-url != nil %}  
+      {% if connector.category == "format" and connector.built-in != true and connector.sql-url != nil %}
+        {% assign url = connector.sql-url | liquify %}
         <tr>
             <td style="text-align: left">{{connector.name}}</td>
-            <td style="text-align: left"><a href="{{ connector.sql-url | liquify }}">Download</a></td>
+            <td style="text-align: left"><a href="{{ url }}">Download</a> (<a href="{{ url }}.asc">asc</a>, <a href="{{ url }}.sha1">sha1</a>) </td>
         </tr>
       {% endif %}
     {% endfor %}
@@ -72,19 +73,22 @@ The page contains links to optional sql-client connectors and formats that are n
             <tr>
                 <td style="text-align: left" rowspan="{{connector.versions | size}}">{{connector.name}}</td>
                 <td style="text-align: left">{{row0.version}}</td>
-                <td style="text-align: left"><a href="{{ row0.sql-url | liquify }}">Download</a></td>
+                {% assign url = row0.sql-url | liquify %}
+                <td style="text-align: left"><a href="{{ url }}">Download</a> (<a href="{{ url }}.asc">asc</a>, <a href="{{ url }}.sha1">sha1</a>) </td>
             </tr>
             {% for version in connector.versions offset:1 %}
                 <tr>
                     <td style="text-align: left">{{version.version}}</td>
-                    <td style="text-align: left"><a href="{{ version.sql-url | liquify }}">Download</a></td>
+                    {% assign url = version.sql-url | liquify %}
+                    <td style="text-align: left"><a href="{{ url }}">Download</a> (<a href="{{ url }}.asc">asc</a>, <a href="{{ url }}.sha1">sha1</a>) </td>
                 </tr>
             {% endfor %}
         {% elsif connector.sql-url != nil %}
             <tr>
                 <td style="text-align: left">{{connector.name}}</td>
                 <td style="text-align: left"></td>
-                <td style="text-align: left"><a href="{{ connector.sql-url | liquify }}">Download</a></td>
+                {% assign url = connector.sql-url | liquify %}
+                <td style="text-align: left"><a href="{{ url }}">Download</a> (<a href="{{ url }}.asc">asc</a>, <a href="{{ url }}.sha1">sha1</a>) </td>
             </tr>
         {% endif %}
       {% endif %}

--- a/docs/dev/table/connectors/downloads.md
+++ b/docs/dev/table/connectors/downloads.md
@@ -1,0 +1,100 @@
+---
+title: "SQL Connectors download page"
+nav-title: Download
+nav-parent_id: sql-connectors
+nav-pos: 99
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+The page contains links to optional sql-client connectors and formats that are not part of the
+ binary distribution.
+ 
+{% if site.is_stable %}
+
+# Optional SQL formats
+-------------------
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+        <th style="text-align: left">Name</th>
+        <th style="text-align: left">Download link</th>
+    </tr>
+    </thead>
+    <tbody>
+{% for entry in site.data.sql-connectors %}
+    {% for connector in entry %}
+      {% if connector.category == "format" and connector.built-in != true and connector.sql-url != nil %}  
+        <tr>
+            <td style="text-align: left">{{connector.name}}</td>
+            <td style="text-align: left"><a href="{{ connector.sql-url | liquify }}">Download</a></td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+{% endfor %}
+    </tbody>
+</table>
+
+# Optional SQL connectors
+-------------------  
+
+<table class="table table-bordered">
+    <thead>
+    <tr>
+        <th style="text-align: left">Name</th>
+        <th style="text-align: left">Versions</th>
+        <th style="text-align: left">Download link</th>
+    </tr>
+    </thead>
+    <tbody>
+{% for entry in site.data.sql-connectors %}
+    {% for connector in entry %}
+      {% if connector.category == "connector" and connector.built-in != true %}
+        {% if connector.versions != nil %}
+            {% assign row0=connector.versions[0] %}
+            <tr>
+                <td style="text-align: left" rowspan="{{connector.versions | size}}">{{connector.name}}</td>
+                <td style="text-align: left">{{row0.version}}</td>
+                <td style="text-align: left"><a href="{{ row0.sql-url | liquify }}">Download</a></td>
+            </tr>
+            {% for version in connector.versions offset:1 %}
+                <tr>
+                    <td style="text-align: left">{{version.version}}</td>
+                    <td style="text-align: left"><a href="{{ version.sql-url | liquify }}">Download</a></td>
+                </tr>
+            {% endfor %}
+        {% elsif connector.sql-url != nil %}
+            <tr>
+                <td style="text-align: left">{{connector.name}}</td>
+                <td style="text-align: left"></td>
+                <td style="text-align: left"><a href="{{ connector.sql-url | liquify }}">Download</a></td>
+            </tr>
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+{% endfor %}
+    </tbody>
+</table>
+
+{% else %}
+<p style="border-radius: 5px; padding: 5px" class="bg-info">
+  <b>Note</b>: The links are available only for stable releases.
+</p>
+{% endif %}

--- a/docs/dev/table/connectors/elasticsearch.md
+++ b/docs/dev/table/connectors/elasticsearch.md
@@ -38,12 +38,10 @@ If no primary key is defined on the DDL, the connector can only operate in appen
 Dependencies
 ------------
 
-In order to setup the Elasticsearch connector, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Elasticsearch Version   | Maven dependency                                                   | SQL Client JAR         |
-| :---------------------- | :----------------------------------------------------------------- | :----------------------|
-| 6.x                     | `flink-connector-elasticsearch6{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch6{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/elasticsearch.html) {% endif %}|
-| 7.x and later versions  | `flink-connector-elasticsearch7{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-elasticsearch7{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/elasticsearch.html) {% endif %}|
+{% assign connector = site.data.sql-connectors['elastic'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 <br>
 <span class="label label-danger">Attention</span> Elasticsearch connector works with JSON format which defines how to encode documents for the external system, therefore, it must be added as a [dependency]({% link dev/table/connectors/formats/index.md %}).

--- a/docs/dev/table/connectors/formats/avro-confluent.md
+++ b/docs/dev/table/connectors/formats/avro-confluent.md
@@ -40,11 +40,10 @@ The Avro Schema Registry format can only be used in conjunction with [Apache Kaf
 Dependencies
 ------------
 
-In order to use the Avro Schema Registry format the following dependencies are required for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency                     | SQL Client JAR         |
-| :----------------------------------- | :----------------------|
-| `flink-avro-confluent-registry`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/{{site.version}}/flink-sql-avro-confluent-registry-{{site.version}}.jar) {% else %} Only available for stable releases. {% endif %} |
+{% assign connector = site.data.sql-connectors['avro-confluent'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with Avro-Confluent format
 ----------------

--- a/docs/dev/table/connectors/formats/avro.md
+++ b/docs/dev/table/connectors/formats/avro.md
@@ -34,22 +34,10 @@ The [Apache Avro](https://avro.apache.org/) format allows to read and write Avro
 Dependencies
 ------------
 
-In order to setup the Avro format, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-<div class="codetabs" markdown="1">
-<div data-lang="SQL Client JAR" markdown="1">
-You can download flink-sql-avro from [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro/{{site.version}}/flink-sql-avro-{{site.version}}.jar)
-</div>
-<div data-lang="Maven dependency" markdown="1">
-{% highlight xml %}
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-avro</artifactId>
-  <version>{{ site.version }}</version>
-</dependency>
-{% endhighlight %}
-</div>
-</div>
+{% assign connector = site.data.sql-connectors['avro'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with Avro format
 ----------------

--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -46,11 +46,10 @@ However, currently Flink can't combine UPDATE_BEFORE and UPDATE_AFTER into a sin
 Dependencies
 ------------
 
-In order to setup the Canal format, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| `flink-json`       | Built-in               |
+{% assign connector = site.data.sql-connectors['canal'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 *Note: please refer to [Canal documentation](https://github.com/alibaba/canal/wiki) about how to deploy Canal to synchronize changelog to message queues.*
 

--- a/docs/dev/table/connectors/formats/csv.md
+++ b/docs/dev/table/connectors/formats/csv.md
@@ -34,11 +34,10 @@ The [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) format allows to
 Dependencies
 ------------
 
-In order to setup the CSV format, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| `flink-csv`        | Built-in               |
+{% assign connector = site.data.sql-connectors['csv'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with CSV format
 ----------------

--- a/docs/dev/table/connectors/formats/debezium.md
+++ b/docs/dev/table/connectors/formats/debezium.md
@@ -46,11 +46,10 @@ However, currently Flink can't combine UPDATE_BEFORE and UPDATE_AFTER into a sin
 Dependencies
 ------------
 
-In order to setup the Debezium format, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| `flink-json`       | Built-in               |
+{% assign connector = site.data.sql-connectors['debezium'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 *Note: please refer to [Debezium documentation](https://debezium.io/documentation/reference/1.1/index.html) about how to setup a Debezium Kafka Connect to synchronize changelog to Kafka topics.*
 

--- a/docs/dev/table/connectors/formats/json.md
+++ b/docs/dev/table/connectors/formats/json.md
@@ -34,11 +34,10 @@ The [JSON](https://www.json.org/json-en.html) format allows to read and write JS
 Dependencies
 ------------
 
-In order to setup the JSON format, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| `flink-json`       | Built-in               |
+{% assign connector = site.data.sql-connectors['json'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with JSON format
 ----------------

--- a/docs/dev/table/connectors/formats/orc.md
+++ b/docs/dev/table/connectors/formats/orc.md
@@ -34,12 +34,10 @@ The [Apache Orc](https://orc.apache.org/) format allows to read and write Orc da
 Dependencies
 ------------
 
-In order to setup the Orc format, the following table provides dependency information for both
-projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| flink-orc{{site.scala_version_suffix}}        |{% if site.is_stable %}[Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-orc{{site.scala_version_suffix}}/{{site.version}}/flink-sql-orc{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %}|
+{% assign connector = site.data.sql-connectors['orc'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with Orc format
 ----------------

--- a/docs/dev/table/connectors/formats/parquet.md
+++ b/docs/dev/table/connectors/formats/parquet.md
@@ -34,12 +34,10 @@ The [Apache Parquet](https://parquet.apache.org/) format allows to read and writ
 Dependencies
 ------------
 
-In order to setup the Parquet format, the following table provides dependency information for both
-projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| Maven dependency   | SQL Client JAR         |
-| :----------------- | :----------------------|
-| flink-parquet{{site.scala_version_suffix}}  |{% if site.is_stable %}[Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-parquet{{site.scala_version_suffix}}/{{site.version}}/flink-sql-parquet{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for stable releases {% endif %}|
+{% assign connector = site.data.sql-connectors['parquet'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a table with Parquet format
 ----------------

--- a/docs/dev/table/connectors/hbase.md
+++ b/docs/dev/table/connectors/hbase.md
@@ -38,12 +38,10 @@ HBase always works in upsert mode for exchange changelog messages with the exter
 Dependencies
 ------------
 
-In order to setup the HBase connector, the following table provide dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-| HBase Version       | Maven dependency                                          | SQL Client JAR         |
-| :------------------ | :-------------------------------------------------------- | :----------------------|
-| 1.4.x               | `flink-connector-hbase{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hbase{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-hbase{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/hbase.html) {% endif %}|
-
+{% assign connector = site.data.sql-connectors['hbase'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to use HBase table
 ----------------

--- a/docs/dev/table/connectors/jdbc.md
+++ b/docs/dev/table/connectors/jdbc.md
@@ -38,11 +38,10 @@ The JDBC sink operate in upsert mode for exchange UPDATE/DELETE messages with th
 Dependencies
 ------------
 
-In order to setup the JDBC connector, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
-
-|  Maven dependency                                  |  SQL Client JAR                                           |
-| :------------------------------------------------- | :-------------------------------------------------------- |
-| `flink-connector-jdbc{{site.scala_version_suffix}}`| {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc{{site.scala_version_suffix}}/{{site.version}}/flink-connector-jdbc{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/jdbc.html) {% endif %}|
+{% assign connector = site.data.sql-connectors['jdbc'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 <br>
 A driver dependency is also required to connect to a specified database. Here are drivers currently supported:

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -34,17 +34,10 @@ The Kafka connector allows for reading data from and writing data into Kafka top
 Dependencies
 ------------
 
-Apache Flink ships with multiple Kafka connectors: universal, 0.10, and 0.11.
-This universal Kafka connector attempts to track the latest version of the Kafka client.
-The version of the client it uses may change between Flink releases.
-Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
-For most users the universal Kafka connector is the most appropriate.
-However, for Kafka versions 0.11.x and 0.10.x, we recommend using the dedicated ``0.11`` and ``0.10`` connectors, respectively.
-For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
-
-| Kafka Version       | Maven dependency                                          | SQL Client JAR         |
-| :------------------ | :-------------------------------------------------------- | :----------------------|
-| universal           | `flink-connector-kafka{{site.scala_version_suffix}}`      | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kafka{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/kafka.html) {% endif %} |
+{% assign connector = site.data.sql-connectors['kafka'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 The Kafka connectors are not currently part of the binary distribution.
 See how to link with them for cluster execution [here]({% link dev/project-configuration.md %}).

--- a/docs/dev/table/connectors/kinesis.md
+++ b/docs/dev/table/connectors/kinesis.md
@@ -34,15 +34,10 @@ The Kinesis connector allows for reading data from and writing data into [Amazon
 Dependencies
 ------------
 
-To use the connector, add the following Maven dependency to your project:
-
-{% highlight xml %}
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-connector-kinesis{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version }}</version>
-</dependency>
-{% endhighlight %}
+{% assign connector = site.data.sql-connectors['kinesis'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a Kinesis data stream table
 -----------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

The PR creates a single page that lists all optional binaries for sql client. In the end we could link that page from the "Optional components" section in the https://flink.apache.org/downloads.html

## Brief change log
  - Adds a `liquify.rb` script which allows substituting variables in liquid variables
  - Creates a common mechanism for creating a table with download links for connector/format specific pages
  - Creates a page with an overview of all available format/connectors

Some screenshots:

Download:

![image](https://user-images.githubusercontent.com/6242259/98837655-7e947780-2443-11eb-94d5-ebc3a0602650.png)

Elasitcsearch (multiple versions):

![image](https://user-images.githubusercontent.com/6242259/98838010-f5317500-2443-11eb-9aec-fd686e141336.png)

Json (built-in connector):

![image](https://user-images.githubusercontent.com/6242259/98838042-04182780-2444-11eb-9da1-57a25f53eb96.png)

Orc (no versions):

![image](https://user-images.githubusercontent.com/6242259/98838731-f3b47c80-2444-11eb-8fa8-58f6d57e34bf.png)

## Verifying this change

1. Build the documentation, check pages for all connector, formats and the `Download` page
2. Repeat with `is_stable` set to true in `_config.yml`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
