### PR TITLE
[FLINK-20098] Don't add flink-connector-files to flink-dist

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -50,14 +50,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-file-sink-common</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -173,16 +173,8 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- format dependencies -->

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -137,19 +137,6 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<!-- Base Connector Support -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-files</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Default file system support. The Hadoop and MapR dependencies -->
 		<!--       are optional, so not being added to the dist jar        -->
 

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -50,12 +50,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Used for structured types extraction. -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## What is the purpose of the change

Before, we had both flink-connector-files and flink-connector-base as dependencies of flink-dist.

This implies, that users should use the dependency like this:

```
<dependency>
	<groupId>org.apache.flink</groupId>
	<artifactId>flink-connector-files</artifactId>
	<version>${project.version}</version>
	<scope>provided</scope>
</dependency>
```

which differs from other connectors where users don't need to specify `<scope>provided</scope>`.

Also, flink-connector-files has flink-connector-base as a provided dependency, which means that examples that use this dependency will not run out-of-box in IntelliJ because transitive provided dependencies will not be considered.

This change removes the dependencies from flink-dist and lets users use the File Connector like any other connector.

I believe the initial motivation for "providing" the File Connector in flink-dist was to allow us to use the File Connector under the hood in methods such as StreamExecutionEnvironment.readFile(...). We could decide to deprecate and remove those methods or re-add the File Connector as an explicit (non-provided) dependency again in the future.

## Brief change log

* only changes poms

## Verifying this change

Covered by existing tests, that still pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): _maybe_
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
