### PR TITLE
[FLINK-20046][python] Fix the unstable test case 'StreamTableAggregateTests.test_map_view_iterate'.

### DIFF
--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -345,7 +345,7 @@ class CachingMapStateHandler(object):
                     cached_map_state.put(map_key, (True, map_value))
                 else:
                     raise Exception("Unknown flag: " + str(request_flag))
-        self._append_raw(
+        return self._append_raw(
             state_key,
             items,
             map_key_coder,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the unstable test case 'StreamTableAggregateTests.test_map_view_iterate'.*


## Brief change log

  - *Fix the unstable test case 'StreamTableAggregateTests.test_map_view_iterate'.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
