### PR TITLE
[BP-1.11][FLINK-19816] Make job state cleanup dependent on final job result

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -112,20 +112,24 @@ public class MiniDispatcher extends Dispatcher {
 	}
 
 	@Override
-	protected void jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
-		super.jobReachedGloballyTerminalState(archivedExecutionGraph);
+	protected CleanupJobState jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
+		final CleanupJobState cleanupHAState = super.jobReachedGloballyTerminalState(archivedExecutionGraph);
 
 		if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
 			// shut down if job is cancelled or we don't have to wait for the execution result retrieval
 			shutDownFuture.complete(ApplicationStatus.fromJobStatus(archivedExecutionGraph.getState()));
 		}
+
+		return cleanupHAState;
 	}
 
 	@Override
-	protected void jobNotFinished(JobID jobId) {
-		super.jobNotFinished(jobId);
+	protected CleanupJobState jobNotFinished(JobID jobId) {
+		final CleanupJobState cleanupJobState = super.jobNotFinished(jobId);
 
 		// shut down since we have done our job
 		shutDownFuture.complete(ApplicationStatus.UNKNOWN);
+
+		return cleanupJobState;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -194,17 +194,14 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 						classLoaderLease.release();
 
+						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
+
 						if (throwable != null) {
 							terminationFuture.completeExceptionally(
 								new FlinkException("Could not properly shut down the JobManagerRunner", throwable));
 						} else {
 							terminationFuture.complete(null);
 						}
-					});
-
-				terminationFuture.whenComplete(
-					(Void ignored, Throwable throwable) -> {
-						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
 					});
 			}
 


### PR DESCRIPTION
Backport of #14055 to `release-1.11`.