### PR TITLE
[FLINK-20187][table-common] Fix factory discovering fails when source and sink factories are not implemented in one class

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -250,6 +250,7 @@ public final class FactoryUtil {
 					factoryClass.getName(),
 					foundFactories.stream()
 						.map(Factory::factoryIdentifier)
+						.distinct()
 						.sorted()
 						.collect(Collectors.joining("\n"))));
 		}
@@ -365,40 +366,48 @@ public final class FactoryUtil {
 					"Table options do not contain an option key '%s' for discovering a connector.",
 					CONNECTOR.key()));
 		}
+		try {
+			return discoverFactory(context.getClassLoader(), factoryClass, connectorOption);
+		} catch (ValidationException e) {
+			throw enrichNoMatchingConnectorError(factoryClass, context, connectorOption);
+		}
+	}
+
+	private static ValidationException enrichNoMatchingConnectorError(
+			Class<?> factoryClass,
+			DefaultDynamicTableContext context,
+			String connectorOption) {
+
 		final DynamicTableFactory factory;
 		try {
 			factory = discoverFactory(context.getClassLoader(), DynamicTableFactory.class, connectorOption);
 		} catch (ValidationException e) {
-			throw new ValidationException(
+			return new ValidationException(
 				String.format(
 					"Cannot discover a connector using option '%s'.",
 					stringifyOption(CONNECTOR.key(), connectorOption)),
 				e);
 		}
 
-		if (factoryClass.isAssignableFrom(factory.getClass())) {
-			return (T) factory;
+		final Class<?> sourceFactoryClass = DynamicTableSourceFactory.class;
+		final Class<?> sinkFactoryClass = DynamicTableSinkFactory.class;
+		// for a better exception message
+		if (sourceFactoryClass.equals(factoryClass) && sinkFactoryClass.isAssignableFrom(factory.getClass())) {
+			// discovering source, but not found, and this is a sink connector.
+			return new ValidationException(String.format(
+				"Connector '%s' only supports to be used as sink, can't be used as source.",
+				connectorOption));
+		} else if (sinkFactoryClass.equals(factoryClass) && sourceFactoryClass.isAssignableFrom(factory.getClass())) {
+			// discovering sink, but not found, and this is a a source connector.
+			return new ValidationException(String.format(
+				"Connector '%s' only supports to be used as source, can't be used as sink.",
+				connectorOption));
 		} else {
-			final Class<?> sourceFactoryClass = DynamicTableSourceFactory.class;
-			final Class<?> sinkFactoryClass = DynamicTableSinkFactory.class;
-			// for a better exception message
-			if (sourceFactoryClass.equals(factoryClass) && sinkFactoryClass.isAssignableFrom(factory.getClass())) {
-				// discovering source, but not found, and this is a sink connector.
-				throw new ValidationException(String.format(
-					"Connector '%s' only supports to be used as sink, can't be used as source.",
-					connectorOption));
-			} else if (sinkFactoryClass.equals(factoryClass) && sourceFactoryClass.isAssignableFrom(factory.getClass())) {
-				// discovering sink, but not found, and this is a a source connector.
-				throw new ValidationException(String.format(
-					"Connector '%s' only supports to be used as source, can't be used as sink.",
-					connectorOption));
-			} else {
-				throw new ValidationException(String.format(
-					"Connector '%s' should at least implements '%s' or '%s' interface.",
-					connectorOption,
-					sourceFactoryClass.getName(),
-					sinkFactoryClass.getName()));
-			}
+			return new ValidationException(String.format(
+				"Connector '%s' should at least implements '%s' or '%s' interface.",
+				connectorOption,
+				sourceFactoryClass.getName(),
+				sinkFactoryClass.getName()));
 		}
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -67,7 +67,7 @@ public class FactoryUtilTest {
 			"Could not find any factory for identifier 'FAIL' that implements '" +
 				DynamicTableFactory.class.getName() + "' in the classpath.\n\n" +
 			"Available factory identifiers are:\n\n" +
-			"sink-only\nsource-only\ntest-connector");
+			"sink-only\nsource-only\ntest\ntest-connector");
 		testError(options -> options.put("connector", "FAIL"));
 	}
 
@@ -157,6 +157,29 @@ public class FactoryUtilTest {
 			new DecodingFormatMock(",", false),
 			new DecodingFormatMock("|", true));
 		assertEquals(expectedSource, actualSource);
+		final DynamicTableSink actualSink = createTableSink(options);
+		final DynamicTableSink expectedSink = new DynamicTableSinkMock(
+			"MyTarget",
+			1000L,
+			new EncodingFormatMock(","),
+			new EncodingFormatMock("|"));
+		assertEquals(expectedSink, actualSink);
+	}
+
+	@Test
+	public void testDiscoveryForSeparateSourceSinkFactory() {
+		final Map<String, String> options = createAllOptions();
+		// the "test" source and sink factory is not in one factory class
+		// see TestDynamicTableSinkFactory and TestDynamicTableSourceFactory
+		options.put("connector", "test");
+
+		final DynamicTableSource actualSource = createTableSource(options);
+		final DynamicTableSource expectedSource = new DynamicTableSourceMock(
+			"MyTarget",
+			new DecodingFormatMock(",", false),
+			new DecodingFormatMock("|", true));
+		assertEquals(expectedSource, actualSource);
+
 		final DynamicTableSink actualSink = createTableSink(options);
 		final DynamicTableSink expectedSink = new DynamicTableSinkMock(
 			"MyTarget",

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSinkFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSinkFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+
+import java.util.Set;
+
+/**
+ * Test implementations for {@link DynamicTableSinkFactory}. The source and sink "test" connector
+ * is separated into two factory implementation.
+ *
+ * @see TestDynamicTableSourceFactory
+ */
+public final class TestDynamicTableSinkFactory implements DynamicTableSinkFactory {
+
+	public static final String IDENTIFIER = "test";
+
+	private static final TestDynamicTableFactory delegate = new TestDynamicTableFactory();
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		return delegate.createDynamicTableSink(context);
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return delegate.requiredOptions();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return delegate.optionalOptions();
+	}
+
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSourceFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableSourceFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+
+import java.util.Set;
+
+/**
+ * Test implementations for {@link DynamicTableSourceFactory}. The source and sink "test" connector
+ * is separated into two factory implementation.
+ *
+ * @see TestDynamicTableSinkFactory
+ */
+public final class TestDynamicTableSourceFactory implements DynamicTableSourceFactory {
+
+	public static final String IDENTIFIER = "test";
+
+	private static final TestDynamicTableFactory delegate = new TestDynamicTableFactory();
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		return delegate.createDynamicTableSource(context);
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return delegate.requiredOptions();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return delegate.optionalOptions();
+	}
+}

--- a/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -15,5 +15,7 @@
 
 org.apache.flink.table.factories.TestDynamicTableFactory
 org.apache.flink.table.factories.TestFormatFactory
+org.apache.flink.table.factories.TestDynamicTableSourceFactory
+org.apache.flink.table.factories.TestDynamicTableSinkFactory
 org.apache.flink.table.factories.TestDynamicTableSinkOnlyFactory
 org.apache.flink.table.factories.TestDynamicTableSourceOnlyFactory


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The the "odps" connector has two factory implementation, each implements DynamicTableSinkFactory and DynamicTableSourceFactory. But `FactoryUtil#createTableSource` fails with following exception.

```
Caused by: org.apache.flink.table.api.ValidationException: Multiple factories for identifier 'odps' that implement 'org.apache.flink.table.factories.DynamicTableFactory' found in the classpath.
```

## Brief change log

- Fix `FactoryUtil#createTableSource` to `discoverFactory` using provided `factoryClass` first. 
- And `discoverFactory`  using `DynamicTableFactory.class` for better exception if the above is failed. 


## Verifying this change

- Added a connector factory whose source and sink factories are not implemented in one class. 
- Added a test to discovery source and sink using the above factory identifier. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
