### PR TITLE
[FLINK-19997] Implement an e2e test for sql-client with Confluent Registry Avro format

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -30,6 +30,13 @@ under the License.
 	<artifactId>flink-end-to-end-tests-common-kafka</artifactId>
 	<name>Flink : E2E Tests : Common Kafka</name>
 
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>https://packages.confluent.io/maven/</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -61,6 +68,12 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>2.4.1</version>
+		</dependency>
+
 		<!-- The following dependencies are for connector/format sql-jars that
 			we copy using the maven-dependency-plugin. When extending the test
  			to cover more connectors/formats, add a dependency here and an entry
@@ -78,6 +91,47 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-avro</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<!-- Used by maven-dependency-plugin -->
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-avro-confluent-registry</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<version>1.15.0</version>
+		</dependency>
+
+		<dependency>
+			<!-- https://mvnrepository.com/artifact/io.confluent/kafka-avro-serializer -->
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-avro-serializer</artifactId>
+			<version>5.5.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-schema-registry-client</artifactId>
+			<version>5.5.2</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.kafka</groupId>
+					<artifactId>kafka-clients</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+			<version>1.10.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -120,6 +174,14 @@ under the License.
 							<artifactId>flink-sql-avro</artifactId>
 							<version>${project.version}</version>
 							<destFileName>avro.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+						</artifactItem>
+						<artifactItem>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-sql-avro-confluent-registry</artifactId>
+							<version>${project.version}</version>
+							<destFileName>avro-confluent.jar</destFileName>
 							<type>jar</type>
 							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
 						</artifactItem>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka;
