### PR TITLE
[BP-1.11][FLINK-20013][network] BoundedBlockingSubpartition may leak network buffer if task is failed or canceled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -200,6 +201,10 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 			isReleased = true;
 			isFinished = true; // for fail fast writes
 
+			if (currentBuffer != null) {
+				currentBuffer.close();
+				currentBuffer = null;
+			}
 			checkReaderReferencesAndDispose();
 		}
 	}
@@ -240,6 +245,11 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
 		if (readers.isEmpty()) {
 			data.close();
 		}
+	}
+
+	@VisibleForTesting
+	public BufferConsumer getCurrentBuffer() {
+		return currentBuffer;
 	}
 
 	// ------------------------------ legacy ----------------------------------


### PR DESCRIPTION
Backport of #14008 to `release-1.11`.