### PR TITLE
[FLINK-18500][table] Make the legacy planner exception more clear whe…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -83,6 +83,6 @@ public class ParserImpl implements Parser {
 
 	@Override
 	public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException("Computed columns is only supported by the Blink planner.");
 	}
 }


### PR DESCRIPTION
…n resolving computed columns types for schema

## What is the purpose of the change

The original stack trace throws an `UnsupportedOperationException` with null error message which is very confusing.
The new message suggest user to use the new planner.


## Brief change log

  - Enhance the error message for computed columns of legacy planner
  - Add test cases


## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
