### PR TITLE
[FLINK-20156] Correct JavaDoc example code in WatermarkStrategy.withTimestampAssigner

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategy.java
@@ -106,7 +106,7 @@ public interface WatermarkStrategy<T> extends
 	 *
 	 * <pre>
 	 * {@code WatermarkStrategy<CustomObject> wmStrategy = WatermarkStrategy
-	 *   .forMonotonousTimestamps()
+	 *   .<CustomObject>forMonotonousTimestamps()
 	 *   .withTimestampAssigner((event, timestamp) -> event.getTimestamp());
 	 * }</pre>
 	 */


### PR DESCRIPTION
In order to compile with Java 8 we have to specify the generic parameter when
chaining WatermarkStrategy.withTimestampAssigner.

cc @aljoscha 