### PR TITLE
[FLINK-20098] Don't add flink-connector-files to flink-dist, make dependencies explicit

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -50,14 +50,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-file-sink-common</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -173,16 +173,8 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- format dependencies -->

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -137,19 +137,6 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<!-- Base Connector Support -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-files</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Default file system support. The Hadoop and MapR dependencies -->
 		<!--       are optional, so not being added to the dist jar        -->
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -31,6 +31,14 @@ under the License.
 	<name>Flink : E2E Tests : Common Kafka</name>
 
 	<dependencies>
+<!--		&lt;!&ndash; The SQL Client test uses a Table FileSource, which is not included in the normal table-->
+<!--		dependencies &ndash;&gt;-->
+<!--		<dependency>-->
+<!--			<groupId>org.apache.flink</groupId>-->
+<!--			<artifactId>flink-connector-files</artifactId>-->
+<!--			<version>${project.version}</version>-->
+<!--		</dependency>-->
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-end-to-end-tests-common</artifactId>

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -50,12 +50,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Used for structured types extraction. -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -116,6 +116,9 @@ under the License.
 									<include>org.apache.flink:flink-table-planner-blink_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-runtime-blink_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-connector-files</include>
+									<include>org.apache.flink:flink-connector-base</include>
+									<include>org.apache.flink:flink-file-sink-common</include>
 								</includes>
 							</artifactSet>
 							<relocations>

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -103,6 +103,9 @@ under the License.
 									<include>org.apache.flink:flink-table-api-scala-bridge_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-table-planner_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-cep_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-connector-files</include>
+									<include>org.apache.flink:flink-connector-base</include>
+									<include>org.apache.flink:flink-file-sink-common</include>
 								</includes>
 							</artifactSet>
 							<relocations>


### PR DESCRIPTION
## [FLINK-20098] Don't add flink-connector-files to flink-dist, make dependencies explicit

We currently add both flink-connector-files and flink-connector-base to flink-dist.

This implies, that users should use the dependency like this:

```
<dependency>
  <groupId>org.apache.flink</groupId>
  <artifactId>flink-connector-files</artifactId>
  <version>${project.version}</version>
  <scope>provided</scope>
</dependency>
```

which differs from other connectors where users don't need to specify <scope>provided</scope>.

Also, `flink-connector-files` had `flink-connector-base` as a provided dependency, which means that examples that use this dependency would not run out-of-box in IntelliJ because transitive provided dependencies will not be considered.

This removes the dependencies from `flink-dist` which lets users use the File Connector like any other connector.

I believe the initial motivation for "providing" the File Connector in `flink-dist` was to allow us to use the File Connector under the hood in methods such as `StreamExecutionEnvironment.readFile(...)`. We could decide to deprecate and remove those methods or re-add the File Connector as an explicit (non-provided) dependency again in the future.

## Brief change log

- remove dependencies from `flink-dist`
- change `provided` dependencies to instead be in `compile` scope
- add File Connector modules to Table API uber jars because they are using them and were relying on them being present in `flink-dist`. This increases the size of the Table uber jars by a couple of kilo bytes but it should be negligible.

## Verifying this change

Covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): maybe
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`may: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Not applicable