### PR TITLE
[hotfix][doc] fix the usage example of datagen connector doc

### DIFF
--- a/docs/dev/table/connectors/datagen.md
+++ b/docs/dev/table/connectors/datagen.md
@@ -51,7 +51,7 @@ Time types are always the local machines current system time.
 CREATE TABLE Orders (
     order_number BIGINT,
     price        DECIMAL(32,2),
-    buyer        ROW<first_name STRING, last_name STRING>
+    buyer        ROW<first_name STRING, last_name STRING>,
     order_time   TIMESTAMP(3)
 ) WITH (
   'connector' = 'datagen'
@@ -64,7 +64,7 @@ Often, the data generator connector is used in conjuction with the ``LIKE`` clau
 CREATE TABLE Orders (
     order_number BIGINT,
     price        DECIMAL(32,2),
-    buyer        ROW<first_name STRING, last_name STRING>
+    buyer        ROW<first_name STRING, last_name STRING>,
     order_time   TIMESTAMP(3)
 ) WITH (...)
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the usage example of datagen connector doc*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
