### PR TITLE
[FLINK-20043][kinesis] Add flink-sql-connector-kinesis package

### DIFF
--- a/docs/_data/sql-connectors.yml
+++ b/docs/_data/sql-connectors.yml
@@ -121,4 +121,5 @@ kinesis:
     name: Kinesis
     category: connector
     maven: flink-connector-kinesis{{ site.scala_version_suffix }}
+    sql-url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kinesis{{site.scala_version_suffix}}-{{site.version}}.jar
 

--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -70,6 +70,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis</a></td>
+      <td></td>
+      <td>Unbounded Scan</td>
+      <td>Streaming Sink</td>
+    </tr>
+    <tr>
       <td><a href="{% link dev/table/connectors/jdbc.md %}">JDBC</a></td>
       <td></td>
       <td>Bounded Scan, Lookup</td>

--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -70,7 +70,7 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
-      <td><a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis</a></td>
+      <td><a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>
       <td>Streaming Sink</td>

--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -70,6 +70,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis Data Streams</a></td>
+      <td></td>
+      <td>Unbounded Scan</td>
+      <td>Streaming Sink</td>
+    </tr>
+    <tr>
       <td><a href="{% link dev/table/connectors/jdbc.zh.md %}">JDBC</a></td>
       <td></td>
       <td>Bounded Scan, Lookup</td>

--- a/docs/dev/table/connectors/kinesis.md
+++ b/docs/dev/table/connectors/kinesis.md
@@ -39,9 +39,10 @@ Dependencies
     connector=connector
 %}
 
