### PR TITLE
[FLINK-20207][python] improve the error message printed when submitting the pyflink jobs via 'flink run'.

### DIFF
--- a/flink-python/pyflink/util/exceptions.py
+++ b/flink-python/pyflink/util/exceptions.py
@@ -25,7 +25,7 @@ class JavaException(Exception):
         self.stack_trace = stack_trace
 
     def __str__(self):
-        return repr(self.msg)
+        return self.msg + "\n\t at " + self.stack_trace
 
 
 class TableException(JavaException):
@@ -151,8 +151,12 @@ def capture_java_exception(f):
                                               e.java_exception.getStackTrace()))
             for exception in exception_mapping.keys():
                 if s.startswith(exception):
-                    raise exception_mapping[exception](s.split(': ', 1)[1], stack_trace)
-            raise
+                    java_exception = \
+                        exception_mapping[exception](s.split(': ', 1)[1], stack_trace)
+                    break
+            else:
+                raise
+        raise java_exception
     return deco
 
 

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import py4j.GatewayServer;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -82,8 +84,22 @@ public final class PythonDriver {
 				config,
 				commands,
 				pythonDriverOptions.getEntryPointScript().orElse(null),
-				tmpDir);
+				tmpDir,
+				true);
+			BufferedReader in = new BufferedReader(new InputStreamReader(pythonProcess.getInputStream()));
+			LOG.info("--------------------------- Python Process Started --------------------------");
+			// print the python process output to stdout and log file
+			while (true) {
+				String line = in.readLine();
+				if (line == null) {
+					break;
+				} else {
+					System.out.println(line);
+					LOG.info(line);
+				}
+			}
 			int exitCode = pythonProcess.waitFor();
+			LOG.info("--------------------------- Python Process Exited ---------------------------");
 			if (exitCode != 0) {
 				throw new RuntimeException("Python process exits with code: " + exitCode);
 			}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -241,7 +241,10 @@ final class PythonEnvUtils {
 	 * @return the process represent the python process.
 	 * @throws IOException Thrown if an error occurred when python process start.
 	 */
-	static Process startPythonProcess(PythonEnvironment pythonEnv, List<String> commands) throws IOException {
+	static Process startPythonProcess(
+		PythonEnvironment pythonEnv,
+		List<String> commands,
+		boolean redirectToPipe) throws IOException {
 		ProcessBuilder pythonProcessBuilder = new ProcessBuilder();
 		Map<String, String> env = pythonProcessBuilder.environment();
 		if (pythonEnv.pythonPath != null) {
@@ -252,8 +255,12 @@ final class PythonEnvUtils {
 		pythonProcessBuilder.command(commands);
 		// redirect the stderr to stdout
 		pythonProcessBuilder.redirectErrorStream(true);
-		// set the child process the output same as the parent process.
-		pythonProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+		if (redirectToPipe) {
+			pythonProcessBuilder.redirectOutput(ProcessBuilder.Redirect.PIPE);
+		} else {
+			// set the child process the output same as the parent process.
+			pythonProcessBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+		}
 		Process process = pythonProcessBuilder.start();
 		if (!process.isAlive()) {
 			throw new RuntimeException("Failed to start Python process. ");
@@ -352,12 +359,13 @@ final class PythonEnvUtils {
 		ReadableConfig config,
 		List<String> commands,
 		String entryPointScript,
-		String tmpDir) throws IOException {
+		String tmpDir,
+		boolean redirectToPipe) throws IOException {
 		PythonEnvironment pythonEnv = PythonEnvUtils.preparePythonEnvironment(
 			config, entryPointScript, tmpDir);
 		// set env variable PYFLINK_GATEWAY_PORT for connecting of python gateway in python process.
 		pythonEnv.systemEnv.put("PYFLINK_GATEWAY_PORT", String.valueOf(gatewayServer.getListeningPort()));
 		// start the python process.
-		return PythonEnvUtils.startPythonProcess(pythonEnv, commands);
+		return PythonEnvUtils.startPythonProcess(pythonEnv, commands, redirectToPipe);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
@@ -103,7 +103,8 @@ public interface PythonFunctionFactory {
 						commands.add("pyflink.pyflink_callback_server");
 						String tmpDir = System.getProperty("java.io.tmpdir") +
 						File.separator + "pyflink" + File.separator + UUID.randomUUID();
-						pythonProcess = launchPy4jPythonClient(gatewayServer, config, commands, null, tmpDir);
+						pythonProcess = launchPy4jPythonClient(
+							gatewayServer, config, commands, null, tmpDir, false);
 						entryPoint = (Map<String, Object>) gatewayServer.getGateway().getEntryPoint();
 						int i = 0;
 						while (!entryPoint.containsKey("PythonFunctionFactory")) {

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
@@ -145,7 +145,7 @@ public class PythonEnvUtilsTest {
 			String result = String.join(File.separator, tmpDirPath, "python_working_directory.txt");
 			commands.add(pyPath);
 			commands.add(result);
-			Process pythonProcess = PythonEnvUtils.startPythonProcess(pythonEnv, commands);
+			Process pythonProcess = PythonEnvUtils.startPythonProcess(pythonEnv, commands, false);
 			int exitCode = pythonProcess.waitFor();
 			if (exitCode != 0) {
 				throw new RuntimeException("Python process exits with code: " + exitCode);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request improves the error reporting logic when submitting the pyflink jobs via 'flink run'.*


## Brief change log

  - *Print the Java stack trace when printing the Java exceptions.*
  - *Print the Python process output both on stdout and log file.*

## Verifying this change

This change is already covered by existing tests, such as *PyFlink e2e test*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
