### PR TITLE
[FLINK-20213][fs-connector] Partition commit is delayed when records keep coming

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
@@ -144,11 +144,11 @@ public class StreamingFileWriter extends AbstractStreamOperator<CommitMessage>
 	private void commitUpToCheckpoint(long checkpointId) throws Exception {
 		helper.commitUpToCheckpoint(checkpointId);
 
-		NavigableMap<Long, Set<String>> newPartitions = this.newPartitions.headMap(checkpointId, true);
+		NavigableMap<Long, Set<String>> headPartitions = this.newPartitions.headMap(checkpointId, true);
 		Set<String> partitions = new HashSet<>(committablePartitions);
 		committablePartitions.clear();
-		newPartitions.values().forEach(partitions::addAll);
-		newPartitions.clear();
+		headPartitions.values().forEach(partitions::addAll);
+		headPartitions.clear();
 
 		CommitMessage message = new CommitMessage(
 				checkpointId,

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/StreamingFileWriterTest.java
@@ -126,6 +126,31 @@ public class StreamingFileWriterTest {
 		}
 	}
 
+	@Test
+	public void testCommitImmediately() throws Exception {
+		try (OneInputStreamOperatorTestHarness<RowData, CommitMessage> harness = create()) {
+			harness.setup();
+			harness.initializeEmptyState();
+			harness.open();
+
+			harness.processElement(row("1"), 0);
+			harness.processElement(row("2"), 0);
+			harness.processElement(row("2"), 0);
+
+			harness.snapshot(1, 1);
+
+			// repeat partition 1
+			harness.processElement(row("1"), 0);
+
+			harness.processElement(row("3"), 0);
+			harness.processElement(row("4"), 0);
+
+			harness.notifyOfCompletedCheckpoint(1);
+			List<String> partitions = collect(harness);
+			Assert.assertEquals(Arrays.asList("1", "2"), partitions);
+		}
+	}
+
 	private static RowData row(String s) {
 		return GenericRowData.of(StringData.fromString(s));
 	}


### PR DESCRIPTION

## What is the purpose of the change

When set partition-commit.delay=0, Users expect partitions to be committed immediately.

However, if the record of this partition continues to flow in, the bucket for the partition will be activated, and no inactive bucket will appear.

## Brief change log

Consider listening to bucket created.

Collect partitions from bucket created listener. Emit partitions when notify checkpoint complete.

## Verifying this change

`StreamingFileWriterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no