### PR TITLE
[FLINK-19300][flink-core] Fix input stream read to prevent heap based timer loss

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/io/PostVersionedIOReadableWritable.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/PostVersionedIOReadableWritable.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,7 +63,7 @@ public abstract class PostVersionedIOReadableWritable extends VersionedIOReadabl
 	 */
 	public final void read(InputStream inputStream) throws IOException {
 		byte[] tmp = new byte[VERSIONED_IDENTIFIER.length];
-		inputStream.read(tmp);
+		int totalRead = IOUtils.readFully(inputStream, tmp);
 
 		if (Arrays.equals(tmp, VERSIONED_IDENTIFIER)) {
 			DataInputView inputView = new DataInputViewStreamWrapper(inputStream);
@@ -70,10 +71,14 @@ public abstract class PostVersionedIOReadableWritable extends VersionedIOReadabl
 			super.read(inputView);
 			read(inputView, true);
 		} else {
-			PushbackInputStream resetStream = new PushbackInputStream(inputStream, VERSIONED_IDENTIFIER.length);
-			resetStream.unread(tmp);
+			InputStream streamToRead = inputStream;
+			if (totalRead > 0) {
+				PushbackInputStream resetStream = new PushbackInputStream(inputStream, totalRead);
+				resetStream.unread(tmp, 0, totalRead);
+				streamToRead = resetStream;
+			}
 
-			read(new DataInputViewStreamWrapper(resetStream), false);
+			read(new DataInputViewStreamWrapper(streamToRead), false);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -144,6 +144,30 @@ public final class IOUtils {
 	}
 
 	/**
+	 * Similar to readFully(). Returns the total number of bytes read into the buffer.
+	 * @param in
+	 *        The InputStream to read from
+	 * @param buf
+	 *        The buffer to fill
+	 * @return
+	 *        The total number of bytes read into the buffer
+	 * @throws IOException
+	 *         If the first byte cannot be read for any reason other than end of file,
+	 *         or if the input stream has been closed, or if some other I/O error occurs.
+	 */
+	public static int readFully(final InputStream in, final byte[] buf) throws IOException {
+		int totalRead = 0;
+		while (totalRead != buf.length) {
+			int read = in.read(buf, totalRead, buf.length - totalRead);
+			if (read == -1) {
+				break;
+			}
+			totalRead += read;
+		}
+		return totalRead;
+	}
+
+	/**
 	 * Similar to readFully(). Skips bytes in a loop.
 	 *
 	 * @param in

--- a/flink-core/src/test/java/org/apache/flink/util/IOUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/IOUtilsTest.java
@@ -1,0 +1,34 @@
+package org.apache.flink.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Tests for the {@link IOUtils}.
+ */
+public class IOUtilsTest extends TestLogger {
+
+	@Test
+	public void testReadFullyFromLongerStream() throws IOException {
+		ByteArrayInputStream inputStream = new ByteArrayInputStream("test-data".getBytes());
+
+		byte[] out = new byte[4];
+		int read = IOUtils.readFully(inputStream, out);
+
+		Assert.assertArrayEquals("test".getBytes(), Arrays.copyOfRange(out, 0, read));
+	}
+
+	@Test
+	public void testReadFullyFromShorterStream() throws IOException {
+		ByteArrayInputStream inputStream = new ByteArrayInputStream("t".getBytes());
+
+		byte[] out = new byte[4];
+		int read = IOUtils.readFully(inputStream, out);
+
+		Assert.assertArrayEquals("t".getBytes(), Arrays.copyOfRange(out, 0, read));
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fixes a timer loss issue when deserializing heap based timers, by fully reading input stream.

Currently we depend on InputStream.read(byte[]) to read in VERSIONED_IDENTIFIER bytes, however the read method for java InputStream will not guarantee reading all expected number of bytes. This change is to fix this behavior by keep reading until we read all expected bytes or if EOF is reached. 

In case of non-versioned payload, only push back the number of bytes we read above.

## Brief change log
- Attempt to read into versioned identifier byte array as much as possible from input stream.
- In case of non-versioned input, only push back the bytes that were read.

## Verifying this change

This change added tests and can be verified as follows:

- Unit test is added to verify the behavior
- Manually tested the restore behavior after the change and verified no timer loss after.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
