### PR TITLE
[FLINK-20030][network] Rewrite RemoteInputChannel#getInflightBuffersUnsafe to use sequence numbers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -30,6 +30,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -87,16 +88,16 @@ final class ChannelStatePersister {
 		}
 	}
 
-	protected boolean checkForBarrier(Buffer buffer) throws IOException {
+	protected Optional<Long> checkForBarrier(Buffer buffer) throws IOException {
 		final AbstractEvent priorityEvent = parsePriorityEvent(buffer);
 		if (priorityEvent instanceof CheckpointBarrier) {
 			if (((CheckpointBarrier) priorityEvent).getId() >= lastSeenBarrier) {
 				checkpointStatus = CheckpointStatus.BARRIER_RECEIVED;
 				lastSeenBarrier = ((CheckpointBarrier) priorityEvent).getId();
-				return true;
+				return Optional.of(lastSeenBarrier);
 			}
 		}
-		return false;
+		return Optional.empty();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -45,7 +45,6 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -61,7 +60,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class RemoteInputChannel extends InputChannel {
 
-	public static final int ALL = -1;
+	private static final int NONE = -1;
+
 	/** ID to distinguish this channel from other channels sharing the same TCP connection. */
 	private final InputChannelID id = new InputChannelID();
 
@@ -99,9 +99,13 @@ public class RemoteInputChannel extends InputChannel {
 
 	private final BufferManager bufferManager;
 
-	/** Stores #overtaken buffers when a checkpoint barrier is received before task thread started checkpoint. */
+	/**
+	 * Indicates the last overtaken sequence number by the most recent {@link CheckpointBarrier}
+	 * before task thread started checkpoint, or {@code null} if {@link CheckpointBarrier} hasn't
+	 * arrived yet.
+	 */
 	@GuardedBy("receivedBuffers")
-	private int numBuffersOvertaken = ALL;
+	private int lastOvertakenSequenceNumber = NONE;
 
 	private final ChannelStatePersister channelStatePersister;
 
@@ -125,6 +129,11 @@ public class RemoteInputChannel extends InputChannel {
 		this.connectionManager = checkNotNull(connectionManager);
 		this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
 		this.channelStatePersister = new ChannelStatePersister(stateWriter, getChannelInfo());
+	}
+
+	@VisibleForTesting
+	void setExpectedSequenceNumber(int expectedSequenceNumber) {
+		this.expectedSequenceNumber = expectedSequenceNumber;
 	}
 
 	/**
@@ -476,7 +485,7 @@ public class RemoteInputChannel extends InputChannel {
 		if (channelStatePersister.checkForBarrier(sequenceBuffer.buffer)) {
 			// checkpoint was not yet started by task thread,
 			// so remember the numbers of buffers to spill for the time when it will be started
-			numBuffersOvertaken = receivedBuffers.getNumUnprioritizedElements();
+			lastOvertakenSequenceNumber = sequenceBuffer.sequenceNumber;
 		}
 		return receivedBuffers.getNumPriorityElements() == 1;
 	}
@@ -501,41 +510,77 @@ public class RemoteInputChannel extends InputChannel {
 		synchronized (receivedBuffers) {
 			channelStatePersister.startPersisting(
 				barrier.getId(),
-				getInflightBuffers(numBuffersOvertaken == ALL ? receivedBuffers.getNumUnprioritizedElements() : numBuffersOvertaken));
+				getInflightBuffers());
 		}
 	}
 
 	public void checkpointStopped(long checkpointId) {
 		synchronized (receivedBuffers) {
 			channelStatePersister.stopPersisting(checkpointId);
-			numBuffersOvertaken = ALL;
+			lastOvertakenSequenceNumber = NONE;
+		}
+	}
+
+	@VisibleForTesting
+	List<Buffer> getInflightBuffers() {
+		synchronized (receivedBuffers) {
+			return getInflightBuffersUnsafe();
 		}
 	}
 
 	/**
 	 * Returns a list of buffers, checking the first n non-priority buffers, and skipping all events.
 	 */
-	private List<Buffer> getInflightBuffers(int numBuffers) {
+	private List<Buffer> getInflightBuffersUnsafe() {
 		assert Thread.holdsLock(receivedBuffers);
 
-		if (numBuffers == 0) {
-			return Collections.emptyList();
-		}
-
-		final List<Buffer> inflightBuffers = new ArrayList<>(numBuffers);
+		final List<Buffer> inflightBuffers = new ArrayList<>();
 		Iterator<SequenceBuffer> iterator = receivedBuffers.iterator();
 		// skip all priority events (only buffers are stored anyways)
 		Iterators.advance(iterator, receivedBuffers.getNumPriorityElements());
 
-		// spill number of overtaken buffers or all of them if barrier has not been seen yet
-		for (int pos = 0; pos < numBuffers; pos++) {
-			Buffer buffer = iterator.next().buffer;
-			if (buffer.isBuffer()) {
-				inflightBuffers.add(buffer.retainBuffer());
+		while (iterator.hasNext()) {
+			SequenceBuffer sequenceBuffer = iterator.next();
+			if (sequenceBuffer.buffer.isBuffer()) {
+				if (shouldBeSpilled(sequenceBuffer.sequenceNumber)) {
+					inflightBuffers.add(sequenceBuffer.buffer.retainBuffer());
+				} else {
+					break;
+				}
 			}
 		}
 
+		lastOvertakenSequenceNumber = NONE;
+
 		return inflightBuffers;
+	}
+
+	/**
+	 * @return if given {@param sequenceNumber} should be spilled given {@link #lastOvertakenSequenceNumber}.
+	 * We might not have yet received {@link CheckpointBarrier} and we might need to spill everything.
+	 * If we have already received it, there is a bit nasty corner case of {@link SequenceBuffer#sequenceNumber}
+	 * overflowing that needs to be handled as well.
+	 */
+	private boolean shouldBeSpilled(int sequenceNumber) {
+		if (lastOvertakenSequenceNumber == NONE) {
+			return true;
+		}
+		checkState(
+			receivedBuffers.size() < Integer.MAX_VALUE / 2,
+			"Too many buffers for sequenceNumber overflow detection code to work correctly");
+
+		boolean possibleOverflowAfterOvertaking = Integer.MAX_VALUE / 2 < lastOvertakenSequenceNumber;
+		boolean possibleOverflowBeforeOvertaking = lastOvertakenSequenceNumber < -Integer.MAX_VALUE / 2;
+
+		if (possibleOverflowAfterOvertaking) {
+			return sequenceNumber < lastOvertakenSequenceNumber && sequenceNumber > 0;
+		}
+		else if (possibleOverflowBeforeOvertaking) {
+			return sequenceNumber < lastOvertakenSequenceNumber || sequenceNumber > 0;
+		}
+		else {
+			return sequenceNumber < lastOvertakenSequenceNumber;
+		}
 	}
 
 	public void onEmptyBuffer(int sequenceNumber, int backlog) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -59,7 +59,7 @@ public class ChannelStatePersisterTest {
 		persister.startPersisting(1L, Collections.emptyList());
 		persister.startPersisting(2L, Collections.emptyList());
 
-		assertFalse(persister.checkForBarrier(barrier(1L)));
+		assertFalse(persister.checkForBarrier(barrier(1L)).isPresent());
 
 		assertFalse(persister.hasBarrierReceived());
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -59,6 +59,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
@@ -72,6 +73,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.runtime.io.network.api.serialization.EventSerializer.toBuffer;
@@ -82,6 +84,7 @@ import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtil
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
@@ -1125,58 +1128,91 @@ public class RemoteInputChannelTest {
 
 	@Test
 	public void testPrioritySequenceNumbers() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
-		SingleInputGate inputGate = new SingleInputGateBuilder()
-			.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
-			.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
-			.setSegmentProvider(networkBufferPool)
-			.build();
-		final RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
-		inputGate.setup();
-		inputGate.requestPartitions();
+		int sequenceNumber = 0;
+		int bufferSize = 1;
+		final RemoteInputChannel channel = buildInputGateAndGetChannel(sequenceNumber);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBarrier(channel, sequenceNumber++, 0);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
 
-		CheckpointOptions options = new CheckpointOptions(CHECKPOINT, CheckpointStorageLocationReference.getDefault());
-		channel.onBuffer(createBuffer(1), 0, 0);
-		channel.onBuffer(toBuffer(new CheckpointBarrier(1L, 123L, options), true), 1, 0);
-		channel.onBuffer(createBuffer(1), 2, 0);
-		channel.onBuffer(createBuffer(1), 3, 0);
+		assertGetNextBufferSequenceNumbers(channel, 2, 0, 1, 3, 4);
+	}
 
-		assertEquals(1, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(0, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(2, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(3, channel.getNextBuffer().get().getSequenceNumber());
+	@Test
+	public void testGetInflightBuffers() throws Exception {
+		int bufferSize = 1;
+		int sequenceNumber = 0;
+		final RemoteInputChannel channel = buildInputGateAndGetChannel(sequenceNumber);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBarrier(channel, sequenceNumber++, 0);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		assertInflightBufferSizes(channel, 1, 2);
+	}
+
+	@Test
+	public void testGetAllInflightBuffers() throws Exception {
+		int sequenceNumber = Integer.MAX_VALUE - 2;
+		int bufferSize = 1;
+		final RemoteInputChannel channel = buildInputGateAndGetChannel(sequenceNumber);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		assertInflightBufferSizes(channel, 1, 2, 3, 4);
+	}
+
+	@Test
+	public void testGetInflightBuffersOverflow() throws Exception {
+		for (int startingSequence = Integer.MAX_VALUE - 10; startingSequence != Integer.MIN_VALUE + 2; startingSequence++) {
+			final RemoteInputChannel channel = buildInputGateAndGetChannel(startingSequence);
+			int bufferSize = 1;
+			int sequenceNumber = startingSequence;
+			sendBuffer(channel, sequenceNumber++, bufferSize++);
+			sendBuffer(channel, sequenceNumber++, bufferSize++);
+			sendBarrier(channel, sequenceNumber++, 0);
+			sendBuffer(channel, sequenceNumber++, bufferSize++);
+			sendBuffer(channel, sequenceNumber++, bufferSize++);
+			assertThat(
+				"For starting sequence " + startingSequence,
+				toBufferSizes(channel.getInflightBuffers()),
+				contains(1, 2));
+		}
+	}
+
+	@Test
+	public void testGetInflightBuffersAfterPollingBuffer() throws Exception {
+		int bufferSize = 1;
+		int sequenceNumber = 0;
+		final RemoteInputChannel channel = buildInputGateAndGetChannel(sequenceNumber);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBarrier(channel, sequenceNumber++, 0);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		assertGetNextBufferSequenceNumbers(channel, 2, 0);
+		assertInflightBufferSizes(channel, 2);
+	}
+
+	private static List<Integer> toBufferSizes(List<Buffer> inflightBuffers) {
+		return inflightBuffers.stream()
+			.map(buffer -> buffer.getSize())
+			.collect(Collectors.toList());
 	}
 
 	@Test
 	public void testRequiresAnnouncement() throws Exception {
-		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
-		SingleInputGate inputGate = new SingleInputGateBuilder()
-				.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
-				.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
-				.setSegmentProvider(networkBufferPool)
-				.build();
-		final RemoteInputChannel channel = (RemoteInputChannel) inputGate.getChannel(0);
-		inputGate.setup();
-		inputGate.requestPartitions();
-
-		final long timeout = 10;
-		CheckpointOptions options = CheckpointOptions.create(
-				CHECKPOINT,
-				CheckpointStorageLocationReference.getDefault(),
-				true,
-				true,
-				timeout);
-
-		assertTrue(options.needsAlignment());
-		assertTrue(options.isTimeoutable());
-		assertFalse(options.isUnalignedCheckpoint());
-		Buffer checkpointBarrierBuffer = toBuffer(new CheckpointBarrier(1L, 123L, options), false);
-		assertEquals(DataType.TIMEOUTABLE_ALIGNED_CHECKPOINT_BARRIER, checkpointBarrierBuffer.getDataType());
-
-		channel.onBuffer(createBuffer(1), 0, 0);
-		channel.onBuffer(createBuffer(1), 1, 0);
-		channel.onBuffer(checkpointBarrierBuffer, 2, 0);
-		channel.onBuffer(createBuffer(1), 3, 0);
+		int sequenceNumber = 0;
+		int bufferSize = 1;
+		final RemoteInputChannel channel = buildInputGateAndGetChannel(sequenceNumber);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBarrier(channel, sequenceNumber++, 10);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
+		sendBuffer(channel, sequenceNumber++, bufferSize++);
 
 		BufferAndAvailability nextBuffer = channel.getNextBuffer().get();
 		assertEquals(2, nextBuffer.getSequenceNumber());
@@ -1184,11 +1220,52 @@ public class RemoteInputChannelTest {
 		assertTrue(nextBuffer.moreAvailable());
 		assertEquals(DataType.PRIORITIZED_EVENT_BUFFER, nextBuffer.buffer().getDataType());
 
-		assertEquals(0, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(1, channel.getNextBuffer().get().getSequenceNumber());
-		assertEquals(2, channel.getNextBuffer().get().getSequenceNumber());
+		assertGetNextBufferSequenceNumbers(channel, 0, 1);
+
+		nextBuffer = channel.getNextBuffer().get();
+		assertEquals(2, nextBuffer.getSequenceNumber());
+		assertEquals(DataType.TIMEOUTABLE_ALIGNED_CHECKPOINT_BARRIER, nextBuffer.buffer().getDataType());
+
 		assertEquals(3, channel.getNextBuffer().get().getSequenceNumber());
 	}
+
+	private void sendBarrier(RemoteInputChannel channel, int sequenceNumber, int alignmentTimeout) throws IOException {
+		CheckpointOptions checkpointOptions = CheckpointOptions.create(
+			CHECKPOINT,
+			CheckpointStorageLocationReference.getDefault(),
+			true,
+			true,
+			alignmentTimeout);
+		send(
+			channel,
+			sequenceNumber,
+			toBuffer(new CheckpointBarrier(1L, 123L, checkpointOptions), checkpointOptions.isUnalignedCheckpoint())
+		);
+	}
+
+	private void sendBuffer(RemoteInputChannel channel, int sequenceNumber, int dataSize) throws IOException {
+		send(channel, sequenceNumber, createBuffer(dataSize));
+	}
+
+	private void send(RemoteInputChannel channel, int sequenceNumber, Buffer buffer) throws IOException {
+		channel.onBuffer(buffer, sequenceNumber, 0);
+		channel.checkError();
+	}
+
+	private void assertInflightBufferSizes(RemoteInputChannel channel, Integer ...bufferSizes) {
+		assertEquals(Arrays.asList(bufferSizes), toBufferSizes(channel.getInflightBuffers()));
+	}
+
+	private void assertGetNextBufferSequenceNumbers(RemoteInputChannel channel, Integer ...sequenceNumbers) throws IOException {
+		List<Integer> actualSequenceNumbers = new ArrayList<>();
+		for (int i = 0; i < sequenceNumbers.length; i++) {
+			channel.getNextBuffer()
+				.map(BufferAndAvailability::getSequenceNumber)
+				.ifPresent(actualSequenceNumbers::add);
+		}
+		assertThat(actualSequenceNumbers, contains(sequenceNumbers));
+	}
+
 	// ---------------------------------------------------------------------------------------------
 
 	private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate) {
@@ -1214,6 +1291,28 @@ public class RemoteInputChannelTest {
 			.setPartitionId(partitionId)
 			.setConnectionManager(connectionManager)
 			.buildRemoteChannel(inputGate);
+	}
+
+	private RemoteInputChannel buildInputGateAndGetChannel(int expectedSequenceNumber) throws IOException {
+		final RemoteInputChannel channel = buildInputGateAndGetChannel();
+		channel.setExpectedSequenceNumber(expectedSequenceNumber);
+		return channel;
+	}
+
+	private RemoteInputChannel buildInputGateAndGetChannel() throws IOException {
+		return (RemoteInputChannel) buildInputGate().getChannel(0);
+	}
+
+	private SingleInputGate buildInputGate() throws IOException {
+		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(4, 4096);
+		SingleInputGate inputGate = new SingleInputGateBuilder()
+			.setChannelFactory(InputChannelBuilder::buildRemoteChannel)
+			.setBufferPoolFactory(networkBufferPool.createBufferPool(1, 4))
+			.setSegmentProvider(networkBufferPool)
+			.build();
+		inputGate.setup();
+		inputGate.requestPartitions();
+		return inputGate;
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -106,6 +106,8 @@ import static org.mockito.Mockito.when;
  */
 public class RemoteInputChannelTest {
 
+	public static final long CHECKPOINT_ID = 1L;
+
 	@Test
 	public void testExceptionOnReordering() throws Exception {
 		// Setup
@@ -1178,7 +1180,7 @@ public class RemoteInputChannelTest {
 			sendBuffer(channel, sequenceNumber++, bufferSize++);
 			assertThat(
 				"For starting sequence " + startingSequence,
-				toBufferSizes(channel.getInflightBuffers()),
+				toBufferSizes(channel.getInflightBuffers(CHECKPOINT_ID)),
 				contains(1, 2));
 		}
 	}
@@ -1253,7 +1255,7 @@ public class RemoteInputChannelTest {
 	}
 
 	private void assertInflightBufferSizes(RemoteInputChannel channel, Integer ...bufferSizes) {
-		assertEquals(Arrays.asList(bufferSizes), toBufferSizes(channel.getInflightBuffers()));
+		assertEquals(Arrays.asList(bufferSizes), toBufferSizes(channel.getInflightBuffers(CHECKPOINT_ID)));
 	}
 
 	private void assertGetNextBufferSequenceNumbers(RemoteInputChannel channel, Integer ...sequenceNumbers) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

#13827 revealed some issues with `RemoteInputChannel.getInflightBuffers` which are also relevant for the master branch.
1. `numBuffersOvertaken` is ambiguous
1. it can be overwritten
1. sequence number can overflow

## Brief change log

1. pull commit from #13827 to replace `numBuffersOvertaken` with sequence number
1. add `lastBarrierId` to prevent overwriting it

## Verifying this change

Added unit tests (`testGetInflightBuffersAfterPollingBuffer`, `testGetInflightBuffersOverflow`, `testGetAllInflightBuffers`, `testGetInflightBuffers` in `RemoteInputChannelTest`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
