### PR TITLE
[FLINK-20202][python] Add the Check of Unsupported Result Type in Pandas UDAF

### DIFF
--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.md
@@ -66,6 +66,7 @@ table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 ## Vectorized Aggregate Functions
 
 Vectorized Python aggregate functions takes one or more `pandas.Series` as the inputs and return one scalar value as output.
+<span class="label label-info">Note</span>Now the return type does not support `RowType` and `MapType`
 
 Vectorized Python aggregate function could be used in `GroupBy Aggregation`(Batch), `GroupBy Window Aggregation`(Batch and Stream) and 
 `Over Window Aggregation`(Batch and Stream bounded over window). For more details on the usage of Aggregations, you can refer

--- a/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
+++ b/docs/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.zh.md
@@ -64,6 +64,7 @@ table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 ## 向量化聚合函数
 
 向量化Python聚合函数以一个或多个`pandas.Series`类型的参数作为输入，并返回一个标量值作为输出。
+<span class="label label-info">注意</span>现在返回类型还不支持 `RowType` 和 `MapType` 。
 
 向量化Python聚合函数能够用在`GroupBy Aggregation`（Batch），`GroupBy Window Aggregation`(Batch and Stream) 和 
 `Over Window Aggregation`(Batch and Stream bounded over window)。关于聚合的更多使用细节，你可以参考

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -27,6 +27,22 @@ from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
 
 
 class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
+
+    def test_check_result_type(self):
+        def pandas_udaf():
+            pass
+
+        with self.assertRaises(
+                TypeError,
+                msg="Invalid returnType: Pandas UDAF doesn't support DataType type ROW currently"):
+            udaf(pandas_udaf, result_type=DataTypes.ROW(), func_type="pandas")
+
+        with self.assertRaises(
+                TypeError,
+                msg="Invalid returnType: Pandas UDAF doesn't support DataType type MAP currently"):
+            udaf(pandas_udaf, result_type=DataTypes.MAP(DataTypes.INT(), DataTypes.INT()),
+                 func_type="pandas")
+
     def test_group_aggregate_function(self):
         t = self.t_env.from_elements(
             [(1, 2, 3), (3, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -448,6 +448,11 @@ class UserDefinedAggregateFunctionWrapper(UserDefinedFunctionWrapper):
         if not isinstance(result_type, DataType):
             raise TypeError(
                 "Invalid returnType: returnType should be DataType but is {}".format(result_type))
+        from pyflink.table.types import RowType, MapType
+        if func_type == 'pandas' and isinstance(result_type, (RowType, MapType)):
+            raise TypeError(
+                "Invalid returnType: Pandas UDAF doesn't support DataType type {} currently"
+                .format(result_type))
         if accumulator_type is not None and not isinstance(accumulator_type, DataType):
             raise TypeError(
                 "Invalid accumulator_type: accumulator_type should be DataType but is {}".format(


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add the check of unsupported result type in Pandas UDAF and related notes in docs*


## Brief change log

  - *Add check logic in `udf.py*
  - *Add notes in `vectorized_python_udfs.md` and `vectorized_python_udfs.zh.md`*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added UT `test_check_result_type` in `test_pandas_udaf.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
