### PR TITLE
[FLINK-20233][streaming] change DataGeneratorSource serialVersionUID

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 @Experimental
 public class DataGeneratorSource<T> extends RichParallelSourceFunction<T> implements CheckpointedFunction {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = -2838201805198396165L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(DataGeneratorSource.class);
 


### PR DESCRIPTION

## What is the purpose of the change

Change DataGeneratorSource serialVersionUID in order to compatible the Modification of enhancing DataGeneratorSource.

## Brief change log

Change DataGeneratorSource serialVersionUID

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
