### PR TITLE
[FLINK-20143][yarn] Support non-qualified path for Yarn shared lib

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -19,10 +19,13 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.util.HadoopUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.StringUtils;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.configuration.YarnResourceManagerDriverConfiguration;
 
 import org.apache.hadoop.conf.Configuration;
@@ -560,5 +563,26 @@ public final class Utils {
 		}
 
 		return Resource.newInstance(unitMemMB, unitVcore);
+	}
+
+	public static List<Path> getRemoteSharedPaths(
+			org.apache.flink.configuration.Configuration configuration,
+			YarnConfiguration yarnConfiguration) throws IOException, FlinkException {
+		final List<Path> providedLibDirs = ConfigUtils.decodeListFromConfig(
+			configuration,
+			YarnConfigOptions.PROVIDED_LIB_DIRS,
+			pathStr -> {
+				final Path path = new Path(pathStr);
+				return path.getFileSystem(yarnConfiguration).makeQualified(path);
+			});
+
+		for (Path path : providedLibDirs) {
+			if (!Utils.isRemotePath(path.toString())) {
+				throw new FlinkException(
+					"The \"" + YarnConfigOptions.PROVIDED_LIB_DIRS.key() + "\" should only contain" +
+						" dirs accessible from all worker nodes, while the \"" + path + "\" is local.");
+			}
+		}
+		return providedLibDirs;
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -705,7 +705,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		ApplicationSubmissionContext appContext = yarnApplication.getApplicationSubmissionContext();
 
-		final List<Path> providedLibDirs = getRemoteSharedPaths(configuration);
+		final List<Path> providedLibDirs = Utils.getRemoteSharedPaths(configuration, yarnConfiguration);
 
 		final YarnApplicationFileUploader fileUploader = YarnApplicationFileUploader.from(
 			fs,
@@ -1117,20 +1117,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		final int yarnFileReplication = yarnConfiguration.getInt(DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
 		final int fileReplication = flinkConfiguration.getInteger(YarnConfigOptions.FILE_REPLICATION);
 		return fileReplication > 0 ? fileReplication : yarnFileReplication;
-	}
-
-	private List<Path> getRemoteSharedPaths(Configuration configuration) throws IOException, FlinkException {
-		final List<Path> providedLibDirs = ConfigUtils.decodeListFromConfig(
-			configuration, YarnConfigOptions.PROVIDED_LIB_DIRS, Path::new);
-
-		for (Path path : providedLibDirs) {
-			if (!Utils.isRemotePath(path.toString())) {
-				throw new FlinkException(
-						"The \"" + YarnConfigOptions.PROVIDED_LIB_DIRS.key() + "\" should only contain" +
-								" dirs accessible from all worker nodes, while the \"" + path + "\" is local.");
-			}
-		}
-		return providedLibDirs;
 	}
 
 	private static String encodeYarnLocalResourceDescriptorListToString(List<YarnLocalResourceDescriptor> resources) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -18,21 +18,30 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link Utils}.
@@ -83,6 +92,39 @@ public class UtilsTest extends TestLogger {
 		yarnConfig.setInt(Utils.YARN_RM_INCREMENT_ALLOCATION_VCORES_KEY, incVcore);
 
 		verifyUnitResourceVariousSchedulers(yarnConfig, minMem, minVcore, incMem, incVcore);
+	}
+
+	@Test
+	public void testSharedLibWithNonQualifiedPath() throws Exception {
+		final String sharedLibPath = "/flink/sharedLib";
+		final String nonQualifiedPath = "hdfs://" + sharedLibPath;
+		final String defaultFs = "hdfs://localhost:9000";
+		final String qualifiedPath = defaultFs + sharedLibPath;
+
+		final Configuration flinkConfig = new Configuration();
+		flinkConfig.set(YarnConfigOptions.PROVIDED_LIB_DIRS, Collections.singletonList(nonQualifiedPath));
+		final YarnConfiguration yarnConfig = new YarnConfiguration();
+		yarnConfig.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, defaultFs);
+
+		final List<org.apache.hadoop.fs.Path> sharedLibs = Utils.getRemoteSharedPaths(flinkConfig, yarnConfig);
+		assertThat(sharedLibs.size(), is(1));
+		assertThat(sharedLibs.get(0).toUri().toString(), is(qualifiedPath));
+	}
+
+	@Test
+	public void testSharedLibIsNotRemotePathShouldThrowException() throws IOException {
+		final String localLib = "file:///flink/sharedLib";
+		final Configuration flinkConfig = new Configuration();
+		flinkConfig.set(YarnConfigOptions.PROVIDED_LIB_DIRS, Collections.singletonList(localLib));
+
+		try {
+			Utils.getRemoteSharedPaths(flinkConfig, new YarnConfiguration());
+			fail("We should throw an exception when the shared lib is set to local path.");
+		} catch (FlinkException ex) {
+			final String msg = "The \"" + YarnConfigOptions.PROVIDED_LIB_DIRS.key() + "\" should only " +
+				"contain dirs accessible from all worker nodes";
+			assertThat(ex, FlinkMatchers.containsMessage(msg));
+		}
 	}
 
 	private static void verifyUnitResourceVariousSchedulers(YarnConfiguration yarnConfig, int minMem, int minVcore, int incMem, int incVcore) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When the `yarn.provided.lib.dirs` is set to a non-qualified path(e.g. `hdfs:///flink/flink-1.12-SNAPSHOT/lib`), the Flink cluster could not start. The root cause is `URI#relativize` in `YarnApplicationFileUploader#getAllFilesInProvidedLibDirs` could not work as expected.


## Brief change log

* Support non-qualified path for Yarn shared lib


## Verifying this change

* New added unit test to cover the non-qualified path case
* All the existing ITCase should work without any change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
