### PR TITLE
[FLINK-20028][table-planner-blink] FileCompactionITCase is unstable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/ParallelFiniteTestSource.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/ParallelFiniteTestSource.java
@@ -34,7 +34,7 @@ public class ParallelFiniteTestSource<T> extends RichSourceFunction<T> implement
 	private final Iterable<T> elements;
 
 	private transient volatile boolean running;
-	private transient int numCheckpointsComplete;
+	private transient volatile long currentCheckpointId;
 
 	public ParallelFiniteTestSource(Iterable<T> elements) {
 		this.elements = elements;
@@ -44,7 +44,7 @@ public class ParallelFiniteTestSource<T> extends RichSourceFunction<T> implement
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 		running = true;
-		numCheckpointsComplete = 0;
+		currentCheckpointId = 0;
 	}
 
 	public boolean isTaskMessage(int id) {
@@ -58,21 +58,17 @@ public class ParallelFiniteTestSource<T> extends RichSourceFunction<T> implement
 		emitElementsAndWaitForCheckpoints(ctx, 2);
 
 		// second round of the same
-		emitElementsAndWaitForCheckpoints(ctx, 2);
+		emitElementsAndWaitForCheckpoints(ctx, 4);
 	}
 
 	private void emitElementsAndWaitForCheckpoints(
-			SourceContext<T> ctx, int checkpointsToWaitFor) throws InterruptedException {
+			SourceContext<T> ctx, int checkpointIdToWaitFor) throws InterruptedException {
 		final Object lock = ctx.getCheckpointLock();
 
-		final int checkpointToAwait;
 		synchronized (lock) {
-			checkpointToAwait = numCheckpointsComplete + checkpointsToWaitFor;
 			emitRecords(ctx);
-		}
 
-		synchronized (lock) {
-			while (running && numCheckpointsComplete < checkpointToAwait) {
+			while (running && currentCheckpointId < checkpointIdToWaitFor) {
 				lock.wait(1);
 			}
 		}
@@ -97,6 +93,6 @@ public class ParallelFiniteTestSource<T> extends RichSourceFunction<T> implement
 
 	@Override
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		numCheckpointsComplete++;
+		currentCheckpointId = checkpointId;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/ParallelFiniteTestSource.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/ParallelFiniteTestSource.java
@@ -62,7 +62,7 @@ public class ParallelFiniteTestSource<T> extends RichSourceFunction<T> implement
 	}
 
 	private void emitElementsAndWaitForCheckpoints(
-			SourceContext<T> ctx, int checkpointIdToWaitFor) throws InterruptedException {
+			SourceContext<T> ctx, long checkpointIdToWaitFor) throws InterruptedException {
 		final Object lock = ctx.getCheckpointLock();
 
 		synchronized (lock) {


### PR DESCRIPTION
## What is the purpose of the change

`CompactionITCaseBase` use `ParallelFiniteTestSource`, but there is some risk that a source task never end:
- A `ParallelFiniteTestSource` task wait for next checkpoint, but maybe some source tasks have ended, so there will never be another checkpoint.

## Brief change log

Change `CompactionITCaseBase` to wait a absolute checkpointID instead of a relative checkpointID, different tasks may have different relative checkpointIDs.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no