### PR TITLE
[FLINK-20247][config] Hide unused unaligned checkpoint configuration options

### DIFF
--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>execution.checkpointing.alignment-timeout</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
-            <td>Duration</td>
-            <td>Only relevant if <span markdown="span">`execution.checkpointing.unaligned`</span> is enabled.<br /><br />If timeout is 0, checkpoints will always start unaligned.<br /><br />If timeout has a positive value, checkpoints will start aligned. If during checkpointing, checkpoint start delay exceeds this timeout, alignment will timeout and checkpoint barrier will start working as unaligned checkpoint.</td>
-        </tr>
-        <tr>
             <td><h5>execution.checkpointing.externalized-checkpoint-retention</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td><p>Enum</p>Possible values: [DELETE_ON_CANCELLATION, RETAIN_ON_CANCELLATION]</td>

--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -62,11 +62,5 @@
             <td>Boolean</td>
             <td>Enables unaligned checkpoints, which greatly reduce checkpointing times under backpressure.<br /><br />Unaligned checkpoints contain data stored in buffers as part of the checkpoint state, which allows checkpoint barriers to overtake these buffers. Thus, the checkpoint duration becomes independent of the current throughput as checkpoint barriers are effectively not embedded into the stream of data anymore.<br /><br />Unaligned checkpoints can only be enabled if <span markdown="span">`execution.checkpointing.mode`</span> is <span markdown="span">`EXACTLY_ONCE`</span> and if <span markdown="span">`execution.checkpointing.max-concurrent-checkpoints`</span> is 1</td>
         </tr>
-        <tr>
-            <td><h5>execution.checkpointing.unaligned.forced</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Forces unaligned checkpoints, particularly allowing them for iterative jobs.</td>
-        </tr>
     </tbody>
 </table>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -162,10 +162,11 @@ public class ExecutionCheckpointingOptions {
 					"will timeout and checkpoint barrier will start working as unaligned checkpoint.")
 				.build());
 
+	@Documentation.ExcludeFromDocumentation("Do not advertise this option until rescaling of unaligned checkpoint is completed.")
 	public static final ConfigOption<Boolean> FORCE_UNALIGNED =
 		ConfigOptions.key("execution.checkpointing.unaligned.forced")
 			.booleanType()
-			.defaultValue(false)
+			.defaultValue(true)
 			.withDescription(Description.builder()
 				.text("Forces unaligned checkpoints, particularly allowing them for iterative jobs.")
 				.build());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -144,10 +145,11 @@ public class ExecutionCheckpointingOptions {
 					TextElement.code(MAX_CONCURRENT_CHECKPOINTS.key()))
 				.build());
 
+	@Documentation.ExcludeFromDocumentation("Do not advertise this option until timeout in unaligned checkpoint is completed.")
 	public static final ConfigOption<Duration> ALIGNMENT_TIMEOUT =
 		ConfigOptions.key("execution.checkpointing.alignment-timeout")
 			.durationType()
-			.defaultValue(Duration.ofSeconds(30))
+			.defaultValue(Duration.ofSeconds(0L))
 			.withDescription(Description.builder()
 				.text("Only relevant if %s is enabled.", TextElement.code(ENABLE_UNALIGNED.key()))
 				.linebreak()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -501,7 +501,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		actionExecutor.runThrowing(() -> {
 
 			SequentialChannelStateReader reader = getEnvironment().getTaskStateManager().getSequentialChannelStateReader();
-			reader.readOutputData(getEnvironment().getAllWriters(), !configuration.isGraphContainingLoops());
+			// TODO: for UC rescaling, reenable notifyAndBlockOnCompletion for non-iterative jobs
+			reader.readOutputData(getEnvironment().getAllWriters(), false);
 
 			operatorChain.initializeStateAndOpenOperators(createStreamTaskStateInitializer());
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

As long as the related unaligned checkpoint features rescaling and timeout are not finished, users shouldn't see the related config options. Defaults should be adjusted to show the behavior of unaligned checkpoint without these features.


## Brief change log

- Hide timeout option.
- Hide force unaligned checkpoint option.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
