### PR TITLE
[FLINK-18500][table] Make the legacy planner exception more clear whe…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -83,6 +83,6 @@ public class ParserImpl implements Parser {
 
 	@Override
 	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException("Computed columns is only supported by the Blink planner.");
 	}
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.internal.CatalogTableSchemaResolver;
 import org.apache.flink.table.calcite.CalciteParser;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogManagerCalciteSchema;
@@ -55,13 +56,15 @@ import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.operations.ddl.DropDatabaseOperation;
+import org.apache.flink.table.planner.ParserImpl;
 import org.apache.flink.table.planner.PlanningConfigurationBuilder;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.utils.CatalogManagerMocks;
-import org.apache.flink.table.utils.ParserMock;
 
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSelect;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -105,7 +108,13 @@ public class SqlToOperationConverterTest {
 
 	@Before
 	public void before() throws TableAlreadyExistException, DatabaseNotExistException {
-		catalogManager.setCatalogTableSchemaResolver(new CatalogTableSchemaResolver(new ParserMock(), true));
+		catalogManager.setCatalogTableSchemaResolver(
+				new CatalogTableSchemaResolver(
+						new ParserImpl(
+								catalogManager,
+								() -> getPlannerBySqlDialect(SqlDialect.DEFAULT),
+								() -> getParserBySqlDialect(SqlDialect.DEFAULT)),
+						true));
 		final ObjectPath path1 = new ObjectPath(catalogManager.getCurrentDatabase(), "t1");
 		final ObjectPath path2 = new ObjectPath(catalogManager.getCurrentDatabase(), "t2");
 		final TableSchema tableSchema = TableSchema.builder()
@@ -264,6 +273,29 @@ public class SqlToOperationConverterTest {
 				DataTypes.VARCHAR(Integer.MAX_VALUE),
 				DataTypes.INT(),
 				DataTypes.VARCHAR(Integer.MAX_VALUE)});
+	}
+
+	@Test
+	public void testCreateTableWithComputedColumn() throws TableAlreadyExistException, DatabaseNotExistException {
+		Map<String, String> props = new HashMap<>();
+		props.put("connector", "kafka");
+		props.put("kafka.topic", "log.test");
+		CatalogBaseTable table = new CatalogTableImpl(
+				TableSchema.builder()
+						.field("a", DataTypes.BIGINT())
+						.field("b", DataTypes.BIGINT(), "a + 1")
+						.build(),
+				props,
+				"Test table with computed column");
+		ObjectPath path = ObjectPath.fromString("default.kafka");
+		this.catalog.createTable(path, table, false);
+		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.DEFAULT);
+		String sql = "select * from kafka";
+		SqlNode node = getParserBySqlDialect(SqlDialect.DEFAULT).parse(sql);
+		assert node instanceof SqlSelect;
+		expectedEx.expectCause(Matchers.isA(UnsupportedOperationException.class));
+		expectedEx.expectMessage("Computed columns is only supported by the Blink planner");
+		SqlToOperationConverter.convert(planner, catalogManager, node);
 	}
 
 	@Test


### PR DESCRIPTION
…n resolving computed columns types for schema

## What is the purpose of the change

The original stack trace throws an `UnsupportedOperationException` with null error message which is very confusing.
The new message suggest user to use the new planner.


## Brief change log

  - Enhance the error message for computed columns of legacy planner
  - Add test cases


## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

