### PR TITLE
[FLINK-18673][table] Improve support for ROW constructor

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -298,14 +298,15 @@ public final class LogicalTypeCasts {
 		final LogicalTypeRoot sourceRoot = sourceType.getTypeRoot();
 		final LogicalTypeRoot targetRoot = targetType.getTypeRoot();
 
-		if (hasFamily(sourceType, INTERVAL) && hasFamily(targetType, EXACT_NUMERIC)) {
+		if (sourceRoot == NULL) {
+			// null can be cast to an arbitrary type
+			return true;
+		} else if (hasFamily(sourceType, INTERVAL) && hasFamily(targetType, EXACT_NUMERIC)) {
 			// cast between interval and exact numeric is only supported if interval has a single field
 			return isSingleFieldInterval(sourceType);
 		} else if (hasFamily(sourceType, EXACT_NUMERIC) && hasFamily(targetType, INTERVAL)) {
 			// cast between interval and exact numeric is only supported if interval has a single field
 			return isSingleFieldInterval(targetType);
-		} else if (hasFamily(sourceType, CONSTRUCTED) || hasFamily(targetType, CONSTRUCTED)) {
-			return supportsConstructedCasting(sourceType, targetType, allowExplicit);
 		} else if (sourceRoot == DISTINCT_TYPE && targetRoot == DISTINCT_TYPE) {
 			// the two distinct types are not equal (from initial invariant), casting is not possible
 			return false;
@@ -313,12 +314,11 @@ public final class LogicalTypeCasts {
 			return supportsCasting(((DistinctType) sourceType).getSourceType(), targetType, allowExplicit);
 		} else if (targetRoot == DISTINCT_TYPE) {
 			return supportsCasting(sourceType, ((DistinctType) targetType).getSourceType(), allowExplicit);
+		} else if (hasFamily(sourceType, CONSTRUCTED) || hasFamily(targetType, CONSTRUCTED)) {
+			return supportsConstructedCasting(sourceType, targetType, allowExplicit);
 		} else if (sourceRoot == STRUCTURED_TYPE || targetRoot == STRUCTURED_TYPE) {
 			// inheritance is not supported yet, so structured type must be fully equal
 			return false;
-		} else if (sourceRoot == NULL) {
-			// null can be cast to an arbitrary type
-			return true;
 		} else if (sourceRoot == RAW || targetRoot == RAW) {
 			// the two raw types are not equal (from initial invariant), casting is not possible
 			return false;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -106,6 +106,18 @@ public class LogicalTypeCastsTest {
 
 				{new NullType(), new IntType(), true, true},
 
+				{
+					new NullType(),
+					new RowType(
+						Arrays.asList(
+							new RowField("f1", new IntType()),
+							new RowField("f2", new IntType())
+						)
+					),
+					true,
+					true
+				},
+
 				{new ArrayType(new IntType()), new ArrayType(new BigIntType()), true, true},
 
 				{new ArrayType(new IntType()), new ArrayType(new VarCharType(Integer.MAX_VALUE)), false, true},

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -22,9 +22,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.logical.DecimalType;
 
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
@@ -39,6 +41,7 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Static;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 
@@ -95,5 +98,12 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
 			}
 		}
 		super.validateJoin(join, scope);
+	}
+
+	@Override
+	public void validateColumnListParams(SqlFunction function, List<RelDataType> argTypes, List<SqlNode> operands) {
+		// we don't support column lists and translate them into the unknown type in the type factory,
+		// this makes it possible to ignore them in the validator and fall back to regular row types
+		// see also SqlFunction#deriveType
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -330,6 +330,11 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem)
       // keep precision/scale in sync with our type system's default value,
       // see DecimalType.USER_DEFAULT.
       createSqlType(typeName, DecimalType.DEFAULT_PRECISION, DecimalType.DEFAULT_SCALE)
+    } else if (typeName == COLUMN_LIST) {
+      // we don't support column lists and translate them into the unknown type,
+      // this makes it possible to ignore them in the validator and fall back to regular row types
+      // see also SqlFunction#deriveType
+      createUnknownType()
     } else {
       super.createSqlType(typeName)
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -188,19 +188,26 @@ public abstract class BuiltInFunctionTestBase {
 
 		private final BuiltInFunctionDefinition definition;
 
+		private final @Nullable String description;
+
 		private Object[] fieldData;
 
 		private @Nullable AbstractDataType<?>[] fieldDataTypes;
 
 		private List<TestItem> testItems;
 
-		private TestSpec(BuiltInFunctionDefinition definition) {
+		private TestSpec(BuiltInFunctionDefinition definition, @Nullable String description) {
 			this.definition = definition;
+			this.description = description;
 			this.testItems = new ArrayList<>();
 		}
 
 		static TestSpec forFunction(BuiltInFunctionDefinition definition) {
-			return new TestSpec(definition);
+			return new TestSpec(definition, null);
+		}
+
+		static TestSpec forFunction(BuiltInFunctionDefinition definition, String description) {
+			return new TestSpec(definition, description);
 		}
 
 		TestSpec onFieldsWithData(Object... fieldData) {
@@ -241,7 +248,7 @@ public abstract class BuiltInFunctionTestBase {
 
 		@Override
 		public String toString() {
-			return definition.getName();
+			return definition.getName() + (description != null ? " : " + description : "");
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.expressions;
+package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.DataTypes;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.expressions;
+package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
@@ -62,11 +62,11 @@ import static org.junit.Assert.assertThat;
 @RunWith(Suite.class)
 @Suite.SuiteClasses(
 	{
-		CompositeTypeAccessExpressionITCase.FieldAccessFromTable.class,
-		CompositeTypeAccessExpressionITCase.FieldAccessAfterCall.class
+		ConstructedAccessFunctionITCase.FieldAccessFromTable.class,
+		ConstructedAccessFunctionITCase.FieldAccessAfterCall.class
 	}
 )
-public class CompositeTypeAccessExpressionITCase {
+public class ConstructedAccessFunctionITCase {
 
 	/**
 	 * Regular tests. See also {@link FieldAccessAfterCall} for tests that access a nested field of an expression or

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.expressions;
+package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/RowConstructorITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/RowConstructorITCase.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
+
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.row;
+
+/**
+ * Tests for different combinations around {@link BuiltInFunctionDefinitions#ROW}.
+ */
+public class RowConstructorITCase extends BuiltInFunctionTestBase {
+
+	@Parameters(name = "{index}: {0}")
+	public static List<TestSpec> testData() {
+		return Arrays.asList(
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.ROW, "with field access")
+				.onFieldsWithData(12, "Hello world")
+				.andDataTypes(DataTypes.INT(), DataTypes.STRING())
+				.testTableApiResult(
+					row($("f0"), $("f1")),
+					Row.of(12, "Hello world"),
+					DataTypes.ROW(
+						DataTypes.FIELD("f0", DataTypes.INT()),
+						DataTypes.FIELD("f1", DataTypes.STRING())).notNull())
+				.testSqlResult(
+					"ROW(f0, f1)",
+					Row.of(12, "Hello world"),
+					DataTypes.ROW(
+						DataTypes.FIELD("EXPR$0", DataTypes.INT()),
+						DataTypes.FIELD("EXPR$1", DataTypes.STRING())).notNull()),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.ROW, "within function call")
+				.onFieldsWithData(12, "Hello world")
+				.andDataTypes(DataTypes.INT(), DataTypes.STRING())
+				.withFunction(TakesRow.class)
+				.testResult(
+					call("TakesRow", row($("f0"), $("f1")), 1),
+					"TakesRow(ROW(f0, f1), 1)",
+					Row.of(13, "Hello world"),
+					DataTypes.ROW(
+						DataTypes.FIELD("i", DataTypes.INT()),
+						DataTypes.FIELD("s", DataTypes.STRING()))),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.ROW, "within cast")
+				.onFieldsWithData(1)
+				.testResult(
+					row($("f0").plus(12), "Hello world")
+						.cast(
+							DataTypes.ROW(
+								DataTypes.FIELD("i", DataTypes.INT()),
+								DataTypes.FIELD("s", DataTypes.STRING())).notNull()
+						),
+					// TODO parser has problems with "f0 + 12" see FLINK-18027
+					"CAST(ROW(12 + f0, 'Hello world') AS ROW<i INT, s STRING>)",
+					Row.of(13, "Hello world"),
+					DataTypes.ROW(
+						DataTypes.FIELD("i", DataTypes.INT()),
+						DataTypes.FIELD("s", DataTypes.STRING())).notNull())
+		);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Identity function for a row.
+	 */
+	public static class TakesRow extends ScalarFunction {
+		public @DataTypeHint("ROW<i INT, s STRING>") Row eval(@DataTypeHint("ROW<i INT, s STRING>") Row row, Integer i) {
+			row.setField(0, (int) row.getField(0) + i);
+			return row;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes bugs around the usage of a `ROW` constructor.

## Brief change log

- Avoid the column list logic in SQL validator
- Fix order for implicit casting

## Verifying this change

This change added tests and can be verified as follows: `RowConstructorITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
