### PR TITLE
[FLINK-20152] Document supported execution.target values

### DIFF
--- a/docs/_includes/generated/deployment_configuration.html
+++ b/docs/_includes/generated/deployment_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>execution.target</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The deployment target for the execution, e.g. "local" for local execution.</td>
+            <td> The deployment target for the execution. This can take one of the following values:"remote", "local", "yarn-per-job", "yarn-session", "yarn-application", "kubernetes-session" and "kubernetes-application". Note that "yarn-application" and "kubernetes-application" can only be used through the CLI using the "run-application -t" command.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/deployment_configuration.html
+++ b/docs/_includes/generated/deployment_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>execution.target</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td> The deployment target for the execution. This can take one of the following values:"remote", "local", "yarn-per-job", "yarn-session", "yarn-application", "kubernetes-session" and "kubernetes-application". Note that "yarn-application" and "kubernetes-application" can only be used through the CLI using the "run-application -t" command.</td>
+            <td>The deployment target for the execution. This can take one of the following values:<ul><li>remote</li><li>local</li><li>yarn-per-job</li><li>yarn-session</li><li>kubernetes-session</li></ul>.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -19,10 +19,12 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
 
 import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * The {@link ConfigOption configuration options} relevant for all Executors.
@@ -34,13 +36,16 @@ public class DeploymentOptions {
 			key("execution.target")
 					.stringType()
 					.noDefaultValue()
-					.withDescription(" The deployment target for the execution. " +
-							"This can take one of the following values:" +
-							"\"remote\", \"local\", \"yarn-per-job\", " +
-							"\"yarn-session\", \"yarn-application\", " +
-							"\"kubernetes-session\" and \"kubernetes-application\". " +
-							"Note that \"yarn-application\" and \"kubernetes-application\" " +
-							"can only be used through the CLI using the \"run-application -t\" command.");
+					.withDescription(Description.builder()
+							.text("The deployment target for the execution. This can take one of the following values:")
+							.list(
+									text("remote"),
+									text("local"),
+									text("yarn-per-job"),
+									text("yarn-session"),
+									text("kubernetes-session"))
+							.text(".")
+							.build());
 
 	public static final ConfigOption<Boolean> ATTACHED =
 			key("execution.attached")

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -34,7 +34,13 @@ public class DeploymentOptions {
 			key("execution.target")
 					.stringType()
 					.noDefaultValue()
-					.withDescription("The deployment target for the execution, e.g. \"local\" for local execution.");
+					.withDescription(" The deployment target for the execution. " +
+							"This can take one of the following values:" +
+							"\"remote\", \"local\", \"yarn-per-job\", " +
+							"\"yarn-session\", \"yarn-application\", " +
+							"\"kubernetes-session\" and \"kubernetes-application\". " +
+							"Note that \"yarn-application\" and \"kubernetes-application\" " +
+							"can only be used through the CLI using the \"run-application -t\" command.");
 
 	public static final ConfigOption<Boolean> ATTACHED =
 			key("execution.attached")


### PR DESCRIPTION
## What is the purpose of the change

This PR document supported `execution.target` values.

## Brief change log

Changed the description of the `DeploymentOptions.TARGET`.

## Verifying this change

Build and check the documentation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
