### PR TITLE
[FLINK-20171][coordination] Improve error message for Flink process memory configuration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -100,7 +100,11 @@ public class TaskExecutorProcessUtils {
 	}
 
 	public static TaskExecutorProcessSpec processSpecFromConfig(final Configuration config) {
-		return createMemoryProcessSpec(config, PROCESS_MEMORY_UTILS.memoryProcessSpecFromConfig(config));
+		try {
+			return createMemoryProcessSpec(config, PROCESS_MEMORY_UTILS.memoryProcessSpecFromConfig(config));
+		} catch (IllegalConfigurationException e) {
+			throw new IllegalConfigurationException("TaskManager memory configuration failed: " + e.getMessage(), e);
+		}
 	}
 
 	public static TaskExecutorProcessSpec processSpecFromWorkerResourceSpec(
@@ -164,6 +168,12 @@ public class TaskExecutorProcessUtils {
 	public static Configuration getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			final Configuration configuration,
 			final ConfigOption<MemorySize> configOption) {
-		return LEGACY_MEMORY_UTILS.getConfWithLegacyHeapSizeMappedToNewConfigOption(configuration, configOption);
+		try {
+			return LEGACY_MEMORY_UTILS.getConfWithLegacyHeapSizeMappedToNewConfigOption(configuration, configOption);
+		} catch (IllegalConfigurationException e) {
+			throw new IllegalConfigurationException(
+				"TaskManager failed to map legacy JVM heap option to the new one: " + e.getMessage(),
+				e);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.util.config.memory.CommonProcessMemorySpec;
@@ -71,8 +72,14 @@ public class JobManagerProcessUtils {
 	public static JobManagerProcessSpec processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			Configuration config,
 			ConfigOption<MemorySize> newOptionToInterpretLegacyHeap) {
-		return processSpecFromConfig(
-			getConfigurationWithLegacyHeapSizeMappedToNewConfigOption(config, newOptionToInterpretLegacyHeap));
+		try {
+			return processSpecFromConfig(
+				getConfigurationWithLegacyHeapSizeMappedToNewConfigOption(
+					config,
+					newOptionToInterpretLegacyHeap));
+		} catch (IllegalConfigurationException e) {
+			throw new IllegalConfigurationException("JobManager memory configuration failed: " + e.getMessage(), e);
+		}
 	}
 
 	static JobManagerProcessSpec processSpecFromConfig(Configuration config) {


### PR DESCRIPTION
Originates from [discussion](https://issues.apache.org/jira/browse/FLINK-19461?focusedCommentId=17232012&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17232012) in FLINK-19461.

Currently, all configuration failures will result in `IllegalConfigurationException` from `JobManagerProcessUtils` or `TaskExecutorProcessUtils`. The exception error messages do not refer to the process type (JM or TM), it can only become clear from the stack trace.

We can wrap main configuration calls with extra try/catch (`TaskExecutorProcessUtils::processSpecFromConfig` and `JobManagerProcessUtils::processSpecFromConfigWithNewOptionToInterpretLegacyHeap`) where `IllegalConfigurationException` is wrapped into another one which states type of the process (JM or TM).