### PR TITLE
[FLINK-20211][doc] Use <ClusterId>-rest to get the external ip address

### DIFF
--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -170,7 +170,7 @@ You could find it in your kube config file.
 
 - `LoadBalancer`: Exposes the service externally using a cloud provider’s load balancer.
 Since the cloud provider and Kubernetes needs some time to prepare the load balancer, you may get a `NodePort` JobManager Web Interface in the client log.
-You can use `kubectl get services/<ClusterId>` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
+You can use `kubectl get services/<ClusterId>-rest` to get EXTERNAL-IP and then construct the load balancer JobManager Web Interface manually `http://<EXTERNAL-IP>:8081`.
 
   <span class="label label-warning">Warning!</span> Your JobManager (which can run arbitary jar files) might be exposed to the public internet, without authentication.
 

--- a/docs/ops/deployment/native_kubernetes.zh.md
+++ b/docs/ops/deployment/native_kubernetes.zh.md
@@ -166,7 +166,7 @@ $ kubectl port-forward service/<ServiceName> 8081
 
 - `LoadBalancer`：使用云提供商的负载均衡器在外部暴露服务。
 由于云提供商和 Kubernetes 需要一些时间来准备负载均衡器，因为你可能在客户端日志中获得一个 `NodePort` 的 JobManager Web 界面。
-你可以使用 `kubectl get services/<ClusterId>` 获取 EXTERNAL-IP 然后手动构建负载均衡器 JobManager Web 界面 `http://<EXTERNAL-IP>:8081`。
+你可以使用 `kubectl get services/<ClusterId>-rest` 获取 EXTERNAL-IP 然后手动构建负载均衡器 JobManager Web 界面 `http://<EXTERNAL-IP>:8081`。
 
   <span class="label label-warning">警告!</span> JobManager 可能会在无需认证的情况下暴露在公网上，同时可以提交任务运行。
 


### PR DESCRIPTION
Fix the documentation of native K8s for getting the EXTERNAL-IP. The external ip is allocated in `<ClusterID>-rest` service, not the `ClusterID` service.

We could get the result like following.
```
wangyang-pc:apache-flink-k8s-ha danrtsey.wy$ kubectl get svc/k8s-ha-app-1-rest
NAME                TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)          AGE
k8s-ha-app-1-rest   LoadBalancer   172.21.15.66   8.131.x.x   8081:32000/TCP   17h
```