### PR TITLE
[FLINK-20147][connector-kafka] Replace lambdas with classes to prevent serialization issues

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSink.java
@@ -306,10 +306,13 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 	enum WritableMetadata {
 
 		HEADERS(
-				"headers",
-				// key and value of the map are nullable to make handling easier in queries
-				DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable()).nullable(),
-				(row, pos) -> {
+			"headers",
+			// key and value of the map are nullable to make handling easier in queries
+			DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable()).nullable(),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(RowData row, int pos) {
 					if (row.isNullAt(pos)) {
 						return null;
 					}
@@ -326,17 +329,23 @@ public class KafkaDynamicSink implements DynamicTableSink, SupportsWritingMetada
 					}
 					return headers;
 				}
+			}
 		),
 
 		TIMESTAMP(
-				"timestamp",
-				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
-				(row, pos) -> {
+			"timestamp",
+			DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(RowData row, int pos) {
 					if (row.isNullAt(pos)) {
 						return null;
 					}
 					return row.getTimestamp(pos, 3).getMillisecond();
-				});
+				}
+			}
+		);
 
 		final String key;
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -409,48 +409,90 @@ public class KafkaDynamicSource implements ScanTableSource, SupportsReadingMetad
 		TOPIC(
 			"topic",
 			DataTypes.STRING().notNull(),
-			record -> StringData.fromString(record.topic())
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return StringData.fromString(record.topic());
+				}
+			}
 		),
 
 		PARTITION(
 			"partition",
 			DataTypes.INT().notNull(),
-			ConsumerRecord::partition
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return record.partition();
+				}
+			}
 		),
 
 		HEADERS(
 			"headers",
 			// key and value of the map are nullable to make handling easier in queries
 			DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.BYTES().nullable()).notNull(),
-			record -> {
-				final Map<StringData, byte[]> map = new HashMap<>();
-				for (Header header : record.headers()) {
-					map.put(StringData.fromString(header.key()), header.value());
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					final Map<StringData, byte[]> map = new HashMap<>();
+					for (Header header : record.headers()) {
+						map.put(StringData.fromString(header.key()), header.value());
+					}
+					return new GenericMapData(map);
 				}
-				return new GenericMapData(map);
 			}
 		),
 
 		LEADER_EPOCH(
 			"leader-epoch",
 			DataTypes.INT().nullable(),
-			record -> record.leaderEpoch().orElse(null)
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return record.leaderEpoch().orElse(null);
+				}
+			}
 		),
 
 		OFFSET(
 			"offset",
 			DataTypes.BIGINT().notNull(),
-			ConsumerRecord::offset),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return record.offset();
+				}
+			}
+		),
 
 		TIMESTAMP(
 			"timestamp",
 			DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-			record -> TimestampData.fromEpochMillis(record.timestamp())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return TimestampData.fromEpochMillis(record.timestamp());
+				}
+			}
+		),
 
 		TIMESTAMP_TYPE(
 			"timestamp-type",
 			DataTypes.STRING().notNull(),
-			record -> StringData.fromString(record.timestampType().toString())
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object read(ConsumerRecord<?, ?> record) {
+					return StringData.fromString(record.timestampType().toString());
+				}
+			}
 		);
 
 		final String key;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -135,74 +135,106 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
 	 */
 	enum ReadableMetadata {
 		SCHEMA(
-				"schema",
-				DataTypes.STRING().nullable(),
-				false,
-				DataTypes.FIELD("schema", DataTypes.STRING()),
-				GenericRowData::getString
+			"schema",
+			DataTypes.STRING().nullable(),
+			false,
+			DataTypes.FIELD("schema", DataTypes.STRING()),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
+					return row.getString(pos);
+				}
+			}
 		),
 
 		INGESTION_TIMESTAMP(
-				"ingestion-timestamp",
-				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-				true,
-				DataTypes.FIELD("ts_ms", DataTypes.BIGINT()),
-				(row, pos) -> {
+			"ingestion-timestamp",
+			DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+			true,
+			DataTypes.FIELD("ts_ms", DataTypes.BIGINT()),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
 					return TimestampData.fromEpochMillis(row.getLong(pos));
 				}
+			}
 		),
 
 		SOURCE_TIMESTAMP(
-				"source.timestamp",
-				DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
-				true,
-				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-				(row, pos) -> {
+			"source.timestamp",
+			DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+			true,
+			DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
 					final StringData timestamp = (StringData) readProperty(row, pos, KEY_SOURCE_TIMESTAMP);
 					if (timestamp == null) {
 						return null;
 					}
 					return TimestampData.fromEpochMillis(Long.parseLong(timestamp.toString()));
 				}
+			}
 		),
 
 		SOURCE_DATABASE(
-				"source.database",
-				DataTypes.STRING().nullable(),
-				true,
-				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-				(row, pos) -> {
+			"source.database",
+			DataTypes.STRING().nullable(),
+			true,
+			DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
 					return readProperty(row, pos, KEY_SOURCE_DATABASE);
 				}
+			}
 		),
 
 		SOURCE_SCHEMA(
-				"source.schema",
-				DataTypes.STRING().nullable(),
-				true,
-				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-				(row, pos) -> {
+			"source.schema",
+			DataTypes.STRING().nullable(),
+			true,
+			DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
 					return readProperty(row, pos, KEY_SOURCE_SCHEMA);
 				}
+			}
 		),
 
 		SOURCE_TABLE(
-				"source.table",
-				DataTypes.STRING().nullable(),
-				true,
-				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-				(row, pos) -> {
+			"source.table",
+			DataTypes.STRING().nullable(),
+			true,
+			DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
 					return readProperty(row, pos, KEY_SOURCE_TABLE);
 				}
+			}
 		),
 
 		SOURCE_PROPERTIES(
-				"source.properties",
-				// key and value of the map are nullable to make handling easier in queries
-				DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
-				true,
-				DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-				GenericRowData::getMap
+			"source.properties",
+			// key and value of the map are nullable to make handling easier in queries
+			DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
+			true,
+			DataTypes.FIELD("source", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
+			new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData row, int pos) {
+					return row.getMap(pos);
+				}
+			}
 		);
 
 		final String key;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
@@ -284,7 +284,13 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
 			RowType jsonRowType,
 			ReadableMetadata metadata) {
 		final int pos = findFieldPos(metadata, jsonRowType);
-		return (root, unused) -> metadata.converter.convert(root, pos);
+		return new MetadataConverter() {
+			private static final long serialVersionUID = 1L;
+			@Override
+			public Object convert(GenericRowData root, int unused) {
+				return metadata.converter.convert(root, pos);
+			}
+		};
 	}
 
 	private static MetadataConverter convertInPayload(
@@ -293,9 +299,13 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
 			boolean schemaInclude) {
 		if (schemaInclude) {
 			final int pos = findFieldPos(metadata, (RowType) jsonRowType.getChildren().get(0));
-			return (root, unused) -> {
-				final GenericRowData payload = (GenericRowData) root.getField(0);
-				return metadata.converter.convert(payload, pos);
+			return new MetadataConverter() {
+				private static final long serialVersionUID = 1L;
+				@Override
+				public Object convert(GenericRowData root, int unused) {
+					final GenericRowData payload = (GenericRowData) root.getField(0);
+					return metadata.converter.convert(payload, pos);
+				}
 			};
 		}
 		return convertInRoot(jsonRowType, metadata);


### PR DESCRIPTION
## What is the purpose of the change

Replaces lambdas with anonymous classes to prevent deserialization issues during runtime after shading.

## Brief change log

- Fix the Kafka table source and sink
- Perform a similar change to the Debezium format just in case.

## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
