### PR TITLE
[FLINK-20165] Update test docker image & improve YARN logging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-bcef226
+    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-bcef226
+    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository

--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -33,8 +33,8 @@ print_system_info() {
 
 # locate YARN logs and put them into artifacts directory
 put_yarn_logs_to_artifacts() {
-	for file in `find ./flink-yarn-tests/target -type f -name '*.log'`; do
-		TARGET_FILE=`echo "$file" | grep -Eo "container_[0-9_]+/(.*).log"`
+	for file in `find ./flink-yarn-tests/target -type f -name '*.log' -or -name '*.out'`; do
+		TARGET_FILE=`echo "$file" | grep -Eo "container_[0-9_]+/(.*).[a-z]{3}"`
 		TARGET_DIR=`dirname	 "$TARGET_FILE"`
 		mkdir -p "$DEBUG_FILES_OUTPUT_DIR/yarn-tests/$TARGET_DIR"
 		cp $file "$DEBUG_FILES_OUTPUT_DIR/yarn-tests/$TARGET_FILE"


### PR DESCRIPTION
## What is the purpose of the change

We had a JVM failure in the YARN tests, that seems extremely rare.
Before filing a ticket with Java, I want to see if we are experiencing this issue again with the latest JDK11, that's why I'm updating the docker image.

This is related to https://github.com/apache/flink/pull/14118.
