### PR TITLE
[FLINK-20169] Move emitting MAX_WATERMARK out of the SourceOperator processing loop

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.source.TimestampsAndWatermarks;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.CollectionUtil;
@@ -226,21 +225,13 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 
 		// short circuit the common case (every invocation except the first)
 		if (currentMainOutput != null) {
-			return pollNextRecord(output);
+			return sourceReader.pollNext(currentMainOutput);
 		}
 
 		// this creates a batch or streaming output based on the runtime mode
 		currentMainOutput = eventTimeLogic.createMainOutput(output);
 		lastInvokedOutput = output;
-		return pollNextRecord(output);
-	}
-
-	private InputStatus pollNextRecord(DataOutput<OUT> output) throws Exception {
-		InputStatus inputStatus = sourceReader.pollNext(currentMainOutput);
-		if (inputStatus == InputStatus.END_OF_INPUT) {
-			output.emitWatermark(Watermark.MAX_WATERMARK);
-		}
-		return inputStatus;
+		return sourceReader.pollNext(currentMainOutput);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -71,6 +71,14 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 		output.emitWatermark(Watermark.MAX_WATERMARK);
 	}
 
+	@Override
+	protected void afterInvoke() throws Exception {
+		if (!isCanceled()) {
+			advanceToEndOfEventTime();
+		}
+		super.afterInvoke();
+	}
+
 	/**
 	 * Implementation of {@link DataOutput} that wraps a specific {@link Output}.
 	 */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -43,8 +43,6 @@ import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
-import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.util.MockOutput;
@@ -54,7 +52,6 @@ import org.apache.flink.util.CollectionUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,17 +145,6 @@ public class SourceOperatorTest {
 	}
 
 	@Test
-	public void testCloseWillSendMaxWatermark() throws Exception {
-		MockSourceSplit mockSplit = new MockSourceSplit(1, 0, 0);
-		operator.initializeState(getStateContext(mockSplit));
-		PushingAsyncDataInput.DataOutput<Integer> dataOutput =
-			Mockito.mock(PushingAsyncDataInput.DataOutput.class);
-		operator.open();
-		operator.emitNext(dataOutput);
-		Mockito.verify(dataOutput, Mockito.times(1)).emitWatermark(Watermark.MAX_WATERMARK);
-	}
-
-	@Test
 	public void testSnapshotState() throws Exception {
 		StateInitializationContext stateContext = getStateContext();
 		operator.initializeState(stateContext);
@@ -196,13 +182,9 @@ public class SourceOperatorTest {
 	// ---------------- helper methods -------------------------
 
 	private StateInitializationContext getStateContext() throws Exception {
-		return getStateContext(MOCK_SPLIT);
-	}
-
-	private StateInitializationContext getStateContext(MockSourceSplit mockSplit) throws Exception {
 		// Create a mock split.
 		byte[] serializedSplitWithVersion = SimpleVersionedSerialization
-			.writeVersionAndSerialize(new MockSourceSplitSerializer(), mockSplit);
+			.writeVersionAndSerialize(new MockSourceSplitSerializer(), MOCK_SPLIT);
 
 		// Crate the state context.
 		OperatorStateStore operatorStateStore = createOperatorStateStore();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/SourceOperatorEventTimeTest.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -178,10 +179,9 @@ public class SourceOperatorEventTimeTest {
 		// "STREAMING" and "BATCH" mode.
 		if (emitProgressiveWatermarks) {
 			ArrayList<Watermark> watermarks = Lists.newArrayList(expectedWatermarks);
-			watermarks.add(new Watermark(Long.MAX_VALUE));
 			assertThat(actualWatermarks, contains(watermarks.toArray()));
 		} else {
-			assertThat(actualWatermarks, contains(new Watermark(Long.MAX_VALUE)));
+			assertThat(actualWatermarks, hasSize(0));
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -143,12 +143,17 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 		}
 	}
 
-	@Override
-	public void close() throws Exception {
-		streamTask.cancel();
-
+	public void finishProcessing() throws Exception {
 		streamTask.afterInvoke();
 		streamTask.cleanUpInvoke();
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (streamTask.isRunning()) {
+			streamTask.cancel();
+			finishProcessing();
+		}
 
 		streamMockEnvironment.getIOManager().close();
 		MemoryManager memMan = this.streamMockEnvironment.getMemoryManager();


### PR DESCRIPTION
## What is the purpose of the change

This commit reverts some of the changes introduced in fada6fb6ac9fd7f6510f1f2d77b6baa06563e222.
    
Instead of checking for END_OF_INPUT in the SourceOperator, I emit the MAX_WATERMARK from SourceOperatorStreamTask#afterInvoke. I check if the Task was cancelled or not. If it was not that means the Task finished succesfully and we emit the MAX_WATERMARK.


## Verifying this change

This change added tests in `SourceOperatorStreamTaskTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
