### PR TITLE
[FLINK-20198][doc] Correct the wrong link in upsert-kafka.zh.md

### DIFF
--- a/docs/dev/table/connectors/upsert-kafka.zh.md
+++ b/docs/dev/table/connectors/upsert-kafka.zh.md
@@ -145,7 +145,7 @@ Connector Options
       <td>String</td>
       <td>The format used to deserialize and serialize the key part of the Kafka messages. The key part
       fields are specified by the PRIMARY KEY syntax. The supported formats include <code>'csv'</code>,
-      <code>'json'</code>, <code>'avro'</code>. Please refer to <a href="{% link dev/table/connectors/formats/index.md %}">Formats</a>
+      <code>'json'</code>, <code>'avro'</code>. Please refer to <a href="{% link dev/table/connectors/formats/index.zh.md %}">Formats</a>
       page for more details and more format options.
       </td>
     </tr>
@@ -156,7 +156,7 @@ Connector Options
       <td>String</td>
       <td>The format used to deserialize and serialize the value part of the Kafka messages.
       The supported formats include <code>'csv'</code>, <code>'json'</code>, <code>'avro'</code>.
-      Please refer to <a href="{% link dev/table/connectors/formats/index.md %}">Formats</a> page for more details and more format options.
+      Please refer to <a href="{% link dev/table/connectors/formats/index.zh.md %}">Formats</a> page for more details and more format options.
       </td>
     </tr>
     <tr>
@@ -194,7 +194,7 @@ keys. The primary key definition will also control which fields should end up in
 ### Consistency Guarantees
 
 By default, an Upsert Kafka sink ingests data with at-least-once guarantees into a Kafka topic if
-the query is executed with [checkpointing enabled]({% link dev/stream/state/checkpointing.md %}#enabling-and-configuring-checkpointing).
+the query is executed with [checkpointing enabled]({% link dev/stream/state/checkpointing.zh.md %}#enabling-and-configuring-checkpointing).
 
 This means, Flink may write duplicate records with the same key into the Kafka topic. But as the
 connector is working in the upsert mode, the last record on the same key will take effect when
@@ -206,7 +206,7 @@ Data Type Mapping
 
 Upsert Kafka stores message keys and values as bytes, so Upsert Kafka doesn't have schema or data types.
 The messages are deserialized and serialized by formats, e.g. csv, json, avro. Thus, the data type mapping
-is determined by specific formats. Please refer to [Formats]({% link dev/table/connectors/formats/index.md %})
+is determined by specific formats. Please refer to [Formats]({% link dev/table/connectors/formats/index.zh.md %})
 pages for more details.
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will correct the wrong link in `upsert-kafka.zh.md`*


## Brief change log

  - *correct the wrong link in `upsert-kafka.zh.md`*


## Verifying this change

This change added tests and can be verified as follows:

  - *Executing the script build_docs.sh*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
