### PR TITLE
[FLINK-19940][task] Improve naming of multi-input transformation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
+import static java.util.stream.Collectors.joining;
+
 /**
  * {@link AbstractMultipleInputTransformation} implementation for non-keyed streams.
  */
@@ -39,5 +41,10 @@ public class MultipleInputTransformation<OUT> extends AbstractMultipleInputTrans
 	public MultipleInputTransformation<OUT> addInput(Transformation<?> input) {
 		inputs.add(input);
 		return this;
+	}
+
+	@Override
+	public String getName() {
+		return inputs.isEmpty() ? super.getName() : "[" + inputs.stream().map(Transformation::getName).collect(joining(", ")) + "]";
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -258,7 +258,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
 		MultipleInputTransformation<String> transform = new MultipleInputTransformation<String>(
 			"My Operator",
-			new MultipleInputOperatorFactory(),
+			unsupportedOperatorFactory(),
 			BasicTypeInfo.STRING_TYPE_INFO,
 			3);
 
@@ -605,25 +605,27 @@ public class StreamGraphGeneratorTest extends TestLogger {
 		}
 	}
 
-	private static class MultipleInputOperatorFactory implements StreamOperatorFactory<String> {
-		@Override
-		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
-			throw new UnsupportedOperationException();
-		}
+	public static <X> StreamOperatorFactory<X> unsupportedOperatorFactory() {
+		return new StreamOperatorFactory<X>() {
+			@Override
+			public <T extends StreamOperator<X>> T createStreamOperator(StreamOperatorParameters<X> parameters) {
+				throw new UnsupportedOperationException();
+			}
 
-		@Override
-		public void setChainingStrategy(ChainingStrategy strategy) {
-			throw new UnsupportedOperationException();
-		}
+			@Override
+			public void setChainingStrategy(ChainingStrategy strategy) {
+				throw new UnsupportedOperationException();
+			}
 
-		@Override
-		public ChainingStrategy getChainingStrategy() {
-			throw new UnsupportedOperationException();
-		}
+			@Override
+			public ChainingStrategy getChainingStrategy() {
+				throw new UnsupportedOperationException();
+			}
 
-		@Override
-		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
-			throw new UnsupportedOperationException();
-		}
+			@Override
+			public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+				throw new UnsupportedOperationException();
+			}
+		};
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static org.apache.flink.streaming.api.graph.StreamGraphGeneratorTest.unsupportedOperatorFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link MultipleInputTransformation} test.
+ */
+public class MultipleInputTransformationTest {
+
+	@Test
+	public void testNaming() {
+		Random random = new Random();
+		MultipleInputTransformation<Long> transformation =
+			new MultipleInputTransformation<>(getString(random), unsupportedOperatorFactory(), TypeInformation.of(Long.class), 1);
+		for (int i = 0; i < 10; i++) {
+			transformation.addInput(new SourceTransformation<>(getString(random),
+				new NumberSequenceSource(0, 1),
+				WatermarkStrategy.noWatermarks(),
+				TypeInformation.of(Long.class),
+				1));
+		}
+		transformation.getInputs().forEach(input -> assertTrue(transformation.getName().contains(input.getName())));
+	}
+
+	@Test
+	public void testNamingWithNoInputs() {
+		Random random = new Random();
+		String name = getString(random);
+		MultipleInputTransformation<Long> transformation =
+			new MultipleInputTransformation<>(name, unsupportedOperatorFactory(), TypeInformation.of(Long.class), 1);
+		assertEquals(transformation.getName(), name);
+	}
+
+	private String getString(Random random) {
+		byte[] buf = new byte[15];
+		random.nextBytes(buf);
+		return new String(buf, StandardCharsets.UTF_8);
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the name ignores passed inputs.
This change uses pattern: OriginalName [src1, srcN]
The name is shown in logs and web UI.

## Verifying this change

- Added `MultipleInputTransformationTest` (unit test)
- Checked manually in logs and web ui

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
