### PR TITLE
[FLINK-20214][k8s] Fix the unnecessary warning logs when Hadoop environment is not set

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -159,15 +159,23 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
 	@Override
 	public Optional<String> getLocalHadoopConfigurationDirectory() {
-		final String[] possibleHadoopConfPaths = new String[] {
-			System.getenv(Constants.ENV_HADOOP_CONF_DIR),
-			System.getenv(Constants.ENV_HADOOP_HOME) + "/etc/hadoop", // hadoop 2.2
-			System.getenv(Constants.ENV_HADOOP_HOME) + "/conf"
-		};
+		final String hadoopConfDirEnv = System.getenv(Constants.ENV_HADOOP_CONF_DIR);
+		if (StringUtils.isNotBlank(hadoopConfDirEnv)) {
+			return Optional.of(hadoopConfDirEnv);
+		}
 
-		for (String hadoopConfPath: possibleHadoopConfPaths) {
-			if (StringUtils.isNotBlank(hadoopConfPath)) {
-				return Optional.of(hadoopConfPath);
+		final String hadoopHomeEnv = System.getenv(Constants.ENV_HADOOP_HOME);
+		if (StringUtils.isNotBlank(hadoopHomeEnv)) {
+			// Hadoop 2.2+
+			final File hadoop2ConfDir = new File(hadoopHomeEnv, "/etc/hadoop");
+			if (hadoop2ConfDir.exists()) {
+				return Optional.of(hadoop2ConfDir.getAbsolutePath());
+			}
+
+			// Hadoop 1.x
+			final File hadoop1ConfDir = new File(hadoopHomeEnv, "/conf");
+			if (hadoop1ConfDir.exists()) {
+				return Optional.of(hadoop1ConfDir.getAbsolutePath());
 			}
 		}
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParametersTest.java
@@ -20,15 +20,22 @@ package org.apache.flink.kubernetes.kubeclient.parameters;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
 import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
@@ -42,6 +49,9 @@ public class AbstractKubernetesParametersTest extends TestLogger {
 
 	private final Configuration flinkConfig = new Configuration();
 	private final TestingKubernetesParameters testingKubernetesParameters = new TestingKubernetesParameters(flinkConfig);
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	@Test
 	public void testClusterIdMustNotBeBlank() {
@@ -76,6 +86,67 @@ public class AbstractKubernetesParametersTest extends TestLogger {
 	public void getConfigDirectoryFallbackToPodConfDir() {
 		final String confDirInPod = flinkConfig.get(KubernetesConfigOptions.FLINK_CONF_DIR);
 		assertThat(testingKubernetesParameters.getConfigDirectory(), is(confDirInPod));
+	}
+
+	@Test
+	public void testGetLocalHadoopConfigurationDirectoryReturnEmptyWhenHadoopEnvIsNotSet() throws Exception {
+		runTestWithEmptyEnv(() -> {
+			final Optional<String> optional = testingKubernetesParameters.getLocalHadoopConfigurationDirectory();
+			assertThat(optional.isPresent(), is(false));
+		});
+	}
+
+	@Test
+	public void testGetLocalHadoopConfigurationDirectoryFromHadoopConfDirEnv() throws Exception {
+		runTestWithEmptyEnv(() -> {
+			final String hadoopConfDir = "/etc/hadoop/conf";
+			setEnv(Constants.ENV_HADOOP_CONF_DIR, hadoopConfDir);
+
+			final Optional<String> optional = testingKubernetesParameters.getLocalHadoopConfigurationDirectory();
+			assertThat(optional.isPresent(), is(true));
+			assertThat(optional.get(), is(hadoopConfDir));
+		});
+	}
+
+	@Test
+	public void testGetLocalHadoopConfigurationDirectoryFromHadoop2HomeEnv() throws Exception {
+		runTestWithEmptyEnv(() -> {
+			final String hadoopHome = temporaryFolder.getRoot().getAbsolutePath();
+			temporaryFolder.newFolder("etc", "hadoop");
+			setEnv(Constants.ENV_HADOOP_HOME, hadoopHome);
+
+			final Optional<String> optional = testingKubernetesParameters.getLocalHadoopConfigurationDirectory();
+			assertThat(optional.isPresent(), is(true));
+			assertThat(optional.get(), is(hadoopHome + "/etc/hadoop"));
+		});
+	}
+
+	@Test
+	public void testGetLocalHadoopConfigurationDirectoryFromHadoop1HomeEnv() throws Exception {
+		runTestWithEmptyEnv(() -> {
+			final String hadoopHome = temporaryFolder.getRoot().getAbsolutePath();
+			temporaryFolder.newFolder("conf");
+			setEnv(Constants.ENV_HADOOP_HOME, hadoopHome);
+
+			final Optional<String> optional = testingKubernetesParameters.getLocalHadoopConfigurationDirectory();
+			assertThat(optional.isPresent(), is(true));
+			assertThat(optional.get(), is(hadoopHome + "/conf"));
+		});
+	}
+
+	private void runTestWithEmptyEnv(RunnableWithException testMethod) throws Exception {
+		final Map<String, String> current = new HashMap<>(System.getenv());
+		// Clear the environments
+		CommonTestUtils.setEnv(Collections.emptyMap(), true);
+		testMethod.run();
+		// Restore the environments
+		CommonTestUtils.setEnv(current, true);
+	}
+
+	private void setEnv(String key, String value) {
+		final Map<String, String> map = new HashMap<>();
+		map.put(key, value);
+		CommonTestUtils.setEnv(map, false);
 	}
 
 	/**


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When we are submitting a Flink cluster(both session and application) to K8s, we could find the following unnecessary warning log even though the hadoop environment is not set.

```
2020-11-18 17:46:36,727 WARN org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator [] - Found 0 files in directory null/etc/hadoop, skip to mount the Hadoop Configuration ConfigMap.
2020-11-18 17:46:36,727 WARN org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator [] - Found 0 files in directory null/etc/hadoop, skip to create the Hadoop Configuration ConfigMap.
```
The root cause is a nit bug in `AbstractKubernetesParameters#getLocalHadoopConfigurationDirectory`. The production code is correct and the only side effect is the unnecessary warning log.

## Brief change log

* Fix the unnecessary warning logs when Hadoop environment is not set


## Verifying this change

* Add two unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
