### PR TITLE
[FLINK-20097][checkpointing] Race conditions in InputChannel.ChannelStatePersister

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.util.CloseableIterator;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Helper class for persisting channel state via {@link ChannelStateWriter}.
+ */
+@NotThreadSafe
+final class ChannelStatePersister {
+	protected final InputChannelInfo channelInfo;
+	private static final long CHECKPOINT_COMPLETED = -1;
+
+	private static final long BARRIER_RECEIVED = -2;
+
+	/**
+	 * All started checkpoints where a barrier has not been received yet.
+	 */
+	private long pendingCheckpointBarrierId = CHECKPOINT_COMPLETED;
+
+	/**
+	 * Writer must be initialized before usage. {@link #startPersisting(long, List)} enforces this invariant.
+	 */
+	@Nullable
+	private final ChannelStateWriter channelStateWriter;
+
+	ChannelStatePersister(@Nullable ChannelStateWriter channelStateWriter, InputChannelInfo channelInfo) {
+		this.channelStateWriter = channelStateWriter;
+		this.channelInfo = channelInfo;
+	}
+
+	protected void startPersisting(long barrierId, List<Buffer> knownBuffers) {
+		checkState(isInitialized(), "Channel state writer not injected");
+
+		if (pendingCheckpointBarrierId != BARRIER_RECEIVED) {
+			pendingCheckpointBarrierId = barrierId;
+		}
+		if (knownBuffers.size() > 0) {
+			channelStateWriter.addInputData(
+				barrierId,
+				channelInfo,
+				ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
+				CloseableIterator.fromList(knownBuffers, Buffer::recycleBuffer));
+		}
+	}
+
+	protected boolean isInitialized() {
+		return channelStateWriter != null;
+	}
+
+	protected void stopPersisting() {
+		pendingCheckpointBarrierId = CHECKPOINT_COMPLETED;
+	}
+
+	protected void maybePersist(Buffer buffer) {
+		if (pendingCheckpointBarrierId >= 0 && buffer.isBuffer()) {
+			channelStateWriter.addInputData(
+				pendingCheckpointBarrierId,
+				channelInfo,
+				ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
+				CloseableIterator.ofElement(buffer.retainBuffer(), Buffer::recycleBuffer));
+		}
+	}
+
+	protected boolean checkForBarrier(Buffer buffer) throws IOException {
+		final AbstractEvent priorityEvent = parsePriorityEvent(buffer);
+		if (priorityEvent instanceof CheckpointBarrier) {
+			pendingCheckpointBarrierId = BARRIER_RECEIVED;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Parses the buffer as an event and returns the {@link CheckpointBarrier} if the event is indeed a barrier or
+	 * returns null in all other cases.
+	 */
+	@Nullable
+	protected AbstractEvent parsePriorityEvent(Buffer buffer) throws IOException {
+		if (buffer.isBuffer() || !buffer.getDataType().hasPriority()) {
+			return null;
+		}
+
+		AbstractEvent event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
+		// reset the buffer because it would be deserialized again in SingleInputGate while getting next buffer.
+		// we can further improve to avoid double deserialization in the future.
+		buffer.setReaderIndex(0);
+		return event;
+	}
+
+	protected boolean hasBarrierReceived() {
+		return pendingCheckpointBarrierId == BARRIER_RECEIVED;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -116,7 +116,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	}
 
 	public void checkpointStopped(long checkpointId) {
-		channelStatePersister.stopPersisting();
+		channelStatePersister.stopPersisting(checkpointId);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -71,7 +71,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
 	private volatile boolean isReleased;
 
-	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null);
+	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null, channelInfo);
 
 	public LocalInputChannel(
 		SingleInputGate inputGate,
@@ -108,7 +108,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
 	public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {
 		checkState(!channelStatePersister.isInitialized(), "Already initialized");
-		channelStatePersister = new ChannelStatePersister(checkNotNull(channelStateWriter));
+		channelStatePersister = new ChannelStatePersister(checkNotNull(channelStateWriter), channelInfo);
 	}
 
 	public void checkpointStarted(CheckpointBarrier barrier) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -512,7 +512,7 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 
 	public void checkpointStopped(long checkpointId) {
 		synchronized (receivedBuffers) {
-			channelStatePersister.stopPersisting();
+			channelStatePersister.stopPersisting(checkpointId);
 			numBuffersOvertaken = ALL;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -105,7 +105,7 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 	private int numBuffersOvertaken = ALL;
 
 	@GuardedBy("receivedBuffers")
-	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null);
+	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null, channelInfo);
 
 	public RemoteInputChannel(
 		SingleInputGate inputGate,
@@ -129,7 +129,7 @@ public class RemoteInputChannel extends InputChannel implements ChannelStateHold
 
 	public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {
 		checkState(!channelStatePersister.isInitialized(), "Already initialized");
-		channelStatePersister = new ChannelStatePersister(checkNotNull(channelStateWriter));
+		channelStatePersister = new ChannelStatePersister(checkNotNull(channelStateWriter), channelInfo);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ChannelStatePersister} test.
+ */
+public class ChannelStatePersisterTest {
+
+	@Test
+	public void testNewBarrierNotOverwrittenByStopPersisting() throws IOException {
+		ChannelStatePersister persister = new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
+
+		persister.checkForBarrier(barrier(1L));
+		persister.startPersisting(1L, Collections.emptyList());
+
+		// meanwhile, checkpoint coordinator timed out the 1st checkpoint and started the 2nd
+		// now task thread is picking up the barrier and aborts the 1st:
+		persister.checkForBarrier(barrier(2L));
+		persister.stopPersisting(1L);
+
+		assertTrue(persister.hasBarrierReceived());
+	}
+
+	@Test
+	public void testNewBarrierNotOverwrittenByCheckForBarrier() throws IOException {
+		ChannelStatePersister persister = new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
+
+		persister.startPersisting(1L, Collections.emptyList());
+		persister.startPersisting(2L, Collections.emptyList());
+
+		assertFalse(persister.checkForBarrier(barrier(1L)));
+
+		assertFalse(persister.hasBarrierReceived());
+	}
+
+	private static Buffer barrier(long id) throws IOException {
+		return EventSerializer.toBuffer(
+			new CheckpointBarrier(id, 1L, CheckpointOptions.forCheckpointWithDefaultLocation()),
+			true
+		);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix race conditions in InputChannel.ChannelStatePersister
(please see FLINK-20097 for more details).

## Verifying this change

- Added two unit tests (`ChannelStatePersisterTest`)
- `UnalignedCheckpointITCase` untouched for now (created a follow-up FLINK-20103)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (`checkForBarrier`)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
