### PR TITLE
[FLINK-20193] Catch exception thrown from SplitEnumerator.start()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -107,7 +107,14 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 		// The start sequence is the first task in the coordinator executor.
 		// We rely on the single-threaded coordinator executor to guarantee
 		// the other methods are invoked after the enumerator has started.
-		coordinatorExecutor.execute(() -> enumerator.start());
+		coordinatorExecutor.execute(() -> {
+			try {
+				enumerator.start();
+			} catch (Exception e) {
+				LOG.error("Failed to start the enumerator of operator {} due to", operatorName, e);
+				context.failJob(e);
+			}
+		});
 		started = true;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -35,6 +35,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
 	private final Map<Integer, List<OperatorEvent>> eventsToOperator;
 	private boolean jobFailed;
+	private Throwable jobFailureReason;
 
 	public MockOperatorCoordinatorContext(OperatorID operatorID, int numSubtasks) {
 		this(operatorID, numSubtasks, true);
@@ -45,6 +46,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 		this.numSubtasks = numSubtasks;
 		this.eventsToOperator = new HashMap<>();
 		this.jobFailed = false;
+		this.jobFailureReason = null;
 		this.failEventSending = failEventSending;
 	}
 
@@ -70,6 +72,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 	@Override
 	public void failJob(Throwable cause) {
 		jobFailed = true;
+		jobFailureReason = cause;
 	}
 
 	@Override
@@ -89,5 +92,9 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
 	public boolean isJobFailed() {
 		return jobFailed;
+	}
+
+	public Throwable getJobFailureReason() {
+		return jobFailureReason;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The patch fixes a bug introduced in FLINK-18323 where we delegate `SplitEnumrator.start()` to the CoordinatorExecutor without catching exception. When the method throws exception, it will result the coordinator thread to exit. The fix is catching exception thrown from SplitEnumerator.start() and fail the job accordingly, just like the other method delegated to the CoordinatorExecutor.

## Brief change log
- Catch exception thrown from SplitEnumerator.start().

## Verifying this change
A unit test
`SourceCoordinatorTest.testFailJobWhenExceptionThrownFromStart()` was added to verify the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
