### PR TITLE
[FLINK-20139][dispatcher] Enrich logs when MiniDispatcher shutting down

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -30,9 +30,6 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
@@ -47,7 +44,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * terminate after job completion if its execution mode is {@link ClusterEntrypoint.ExecutionMode#DETACHED}.
  */
 public class MiniDispatcher extends Dispatcher {
-	private static final Logger LOG = LoggerFactory.getLogger(MiniDispatcher.class);
 
 	private final JobClusterEntrypoint.ExecutionMode executionMode;
 	private boolean jobCancelled = false;
@@ -95,11 +91,11 @@ public class MiniDispatcher extends Dispatcher {
 				ApplicationStatus status = result.getSerializedThrowable().isPresent() ?
 						ApplicationStatus.FAILED : ApplicationStatus.SUCCEEDED;
 
-				LOG.debug("Shutting down cluster because someone retrieved the job result.");
+				log.info("Shutting down cluster because someone retrieved the job result.");
 				shutDownFuture.complete(status);
 			});
 		} else {
-			LOG.debug("Not shutting down cluster after someone retrieved the job result.");
+			log.info("Not shutting down cluster after someone retrieved the job result.");
 		}
 
 		return jobResultFuture;
@@ -117,6 +113,7 @@ public class MiniDispatcher extends Dispatcher {
 
 		if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
 			// shut down if job is cancelled or we don't have to wait for the execution result retrieval
+			log.info("Shutting down cluster with state {}, jobCancelled: {}, executionMode: {}", archivedExecutionGraph.getState(), jobCancelled, executionMode);
 			shutDownFuture.complete(ApplicationStatus.fromJobStatus(archivedExecutionGraph.getState()));
 		}
 	}
@@ -124,8 +121,8 @@ public class MiniDispatcher extends Dispatcher {
 	@Override
 	protected void jobNotFinished(JobID jobId) {
 		super.jobNotFinished(jobId);
-
 		// shut down since we have done our job
+		log.info("Shutting down cluster because job not finished");
 		shutDownFuture.complete(ApplicationStatus.UNKNOWN);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

From [discuss](https://lists.apache.org/x/thread.html/rd0061c9181d938780f0d447f8170f2d7f1e4608c5fc31f0e6884574c@%3Cuser-zh.flink.apache.org%3E) in user-zh mailing list I notice that we don't log every exit point when a JobCluster shutting down.

Since we have a bit complex logic for a job cluster to be shutdown, it will be helpful for debugging if we log those code paths. And because they are at most shot once as well as important lifecycle event I'd like to log in INFO level.

## Brief change log

Log all exit points  when a JobCluster shutting down.

## Verifying this change

This change is a trivial work about enrich logging.

## Does this pull request potentially affect one of the following parts:

N/A

## Documentation

N/A