### PR TITLE
[FLINK-20029][table-planner-blink] Support computed columns with metadata

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
@@ -160,6 +160,7 @@ public class MergeTableLikeUtilTest {
 		TableSchema sourceSchema = TableSchema.builder()
 				.add(TableColumn.physical("one", DataTypes.INT()))
 				.add(TableColumn.metadata("two", DataTypes.INT(), false))
+				.add(TableColumn.computed("c", DataTypes.INT(), "ABS(two)"))
 				.build();
 
 		List<SqlNode> derivedColumns = Arrays.asList(
@@ -176,6 +177,7 @@ public class MergeTableLikeUtilTest {
 		TableSchema expectedSchema = TableSchema.builder()
 				.add(TableColumn.physical("one", DataTypes.INT()))
 				.add(TableColumn.metadata("two", DataTypes.INT(), false))
+				.add(TableColumn.computed("c", DataTypes.INT(), "ABS(two)"))
 				.add(TableColumn.physical("three", DataTypes.INT()))
 				.add(TableColumn.metadata("four", DataTypes.INT(), true))
 				.build();

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.java
@@ -198,9 +198,30 @@ public class PushWatermarkIntoTableSourceScanRuleTest extends TableTestBase {
 						"  b BIGINT,\n" +
 						"  c TIMESTAMP(3),\n" +
 						"  d AS func(c, a),\n" +
-						"WATERMARK FOR d AS func(func(d, a), a)\n" +
+						"  WATERMARK FOR d AS func(func(d, a), a)\n" +
 						") WITH (\n" +
 						"  'connector' = 'values',\n" +
+						"  'enable-watermark-push-down' = 'true',\n" +
+						"  'bounded' = 'false',\n" +
+						"  'disable-lookup' = 'true'" +
+						")";
+		util.tableEnv().executeSql(ddl);
+		util.verifyPlan("SELECT * FROM MyTable");
+	}
+
+	@Test
+	public void testWatermarkOnMetadata() {
+		String ddl =
+				"CREATE TABLE MyTable(" +
+						"  `a` INT,\n" +
+						"  `b` BIGINT,\n" +
+						"  `c` TIMESTAMP(3),\n" +
+						"  `metadata` BIGINT METADATA FROM 'metadata_2' VIRTUAL,\n" +
+						"  `computed` AS `metadata` + `b`,\n" +
+						"  WATERMARK for `c` as c - CAST(`metadata` + `computed` AS INTERVAL SECOND)\n" +
+						") WITH (\n" +
+						"  'connector' = 'values',\n" +
+						"  'readable-metadata' = 'metadata_1:STRING,metadata_2:INT',\n" +
 						"  'enable-watermark-push-down' = 'true',\n" +
 						"  'bounded' = 'false',\n" +
 						"  'disable-lookup' = 'true'" +

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushWatermarkIntoTableSourceScanRuleTest.xml
@@ -96,6 +96,26 @@ FlinkLogicalCalc(select=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWatermarkOnMetadata">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[$3], computed=[$4])
++- LogicalWatermarkAssigner(rowtime=[c], watermark=[-($2, CAST(+($3, $4)):INTERVAL SECOND)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], metadata=[CAST($3):BIGINT], computed=[+(CAST($3):BIGINT, $1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, metadata, computed])
++- FlinkLogicalCalc(select=[a, b, Reinterpret(c) AS c, CAST(metadata_2) AS metadata, +(CAST(metadata_2), b) AS computed])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[-($2, CAST(+(CAST($3):BIGINT, +(CAST($3):BIGINT, $1))):INTERVAL SECOND)]]], fields=[a, b, c, metadata_2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testWatermarkOnNestedRow">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -54,6 +54,44 @@ Calc(select=[a, b, EXTRACT(FLAG(SECOND), CAST(Reinterpret(+(c, 5000:INTERVAL SEC
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWatermarkOnNestedRowWithNestedProjection">
+    <Resource name="sql">
+      <![CDATA[select c.e, c.d from NestedTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(e=[$2.d.e], d=[$2.d])
++- LogicalWatermarkAssigner(rowtime=[g], watermark=[-($3, 5000:INTERVAL SECOND)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], g=[$2.d.f])
+      +- LogicalTableScan(table=[[default_catalog, default_database, NestedTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[c.d.e AS e, c.d AS d])
++- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], watermark=[-($0.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWatermarkWithMetadata">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$4])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], originTime=[$3], rowtime=[TO_TIMESTAMP(FROM_UNIXTIME(/($3, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, originTime], watermark=[TO_TIMESTAMP(FROM_UNIXTIME(/($2, 1000)), _UTF-16LE'yyyy-MM-dd HH:mm:ss')]]], fields=[a, b, originTime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testWatermarkOnComputedColumnExcluedRowTime1">
     <Resource name="sql">
       <![CDATA[SELECT a, b FROM VirtualTable WHERE b > 10]]>
@@ -71,25 +109,6 @@ LogicalProject(a=[$0], b=[$1])
       <![CDATA[
 Calc(select=[a, b], where=[>(b, 10)])
 +- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testWatermarkOnNestedRowWithNestedProjection">
-    <Resource name="sql">
-      <![CDATA[select c.e, c.d from NestedTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(e=[$2.d.e], d=[$2.d])
-+- LogicalWatermarkAssigner(rowtime=[g], watermark=[-($3, 5000:INTERVAL SECOND)])
-   +- LogicalProject(a=[$0], b=[$1], c=[$2], g=[$2.d.f])
-      +- LogicalTableScan(table=[[default_catalog, default_database, NestedTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[c.d.e AS e, c.d AS d])
-+- TableSourceScan(table=[[default_catalog, default_database, NestedTable, project=[c], watermark=[-($0.d.f, 5000:INTERVAL SECOND)]]], fields=[c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -196,13 +196,13 @@ Calc(select=[ts, a, b, my_ts, PROCTIME_MATERIALIZE(proc) AS proc], where=[>(a, 1
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a=[$0], other_metadata=[CAST($4):INTEGER], b=[$1], c=[$2], metadata_1=[$3])
+LogicalProject(a=[$0], other_metadata=[CAST($4):INTEGER], b=[$1], c=[$2], metadata_1=[$3], computed=[UPPER($3)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[a, CAST(metadata_3) AS other_metadata, b, c, metadata_1])
+Calc(select=[a, CAST(metadata_3) AS other_metadata, b, c, metadata_1, UPPER(metadata_1) AS computed])
 +- TableSourceScan(table=[[default_catalog, default_database, MetadataTable]], fields=[a, b, c, metadata_1, metadata_3])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -40,7 +40,7 @@ Calc(select=[id, deepNested_nested1_name AS nestedName, nested_value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testNestProjectWithMetadata">
+  <TestCase name="testNestedProjectWithMetadata">
     <Resource name="sql">
       <![CDATA[
 SELECT id,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.scala
@@ -108,10 +108,8 @@ class SourceWatermarkTest extends TableTestBase {
     util.verifyPlan("SELECT a - b FROM UdfTable")
   }
 
-  @Ignore
   @Test
   def testWatermarkWithMetadata(): Unit = {
-    // TODO(FLINK-20029): define computed column on the metadata
     val ddl =
       """
         | CREATE TABLE MyTable(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -86,7 +86,8 @@ class TableScanTest extends TableTestBase {
          |  `other_metadata` INT METADATA FROM 'metadata_3' VIRTUAL,
          |  `b` BIGINT,
          |  `c` INT,
-         |  `metadata_1` STRING METADATA
+         |  `metadata_1` STRING METADATA,
+         |  `computed` AS UPPER(`metadata_1`)
          |) WITH (
          |  'connector' = 'values',
          |  'bounded' = 'false',

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -209,7 +209,7 @@ class TableSourceTest extends TableTestBase {
   }
 
   @Test
-  def testNestProjectWithMetadata(): Unit = {
+  def testNestedProjectWithMetadata(): Unit = {
     val ddl =
       s"""
          |CREATE TABLE T (

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/SourceWatermarkITCase.scala
@@ -139,10 +139,8 @@ class SourceWatermarkITCase extends StreamingTestBase{
     assertEquals(expectedData.sorted, sink.getAppendResults.sorted)
   }
 
-  @Ignore
   @Test
   def testWatermarkWithMetadata(): Unit = {
-    // TODO(FLINK-20029): define computed column on the metadata
     val data = Seq(
       row(1, 2L, Timestamp.valueOf("2020-11-21 19:00:05.23").toInstant.toEpochMilli),
       row(1, 3L, Timestamp.valueOf("2020-11-21 21:00:05.23").toInstant.toEpochMilli)


### PR DESCRIPTION
## What is the purpose of the change

Fixes a bug in `TableMergeUtil` that prevented accessing metadata columns in computed columns.

## Brief change log

- Fix bug in `TableMergeUtil`
- Add plan tests
- Add integration tests

## Verifying this change

This change added tests and can be verified as follows:
`TableSourceITCase`, `TableScanTest` and watermark tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