+
+import org.apache.flink.api.common.time.Deadline;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+/**
+ * A utility class that exposes common methods over a {@link KafkaContainer}.
+ */
+public class KafkaContainerClient {
+	private static final Logger LOG = LoggerFactory.getLogger(KafkaContainerClient.class);
+	private final KafkaContainer container;
+
+	public KafkaContainerClient(KafkaContainer container) {
+		this.container = container;
+	}
+
+	public void createTopic(
+			int replicationFactor,
+			int numPartitions,
+			String topic) {
+		Map<String, Object> properties = new HashMap<>();
+		properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+		try (AdminClient admin = AdminClient.create(properties)) {
+			admin.createTopics(Collections.singletonList(new NewTopic(
+				topic,
+				numPartitions,
+				(short) replicationFactor)));
+		}
+	}
+
+	public <T> void sendMessages(String topic, Serializer<T> valueSerializer, T... messages) {
+		Properties props = new Properties();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+		props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+		try (
+			Producer<Bytes, T> producer = new KafkaProducer<>(
+				props,
+				new BytesSerializer(),
+				valueSerializer)) {
+			for (T message : messages) {
+				producer.send(new ProducerRecord<>(
+					topic,
+					message));
+			}
+		}
+	}
+
+	public <T> List<T> readMessages(
+			int expectedNumMessages,
+			String groupId,
+			String topic,
+			Deserializer<T> valueDeserializer) throws IOException {
+		Properties props = new Properties();
+		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+		final List<T> messages = Collections.synchronizedList(new ArrayList<>(
+			expectedNumMessages));
+		try (
+			Consumer<Bytes, T> consumer = new KafkaConsumer<>(
+				props,
+				new BytesDeserializer(),
+				valueDeserializer)) {
+			consumer.subscribe(Pattern.compile(topic));
+			final Deadline deadline = Deadline.fromNow(Duration.ofSeconds(120));
+			while (deadline.hasTimeLeft() && messages.size() < expectedNumMessages) {
+				LOG.info("Waiting for messages. Received {}/{}.", messages.size(),
+					expectedNumMessages);
+				ConsumerRecords<Bytes, T> records = consumer.poll(Duration.ofMillis(100));
+				for (ConsumerRecord<Bytes, T> record : records) {
+					messages.add(record.value());
+				}
+			}
+			if (messages.size() != expectedNumMessages) {
+				throw new IOException("Could not read expected number of messages.");
+			}
+			return messages;
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka;
+
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.categories.TravisGroup1;
+import org.apache.flink.tests.util.flink.FlinkContainer;
+import org.apache.flink.tests.util.flink.SQLJobSubmission;
+import org.apache.flink.tests.util.kafka.containers.SchemaRegistryContainer;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * End-to-end test for SQL client using Avro Confluent Registry format.
+ */
+@Category(value = {TravisGroup1.class})
+public class SQLClientSchemaRegistryITCase {
+	public static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
+	public static final String INTER_CONTAINER_REGISTRY_ALIAS = "registry";
+	private static final Path sqlAvroJar = TestUtils.getResource(".*avro.jar");
+	private static final Path sqlAvroRegistryJar = TestUtils.getResource(".*avro-confluent.jar");
+	private static final Path sqlToolBoxJar = TestUtils.getResource(".*SqlToolbox.jar");
+	private final Path sqlConnectorKafkaJar = TestUtils.getResource(".*kafka.jar");
+
+	public final Network network = Network.newNetwork();
+
+	@Rule
+	public final KafkaContainer kafka = new KafkaContainer(
+		DockerImageName.parse("confluentinc/cp-kafka:5.5.2"))
+		.withNetwork(network)
+		.withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+
+	@Rule
+	public final SchemaRegistryContainer registry = new SchemaRegistryContainer("5.5.2")
+		.withKafka(INTER_CONTAINER_KAFKA_ALIAS + ":9092")
+		.withNetwork(network)
+		.withNetworkAliases(INTER_CONTAINER_REGISTRY_ALIAS)
+		.dependsOn(kafka);
+
+	@Rule
+	public final FlinkContainer flink = FlinkContainer
+		.builder()
+		.build()
+		.withNetwork(network)
+		.dependsOn(kafka);
+
+	private final KafkaContainerClient kafkaClient = new KafkaContainerClient(kafka);
+	private CachedSchemaRegistryClient registryClient;
+
+	public SQLClientSchemaRegistryITCase() throws IOException {
+	}
+
+	@Before
+	public void setUp() {
+		registryClient = new CachedSchemaRegistryClient(
+			registry.getSchemaRegistryUrl(),
+			10);
+	}
+
+	@Test
+	public void testReading() throws Exception {
+		String testCategoryTopic = "test-category-" + UUID.randomUUID().toString();
+		String testResultsTopic = "test-results-" + UUID.randomUUID().toString();
+		kafkaClient.createTopic(1, 1, testCategoryTopic);
+		Schema categoryRecord = SchemaBuilder.record("record")
+			.fields()
+			.requiredLong("category_id")
+			.optionalString("name")
+			.endRecord();
+		String categorySubject = testCategoryTopic + "-value";
+		registryClient.register(categorySubject, new AvroSchema(categoryRecord));
+		GenericRecordBuilder categoryBuilder = new GenericRecordBuilder(categoryRecord);
+		KafkaAvroSerializer valueSerializer = new KafkaAvroSerializer(registryClient);
+		kafkaClient.sendMessages(
+			testCategoryTopic,
+			valueSerializer,
+			categoryBuilder
+				.set("category_id", 1L)
+				.set("name", "electronics")
+				.build()
+		);
+
+		List<String> sqlLines = Arrays.asList(
+			"CREATE TABLE category (",
+			" category_id BIGINT,",
+			" name STRING,",
+			" description STRING",  // new field, should create new schema version, but still should
+									// be able to read old version
+			") WITH (",
+			" 'connector' = 'kafka',",
+			" 'properties.bootstrap.servers' = '" + INTER_CONTAINER_KAFKA_ALIAS + ":9092',",
+			" 'topic' = '" + testCategoryTopic + "',",
+			" 'scan.startup.mode' = 'earliest-offset',",
+			" 'format' = 'avro-confluent',",
+			" 'avro-confluent.schema-registry.url' = 'http://" + INTER_CONTAINER_REGISTRY_ALIAS + ":8082" + "',",
+			" 'avro-confluent.schema-registry.subject' = '" + categorySubject + "'",
+			");",
+			"",
+			"CREATE TABLE results (",
+			" category_id BIGINT,",
+			" name STRING,",
+			" description STRING",
+			") WITH (",
+			" 'connector' = 'kafka',",
+			" 'properties.bootstrap.servers' = '" + INTER_CONTAINER_KAFKA_ALIAS + ":9092',",
+			" 'topic' = '" + testResultsTopic + "',",
+			" 'format' = 'csv',",
+			" 'csv.null-literal' = 'null'",
+			");",
+			"",
+			"INSERT INTO results SELECT * FROM category;"
+		);
+
+		executeSqlStatements(sqlLines);
+		List<String> categories = kafkaClient.readMessages(
+			1,
+			"test-group",
+			testResultsTopic,
+			new StringDeserializer());
+		assertThat(categories, equalTo(
+			Collections.singletonList(
+				"1,electronics,null"
+			)
+		));
+	}
+
+	@Test
+	public void testWriting() throws Exception {
+		String testUserBehaviorTopic = "test-user-behavior-" + UUID.randomUUID().toString();
+		// Create topic test-avro
+		kafkaClient.createTopic(1, 1, testUserBehaviorTopic);
+
+		String behaviourSubject = "user_behavior";
+		List<String> sqlLines = Arrays.asList(
+			"CREATE TABLE user_behavior (",
+			" user_id BIGINT NOT NULL,",
+			" item_id BIGINT,",
+			" category_id BIGINT,",
+			" behavior STRING,",
+			" ts TIMESTAMP(3)",
+			") WITH (",
+			" 'connector' = 'kafka',",
+			" 'properties.bootstrap.servers' = '" + INTER_CONTAINER_KAFKA_ALIAS + ":9092',",
+			" 'topic' = '" + testUserBehaviorTopic + "',",
+			" 'format' = 'avro-confluent',",
+			" 'avro-confluent.schema-registry.url' = 'http://" + INTER_CONTAINER_REGISTRY_ALIAS + ":8082" + "',",
+			" 'avro-confluent.schema-registry.subject' = '" + behaviourSubject + "'",
+			");",
+			"",
+			"INSERT INTO user_behavior VALUES (1, 1, 1, 'buy', CAST (1234 AS TIMESTAMP(3)));"
+		);
+
+		executeSqlStatements(sqlLines);
+
+		List<Integer> versions = registryClient.getAllVersions(behaviourSubject);
+		assertThat(versions.size(), equalTo(1));
+		List<Object> userBehaviors = kafkaClient.readMessages(
+			1,
+			"test-group",
+			testUserBehaviorTopic,
+			new KafkaAvroDeserializer(registryClient));
+
+		Schema userBehaviorSchema = (Schema) registryClient
+			.getSchemaBySubjectAndId(behaviourSubject, versions.get(0))
+			.rawSchema();
+		GenericRecordBuilder recordBuilder = new GenericRecordBuilder(userBehaviorSchema);
+		assertThat(userBehaviors, equalTo(
+			Collections.singletonList(
+				recordBuilder
+					.set("user_id", 1L)
+					.set("item_id", 1L)
+					.set("category_id", 1L)
+					.set("behavior", "buy")
+					.set("ts", 1234000L)
+					.build()
+			)
+		));
+	}
+
+	private void executeSqlStatements(List<String> sqlLines) throws Exception {
+		flink.submitSQLJob(new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+			.addJars(sqlAvroJar, sqlAvroRegistryJar, sqlConnectorKafkaJar, sqlToolBoxJar)
+			.build());
+	}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/containers/SchemaRegistryContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/containers/SchemaRegistryContainer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.kafka.containers;
+
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * A container over an Confluent Schema Registry. It runs the schema registry on port 8082
+ * in the docker network so that it does not overlap with Flink cluster.
+ */
+public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
+
+	public SchemaRegistryContainer(String version) {
+		super("confluentinc/cp-schema-registry:" + version);
+		withExposedPorts(8082);
+	}
+
+	public SchemaRegistryContainer withKafka(String kafkaBootstrapServer) {
+		withEnv(
+			"SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS",
+			"PLAINTEXT://" + kafkaBootstrapServer);
+		return this;
+	}
+
+	@Override
+	protected void configure() {
+		withEnv("SCHEMA_REGISTRY_HOST_NAME", getNetworkAliases().get(0));
+		withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8082");
+	}
+
+	public String getSchemaRegistryUrl() {
+		return "http://" + getContainerIpAddress() + ":" + getMappedPort(8082);
+	}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
@@ -26,3 +26,9 @@ appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
 appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
+
+# It is recommended to uncomment these lines when enabling the logger. The below package used
+# by testcontainers is quite verbose
+#logger.yarn.name = org.testcontainers.shaded.com.github.dockerjava.core
+#logger.yarn.level = WARN
+#logger.yarn.appenderRef.console.ref = TestLogger

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -63,6 +63,11 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.15.0</version>
+		</dependency>
+		<dependency>
 			<!-- To ensure that flink-dist is built beforehand -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-dist_${scala.binary.version}</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
+import org.apache.flink.tests.util.parameters.ParameterProperty;
+import org.apache.flink.tests.util.util.FileUtils;
+import org.apache.flink.util.IOUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.github.dockerjava.api.DockerClient;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.lifecycle.TestDescription;
+import org.testcontainers.lifecycle.TestLifecycleAware;
+import org.testcontainers.utility.MountableFile;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A container that wraps a Flink distribution and spawns a Flink cluster in a single Docker container.
+ */
+public class FlinkContainer extends GenericContainer<FlinkContainer> implements TestLifecycleAware {
+	private static final Logger LOG = LoggerFactory.getLogger(FlinkContainer.class);
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+	private static final String FLINK_BIN = "flink/bin";
+
+	private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+	private final Path logBackupDir;
+
+	private FlinkContainer(ImageFromDockerfile image, int numTaskManagers, @Nullable Path logBackupDir) {
+		super(image);
+		this.logBackupDir = logBackupDir;
+		withExposedPorts(8081);
+		waitingFor(
+			new HttpWaitStrategy()
+				.forPort(8081)
+				.forPath("/taskmanagers")
+				.forResponsePredicate(
+					response -> {
+						try {
+							TaskManagersInfo managersInfo = objectMapper.readValue(
+								response,
+								TaskManagersInfo.class);
+							return numTaskManagers == managersInfo.getTaskManagerInfos().size();
+						} catch (JsonProcessingException e) {
+							return false;
+						}
+					}
+				)
+		);
+	}
+
+	@Override
+	public void beforeTest(TestDescription description) {
+		try {
+			temporaryFolder.create();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void afterTest(
+			TestDescription description,
+			Optional<Throwable> throwable) {
+		if (throwable.isPresent() && logBackupDir != null) {
+			try {
+				final Path targetDirectory = logBackupDir.resolve(
+					"flink-" + UUID.randomUUID().toString());
+				copyFileOrDirectoryFromContainer("flink/log/", targetDirectory);
+				LOG.info("Backed up logs to {}.", targetDirectory);
+			} catch (IOException e) {
+				LOG.error("Could not backup the flink logs.", e);
+			}
+		}
+		temporaryFolder.delete();
+	}
+
+	/**
+	 * Copies a container path to a local directory. In contrast to
+	 * {@link GenericContainer#copyFileFromContainer(String, String)} it supports copying
+	 * whole directories. <b>NOTE:</b> The {@code hostDirectory} should point to a destination
+	 * directory.
+	 */
+	public void copyFileOrDirectoryFromContainer(String containerPath, Path hostDirectory) throws IOException {
+		DockerClient dockerClient = DockerClientFactory.instance().client();
+		try (
+			InputStream inputStream = dockerClient
+				.copyArchiveFromContainerCmd(getContainerId(), containerPath)
+				.exec();
+			TarArchiveInputStream tarInputStream = new TarArchiveInputStream(inputStream)) {
+			unTar(tarInputStream, hostDirectory.toFile());
+		}
+	}
+
+	private static void unTar(TarArchiveInputStream tis, File destFolder) throws IOException {
+		TarArchiveEntry entry = null;
+		while ((entry = tis.getNextTarEntry()) != null) {
+			FileOutputStream fos = null;
+			try {
+				if (entry.isDirectory()) {
+					continue;
+				}
+				File curfile = new File(destFolder, entry.getName());
+				File parent = curfile.getParentFile();
+				if (!parent.exists()) {
+					parent.mkdirs();
+				}
+				fos = new FileOutputStream(curfile);
+				IOUtils.copyBytes(tis, fos, false);
+			} catch (Exception e) {
+				LOG.warn("Exception extracting {} to {}", tis, destFolder, e);
+			} finally {
+				try {
+					if (fos != null) {
+						fos.flush();
+						fos.getFD().sync();
+						fos.close();
+					}
+				} catch (IOException e) {
+					LOG.warn("Exception closing {}", fos, e);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Submits a SQL job to the running cluster.
+	 *
+	 * <p><b>NOTE:</b> You should not use {@code '\t'}.
+	 */
+	public void submitSQLJob(SQLJobSubmission job) throws IOException, InterruptedException {
+		final List<String> commands = new ArrayList<>();
+		Path script = temporaryFolder.newFile().toPath();
+		Files.write(script, job.getSqlLines());
+		copyFileToContainer(MountableFile.forHostPath(script), "/tmp/script.sql");
+		commands.add("cat /tmp/script.sql | ");
+		commands.add(FLINK_BIN + "/sql-client.sh");
+		commands.add("embedded");
+		job.getDefaultEnvFile().ifPresent(defaultEnvFile -> {
+			commands.add("--defaults");
+			String containerPath = copyAndGetContainerPath(defaultEnvFile);
+			commands.add(containerPath);
+		});
+		job.getSessionEnvFile().ifPresent(sessionEnvFile -> {
+			commands.add("--environment");
+			String containerPath = copyAndGetContainerPath(sessionEnvFile);
+			commands.add(containerPath);
+		});
+		for (String jar : job.getJars()) {
+			commands.add("--jar");
+			String containerPath = copyAndGetContainerPath(jar);
+			commands.add(containerPath);
+		}
+
+		ExecResult execResult = execInContainer("bash", "-c", String.join(" ", commands));
+		LOG.info(execResult.getStdout());
+		LOG.error(execResult.getStderr());
+		if (execResult.getExitCode() != 0) {
+			throw new AssertionError("Failed when submitting the SQL job.");
+		}
+	}
+
+	@Nonnull
+	private String copyAndGetContainerPath(String defaultEnvFile) {
+		Path path = Paths.get(defaultEnvFile);
+		String containerPath = "/tmp/" + path.getFileName();
+		copyFileToContainer(MountableFile.forHostPath(path), containerPath);
+		return containerPath;
+	}
+
+	public static FlinkContainerBuilder builder() {
+		return new FlinkContainerBuilder();
+	}
+
+	/**
+	 * A builder for a {@link FlinkContainer}.
+	 */
+	public static class FlinkContainerBuilder {
+
+		private static final ParameterProperty<Path> DISTRIBUTION_LOG_BACKUP_DIRECTORY = new ParameterProperty<>("logBackupDir", Paths::get);
+
+		private int numTaskManagers = 1;
+		private String javaVersion;
+		private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+		/**
+		 * The expected number of TaskManagers to start. All TaskManagers are created in the same
+		 * container along with the JobManager
+		 */
+		public FlinkContainerBuilder numTaskManagers(int numTaskManagers) {
+			this.numTaskManagers = numTaskManagers;
+			return this;
+		}
+
+		/**
+		 * Specifies which OpenJDK version to use. If not provided explicitly, the image version
+		 * will be derived based on the version of the java that runs the test.
+		 */
+		public FlinkContainerBuilder javaVersion(String javaVersion) {
+			this.javaVersion = javaVersion;
+			return this;
+		}
+
+		public FlinkContainer build() throws IOException {
+			try {
+				Path flinkDist = FileUtils.findFlinkDist();
+				String flinkDistName = flinkDist.getFileName().toString();
+				temporaryFolder.create();
+				Path tmp = temporaryFolder.newFolder().toPath();
+				Path workersFile = tmp.resolve("workers");
+				Files.write(
+					workersFile,
+					IntStream.range(0, numTaskManagers)
+						.mapToObj(i -> "localhost")
+						.collect(Collectors.toList()));
+
+				ImageFromDockerfile image = new ImageFromDockerfile("flink-dist", true)
+					.withDockerfileFromBuilder(
+						builder -> {
+							builder.from("openjdk:" + getJavaVersionSuffix())
+								.copy(flinkDistName, "flink")
+								.copy(flinkDistName + "/conf/workers", "workers")
+								.cmd(FLINK_BIN + "/start-cluster.sh && tail -f /dev/null")
+								.build();
+						}
+					)
+					.withFileFromPath("workers", workersFile)
+					.withFileFromPath(flinkDistName, flinkDist);
+
+				Optional<Path> logBackupDirectory = DISTRIBUTION_LOG_BACKUP_DIRECTORY.get();
+				if (!logBackupDirectory.isPresent()) {
+					LOG.warn(
+						"Property {} not set, logs will not be backed up in case of test failures.",
+						DISTRIBUTION_LOG_BACKUP_DIRECTORY.getPropertyName());
+				}
+				return new FlinkContainer(image, numTaskManagers, logBackupDirectory.orElse(null));
+			} finally {
+				temporaryFolder.delete();
+			}
+		}
+
+		private String getJavaVersionSuffix() {
+			if (javaVersion != null) {
+				return javaVersion;
+			} else {
+				String javaSpecVersion = System.getProperty("java.vm.specification.version");
+				switch (javaSpecVersion) {
+					case "1.8":
+						return "8";
+					case "11":
+						return "11";
+					default:
+						throw new IllegalStateException("Unexpected value: " + javaSpecVersion);
+				}
+			}
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
@@ -19,16 +19,13 @@
 package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.tests.util.parameters.ParameterProperty;
-import org.apache.flink.util.FileUtils;
+import org.apache.flink.tests.util.util.FileUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -37,88 +34,18 @@ import java.util.Optional;
 public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneFlinkResourceFactory.class);
 
-	private static final ParameterProperty<Path> PROJECT_ROOT_DIRECTORY = new ParameterProperty<>("rootDir", Paths::get);
-	private static final ParameterProperty<Path> DISTRIBUTION_DIRECTORY = new ParameterProperty<>("distDir", Paths::get);
 	private static final ParameterProperty<Path> DISTRIBUTION_LOG_BACKUP_DIRECTORY = new ParameterProperty<>("logBackupDir", Paths::get);
 
 	@Override
 	public FlinkResource create(FlinkResourceSetup setup) {
-		Optional<Path> distributionDirectory = DISTRIBUTION_DIRECTORY.get();
-		if (!distributionDirectory.isPresent()) {
-			LOG.debug("The '{}' property was not set; attempting to automatically determine distribution location.", DISTRIBUTION_DIRECTORY.getPropertyName());
-
-			Path projectRootPath;
-			Optional<Path> projectRoot = PROJECT_ROOT_DIRECTORY.get();
-			if (projectRoot.isPresent()) {
-				// running with maven
-				projectRootPath = projectRoot.get();
-			} else {
-				// running in the IDE; working directory is test module
-				Optional<Path> projectRootDirectory = findProjectRootDirectory(Paths.get("").toAbsolutePath());
-				// this distinction is required in case this class is used outside of Flink
-				if (projectRootDirectory.isPresent()) {
-					projectRootPath = projectRootDirectory.get();
-				} else {
-					throw new IllegalArgumentException(
-						"The 'distDir' property was not set and the flink-dist module could not be found automatically." +
-							" Please point the 'distDir' property to the directory containing distribution; you can set it when running maven via -DdistDir=<path> .");
-				}
-			}
-			Optional<Path> distribution = findDistribution(projectRootPath);
-			if (!distribution.isPresent()) {
-				throw new IllegalArgumentException(
-					"The 'distDir' property was not set and a distribution could not be found automatically." +
-						" Please point the 'distDir' property to the directory containing distribution; you can set it when running maven via -DdistDir=<path> .");
-			} else {
-				distributionDirectory = distribution;
-			}
-		}
 		Optional<Path> logBackupDirectory = DISTRIBUTION_LOG_BACKUP_DIRECTORY.get();
 		if (!logBackupDirectory.isPresent()) {
 			LOG.warn("Property {} not set, logs will not be backed up in case of test failures.", DISTRIBUTION_LOG_BACKUP_DIRECTORY.getPropertyName());
 		}
-		return new LocalStandaloneFlinkResource(distributionDirectory.get(), logBackupDirectory.orElse(null), setup);
-	}
-
-	private static Optional<Path> findProjectRootDirectory(Path currentDirectory) {
-		// move up the module structure until we find flink-dist; relies on all modules being prefixed with 'flink'
-		do {
-			if (Files.exists(currentDirectory.resolve("flink-dist"))) {
-				return Optional.of(currentDirectory);
-			}
-			currentDirectory = currentDirectory.getParent();
-		}  while (currentDirectory.getFileName().toString().startsWith("flink"));
-		return Optional.empty();
-	}
-
-	private static Optional<Path> findDistribution(Path projectRootDirectory) {
-		final Path distTargetDirectory = projectRootDirectory.resolve("flink-dist").resolve("target");
-		try {
-			Collection<Path> paths = FileUtils.listFilesInDirectory(
-				distTargetDirectory,
-				LocalStandaloneFlinkResourceFactory::isDistribution);
-			if (paths.size() == 0) {
-				// likely due to flink-dist not having been built
-				return Optional.empty();
-			}
-			if (paths.size() > 1) {
-				// target directory can contain distributions for multiple versions, or it's just a dirty environment
-				LOG.warn("Detected multiple distributions under flink-dist/target. It is recommended to explicitly" +
-					" select the distribution by setting the '{}}' property.", DISTRIBUTION_DIRECTORY.getPropertyName());
-			}
-			// jar should be in /lib; first getParent() returns /lib, second getParent() returns distribution directory
-			return Optional.of(paths.iterator().next().getParent().getParent());
-		} catch (IOException e) {
-			LOG.error("Error while searching for distribution.", e);
-			return Optional.empty();
-		}
-	}
-
-	private static boolean isDistribution(Path path) {
-		// check for `lib/flink-dist*'
-		// searching for the flink-dist jar is not sufficient since it also exists in the modules 'target' directory
-		return path.getFileName().toString().contains("flink-dist")
-			&& path.getParent().getFileName().toString().equals("lib");
+		return new LocalStandaloneFlinkResource(
+			FileUtils.findFlinkDist(),
+			logBackupDirectory.orElse(null),
+			setup);
 	}
 }
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/SQLJobSubmission.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/SQLJobSubmission.java
@@ -90,6 +90,13 @@ public class SQLJobSubmission {
 			return this;
 		}
 
+		public SQLJobSubmissionBuilder addJars(Path... jarFiles) {
+			for (Path jarFile : jarFiles) {
+				addJar(jarFile);
+			}
+			return this;
+		}
+
 		public SQLJobSubmissionBuilder addJars(List<Path> jarFiles) {
 			jarFiles.forEach(this::addJar);
 			return this;

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -91,6 +91,9 @@ under the License.
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- We pick an arbitrary version of net.java.dev.jna:jna to satisfy dependency
+				 convergence for org.testcontainers:testcontainers which transitively depends on
+				 two different versions.-->
 			<dependency>
 				<groupId>net.java.dev.jna</groupId>
 				<artifactId>jna</artifactId>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -89,6 +89,16 @@ under the License.
 		<module>flink-end-to-end-tests-hbase</module>
 	</modules>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>net.java.dev.jna</groupId>
+				<artifactId>jna</artifactId>
+				<version>5.5.0</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<!-- this module depends on the flink-yarn-tests's "target/yarn.classpath" file -->

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -67,13 +67,28 @@ public class RowDataToAvroConverters {
 		final RowDataToAvroConverter converter;
 		switch (type.getTypeRoot()) {
 		case NULL:
-			converter = (schema, object) -> null;
+			converter = new RowDataToAvroConverter() {
+					@Override
+					public Object convert(Schema schema, Object object) {
+						return null;
+					}
+				};
 			break;
 		case TINYINT:
-			converter = (schema, object) -> ((Byte) object).intValue();
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return ((Byte) object).intValue();
+				}
+			};
 			break;
 		case SMALLINT:
-			converter = (schema, object) -> ((Short) object).intValue();
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return ((Short) object).intValue();
+				}
+			};
 			break;
 		case BOOLEAN: // boolean
 		case INTEGER: // int
@@ -84,21 +99,46 @@ public class RowDataToAvroConverters {
 		case DOUBLE: // double
 		case TIME_WITHOUT_TIME_ZONE: // int
 		case DATE: // int
-			converter = (schema, object) -> object;
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return object;
+				}
+			};
 			break;
 		case CHAR:
 		case VARCHAR:
-			converter = (schema, object) -> new Utf8(object.toString());
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return new Utf8(object.toString());
+				}
+			};
 			break;
 		case BINARY:
 		case VARBINARY:
-			converter = (schema, object) -> ByteBuffer.wrap((byte[]) object);
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return ByteBuffer.wrap((byte[]) object);
+				}
+			};
 			break;
 		case TIMESTAMP_WITHOUT_TIME_ZONE:
-			converter = (schema, object) -> ((TimestampData) object).toInstant().toEpochMilli();
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return ((TimestampData) object).toInstant().toEpochMilli();
+				}
+			};
 			break;
 		case DECIMAL:
-			converter = (schema, object) -> ByteBuffer.wrap(((DecimalData) object).toUnscaledBytes());
+			converter = new RowDataToAvroConverter() {
+				@Override
+				public Object convert(Schema schema, Object object) {
+					return ByteBuffer.wrap(((DecimalData) object).toUnscaledBytes());
+				}
+			};
 			break;
 		case ARRAY:
 			converter = createArrayConverter((ArrayType) type);
@@ -116,28 +156,31 @@ public class RowDataToAvroConverters {
 		}
 
 		// wrap into nullable converter
-		return (schema, object) -> {
-			if (object == null) {
-				return null;
-			}
-
-			// get actual schema if it is a nullable schema
-			Schema actualSchema;
-			if (schema.getType() == Schema.Type.UNION) {
-				List<Schema> types = schema.getTypes();
-				int size = types.size();
-				if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
-					actualSchema = types.get(0);
-				} else if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
-					actualSchema = types.get(1);
-				} else {
-					throw new IllegalArgumentException(
-							"The Avro schema is not a nullable type: " + schema.toString());
+		return new RowDataToAvroConverter() {
+			@Override
+			public Object convert(Schema schema, Object object) {
+				if (object == null) {
+					return null;
 				}
-			} else {
-				actualSchema = schema;
+
+				// get actual schema if it is a nullable schema
+				Schema actualSchema;
+				if (schema.getType() == Schema.Type.UNION) {
+					List<Schema> types = schema.getTypes();
+					int size = types.size();
+					if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
+						actualSchema = types.get(0);
+					} else if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
+						actualSchema = types.get(1);
+					} else {
+						throw new IllegalArgumentException(
+							"The Avro schema is not a nullable type: " + schema.toString());
+					}
+				} else {
+					actualSchema = schema;
+				}
+				return converter.convert(actualSchema, object);
 			}
-			return converter.convert(actualSchema, object);
 		};
 	}
 
@@ -154,18 +197,21 @@ public class RowDataToAvroConverters {
 		}
 		final int length = rowType.getFieldCount();
 
-		return (schema, object) -> {
-			final RowData row = (RowData) object;
-			final List<Schema.Field> fields = schema.getFields();
-			final GenericRecord record = new GenericData.Record(schema);
-			for (int i = 0; i < length; ++i) {
-				final Schema.Field schemaField = fields.get(i);
-				Object avroObject = fieldConverters[i].convert(
-					schemaField.schema(),
-					fieldGetters[i].getFieldOrNull(row));
-				record.put(i, avroObject);
+		return new RowDataToAvroConverter() {
+			@Override
+			public Object convert(Schema schema, Object object) {
+				final RowData row = (RowData) object;
+				final List<Schema.Field> fields = schema.getFields();
+				final GenericRecord record = new GenericData.Record(schema);
+				for (int i = 0; i < length; ++i) {
+					final Schema.Field schemaField = fields.get(i);
+					Object avroObject = fieldConverters[i].convert(
+						schemaField.schema(),
+						fieldGetters[i].getFieldOrNull(row));
+					record.put(i, avroObject);
+				}
+				return record;
 			}
-			return record;
 		};
 	}
 
@@ -174,14 +220,19 @@ public class RowDataToAvroConverters {
 		final ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
 		final RowDataToAvroConverter elementConverter = createConverter(arrayType.getElementType());
 
-		return (schema, object) -> {
-			final Schema elementSchema = schema.getElementType();
-			ArrayData arrayData = (ArrayData) object;
-			List<Object> list = new ArrayList<>();
-			for (int i = 0; i < arrayData.size(); ++i) {
-				list.add(elementConverter.convert(elementSchema, elementGetter.getElementOrNull(arrayData, i)));
+		return new RowDataToAvroConverter() {
+			@Override
+			public Object convert(Schema schema, Object object) {
+				final Schema elementSchema = schema.getElementType();
+				ArrayData arrayData = (ArrayData) object;
+				List<Object> list = new ArrayList<>();
+				for (int i = 0; i < arrayData.size(); ++i) {
+					list.add(elementConverter.convert(
+						elementSchema,
+						elementGetter.getElementOrNull(arrayData, i)));
+				}
+				return list;
 			}
-			return list;
 		};
 	}
 
@@ -190,18 +241,23 @@ public class RowDataToAvroConverters {
 		final ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(valueType);
 		final RowDataToAvroConverter valueConverter = createConverter(valueType);
 
-		return (schema, object) -> {
-			final Schema valueSchema = schema.getValueType();
-			final MapData mapData = (MapData) object;
-			final ArrayData keyArray = mapData.keyArray();
-			final ArrayData valueArray = mapData.valueArray();
-			final Map<Object, Object> map = new HashMap<>(mapData.size());
-			for (int i = 0; i < mapData.size(); ++i) {
-				final String key = keyArray.getString(i).toString();
-				final Object value = valueConverter.convert(valueSchema, valueGetter.getElementOrNull(valueArray, i));
-				map.put(key, value);
+		return new RowDataToAvroConverter() {
+			@Override
+			public Object convert(Schema schema, Object object) {
+				final Schema valueSchema = schema.getValueType();
+				final MapData mapData = (MapData) object;
+				final ArrayData keyArray = mapData.keyArray();
+				final ArrayData valueArray = mapData.valueArray();
+				final Map<Object, Object> map = new HashMap<>(mapData.size());
+				for (int i = 0; i < mapData.size(); ++i) {
+					final String key = keyArray.getString(i).toString();
+					final Object value = valueConverter.convert(
+						valueSchema,
+						valueGetter.getElementOrNull(valueArray, i));
+					map.put(key, value);
+				}
+				return map;
 			}
-			return map;
 		};
 	}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -42,7 +42,9 @@ import java.util.Map;
 
 import static org.apache.flink.formats.avro.typeutils.AvroSchemaConverter.extractValueTypeToAvroMap;
 
-/** Tool class used to convert from {@link RowData} to Avro {@link GenericRecord}. **/
+/**
+ * Tool class used to convert from {@link RowData} to Avro {@link GenericRecord}.
+ */
 @Internal
 public class RowDataToAvroConverters {
 
@@ -58,6 +60,13 @@ public class RowDataToAvroConverters {
 	public interface RowDataToAvroConverter extends Serializable {
 		Object convert(Schema schema, Object object);
 	}
+
+	// --------------------------------------------------------------------------------
+	// IMPORTANT! We use anonymous classes instead of lambdas for a reason here. It is
+	// necessary because the maven shade plugin cannot relocate classes in
+	// SerializedLambdas (MSHADE-260). On the other hand we want to relocate Avro for
+	// sql-client uber jars.
+	// --------------------------------------------------------------------------------
 
 	/**
 	 * Creates a runtime converter accroding to the given logical type that converts objects

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -77,6 +77,7 @@ public class RowDataToAvroConverters {
 		switch (type.getTypeRoot()) {
 		case NULL:
 			converter = new RowDataToAvroConverter() {
+					private static final long serialVersionUID = 1L;
 					@Override
 					public Object convert(Schema schema, Object object) {
 						return null;
@@ -85,6 +86,7 @@ public class RowDataToAvroConverters {
 			break;
 		case TINYINT:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return ((Byte) object).intValue();
@@ -93,6 +95,7 @@ public class RowDataToAvroConverters {
 			break;
 		case SMALLINT:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return ((Short) object).intValue();
@@ -109,6 +112,7 @@ public class RowDataToAvroConverters {
 		case TIME_WITHOUT_TIME_ZONE: // int
 		case DATE: // int
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return object;
@@ -118,6 +122,7 @@ public class RowDataToAvroConverters {
 		case CHAR:
 		case VARCHAR:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return new Utf8(object.toString());
@@ -127,6 +132,7 @@ public class RowDataToAvroConverters {
 		case BINARY:
 		case VARBINARY:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return ByteBuffer.wrap((byte[]) object);
@@ -135,6 +141,7 @@ public class RowDataToAvroConverters {
 			break;
 		case TIMESTAMP_WITHOUT_TIME_ZONE:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return ((TimestampData) object).toInstant().toEpochMilli();
@@ -143,6 +150,7 @@ public class RowDataToAvroConverters {
 			break;
 		case DECIMAL:
 			converter = new RowDataToAvroConverter() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public Object convert(Schema schema, Object object) {
 					return ByteBuffer.wrap(((DecimalData) object).toUnscaledBytes());
@@ -166,6 +174,7 @@ public class RowDataToAvroConverters {
 
 		// wrap into nullable converter
 		return new RowDataToAvroConverter() {
+			private static final long serialVersionUID = 1L;
 			@Override
 			public Object convert(Schema schema, Object object) {
 				if (object == null) {
@@ -207,6 +216,7 @@ public class RowDataToAvroConverters {
 		final int length = rowType.getFieldCount();
 
 		return new RowDataToAvroConverter() {
+			private static final long serialVersionUID = 1L;
 			@Override
 			public Object convert(Schema schema, Object object) {
 				final RowData row = (RowData) object;
@@ -230,6 +240,7 @@ public class RowDataToAvroConverters {
 		final RowDataToAvroConverter elementConverter = createConverter(arrayType.getElementType());
 
 		return new RowDataToAvroConverter() {
+			private static final long serialVersionUID = 1L;
 			@Override
 			public Object convert(Schema schema, Object object) {
 				final Schema elementSchema = schema.getElementType();
@@ -251,6 +262,7 @@ public class RowDataToAvroConverters {
 		final RowDataToAvroConverter valueConverter = createConverter(valueType);
 
 		return new RowDataToAvroConverter() {
+			private static final long serialVersionUID = 1L;
 			@Override
 			public Object convert(Schema schema, Object object) {
 				final Schema valueSchema = schema.getValueType();

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverter.java
@@ -391,10 +391,16 @@ public class AvroSchemaConverter {
 						.fields();
 				for (int i = 0; i < rowType.getFieldCount(); i++) {
 					String fieldName = fieldNames.get(i);
-					builder = builder
+					LogicalType fieldType = rowType.getTypeAt(i);
+					SchemaBuilder.GenericDefault<Schema> fieldBuilder = builder
 						.name(fieldName)
-						.type(convertToSchema(rowType.getTypeAt(i), rowName + "_" + fieldName))
-						.noDefault();
+						.type(convertToSchema(fieldType, rowName + "_" + fieldName));
+
+					if (fieldType.isNullable()) {
+						builder = fieldBuilder.withDefault(null);
+					} else {
+						builder = fieldBuilder.noDefault();
+					}
 				}
 				Schema record = builder.endRecord();
 				return nullable ? nullableSchema(record) : record;
@@ -441,6 +447,6 @@ public class AvroSchemaConverter {
 	private static Schema nullableSchema(Schema schema) {
 		return schema.isNullable()
 				? schema
-				: Schema.createUnion(schema, SchemaBuilder.builder().nullType());
+				: Schema.createUnion(SchemaBuilder.builder().nullType(), schema);
 	}
 }

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -76,16 +76,26 @@ under the License.
 							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
+									<pattern>org.apache.kafka</pattern>
+									<shadedPattern>org.apache.flink.avro.registry.confluent.shaded.org.apache.kafka</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.confluent</pattern>
+									<shadedPattern>org.apache.flink.avro.registry.confluent.shaded.io.confluent</shadedPattern>
+								</relocation>
+								<!--The following modules must have the same shading pattern as in flink-sql-avro. It is needed to be able to put
+									both the flink-sql-avro & flink-sql-avro-confluent on the classpath -->
+								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
-									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.com.fasterxml.jackson</shadedPattern>
+									<shadedPattern>org.apache.flink.avro.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.avro</pattern>
+									<shadedPattern>org.apache.flink.avro.shaded.org.apache.avro</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.apache.commons.compress</pattern>
-									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.apache.commons.compress</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>org.apache.kafka</pattern>
-									<shadedPattern>org.apache.flink.formats.avro.registry.confluent.shaded.org.apache.kafka</shadedPattern>
+									<shadedPattern>org.apache.flink.avro.shaded.org.apache.commons.compress</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -75,6 +75,10 @@ under the License.
 									<pattern>org.apache.commons.compress</pattern>
 									<shadedPattern>org.apache.flink.avro.shaded.org.apache.commons.compress</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>org.apache.avro</pattern>
+									<shadedPattern>org.apache.flink.avro.shaded.org.apache.avro</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

* Implement an e2e test for Avro Confluent Registry SQL format

## Brief change log

See commit log

**NOTE to reviewers** If requested I can split it into two separate PRs. The first commit fixes a bug in the `AvroRowDataFormat`


## Verifying this change
Added tests:
* `SQLClientSchemaRegistryITCase`
* `AvroSchemaConverterTest#testAddingOptionalField`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
