### PR TITLE
[FLINK-17470][scripts] Use timeout only if present (osx compat)

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -94,12 +94,15 @@ function guaranteed_kill {
 
   # send sigterm for graceful shutdown
   kill $to_stop_pid
-  # wait 10 seconds for process to stop. By default, Flink kills the JVM 5 seconds after sigterm.
-  timeout 10 tail --pid=$to_stop_pid -f /dev/null
-  if [ "$?" -eq 124 ]; then
-    echo "Daemon $daemon didn't stop within 10 seconds. Killing it."
-    # send sigkill
-    kill -9 $to_stop_pid
+  # if timeout exists, use it
+  if command -v timeout &> /dev/null ; then
+    # wait 10 seconds for process to stop. By default, Flink kills the JVM 5 seconds after sigterm.
+    timeout 10 tail --pid=$to_stop_pid -f /dev/null
+    if [ "$?" -eq 124 ]; then
+      echo "Daemon $daemon didn't stop within 10 seconds. Killing it."
+      # send sigkill
+      kill -9 $to_stop_pid
+    fi
   fi
 }
 


### PR DESCRIPTION
The scripts were causing error messages like this 
```
Stopping taskexecutor daemon (pid: 43659) on host RobertsbabaMac2.localdomain.
/Users/robert/Projects/tmp-release-1.12/flink/flink-dist/target/flink-1.12-SNAPSHOT-bin/flink-1.12-SNAPSHOT/bin/flink-daemon.sh: line 98: timeout: command not found
Stopping taskexecutor daemon (pid: 43403) on host RobertsbabaMac2.localdomain.
/Users/robert/Projects/tmp-release-1.12/flink/flink-dist/target/flink-1.12-SNAPSHOT-bin/flink-1.12-SNAPSHOT/bin/flink-daemon.sh: line 98: timeout: command not found
Stopping standalonesession daemon (pid: 40906) on host RobertsbabaMac2.localdomain.
/Users/robert/Projects/tmp-release-1.12/flink/flink-dist/target/flink-1.12-SNAPSHOT-bin/flink-1.12-SNAPSHOT/bin/flink-daemon.sh: line 98: timeout: command not found
```

I tested the fix on two macs, one with `timeout`, one without.