### PR TITLE
[FLINK-17049][table-planner-blink] Support casting of rows

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -287,7 +287,9 @@ public final class LogicalTypeCasts {
 			LogicalType sourceType,
 			LogicalType targetType,
 			boolean allowExplicit) {
-		if (sourceType.isNullable() && !targetType.isNullable()) {
+		// a NOT NULL type cannot store a NULL type
+		// but it might be useful to cast explicitly with knowledge about the data
+		if (sourceType.isNullable() && !targetType.isNullable() && !allowExplicit) {
 			return false;
 		}
 		// ignore nullability during compare

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -62,7 +62,7 @@ public class LogicalTypeCastsTest {
 				// nullability does not match
 				{new SmallIntType(false), new SmallIntType(), true, true},
 
-				{new SmallIntType(), new SmallIntType(false), false, false},
+				{new SmallIntType(), new SmallIntType(false), false, true},
 
 				{
 					new YearMonthIntervalType(YearMonthIntervalType.YearMonthResolution.YEAR),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -34,6 +34,7 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils._
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType
 import org.apache.flink.util.Preconditions.checkArgument
 
@@ -1295,6 +1296,9 @@ object ScalarOperatorGens {
           | (INTERVAL_YEAR_MONTH, BIGINT) =>
       internalExprCasting(operand, targetType)
 
+    case (ROW, ROW) if LogicalTypeCasts.supportsExplicitCast(operand.resultType, targetType) =>
+      generateCastRowToRow(ctx, operand, targetType)
+
     case (_, _) =>
       throw new CodeGenException(s"Unsupported cast from '${operand.resultType}' to '$targetType'.")
   }
@@ -1881,6 +1885,35 @@ object ScalarOperatorGens {
   // ----------------------------------------------------------------------------------------
   // private generate utils
   // ----------------------------------------------------------------------------------------
+
+  private def generateCastRowToRow(
+      ctx: CodeGeneratorContext,
+      operand: GeneratedExpression,
+      targetRowType: LogicalType)
+    : GeneratedExpression = {
+    // assumes that the arity has been checked before
+    generateCallWithStmtIfArgsNotNull(ctx, targetRowType, Seq(operand)) { case Seq(rowTerm) =>
+      val fieldExprs = operand
+        .resultType
+        .getChildren
+        .zip(targetRowType.getChildren)
+        .zipWithIndex
+        .map { case ((sourceType, targetType), idx) =>
+          val sourceTypeTerm = primitiveTypeTermForType(sourceType)
+          val sourceTerm = newName("field")
+          val sourceAccessCode = rowFieldReadAccess(ctx, idx, rowTerm, sourceType)
+          val sourceExpr = GeneratedExpression(
+            sourceTerm,
+            s"$rowTerm.isNullAt($idx)",
+            s"$sourceTypeTerm $sourceTerm = ($sourceTypeTerm) $sourceAccessCode;",
+            sourceType)
+          generateCast(ctx, sourceExpr, targetType)
+        }
+
+      val generateRowExpr = generateRow(ctx, targetRowType, fieldExprs)
+      (generateRowExpr.code, generateRowExpr.resultTerm)
+    }
+  }
 
   private def generateCastStringLiteralToDateTime(
       ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.types.Row;
+
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+
+/**
+ * Tests for {@link BuiltInFunctionDefinitions#CAST}.
+ */
+public class CastFunctionITCase extends BuiltInFunctionTestBase {
+
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<TestSpec> testData() {
+		return Arrays.asList(
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.CAST, "implicit with different field names")
+				.onFieldsWithData(Row.of(12, "Hello"))
+				.andDataTypes(DataTypes.of("ROW<otherNameInt INT, otherNameString STRING>"))
+				.withFunction(RowToFirstField.class)
+				.testResult(
+					call("RowToFirstField", $("f0")),
+					"RowToFirstField(f0)",
+					12,
+					DataTypes.INT()),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.CAST, "implicit with type widening")
+				.onFieldsWithData(Row.of((byte) 12, "Hello"))
+				.andDataTypes(DataTypes.of("ROW<i TINYINT, s STRING>"))
+				.withFunction(RowToFirstField.class)
+				.testResult(
+					call("RowToFirstField", $("f0")),
+					"RowToFirstField(f0)",
+					12,
+					DataTypes.INT()),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.CAST, "implicit with nested type widening")
+				.onFieldsWithData(Row.of(Row.of(12, 42), "Hello"))
+				.andDataTypes(DataTypes.of("ROW<r ROW<i1 INT, i2 INT>, s STRING>"))
+				.withFunction(NestedRowToFirstField.class)
+				.testResult(
+					call("NestedRowToFirstField", $("f0")),
+					"NestedRowToFirstField(f0)",
+					Row.of(12, 42.0),
+					DataTypes.of("ROW<i INT, d DOUBLE>")),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and valid nullability")
+				.onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
+				.andDataTypes(DataTypes.of("ROW<r ROW<i1 INT, i2 INT, i3 INT>, s STRING>"))
+				.testResult(
+					$("f0").cast(
+						DataTypes.ROW(
+							DataTypes.FIELD(
+								"r",
+								DataTypes.ROW(
+									DataTypes.FIELD("s", DataTypes.STRING()),
+									DataTypes.FIELD("b", DataTypes.BOOLEAN()),
+									DataTypes.FIELD("i", DataTypes.INT()))),
+							DataTypes.FIELD("s", DataTypes.STRING())
+						)
+					),
+					"CAST(f0 AS ROW<r ROW<s STRING NOT NULL, b BOOLEAN, i INT>, s STRING>)",
+					Row.of(Row.of("12", true, null), "Hello"),
+					// the inner NOT NULL is ignored in SQL because the outer ROW is nullable and
+					// the cast does not allow setting the outer nullability but derives it from
+					// the source operand
+					DataTypes.of("ROW<r ROW<s STRING, b BOOLEAN, i INT>, s STRING>")),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and invalid nullability")
+				.onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
+				.andDataTypes(DataTypes.of("ROW<r ROW<i1 INT, i2 INT, i3 INT>, s STRING>"))
+				.testTableApiError(
+					$("f0").cast(
+						DataTypes.ROW(
+							DataTypes.FIELD(
+								"r",
+								DataTypes.ROW(
+									DataTypes.FIELD("s", DataTypes.STRING().notNull()),
+									DataTypes.FIELD("b", DataTypes.BOOLEAN()),
+									DataTypes.FIELD("i", DataTypes.INT()))),
+							DataTypes.FIELD("s", DataTypes.STRING())
+						)
+					),
+					// we are strict when it comes to casting nullability and fail hard in Table API
+					"Unsupported cast from 'ROW<`r` ROW<`i1` INT, `i2` INT, `i3` INT>, `s` STRING>' to "
+						+ "'ROW<`r` ROW<`s` STRING NOT NULL, `b` BOOLEAN, `i` INT>, `s` STRING>'.")
+
+		);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Function that return the first field of the input row.
+	 */
+	public static class RowToFirstField extends ScalarFunction {
+		public Integer eval(@DataTypeHint("ROW<i INT, s STRING>") Row row) {
+			assert row.getField(0) instanceof Integer;
+			assert row.getField(1) instanceof String;
+			return (Integer) row.getField(0);
+		}
+	}
+
+	/**
+	 * Function that return the first field of the nested input row.
+	 */
+	public static class NestedRowToFirstField extends ScalarFunction {
+		public @DataTypeHint("ROW<i INT, d DOUBLE>") Row eval(
+				@DataTypeHint("ROW<r ROW<i INT, d DOUBLE>, s STRING>") Row row) {
+			assert row.getField(0) instanceof Row;
+			assert row.getField(1) instanceof String;
+			return (Row) row.getField(0);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/CastFunctionITCase.java
@@ -74,7 +74,7 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 					DataTypes.of("ROW<i INT, d DOUBLE>")),
 
 			TestSpec
-				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and valid nullability")
+				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and implicit nullability change")
 				.onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
 				.andDataTypes(DataTypes.of("ROW<r ROW<i1 INT, i2 INT, i3 INT>, s STRING>"))
 				.testResult(
@@ -97,10 +97,10 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 					DataTypes.of("ROW<r ROW<s STRING, b BOOLEAN, i INT>, s STRING>")),
 
 			TestSpec
-				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and invalid nullability")
+				.forFunction(BuiltInFunctionDefinitions.CAST, "explicit with nested rows and explicit nullability change")
 				.onFieldsWithData(Row.of(Row.of(12, 42, null), "Hello"))
 				.andDataTypes(DataTypes.of("ROW<r ROW<i1 INT, i2 INT, i3 INT>, s STRING>"))
-				.testTableApiError(
+				.testTableApiResult(
 					$("f0").cast(
 						DataTypes.ROW(
 							DataTypes.FIELD(
@@ -112,10 +112,8 @@ public class CastFunctionITCase extends BuiltInFunctionTestBase {
 							DataTypes.FIELD("s", DataTypes.STRING())
 						)
 					),
-					// we are strict when it comes to casting nullability and fail hard in Table API
-					"Unsupported cast from 'ROW<`r` ROW<`i1` INT, `i2` INT, `i3` INT>, `s` STRING>' to "
-						+ "'ROW<`r` ROW<`s` STRING NOT NULL, `b` BOOLEAN, `i` INT>, `s` STRING>'.")
-
+					Row.of(Row.of("12", true, null), "Hello"),
+					DataTypes.of("ROW<r ROW<s STRING NOT NULL, b BOOLEAN, i INT>, s STRING>"))
 		);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
@@ -142,14 +142,11 @@ class RowTypeTest extends RowTypeTestBase {
 
   @Test
   def testUnsupportedCastSqlApi(): Unit = {
-    expectedException.expect(classOf[CodeGenException])
-    expectedException.expectMessage(
-      "Unsupported cast from 'ROW<`f0` STRING, `f1` BOOLEAN>' to 'ROW<`f0` INT, `f1` STRING>'")
+    expectedException.expect(classOf[ValidationException])
 
     testSqlApi(
-      "CAST(f5 AS ROW<f0 INT, f1 STRING>)",
+      "CAST(f5 AS BIGINT)",
       ""
     )
   }
-
 }


### PR DESCRIPTION
## What is the purpose of the change

This fixes the casting logic of rows to make implicit casting work without exceptions.

## Brief change log

Support row to row casting.

## Verifying this change

This change added tests and can be verified as follows: `CastFunctionITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