-| Maven dependency                                          | SQL Client JAR         |
-| :-------------------------------------------------------- | :----------------------|
-| `flink-connector-kinesis{{site.scala_version_suffix}}`    | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kinesis{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/kinesis.html) {% endif %} |
+{% assign connector = site.data.sql-connectors['kinesis'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a Kinesis data stream table
 -----------------------------------------

--- a/docs/dev/table/connectors/kinesis.md
+++ b/docs/dev/table/connectors/kinesis.md
@@ -39,6 +39,10 @@ Dependencies
     connector=connector
 %}
 
+| Maven dependency                                          | SQL Client JAR         |
+| :-------------------------------------------------------- | :----------------------|
+| `flink-connector-kinesis{{site.scala_version_suffix}}`    | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kinesis{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/kinesis.html) {% endif %} |
+
 How to create a Kinesis data stream table
 -----------------------------------------
 

--- a/docs/dev/table/connectors/kinesis.zh.md
+++ b/docs/dev/table/connectors/kinesis.zh.md
@@ -44,9 +44,10 @@ To use the connector, add the following Maven dependency to your project:
 </dependency>
 {% endhighlight %}
 
-| Maven dependency                                          | SQL Client JAR         |
-| :-------------------------------------------------------- | :----------------------|
-| `flink-connector-kinesis{{site.scala_version_suffix}}`    | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kinesis{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/kinesis.html) {% endif %} |
+{% assign connector = site.data.sql-connectors['kinesis'] %} 
+{% include sql-connector-download-table.html 
+    connector=connector
+%}
 
 How to create a Kinesis data stream table
 -----------------------------------------

--- a/docs/dev/table/connectors/kinesis.zh.md
+++ b/docs/dev/table/connectors/kinesis.zh.md
@@ -44,6 +44,10 @@ To use the connector, add the following Maven dependency to your project:
 </dependency>
 {% endhighlight %}
 
+| Maven dependency                                          | SQL Client JAR         |
+| :-------------------------------------------------------- | :----------------------|
+| `flink-connector-kinesis{{site.scala_version_suffix}}`    | {% if site.is_stable %} [Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis{{site.scala_version_suffix}}/{{site.version}}/flink-sql-connector-kinesis{{site.scala_version_suffix}}-{{site.version}}.jar) {% else %} Only available for [stable releases]({{ site.stable_baseurl }}/dev/table/connectors/kinesis.html) {% endif %} |
+
 How to create a Kinesis data stream table
 -----------------------------------------
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -312,6 +312,12 @@ under the License.
 							</relocations>
 							<filters>
 								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>.gitkeep</exclude>
+									</excludes>
+								</filter>
+								<filter>
 									<artifact>com.amazonaws:amazon-kinesis-producer</artifact>
 									<excludes>
 										<exclude>META-INF/THIRD_PARTY_NOTICES</exclude>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -59,11 +59,19 @@ under the License.
 							<shadeTestJar>false</shadeTestJar>
 							<artifactSet>
 								<includes>
-									<include>*:*</include>
+									<include>org.apache.flink:flink-connector-kinesis_${scala.binary.version}</include>
+									<include>com.fasterxml.jackson.core:jackson-core</include>
+									<include>com.fasterxml.jackson.core:jackson-databind</include>
+									<include>com.fasterxml.jackson.core:jackson-annotations</include>
+									<include>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</include>
+									<include>joda-time:joda-time</include>
+									<include>commons-codec:commons-codec</include>
+									<include>commons-io:commons-io</include>
+									<include>commons-lang:commons-lang</include>
+									<include>commons-logging:commons-logging</include>
+									<include>org.apache.commons:commons-lang3</include>
+									<include>com.google.guava:guava</include>
 								</includes>
-								<excludes>
-									<exclude>org.apache.flink:force-shading</exclude>
-								</excludes>
 							</artifactSet>
 							<filters>
 								<filter>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.12-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-sql-connector-kinesis_${scala.binary.version}</artifactId>
+	<name>Flink : Connectors : SQL : Kinesis</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+								<excludes>
+									<exclude>org.apache.flink:force-shading</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>codegen-resources/**</exclude>
+										<exclude>mozilla/public-suffix-list.txt</exclude>
+										<exclude>VersionInfo.java</exclude>
+										<exclude>mime.types</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<relocations>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.commons</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.org.apache.commons</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.com.google</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.joda.time</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.org.joda.time</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,19 @@
+flink-sql-connector-kinesis
+Copyright 2014-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- joda-time:joda-time:jar:2.5
+- commons-io:commons-io:jar:2.7
+- commons-lang:commons-lang:jar:2.6
+- commons-logging:commons-logging:jar:1.1.3
+- commons-codec:commons-codec:jar:1.13
+- org.apache.commons:commons-lang3:jar:3.3.2
+- com.google.guava:guava:jar:18.0
+- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1
+- com.fasterxml.jackson.core:jackson-core:jar:2.10.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.10.1

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -6,14 +6,14 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- joda-time:joda-time:jar:2.5
-- commons-io:commons-io:jar:2.7
-- commons-lang:commons-lang:jar:2.6
-- commons-logging:commons-logging:jar:1.1.3
-- commons-codec:commons-codec:jar:1.13
-- org.apache.commons:commons-lang3:jar:3.3.2
-- com.google.guava:guava:jar:18.0
-- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1
-- com.fasterxml.jackson.core:jackson-core:jar:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.10.1
+- joda-time:joda-time:2.5
+- commons-io:commons-io:2.7
+- commons-lang:commons-lang:2.6
+- commons-logging:commons-logging:1.1.3
+- commons-codec:commons-codec:1.13
+- org.apache.commons:commons-lang3:3.3.2
+- com.google.guava:guava:18.0
+- com.fasterxml.jackson.core:jackson-annotations:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -102,6 +102,7 @@ under the License.
 				<module>flink-sql-connector-hive-2.3.6</module>
 				<module>flink-sql-connector-hive-3.1.2</module>
 				<module>flink-sql-connector-kafka</module>
+				<module>flink-sql-connector-kinesis</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -77,6 +77,13 @@ under the License.
 		<dependency>
 			<!-- Used by maven-dependency-plugin -->
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-connector-kinesis_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<!-- Used by maven-dependency-plugin -->
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-elasticsearch6_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
@@ -147,6 +154,12 @@ under the License.
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-sql-connector-kafka_${scala.binary.version}</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-sql-connector-kinesis_${scala.binary.version}</artifactId>
 									<version>${project.version}</version>
 									<type>jar</type>
 								</artifactItem>

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -61,15 +61,27 @@ for SQL_JAR in $SQL_JARS_DIR/*.jar; do
         ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/META-INF"* ]] && \
         ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/LICENSE"* ]] && \
         ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/NOTICE"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/org/apache/avro"* ]] ; then
+        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/org/apache/avro"* ]] && \
+        # Following required by amazon-kinesis-producer in flink-connector-kinesis
+        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/amazon-kinesis-producer-native-binaries"* ]] && \
+        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/cacerts"* ]] ; then
       echo "Bad file in JAR: $EXTRACTED_FILE"
       exit 1
     fi
   done
 
-  # check for proper factory
-  if [ ! -f $EXTRACTED_JAR/META-INF/services/org.apache.flink.table.factories.TableFactory ]; then
-    echo "No table factory found in JAR: $SQL_JAR"
+  # check for proper legacy table factory
+  # Kinesis connector does not support legacy Table API
+  if [[ $SQL_JAR == *"flink-sql-connector-kinesis"* ]]; then
+    echo "Skipping Legacy Table API for: $SQL_JAR"
+  elif [ ! -f $EXTRACTED_JAR/META-INF/services/org.apache.flink.table.factories.TableFactory ]; then
+    echo "No legacy table factory found in JAR: $SQL_JAR"
+    exit 1
+  fi
+
+  # check for new legacy table factory
+  if [ ! -f $EXTRACTED_JAR/META-INF/services/org.apache.flink.table.factories.Factory ]; then
+    echo "No new table factory found in JAR: $SQL_JAR"
     exit 1
   fi
 

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -79,7 +79,7 @@ for SQL_JAR in $SQL_JARS_DIR/*.jar; do
     exit 1
   fi
 
-  # check for new legacy table factory
+  # check for table factory
   if [ ! -f $EXTRACTED_JAR/META-INF/services/org.apache.flink.table.factories.Factory ]; then
     echo "No new table factory found in JAR: $SQL_JAR"
     exit 1


### PR DESCRIPTION
## What is the purpose of the change

Add an uber jar client library for Kinesis connector to be used with SQL client. 

## Brief change log

- Added new maven module `flink-sql-connector-kinesis`
- Updated E2E test to verify the shading of client library

## Verifying this change

- Verified manually using SQL client
  - `./sql-client.sh embedded --jar flink-sql-connector-kinesis_2.11-1.12-SNAPSHOT.jar`
- Updated `flink-sql-client-test` to include Kinesis client
- Updated `test_sql_client.sh` to verify the shading of Kinesis jar
  - Legacy Table API is excluded for Kinesis since we are not supporting that

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
