### PR TITLE
[FLINK-20107][network] Make InputChannel.statePersister immutable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.reader;
 
 import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.DeserializationResult;
@@ -88,6 +89,7 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 				Optional<BufferOrEvent> polled = inputGate.pollNext();
 				Preconditions.checkState(!polled.isPresent());
 			}
+			inputGate.setChannelStateWriter(ChannelStateWriter.NO_OP);
 			inputGate.requestPartitions();
 			requestedPartitions = true;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
-import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
@@ -52,7 +51,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * An input channel, which requests a local subpartition.
  */
-public class LocalInputChannel extends InputChannel implements BufferAvailabilityListener, ChannelStateHolder {
+public class LocalInputChannel extends InputChannel implements BufferAvailabilityListener {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocalInputChannel.class);
 
@@ -71,7 +70,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
 	private volatile boolean isReleased;
 
-	private ChannelStatePersister channelStatePersister = new ChannelStatePersister(null, channelInfo);
+	private final ChannelStatePersister channelStatePersister;
 
 	public LocalInputChannel(
 		SingleInputGate inputGate,
@@ -82,7 +81,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		Counter numBytesIn,
 		Counter numBuffersIn) {
 
-		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, 0, 0, numBytesIn, numBuffersIn);
+		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, 0, 0, numBytesIn, numBuffersIn, ChannelStateWriter.NO_OP);
 	}
 
 	public LocalInputChannel(
@@ -94,22 +93,19 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		int initialBackoff,
 		int maxBackoff,
 		Counter numBytesIn,
-		Counter numBuffersIn) {
+		Counter numBuffersIn,
+		ChannelStateWriter stateWriter) {
 
 		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, numBytesIn, numBuffersIn);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
+		this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
 	}
 
 	// ------------------------------------------------------------------------
 	// Consume
 	// ------------------------------------------------------------------------
