### PR TITLE
[FLINK-15867][table-planner-blink] Support time-related types for FIRST_VALUE and LAST_VALUE aggregate functions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -481,7 +481,8 @@ class AggFunctionFactory(
     if (needRetraction(index)) {
       valueType.getTypeRoot match {
         case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
-             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE |
+             TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
           new FirstValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE with retract aggregate function does not " +
@@ -490,7 +491,8 @@ class AggFunctionFactory(
     } else {
       valueType.getTypeRoot match {
         case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
-             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE |
+             TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
           new FirstValueAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE aggregate function does not support " +
@@ -507,7 +509,8 @@ class AggFunctionFactory(
     if (needRetraction(index)) {
       valueType.getTypeRoot match {
         case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
-             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE |
+             TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
           new LastValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE with retract aggregate function does not " +
@@ -516,7 +519,8 @@ class AggFunctionFactory(
     } else {
       valueType.getTypeRoot match {
         case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
-             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE |
+             TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
           new LastValueAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE aggregate function does not support " +

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -480,7 +480,8 @@ class AggFunctionFactory(
     val valueType = argTypes(0)
     if (needRetraction(index)) {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new FirstValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE with retract aggregate function does not " +
@@ -488,7 +489,8 @@ class AggFunctionFactory(
       }
     } else {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new FirstValueAggFunction(valueType)
         case t =>
           throw new TableException(s"FIRST_VALUE aggregate function does not support " +
@@ -504,7 +506,8 @@ class AggFunctionFactory(
     val valueType = argTypes(0)
     if (needRetraction(index)) {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new LastValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE with retract aggregate function does not " +
@@ -512,7 +515,8 @@ class AggFunctionFactory(
       }
     } else {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+             TIME_WITHOUT_TIME_ZONE | DATE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new LastValueAggFunction(valueType)
         case t =>
           throw new TableException(s"LAST_VALUE aggregate function does not support " +

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -682,6 +683,97 @@ public final class FirstValueAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
 			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampFirstValueAggFunctionWithOrderTest
+		extends FirstValueAggFunctionWithOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -421,78 +421,79 @@ public final class FirstValueAggFunctionWithOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-11"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -508,89 +509,88 @@ public final class FirstValueAggFunctionWithOrderTest {
 	public static final class TimeFirstValueAggFunctionWithOrderTest
 		extends FirstValueAggFunctionWithOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:45:00.345"),
-				LocalTime.parse("18:00:00.123"),
-				LocalTime.parse("12:45:00.345"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, RowData> getAggregator() {
-			return new FirstValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new FirstValueAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -600,89 +600,88 @@ public final class FirstValueAggFunctionWithOrderTest {
 	public static final class TimestampFirstValueAggFunctionWithOrderTest
 		extends FirstValueAggFunctionWithOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
-			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithOrderTest.java
@@ -23,13 +23,17 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -37,6 +41,9 @@ import org.apache.flink.testutils.serialization.types.ShortType;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -402,6 +409,280 @@ public final class FirstValueAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateFirstValueAggFunctionWithOrderTest
+		extends FirstValueAggFunctionWithOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-11"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeFirstValueAggFunctionWithOrderTest
+		extends FirstValueAggFunctionWithOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:45:00.345"),
+				LocalTime.parse("18:00:00.123"),
+				LocalTime.parse("12:45:00.345"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampFirstValueAggFunctionWithOrderTest
+		extends FirstValueAggFunctionWithOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -489,6 +490,63 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
 			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampFirstValueAggFunctionWithoutOrderTest
+		extends FirstValueAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -330,44 +330,45 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-11"),
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-12"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-12"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -383,55 +384,54 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	public static final class TimeFirstValueAggFunctionWithoutOrderTest
 		extends FirstValueAggFunctionWithoutOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:00:00.123"),
-				LocalTime.parse("18:00:00.123"),
-				LocalTime.parse("12:00:00.123"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("12:00:00.123"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, RowData> getAggregator() {
-			return new FirstValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new FirstValueAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -441,55 +441,54 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 	public static final class TimestampFirstValueAggFunctionWithoutOrderTest
 		extends FirstValueAggFunctionWithoutOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
-			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueAggFunctionWithoutOrderTest.java
@@ -23,13 +23,17 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -37,6 +41,9 @@ import org.apache.flink.testutils.serialization.types.ShortType;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -311,6 +318,178 @@ public final class FirstValueAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new FirstValueAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateFirstValueAggFunctionWithoutOrderTest
+		extends FirstValueAggFunctionWithoutOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-11"),
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-12"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeFirstValueAggFunctionWithoutOrderTest
+		extends FirstValueAggFunctionWithoutOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:00:00.123"),
+				LocalTime.parse("18:00:00.123"),
+				LocalTime.parse("12:00:00.123"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampFirstValueAggFunctionWithoutOrderTest
+		extends FirstValueAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new FirstValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -683,6 +684,97 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
 			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampFirstValueWithRetractAggFunctionWithOrderTest
+		extends FirstValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -422,78 +422,79 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-11"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -509,89 +510,88 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 	public static final class TimeFirstValueWithRetractAggFunctionWithOrderTest
 		extends FirstValueWithRetractAggFunctionWithOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:45:00.345"),
-				LocalTime.parse("18:00:00.123"),
-				LocalTime.parse("12:45:00.345"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, FirstValueWithRetractAccumulator<LocalTime>> getAggregator() {
-			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -601,89 +601,88 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 	public static final class TimestampFirstValueWithRetractAggFunctionWithOrderTest
 		extends FirstValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithOrderTest.java
@@ -22,14 +22,18 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -38,6 +42,9 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -403,6 +410,280 @@ public final class FirstValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<StringData, FirstValueWithRetractAccumulator<StringData>> getAggregator() {
 			return new FirstValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateFirstValueWithRetractAggFunctionWithOrderTest
+		extends FirstValueWithRetractAggFunctionWithOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-11"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, FirstValueWithRetractAccumulator<LocalDate>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeFirstValueWithRetractAggFunctionWithOrderTest
+		extends FirstValueWithRetractAggFunctionWithOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:45:00.345"),
+				LocalTime.parse("18:00:00.123"),
+				LocalTime.parse("12:45:00.345"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, FirstValueWithRetractAccumulator<LocalTime>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampFirstValueWithRetractAggFunctionWithOrderTest
+		extends FirstValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -491,6 +492,63 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
 			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampFirstValueWithRetractAggFunctionWithoutOrderTest
+		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -332,44 +332,45 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-11"),
-				LocalDate.parse("2020-11-12"),
-				LocalDate.parse("2020-11-12"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-12"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -385,55 +386,54 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	public static final class TimeFirstValueWithRetractAggFunctionWithoutOrderTest
 		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:00:00.123"),
-				LocalTime.parse("18:00:00.123"),
-				LocalTime.parse("12:00:00.123"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("12:00:00.123"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, FirstValueWithRetractAccumulator<LocalTime>> getAggregator() {
-			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -443,55 +443,54 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 	public static final class TimestampFirstValueWithRetractAggFunctionWithoutOrderTest
 		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/FirstValueWithRetractAggFunctionWithoutOrderTest.java
@@ -22,14 +22,18 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueWithRetractAggFunction.FirstValueWithRetractAccumulator;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -38,6 +42,9 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -312,6 +319,179 @@ public final class FirstValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<StringData, FirstValueWithRetractAccumulator<StringData>> getAggregator() {
 			return new FirstValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateFirstValueWithRetractAggFunctionWithoutOrderTest
+		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-11"),
+				LocalDate.parse("2020-11-12"),
+				LocalDate.parse("2020-11-12"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, FirstValueWithRetractAccumulator<LocalDate>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeFirstValueWithRetractAggFunctionWithoutOrderTest
+		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:00:00.123"),
+				LocalTime.parse("18:00:00.123"),
+				LocalTime.parse("12:00:00.123"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, FirstValueWithRetractAccumulator<LocalTime>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampFirstValueWithRetractAggFunctionWithoutOrderTest
+		extends FirstValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, FirstValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new FirstValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -682,6 +683,97 @@ public final class LastValueAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
 			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampLastValueAggFunctionWithOrderTest
+		extends LastValueAggFunctionWithOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -23,13 +23,17 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -37,6 +41,9 @@ import org.apache.flink.testutils.serialization.types.ShortType;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -402,6 +409,280 @@ public final class LastValueAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateLastValueAggFunctionWithOrderTest
+		extends LastValueAggFunctionWithOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-11"),
+				LocalDate.parse("2020-11-14"),
+				LocalDate.parse("2020-11-10"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeLastValueAggFunctionWithOrderTest
+		extends LastValueAggFunctionWithOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:00:00.123"),
+				LocalTime.parse("20:30:15.678"),
+				LocalTime.parse("18:45:00.345"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampLastValueAggFunctionWithOrderTest
+		extends LastValueAggFunctionWithOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithOrderTest.java
@@ -421,78 +421,79 @@ public final class LastValueAggFunctionWithOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-11"),
-				LocalDate.parse("2020-11-14"),
-				LocalDate.parse("2020-11-10"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-14"),
+					LocalDate.parse("2020-11-10"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -508,89 +509,88 @@ public final class LastValueAggFunctionWithOrderTest {
 	public static final class TimeLastValueAggFunctionWithOrderTest
 		extends LastValueAggFunctionWithOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:00:00.123"),
-				LocalTime.parse("20:30:15.678"),
-				LocalTime.parse("18:45:00.345"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("20:30:15.678"),
+					LocalTime.parse("18:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, RowData> getAggregator() {
-			return new LastValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new LastValueAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -600,89 +600,88 @@ public final class LastValueAggFunctionWithOrderTest {
 	public static final class TimestampLastValueAggFunctionWithOrderTest
 		extends LastValueAggFunctionWithOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
-			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -471,6 +472,56 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
 			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampLastValueAggFunctionWithoutOrderTest
+		extends LastValueAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -23,13 +23,17 @@ import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -37,6 +41,9 @@ import org.apache.flink.testutils.serialization.types.ShortType;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -312,6 +319,159 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<StringData, RowData> getAggregator() {
 			return new LastValueAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateLastValueAggFunctionWithoutOrderTest
+		extends LastValueAggFunctionWithoutOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-13"),
+				LocalDate.parse("2020-11-09"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeLastValueAggFunctionWithoutOrderTest
+		extends LastValueAggFunctionWithoutOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("18:30:15.678"),
+				LocalTime.parse("20:30:15.678"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampLastValueAggFunctionWithoutOrderTest
+		extends LastValueAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, RowData> getAggregator() {
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueAggFunctionWithoutOrderTest.java
@@ -331,38 +331,39 @@ public final class LastValueAggFunctionWithoutOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-13"),
-				LocalDate.parse("2020-11-09"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-09"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -378,49 +379,48 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	public static final class TimeLastValueAggFunctionWithoutOrderTest
 		extends LastValueAggFunctionWithoutOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("18:30:15.678"),
-				LocalTime.parse("20:30:15.678"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("18:30:15.678"),
+					LocalTime.parse("20:30:15.678"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, RowData> getAggregator() {
-			return new LastValueAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new LastValueAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -430,48 +430,47 @@ public final class LastValueAggFunctionWithoutOrderTest {
 	public static final class TimestampLastValueAggFunctionWithoutOrderTest
 		extends LastValueAggFunctionWithoutOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, RowData> getAggregator() {
-			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new LastValueAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -689,6 +690,97 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
 			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampLastValueWithRetractAggFunctionWithOrderTest
+		extends LastValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -428,78 +428,79 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13"),
-					LocalDate.parse("2020-11-14")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13"),
+							LocalDate.parse("2020-11-14")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-11"),
-				LocalDate.parse("2020-11-14"),
-				LocalDate.parse("2020-11-10"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-14"),
+					LocalDate.parse("2020-11-10"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -515,89 +516,88 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 	public static final class TimeLastValueWithRetractAggFunctionWithOrderTest
 		extends LastValueWithRetractAggFunctionWithOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("12:00:00.123"),
-				LocalTime.parse("20:30:15.678"),
-				LocalTime.parse("18:45:00.345"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("20:30:15.678"),
+					LocalTime.parse("18:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, LastValueWithRetractAccumulator<LocalTime>> getAggregator() {
-			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -607,89 +607,88 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 	public static final class TimestampLastValueWithRetractAggFunctionWithOrderTest
 		extends LastValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<List<Long>> getInputOrderSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					6L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					1L,
-					2L,
-					3L
-				),
-				Arrays.asList(
-					10L,
-					2L,
-					5L,
-					3L,
-					11L,
-					7L,
-					5L
-				),
-				Arrays.asList(
-					6L,
-					9L,
-					5L
-				),
-				Arrays.asList(
-					4L,
-					3L
-				)
+					Arrays.asList(
+							6L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							1L,
+							2L,
+							3L
+					),
+					Arrays.asList(
+							10L,
+							2L,
+							5L,
+							3L,
+							11L,
+							7L,
+							5L
+					),
+					Arrays.asList(
+							6L,
+							9L,
+							5L
+					),
+					Arrays.asList(
+							4L,
+							3L
+					)
 			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithOrderTest.java
@@ -22,14 +22,18 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LastValueWithRetractAccumulator;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -38,6 +42,9 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -409,6 +416,280 @@ public final class LastValueWithRetractAggFunctionWithOrderTest {
 		@Override
 		protected AggregateFunction<StringData, LastValueWithRetractAccumulator<StringData>> getAggregator() {
 			return new LastValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateLastValueWithRetractAggFunctionWithOrderTest
+		extends LastValueWithRetractAggFunctionWithOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-14")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-11"),
+				LocalDate.parse("2020-11-14"),
+				LocalDate.parse("2020-11-10"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, LastValueWithRetractAccumulator<LocalDate>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeLastValueWithRetractAggFunctionWithOrderTest
+		extends LastValueWithRetractAggFunctionWithOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("12:00:00.123"),
+				LocalTime.parse("20:30:15.678"),
+				LocalTime.parse("18:45:00.345"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, LastValueWithRetractAccumulator<LocalTime>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampLastValueWithRetractAggFunctionWithOrderTest
+		extends LastValueWithRetractAggFunctionWithOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<List<Long>> getInputOrderSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					6L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					1L,
+					2L,
+					3L
+				),
+				Arrays.asList(
+					10L,
+					2L,
+					5L,
+					3L,
+					11L,
+					7L,
+					5L
+				),
+				Arrays.asList(
+					6L,
+					9L,
+					5L
+				),
+				Arrays.asList(
+					4L,
+					3L
+				)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-14T18:45:00.678")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
@@ -471,6 +472,56 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
 			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link LocalZonedTimestampType}.
+	 */
+	public static final class LocalZonedTimestampLastValueWithRetractAggFunctionWithoutOrderTest
+		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -22,14 +22,18 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.DecimalDataUtils;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.planner.functions.aggfunctions.LastValueWithRetractAggFunction.LastValueWithRetractAccumulator;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.serialization.types.ShortType;
@@ -38,6 +42,9 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -312,6 +319,159 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected AggregateFunction<StringData, LastValueWithRetractAccumulator<StringData>> getAggregator() {
 			return new LastValueWithRetractAggFunction<>(DataTypes.STRING().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link DateType}.
+	 */
+	public static final class DateLastValueWithRetractAggFunctionWithoutOrderTest
+		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<LocalDate> {
+
+		@Override
+		protected List<List<LocalDate>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalDate.parse("2020-11-11"),
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-13")
+				),
+				Arrays.asList(
+					LocalDate.parse("2020-11-12"),
+					LocalDate.parse("2020-11-11"),
+					null,
+					LocalDate.parse("2020-11-15"),
+					LocalDate.parse("2020-11-10"),
+					LocalDate.parse("2020-11-09"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalDate.parse("2020-11-12")
+				));
+		}
+
+		@Override
+		protected List<LocalDate> getExpectedResults() {
+			return Arrays.asList(
+				LocalDate.parse("2020-11-13"),
+				LocalDate.parse("2020-11-09"),
+				null,
+				LocalDate.parse("2020-11-12")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalDate, LastValueWithRetractAccumulator<LocalDate>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.DATE().getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimeType}.
+	 */
+	public static final class TimeLastValueWithRetractAggFunctionWithoutOrderTest
+		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<LocalTime> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<LocalTime>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					LocalTime.parse("18:30:15.678")
+				),
+				Arrays.asList(
+					LocalTime.parse("12:00:00.123"),
+					LocalTime.parse("12:45:00.345"),
+					null,
+					LocalTime.parse("18:00:00.123"),
+					LocalTime.parse("18:45:00.345"),
+					LocalTime.parse("20:30:15.678"),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					LocalTime.parse("18:00:00.345")
+				));
+		}
+
+		@Override
+		protected List<LocalTime> getExpectedResults() {
+			return Arrays.asList(
+				LocalTime.parse("18:30:15.678"),
+				LocalTime.parse("20:30:15.678"),
+				null,
+				LocalTime.parse("18:00:00.345")
+			);
+		}
+
+		@Override
+		protected AggregateFunction<LocalTime, LastValueWithRetractAccumulator<LocalTime>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+		}
+	}
+
+	/**
+	 * Test for {@link TimestampType}.
+	 */
+	public static final class TimestampLastValueWithRetractAggFunctionWithoutOrderTest
+		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
+
+		private int precision = 3;
+
+		@Override
+		protected List<List<TimestampData>> getInputValueSets() {
+			return Arrays.asList(
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+				),
+				Arrays.asList(
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null
+				),
+				Arrays.asList(
+					null,
+					null,
+					null
+				),
+				Arrays.asList(
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+				));
+		}
+
+		@Override
+		protected List<TimestampData> getExpectedResults() {
+			return Arrays.asList(
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+				null,
+				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+			);
+		}
+
+		@Override
+		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LastValueWithRetractAggFunctionWithoutOrderTest.java
@@ -331,38 +331,39 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 		@Override
 		protected List<List<LocalDate>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalDate.parse("2020-11-11"),
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-13")
-				),
-				Arrays.asList(
-					LocalDate.parse("2020-11-12"),
-					LocalDate.parse("2020-11-11"),
-					null,
-					LocalDate.parse("2020-11-15"),
-					LocalDate.parse("2020-11-10"),
-					LocalDate.parse("2020-11-09"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalDate.parse("2020-11-12")
-				));
+					Arrays.asList(
+							LocalDate.parse("2020-11-11"),
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-13")
+					),
+					Arrays.asList(
+							LocalDate.parse("2020-11-12"),
+							LocalDate.parse("2020-11-11"),
+							null,
+							LocalDate.parse("2020-11-15"),
+							LocalDate.parse("2020-11-10"),
+							LocalDate.parse("2020-11-09"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalDate.parse("2020-11-12")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalDate> getExpectedResults() {
 			return Arrays.asList(
-				LocalDate.parse("2020-11-13"),
-				LocalDate.parse("2020-11-09"),
-				null,
-				LocalDate.parse("2020-11-12")
+					LocalDate.parse("2020-11-13"),
+					LocalDate.parse("2020-11-09"),
+					null,
+					LocalDate.parse("2020-11-12")
 			);
 		}
 
@@ -378,49 +379,48 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	public static final class TimeLastValueWithRetractAggFunctionWithoutOrderTest
 		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<LocalTime> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<LocalTime>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					LocalTime.parse("18:30:15.678")
-				),
-				Arrays.asList(
-					LocalTime.parse("12:00:00.123"),
-					LocalTime.parse("12:45:00.345"),
-					null,
-					LocalTime.parse("18:00:00.123"),
-					LocalTime.parse("18:45:00.345"),
-					LocalTime.parse("20:30:15.678"),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					LocalTime.parse("18:00:00.345")
-				));
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							LocalTime.parse("18:30:15.678")
+					),
+					Arrays.asList(
+							LocalTime.parse("12:00:00.123"),
+							LocalTime.parse("12:45:00.345"),
+							null,
+							LocalTime.parse("18:00:00.123"),
+							LocalTime.parse("18:45:00.345"),
+							LocalTime.parse("20:30:15.678"),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							LocalTime.parse("18:00:00.345")
+					)
+			);
 		}
 
 		@Override
 		protected List<LocalTime> getExpectedResults() {
 			return Arrays.asList(
-				LocalTime.parse("18:30:15.678"),
-				LocalTime.parse("20:30:15.678"),
-				null,
-				LocalTime.parse("18:00:00.345")
+					LocalTime.parse("18:30:15.678"),
+					LocalTime.parse("20:30:15.678"),
+					null,
+					LocalTime.parse("18:00:00.345")
 			);
 		}
 
 		@Override
 		protected AggregateFunction<LocalTime, LastValueWithRetractAccumulator<LocalTime>> getAggregator() {
-			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(precision).getLogicalType());
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIME(3).getLogicalType());
 		}
 	}
 
@@ -430,48 +430,47 @@ public final class LastValueWithRetractAggFunctionWithoutOrderTest {
 	public static final class TimestampLastValueWithRetractAggFunctionWithoutOrderTest
 		extends LastValueWithRetractAggFunctionWithoutOrderTestBase<TimestampData> {
 
-		private int precision = 3;
-
 		@Override
 		protected List<List<TimestampData>> getInputValueSets() {
 			return Arrays.asList(
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
-				),
-				Arrays.asList(
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-					null
-				),
-				Arrays.asList(
-					null,
-					null,
-					null
-				),
-				Arrays.asList(
-					null,
-					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
-				));
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678"))
+					),
+					Arrays.asList(
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-11T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T15:30:00.345")),
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T12:00:00.123")),
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+							null
+					),
+					Arrays.asList(
+							null,
+							null,
+							null
+					),
+					Arrays.asList(
+							null,
+							TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					)
+			);
 		}
 
 		@Override
 		protected List<TimestampData> getExpectedResults() {
 			return Arrays.asList(
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
-				null,
-				TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T18:45:00.678")),
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-13T15:30:00.345")),
+					null,
+					TimestampData.fromLocalDateTime(LocalDateTime.parse("2020-11-12T18:00:00.345"))
 			);
 		}
 
 		@Override
 		protected AggregateFunction<TimestampData, LastValueWithRetractAccumulator<TimestampData>> getAggregator() {
-			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(precision).getLogicalType());
+			return new LastValueWithRetractAggFunction<>(DataTypes.TIMESTAMP(3).getLogicalType());
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request enables support for time-related types in FIRST_VALUE and LAST_VALUE aggregate functions.


## Brief change log

  - Added types `TIME_WITHOUT_TIME_ZONE`, `DATE`, `TIMESTAMP_WITHOUT_TIME_ZONE` for FIRST_VALUE and LAST_VALUE aggregate functions in `AggFunctionFactory`


## Verifying this change

This change added tests and can be verified as follows:

  - Extended existing unit tests for FIRST_VALUE and LAST_VALUE aggregate functions for the added types


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)


## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
