### PR TITLE
[FLINK-19635][hbase] Fix HBaseConnectorITCase.testTableSourceSinkWithDDL is unstable with a result mismatch

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestingClusterAutoStarter.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestingClusterAutoStarter.java
@@ -114,9 +114,10 @@ public abstract class HBaseTestingClusterAutoStarter extends AbstractTestBase {
 		}
 	}
 
-	private static Configuration initialize(Configuration conf) {
-		conf = HBaseConfiguration.create(conf);
-		conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
+	private static void initialize(Configuration c) {
+		conf = HBaseConfiguration.create(c);
+		// the default retry number is 35 in hbase-1.4, set 5 for test
+		conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 5);
 		try {
 			admin = TEST_UTIL.getHBaseAdmin();
 		} catch (MasterNotRunningException e) {
@@ -126,7 +127,6 @@ public abstract class HBaseTestingClusterAutoStarter extends AbstractTestBase {
 		} catch (IOException e) {
 			assertNull("IOException", e);
 		}
-		return conf;
 	}
 
 	@BeforeClass
@@ -147,7 +147,7 @@ public abstract class HBaseTestingClusterAutoStarter extends AbstractTestBase {
 		LOG.info("Hbase minicluster client port: " + TEST_UTIL.getZkCluster().getClientPort());
 		TEST_UTIL.getConfiguration().set("hbase.zookeeper.quorum", "localhost:" + TEST_UTIL.getZkCluster().getClientPort());
 
-		conf = initialize(TEST_UTIL.getConfiguration());
+		initialize(TEST_UTIL.getConfiguration());
 		LOG.info("HBase minicluster: Running");
 	}
 

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
@@ -110,7 +110,8 @@ public class HBaseTestingClusterAutoStarter {
 
 	private static void initialize(Configuration c) {
 		conf = HBaseConfiguration.create(c);
-		conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
+		// the default retry number is 15 in hbase-2.2, set 5 for test
+		conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 5);
 		try {
 			admin = TEST_UTIL.getAdmin();
 		} catch (MasterNotRunningException e) {
@@ -128,6 +129,14 @@ public class HBaseTestingClusterAutoStarter {
 		String hadoopVersion = System.getProperty("hadoop.version");
 		Assume.assumeTrue(HADOOP_VERSION_RANGE.contains(hadoopVersion));
 		TEST_UTIL.startMiniCluster(1);
+
+		// https://issues.apache.org/jira/browse/HBASE-11711
+		TEST_UTIL.getConfiguration().setInt("hbase.master.info.port", -1);
+
+		// Make sure the zookeeper quorum value contains the right port number (varies per run).
+		LOG.info("Hbase minicluster client port: " + TEST_UTIL.getZkCluster().getClientPort());
+		TEST_UTIL.getConfiguration().set("hbase.zookeeper.quorum", "localhost:" + TEST_UTIL.getZkCluster().getClientPort());
+
 		initialize(TEST_UTIL.getConfiguration());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request aims to fix the unstable test `HBaseConnectorITCase.testTableSourceSinkWithDDL`, the test result is mismatched because the hbase client retry number was set to "1" which means the sink task will never retry which leads the data loss.


## Brief change log

  - Set HBASE_CLIENT_RETRIES_NUMBER to "5" in  `HBaseTestingClusterAutoStarter` like HBase tests do.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