-
-	public void setChannelStateWriter(ChannelStateWriter channelStateWriter) {
-		checkState(!channelStatePersister.isInitialized(), "Already initialized");
-		channelStatePersister = new ChannelStatePersister(checkNotNull(channelStateWriter), channelInfo);
-	}
 
 	public void checkpointStarted(CheckpointBarrier barrier) {
 		channelStatePersister.startPersisting(barrier.getId(), Collections.emptyList());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
@@ -59,7 +59,7 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
 
 	@Override
 	protected InputChannel toInputChannelInternal() {
-		final LocalInputChannel localInputChannel = new LocalInputChannel(
+		return new LocalInputChannel(
 			inputGate,
 			getChannelIndex(),
 			partitionId,
@@ -68,10 +68,7 @@ public class LocalRecoveredInputChannel extends RecoveredInputChannel {
 			initialBackoff,
 			maxBackoff,
 			numBytesIn,
-			numBytesIn);
-		if (channelStateWriter != null) {
-			localInputChannel.setChannelStateWriter(channelStateWriter);
-		}
-		return localInputChannel;
+			numBytesIn,
+			channelStateWriter);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -71,10 +71,8 @@ public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
 			maxBackoff,
 			networkBuffersPerChannel,
 			numBytesIn,
-			numBuffersIn);
-		if (channelStateWriter != null) {
-			remoteInputChannel.setChannelStateWriter(channelStateWriter);
-		}
+			numBuffersIn,
+			channelStateWriter);
 		remoteInputChannel.setup();
 		return remoteInputChannel;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
@@ -637,7 +638,8 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 				100,
 				2,
 				new SimpleCounter(),
-				new SimpleCounter());
+				new SimpleCounter(),
+				ChannelStateWriter.NO_OP);
 			this.expectedMessage = expectedMessage;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -37,6 +37,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Consumer;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -105,11 +106,22 @@ public class InputChannelTestUtils {
 		int initialBackoff,
 		int maxBackoff) {
 
-		return InputChannelBuilder.newBuilder()
+		return createLocalInputChannel(inputGate, partitionManager, initialBackoff, maxBackoff, unused -> { /* no op */ });
+	}
+
+	public static LocalInputChannel createLocalInputChannel(
+			SingleInputGate inputGate,
+			ResultPartitionManager partitionManager,
+			int initialBackoff,
+			int maxBackoff,
+			Consumer<InputChannelBuilder> setter) {
+
+		InputChannelBuilder inputChannelBuilder = InputChannelBuilder.newBuilder()
 			.setPartitionManager(partitionManager)
 			.setInitialBackoff(initialBackoff)
-			.setMaxBackoff(maxBackoff)
-			.buildLocalChannel(inputGate);
+			.setMaxBackoff(maxBackoff);
+		setter.accept(inputChannelBuilder);
+		return inputChannelBuilder.buildLocalChannel(inputGate);
 	}
 
 	public static RemoteInputChannel createRemoteInputChannel(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -141,6 +142,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 			while (!gate.getStateConsumedFuture().isDone()) {
 				gate.pollNext();
 			}
+			gate.setChannelStateWriter(ChannelStateWriter.NO_OP);
 			gate.requestPartitions();
 			Buffer buffer = gate.getNext().orElseThrow(IllegalStateException::new).getBuffer();
 			if (buffer != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -467,12 +467,10 @@ public class LocalInputChannelTest {
 		ResultSubpartitionView subpartitionView = subpartition.createReadView(() -> {});
 
 		TestingResultPartitionManager partitionManager = new TestingResultPartitionManager(subpartitionView);
-		LocalInputChannel channel = createLocalInputChannel(inputGate, partitionManager);
+		final RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+		LocalInputChannel channel = createLocalInputChannel(inputGate, partitionManager, 0, 0, b -> b.setStateWriter(stateWriter));
 		inputGate.setInputChannels(channel);
 		channel.requestSubpartition(0);
-
-		final RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
-		inputGate.setChannelStateWriter(stateWriter);
 
 		final CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
 		CheckpointOptions options = new CheckpointOptions(CheckpointType.CHECKPOINT, location, true, true, 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -153,9 +153,8 @@ public class SingleInputGateBuilder {
 			bufferSize);
 		if (channelFactory != null) {
 			gate.setInputChannels(IntStream.range(0, numberOfChannels)
-				.mapToObj(index -> channelFactory.apply(InputChannelBuilder.newBuilder().setChannelIndex(index), gate))
+				.mapToObj(index -> channelFactory.apply(InputChannelBuilder.newBuilder().setStateWriter(channelStateWriter).setChannelIndex(index), gate))
 				.toArray(InputChannel[]::new));
-			gate.setChannelStateWriter(channelStateWriter);
 		}
 		return gate;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/UnalignedControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/UnalignedControllerTest.java
@@ -650,11 +650,11 @@ public class UnalignedControllerTest {
 			.mapToObj(channelIndex ->
 				InputChannelBuilder.newBuilder()
 					.setChannelIndex(channelIndex)
+					.setStateWriter(channelStateWriter)
 					.setupFromNettyShuffleEnvironment(environment)
 					.setConnectionManager(new TestingConnectionManager())
 					.buildRemoteChannel(gate))
 			.toArray(RemoteInputChannel[]::new));
-		gate.setChannelStateWriter(channelStateWriter);
 		sequenceNumbers = new int[numberOfChannels];
 
 		gate.setup();
@@ -704,8 +704,9 @@ public class UnalignedControllerTest {
 	}
 
 	private void assertInflightData(BufferOrEvent... expected) {
-		assertEquals("Unexpected in-flight sequence", getIds(Arrays.asList(expected)),
-			getIds(getAndResetInflightData()));
+		Collection<BufferOrEvent> andResetInflightData = getAndResetInflightData();
+		assertEquals("Unexpected in-flight sequence: " + andResetInflightData, getIds(Arrays.asList(expected)),
+			getIds(andResetInflightData));
 	}
 
 	private Collection<BufferOrEvent> getAndResetInflightData() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io.benchmark;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -116,7 +117,8 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				initialBackoff,
 				maxBackoff,
 				metrics.getNumBytesInLocalCounter(),
-				metrics.getNumBuffersInLocalCounter());
+				metrics.getNumBuffersInLocalCounter(),
+				ChannelStateWriter.NO_OP);
 		}
 
 		@Override
@@ -162,7 +164,8 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				maxBackoff,
 				networkBuffersPerChannel,
 				metrics.getNumBytesInRemoteCounter(),
-				metrics.getNumBuffersInRemoteCounter());
+				metrics.getNumBuffersInRemoteCounter(),
+				ChannelStateWriter.NO_OP);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Make `InputChannel.statePersister` immutable to
 - prevent possible errors (forgetting to set the field when converting from `UnknownChannel`
 - and visibility problems (write by task thread, read by network thread.

This change leaves `statePersister` mutable in channels that will be converted after requesting partitions. There is no race condition here because requesting partitions and conversion is done by the same (task) thread.

## Verifying this change


This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
