### PR TITLE
[FLINK-19816] Make job state cleanup dependent on final job result

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -108,14 +108,16 @@ public class MiniDispatcher extends Dispatcher {
 	}
 
 	@Override
-	protected void jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
-		super.jobReachedGloballyTerminalState(archivedExecutionGraph);
+	protected CleanupJobState jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
+		final CleanupJobState cleanupHAState = super.jobReachedGloballyTerminalState(archivedExecutionGraph);
 
 		if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
 			// shut down if job is cancelled or we don't have to wait for the execution result retrieval
 			log.info("Shutting down cluster with state {}, jobCancelled: {}, executionMode: {}", archivedExecutionGraph.getState(), jobCancelled, executionMode);
 			shutDownFuture.complete(ApplicationStatus.fromJobStatus(archivedExecutionGraph.getState()));
 		}
+
+		return cleanupHAState;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -195,17 +195,14 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 						classLoaderLease.release();
 
+						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
+
 						if (throwable != null) {
 							terminationFuture.completeExceptionally(
 								new FlinkException("Could not properly shut down the JobManagerRunner", throwable));
 						} else {
 							terminationFuture.complete(null);
 						}
-					});
-
-				terminationFuture.whenComplete(
-					(Void ignored, Throwable throwable) -> {
-						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
 					});
 			}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -75,8 +75,11 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -319,6 +322,35 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 		assertThat(deleteAllHABlobsFuture.isDone(), is(false));
 	}
 
+	@Test
+	public void testHACleanupWhenJobFinishedWhileClosingDispatcher() throws Exception {
+		final TestingJobManagerRunner testingJobManagerRunner = new TestingJobManagerRunner.Builder()
+			.setBlockingTermination(true)
+			.setJobId(jobId)
+			.build();
+
+		final Queue<JobManagerRunner> jobManagerRunners = new ArrayDeque<>(Arrays.asList(testingJobManagerRunner));
+
+		startDispatcher(new QueueJobManagerRunnerFactory(jobManagerRunners));
+		submitJob();
+
+		final CompletableFuture<Void> dispatcherTerminationFuture = dispatcher.closeAsync();
+
+		testingJobManagerRunner.getCloseAsyncCalledLatch().await();
+		testingJobManagerRunner.completeResultFuture(new ArchivedExecutionGraphBuilder()
+			.setJobID(jobId)
+			.setState(JobStatus.FINISHED)
+			.build());
+
+		testingJobManagerRunner.completeTerminationFuture();
+
+		// check that no exceptions have been thrown
+		dispatcherTerminationFuture.get();
+
+		assertThat(cleanupJobFuture.get(), is(jobId));
+		assertThat(deleteAllHABlobsFuture.get(), is(jobId));
+	}
+
 	/**
 	 * Tests that the {@link RunningJobsRegistry} entries are cleared after the
 	 * job reached a terminal state.
@@ -554,6 +586,29 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 			final boolean result = super.cleanupJob(jobId, cleanupBlobStoreFiles);
 			cleanupJobFuture.complete(jobId);
 			return result;
+		}
+	}
+
+	private static final class QueueJobManagerRunnerFactory implements JobManagerRunnerFactory {
+		private final Queue<? extends JobManagerRunner> jobManagerRunners;
+
+		private QueueJobManagerRunnerFactory(Queue<? extends JobManagerRunner> jobManagerRunners) {
+			this.jobManagerRunners = jobManagerRunners;
+		}
+
+		@Override
+		public JobManagerRunner createJobManagerRunner(
+			JobGraph jobGraph,
+			Configuration configuration,
+			RpcService rpcService,
+			HighAvailabilityServices highAvailabilityServices,
+			HeartbeatServices heartbeatServices,
+			JobManagerSharedServices jobManagerServices,
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+			FatalErrorHandler fatalErrorHandler,
+			long initializationTimestamp) {
+			return Optional.ofNullable(jobManagerRunners.poll())
+				.orElseThrow(() -> new IllegalStateException("Cannot create more JobManagerRunners."));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

In order to avoid race conditions between stopping a Dispatcher and a finishing
job, we now wait on the actual job result to decide whether to clean up the job's
HA data or not. A stopping dispatcher will simply close the DispatcherJobs and
continue the clean up operation on the job has been terminated.

cc @XComp, @rmetzger 

## Verifying this change

- Added `DispatcherResourceCleanupTest.testHACleanupWhenJobFinishedWhileClosingDispatcher`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
