### PR TITLE
[FLINK-20145][task] Don't expose modifiable PrioritizedDeque.iterator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -202,8 +202,11 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
 		return size() - getNumPriorityElements();
 	}
 
+	/**
+	 * @return read-only iterator
+	 */
 	public Iterator<T> iterator() {
-		return deque.iterator();
+		return Collections.unmodifiableCollection(deque).iterator();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -27,7 +27,6 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -339,9 +338,7 @@ public class UnionInputGate extends InputGate {
 			}
 		}
 
-		Iterator<IndexedInputGate> inputGateIterator = inputGatesWithData.iterator();
-		IndexedInputGate inputGate = inputGateIterator.next();
-		inputGateIterator.remove();
+		IndexedInputGate inputGate = inputGatesWithData.poll();
 
 		if (inputGatesWithData.isEmpty()) {
 			availabilityHelper.resetUnavailable();


### PR DESCRIPTION
## What is the purpose of the change

Don't expose modifiable PrioritizedDeque.iterator to prevent inconsistency between `numPriorityElements` and `deque`.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
