### PR TITLE
[FLINK-18545] Introduce `pipeline.name` to allow users to specify job name by configuration

### DIFF
--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -87,6 +87,12 @@
             <td>The program-wide maximum parallelism used for operators which haven't specified a maximum parallelism. The maximum parallelism specifies the upper limit for dynamic scaling and the number of key groups used for partitioned state.</td>
         </tr>
         <tr>
+            <td><h5>pipeline.name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The job name used for printing and logging.</td>
+        </tr>
+        <tr>
             <td><h5>pipeline.object-reuse</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.flink.client;
 
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -30,6 +33,7 @@ import org.junit.Test;
 import java.io.Serializable;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -62,5 +66,36 @@ public class ExecutionEnvironmentTest extends TestLogger implements Serializable
 		} catch (Exception e) {
 			fail("Consecutive #getExecutionPlan calls caused an exception.");
 		}
+	}
+
+	@Test
+	public void testDefaultJobName() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		testJobName("Flink Java Job at", env);
+	}
+
+	@Test
+	public void testUserDefinedJobName() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(config);
+		testJobName(jobName, env);
+	}
+
+	@Test
+	public void testUserDefinedJobNameWithConfigure() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.configure(config, this.getClass().getClassLoader());
+		testJobName(jobName, env);
+	}
+
+	private void testJobName(String prefixOfExpectedJobName, ExecutionEnvironment env) {
+		env.fromElements(1, 2, 3).writeAsText("/dev/null");
+		Plan plan = env.createProgramPlan();
+		assertTrue(plan.getJobName().startsWith(prefixOfExpectedJobName));
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -36,6 +36,16 @@ import static org.apache.flink.configuration.description.TextElement.text;
  */
 @PublicEvolving
 public class PipelineOptions {
+
+	/**
+	 * The job name used for printing and logging.
+	 */
+	public static final ConfigOption<String> NAME =
+		key("pipeline.name")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("The job name used for printing and logging.");
+
 	/**
 	 * A list of jar files that contain the user-defined function (UDF) classes and all classes used from within the UDFs.
 	 */

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -418,6 +418,8 @@ public class ExecutionEnvironment {
 				this.cacheFile.clear();
 				this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
 			});
+		configuration.getOptional(PipelineOptions.NAME)
+			.ifPresent(jobName -> this.getConfiguration().set(PipelineOptions.NAME, jobName));
 		config.configure(configuration, classLoader);
 	}
 
@@ -870,7 +872,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program executions fails.
 	 */
 	public JobExecutionResult execute() throws Exception {
-		return execute(getDefaultName());
+		return execute(getJobName());
 	}
 
 	/**
@@ -945,7 +947,7 @@ public class ExecutionEnvironment {
 	 */
 	@PublicEvolving
 	public final JobClient executeAsync() throws Exception {
-		return executeAsync(getDefaultName());
+		return executeAsync(getJobName());
 	}
 
 	/**
@@ -998,7 +1000,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the compiler could not be instantiated.
 	 */
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(getDefaultName(), false);
+		Plan p = createProgramPlan(getJobName(), false);
 		return ExecutionPlanUtil.getExecutionPlanAsJSON(p);
 	}
 
