### PR TITLE
[FLINK-20142][doc] Update the document for CREATE TABLE LIKE that sou…

### DIFF
--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -170,7 +170,10 @@ CREATE TABLE [catalog_name.][db_name.]table_name
 
 <watermark_definition>:
   WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
-  
+
+<source_table>:
+  [catalog_name.][db_name.]table_name
+
 <like_options>:
 {
    { INCLUDING | EXCLUDING } { ALL | CONSTRAINTS | PARTITIONS }
@@ -357,6 +360,8 @@ LIKE Orders_in_file (
 If you provide no like options, `INCLUDING ALL OVERWRITING OPTIONS` will be used as a default.
 
 **NOTE** You cannot control the behavior of merging physical fields. Those will be merged as if you applied the `INCLUDING` strategy.
+
+**NOTE** The `source_table` can be a compound identifier. Thus, it can be a table from a different catalog or database: e.g. `my_catalog.my_db.MyTable` specifies table `MyTable` from catalog `MyCatalog` and database `my_db`; `my_db.MyTable` specifies table `MyTable` from current catalog and database `my_db`.
 
 {% top %}
 

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -171,6 +171,9 @@ CREATE TABLE [catalog_name.][db_name.]table_name
 <watermark_definition>:
   WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
 
+<source_table>:
+  [catalog_name.][db_name.]table_name
+
 <like_options>:
 {
    { INCLUDING | EXCLUDING } { ALL | CONSTRAINTS | PARTITIONS }
@@ -357,6 +360,8 @@ LIKE Orders_in_file (
 如果未提供 like 配置项（like options），默认将使用 `INCLUDING ALL OVERWRITING OPTIONS` 的合并策略。
 
 **注意：** 您无法选择物理列的合并策略，当物理列进行合并时就如使用了 `INCLUDING` 策略。
+
+**注意：** 源表 `source_table` 可以是一个组合 ID。您可以指定不同 catalog 或者 DB 的表作为源表: 例如，`my_catalog.my_db.MyTable` 指定了源表 `MyTable` 来源于名为 `MyCatalog` 的 catalog  和名为 `my_db` 的 DB ，`my_db.MyTable` 指定了源表 `MyTable` 来源于当前 catalog  和名为 `my_db` 的 DB。
 
 {% top %}
 


### PR DESCRIPTION
…rce table from different catalog is supported

## What is the purpose of the change

Update the document to specify `CREATE TABLE LIKE` supports compound identifier as source table.

## Brief change log

  - Modify `create.md` and `create_zh.md`.


## Verifying this change

Build with the local changes:
![image](https://user-images.githubusercontent.com/7644508/99354200-f4379200-28e0-11eb-8208-8aa64b5e4c08.png)
![image](https://user-images.githubusercontent.com/7644508/99354229-09142580-28e1-11eb-9dd5-b7c2e5f7ecc2.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
