### PR TITLE
[FLINK-20177][doc] Fix the wrong link of kinesis in index.zh.md

### DIFF
--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -70,7 +70,7 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
-      <td><a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis Data Streams</a></td>
+      <td><a href="{% link dev/table/connectors/kinesis.zh.md %}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>
       <td>Streaming Sink</td>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Fix the wrong link of kinesis in index.zh.md*


## Brief change log

  - *Correct the link of kinesis in `index.zh.md`*

## Verifying this change

 -*Executing the script of `build_docs.sh`* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