@@ -1051,7 +1053,7 @@ public class ExecutionEnvironment {
 	 */
 	@Internal
 	public Plan createProgramPlan() {
-		return createProgramPlan(getDefaultName());
+		return createProgramPlan(getJobName());
 	}
 
 	/**
@@ -1122,12 +1124,13 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Gets a default job name, based on the timestamp when this method is invoked.
+	 * Gets the job name. If user defined job name is not found in the configuration,
+	 * the default name based on the timestamp when this method is invoked will return.
 	 *
-	 * @return A default job name.
+	 * @return A job name.
 	 */
-	private static String getDefaultName() {
-		return "Flink Java Job at " + Calendar.getInstance().getTime();
+	private String getJobName() {
+		return configuration.getString(PipelineOptions.NAME, "Flink Java Job at " + Calendar.getInstance().getTime());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
 import org.apache.flink.python.PythonOptions;
@@ -153,7 +154,8 @@ public class PythonConfigUtil {
 			}
 		}
 
-		StreamGraph streamGraph = env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, clearTransformations);
+		String jobName = getEnvironmentConfig(env).getString(PipelineOptions.NAME, StreamExecutionEnvironment.DEFAULT_JOB_NAME);
+		StreamGraph streamGraph = env.getStreamGraph(jobName, clearTransformations);
 		Collection<StreamNode> streamNodes = streamGraph.getStreamNodes();
 		for (StreamNode streamNode : streamNodes) {
 			alignStreamNode(streamNode, streamGraph);

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonConfigUtilTest.java
@@ -18,12 +18,17 @@
 package org.apache.flink.python.util;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -36,5 +41,17 @@ public class PythonConfigUtilTest {
 		StreamExecutionEnvironment executionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
 		Configuration envConfig = PythonConfigUtil.getEnvConfigWithDependencies(executionEnvironment);
 		assertNotNull(envConfig);
+	}
+
+	@Test
+	public void testJobName() throws IllegalAccessException, NoSuchMethodException, InvocationTargetException, NoSuchFieldException {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+
+		env.fromCollection(Collections.singletonList("test")).addSink(new DiscardingSink<>());
+		StreamGraph streamGraph = PythonConfigUtil.generateStreamGraphWithDependencies(env, true);
+		assertEquals(jobName, streamGraph.getJobName());
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -839,6 +839,9 @@ public class StreamExecutionEnvironment {
 		configuration.getOptional(ExecutionOptions.USE_BATCH_STATE_BACKEND).ifPresent(
 			sortInputs -> this.getConfiguration().set(ExecutionOptions.USE_BATCH_STATE_BACKEND, sortInputs)
 		);
+		configuration.getOptional(PipelineOptions.NAME).ifPresent(
+			jobName -> this.getConfiguration().set(PipelineOptions.NAME, jobName)
+		);
 		config.configure(configuration, classLoader);
 		checkpointCfg.configure(configuration);
 	}
@@ -1798,7 +1801,7 @@ public class StreamExecutionEnvironment {
 	 * @throws Exception which occurs during job execution.
 	 */
 	public JobExecutionResult execute() throws Exception {
-		return execute(DEFAULT_JOB_NAME);
+		return execute(getJobName());
 	}
 
 	/**
@@ -1891,7 +1894,7 @@ public class StreamExecutionEnvironment {
 	 */
 	@PublicEvolving
 	public final JobClient executeAsync() throws Exception {
-		return executeAsync(DEFAULT_JOB_NAME);
+		return executeAsync(getJobName());
 	}
 
 	/**
@@ -1958,7 +1961,7 @@ public class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public StreamGraph getStreamGraph() {
-		return getStreamGraph(DEFAULT_JOB_NAME);
+		return getStreamGraph(getJobName());
 	}
 
 	/**
@@ -2018,7 +2021,7 @@ public class StreamExecutionEnvironment {
 	 * @return The execution plan of the program, as a JSON String.
 	 */
 	public String getExecutionPlan() {
-		return getStreamGraph(DEFAULT_JOB_NAME, false).getStreamingPlanAsJSON();
+		return getStreamGraph(getJobName(), false).getStreamingPlanAsJSON();
 	}
 
 	/**
@@ -2349,5 +2352,9 @@ public class StreamExecutionEnvironment {
 			}
 		}
 		return (T) resolvedTypeInfo;
+	}
+
+	private String getJobName() {
+		return configuration.getString(PipelineOptions.NAME, DEFAULT_JOB_NAME);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -267,6 +269,37 @@ public class StreamExecutionEnvironmentTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testDefaultJobName() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		testJobName(StreamExecutionEnvironment.DEFAULT_JOB_NAME, env);
+	}
+
+	@Test
+	public void testUserDefinedJobName() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+		testJobName(jobName, env);
+	}
+
+	@Test
+	public void testUserDefinedJobNameWithConfigure() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.configure(config, this.getClass().getClassLoader());
+		testJobName(jobName, env);
+	}
+
+	private void testJobName(String expectedJobName, StreamExecutionEnvironment env) {
+		env.fromElements(1, 2, 3).print();
+		StreamGraph streamGraph = env.getStreamGraph();
+		assertEquals(expectedJobName, streamGraph.getJobName());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

*Users can't specify job name for sql job when using new apis introduced in FLIP-84. As discussion in [FLINK-18545](https://issues.apache.org/jira/browse/FLINK-18545), we should introduce `pipeline.name` in  `PipelineOptions` to support it, which could work for both DataStream jobs and SQL jobs.*


## Brief change log

  - *Introduce `pipeline.name` to allow users to specify job name by configuration*
  - *Specify job name by `pipeline.name` for flink-python*
  - *Specify job name by `pipeline.name` for sql job*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended StreamExecutionEnvironmentTest & PythonConfigUtilTest to verify the job name specified by pipeline.name*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
