### PR TITLE
[FLINK-20145][checkpointing] Fix priority event handling.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileBasedBufferIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileBasedBufferIterator.java
@@ -77,7 +77,7 @@ public class FileBasedBufferIterator implements CloseableIterator<Buffer> {
 	private int read(byte[] buffer) {
 		int limit = Math.min(buffer.length, bytesToRead);
 		try {
-			return stream.read(buffer, offset, limit);
+			return stream.read(buffer, 0, limit);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -314,6 +314,12 @@ public class UnionInputGate extends InputGate {
 					return;
 				}
 
+				if (priority && !inputGate.getPriorityEventAvailableFuture().isDone()) {
+					// Since notification is not atomic in respect to gate enqueuing, priority event may already be polled by
+					// task thread when netty enqueues the gate, so just ignore the notification.
+					return;
+				}
+
 				inputGatesWithData.add(inputGate, priority, alreadyEnqueued);
 
 				if (priority && inputGatesWithData.getNumPriorityElements() == 1) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -76,14 +76,14 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		int readingInputIndex;
 		if (isPrepared) {
 			readingInputIndex = selectNextReadingInputIndex();
-			assert readingInputIndex != InputSelection.NONE_AVAILABLE;
 		} else {
 			// the preparations here are not placed in the constructor because all work in it
 			// must be executed after all operators are opened.
 			readingInputIndex = selectFirstReadingInputIndex();
-			if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
-				return InputStatus.NOTHING_AVAILABLE;
-			}
+		}
+		// In case of double notification (especially with priority notification), there may not be an input after all.
+		if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
+			return InputStatus.NOTHING_AVAILABLE;
 		}
 
 		lastReadInputIndex = readingInputIndex;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -19,76 +19,35 @@
 
 package org.apache.flink.test.checkpointing;
 
-import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.accumulators.IntCounter;
-import org.apache.flink.api.common.accumulators.LongCounter;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.Partitioner;
-import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.time.Time;
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.api.connector.source.ReaderOutput;
-import org.apache.flink.api.connector.source.Source;
-import org.apache.flink.api.connector.source.SourceReader;
-import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.api.connector.source.SourceSplit;
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.configuration.CheckpointingOptions;
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
+import org.apache.flink.util.Collector;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
-
-import org.apache.commons.lang3.ArrayUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ErrorCollector;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.BitSet;
 import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import static java.util.Collections.singletonList;
 import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterables.getOnlyElement;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Integration test for performing the unaligned checkpoint.
@@ -129,387 +88,180 @@ import static org.hamcrest.Matchers.equalTo;
  *     <li>The number of successful checkpoints is indeed {@code >=n}.</li>
  * </ul>
  */
-public class UnalignedCheckpointITCase extends TestLogger {
-	private static final String NUM_OUTPUTS = "outputs";
-	private static final String NUM_OUT_OF_ORDER = "outOfOrder";
-	private static final String NUM_FAILURES = "failures";
-	private static final String NUM_DUPLICATES = "duplicates";
-	private static final String NUM_LOST = "lost";
-	private static final Logger LOG = LoggerFactory.getLogger(UnalignedCheckpointITCase.class);
-	// keep in sync with FailingMapper in #createDAG
-	private static final int EXPECTED_FAILURES = 5;
+@RunWith(Parameterized.class)
+public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
-	@Rule
-	public ErrorCollector collector = new ErrorCollector();
+	@Parameterized.Parameters(name = "{0}")
+	public static Object[][] parameters() {
+		return new Object[][]{
+			new Object[]{"non-parallel pipeline with local channels", createPipelineSettings(1, 1, true)},
+			new Object[]{"non-parallel pipeline with remote channels", createPipelineSettings(1, 1, false)},
+			new Object[]{"parallel pipeline with local channels, p = 5", createPipelineSettings(5, 5, true)},
+			new Object[]{"parallel pipeline with remote channels, p = 5", createPipelineSettings(5, 1, false)},
+			new Object[]{"parallel pipeline with mixed channels, p = 5", createPipelineSettings(5, 3, true)},
+			new Object[]{"parallel pipeline with mixed channels, p = 20", createPipelineSettings(20, 10, true)},
 
-	@Rule
-	public final TemporaryFolder temp = new TemporaryFolder();
+			new Object[]{"Parallel cogroup, p = 5", createCogroupSettings(5)},
+			new Object[]{"Parallel cogroup, p = 10", createCogroupSettings(10)},
 
-	@Rule
-	public final Timeout timeout = Timeout.builder()
-		.withTimeout(300, TimeUnit.SECONDS)
-		.build();
+			new Object[]{"Parallel union, p = 5", createUnionSettings(5)},
+			new Object[]{"Parallel union, p = 10", createUnionSettings(10)},
+		};
+	}
 
-	@Test
-	public void shouldPerformUnalignedCheckpointOnNonParallelLocalChannel() throws Exception {
-		execute(1, 1, true);
+	private static UnalignedSettings createPipelineSettings(int parallelism, int slotsPerTaskManager, boolean slotSharing) {
+		int numShuffles = 5;
+		return new UnalignedSettings(UnalignedCheckpointITCase::createPipeline)
+			.setParallelism(parallelism)
+			.setSlotSharing(slotSharing)
+			.setNumSlots(slotSharing ? parallelism : parallelism * numShuffles)
+			.setNumBuffers(3 * slotsPerTaskManager * parallelism * numShuffles)
+			.setSlotsPerTaskManager(slotsPerTaskManager)
+			.setExpectedFailures(5);
+	}
+
+	private static UnalignedSettings createCogroupSettings(int parallelism) {
+		int numShuffles = 10;
+		return new UnalignedSettings(UnalignedCheckpointITCase::createMultipleInputTopology)
+			.setParallelism(parallelism)
+			.setSlotSharing(true)
+			.setNumSlots(parallelism * numShuffles)
+			.setNumBuffers(3 * parallelism * parallelism * numShuffles)
+			.setSlotsPerTaskManager(parallelism)
+			.setExpectedFailures(5);
+	}
+
+	private static UnalignedSettings createUnionSettings(int parallelism) {
+		int numShuffles = 6;
+		return new UnalignedSettings(UnalignedCheckpointITCase::createUnionTopology)
+			.setParallelism(parallelism)
+			.setSlotSharing(true)
+			.setNumSlots(parallelism * numShuffles)
+			.setNumBuffers(3 * parallelism * parallelism * numShuffles)
+			.setSlotsPerTaskManager(parallelism)
+			.setExpectedFailures(5);
+	}
+
+	private final UnalignedSettings settings;
+
+	public UnalignedCheckpointITCase(String desc, UnalignedSettings settings) {
+		this.settings = settings;
 	}
 
 	@Test
-	public void shouldPerformUnalignedCheckpointOnParallelLocalChannel() throws Exception {
-		execute(5, 5, true);
+	public void execute() throws Exception {
+		execute(settings);
 	}
 
-	@Test
-	public void shouldPerformUnalignedCheckpointOnNonParallelRemoteChannel() throws Exception {
-		execute(1, 1, false);
-	}
-
-	@Test
-	public void shouldPerformUnalignedCheckpointOnParallelRemoteChannel() throws Exception {
-		execute(5, 1, false);
-	}
-
-	@Test
-	public void shouldPerformUnalignedCheckpointOnLocalAndRemoteChannel() throws Exception {
-		execute(5, 3, true);
-	}
-
-	@Test
-	public void shouldPerformUnalignedCheckpointMassivelyParallel() throws Exception {
-		execute(20, 20, true);
-	}
-
-	private void execute(int parallelism, int slotsPerTaskManager, boolean slotSharing) throws Exception {
-		StreamExecutionEnvironment env = createEnv(parallelism, slotsPerTaskManager, slotSharing);
-
-		long minCheckpoints = 8;
-		createDAG(env, minCheckpoints, slotSharing);
-		final JobExecutionResult result = env.execute();
-
-		collector.checkThat(result.<Long>getAccumulatorResult(NUM_OUT_OF_ORDER), equalTo(0L));
-		collector.checkThat(result.<Long>getAccumulatorResult(NUM_DUPLICATES), equalTo(0L));
-		collector.checkThat(result.<Long>getAccumulatorResult(NUM_LOST), equalTo(0L));
-		collector.checkThat(result.<Integer>getAccumulatorResult(NUM_FAILURES), equalTo(EXPECTED_FAILURES));
-	}
-
-	@Nonnull
-	private LocalStreamEnvironment createEnv(int parallelism, int slotsPerTaskManager, boolean slotSharing) throws IOException {
-		Configuration conf = new Configuration();
-		conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
-		conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, .9f);
-		conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
-		final int taskManagers = slotSharing ? (parallelism + slotsPerTaskManager - 1) / slotsPerTaskManager : parallelism * 3;
-		conf.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, taskManagers);
-		final int numBuffers = 3 * slotsPerTaskManager * slotsPerTaskManager * taskManagers * 3;
-		conf.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse(numBuffers * 4 + "kb"));
-
-		conf.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
-		conf.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temp.newFolder().toURI().toString());
-
-		conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 1);
-		conf.set(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, slotsPerTaskManager);
-
-		final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);
-		env.enableCheckpointing(100);
-		env.getCheckpointConfig().setAlignmentTimeout(1);
-		env.setParallelism(parallelism);
-		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(EXPECTED_FAILURES, Time.milliseconds(100)));
-		env.getCheckpointConfig().enableUnalignedCheckpoints(true);
-		return env;
-	}
-
-	private void createDAG(StreamExecutionEnvironment env, long minCheckpoints, boolean slotSharing) {
-		env.fromSource(new LongSource(minCheckpoints, env.getParallelism()), WatermarkStrategy.noWatermarks(), "source")
+	private static void createPipeline(StreamExecutionEnvironment env, long minCheckpoints, boolean slotSharing) {
+		final int parallelism = env.getParallelism();
+		final SingleOutputStreamOperator<Long> stream = env.fromSource(new LongSource(minCheckpoints, parallelism), WatermarkStrategy.noWatermarks(), "source")
 			.slotSharingGroup(slotSharing ? "default" : "source")
+			.disableChaining()
+			.map(i -> i).name("forward").uid("forward")
+			.slotSharingGroup(slotSharing ? "default" : "forward")
+			.keyBy(i -> i % parallelism * parallelism)
+			.process(new KeyedIdentityFunction())
+			.name("keyed").uid("keyed");
+		addFailingPipeline(minCheckpoints, slotSharing, stream);
+	}
+
+	private static void createMultipleInputTopology(StreamExecutionEnvironment env, long minCheckpoints, boolean slotSharing) {
+		final int parallelism = env.getParallelism();
+		DataStream<Long> combinedSource = null;
+		for (int inputIndex = 0; inputIndex < 4; inputIndex++) {
+			final SingleOutputStreamOperator<Long> source = env.fromSource(new LongSource(minCheckpoints, parallelism), WatermarkStrategy.noWatermarks(),
+				"source" + inputIndex)
+				.slotSharingGroup(slotSharing ? "default" : ("source" + inputIndex))
+				.disableChaining();
+			combinedSource = combinedSource == null ? source : combinedSource.connect(source).flatMap(new MinEmittingFunction());
+		}
+
+		addFailingPipeline(minCheckpoints, slotSharing, combinedSource);
+	}
+
+	private static void createUnionTopology(StreamExecutionEnvironment env, long minCheckpoints, boolean slotSharing) {
+		final int parallelism = env.getParallelism();
+		DataStream<Long> combinedSource = null;
+		final int numSources = 4;
+		for (int inputIndex = 0; inputIndex < numSources; inputIndex++) {
+			final SingleOutputStreamOperator<Long> source = env.fromSource(new LongSource(minCheckpoints, parallelism), WatermarkStrategy.noWatermarks(),
+				"source" + inputIndex)
+				.slotSharingGroup(slotSharing ? "default" : ("source" + inputIndex))
+				.disableChaining();
+			combinedSource = combinedSource == null ? source : combinedSource.union(source);
+		}
+
+		final SingleOutputStreamOperator<Long> deduplicated = combinedSource
+			.partitionCustom((key, numPartitions) -> (int) (key % numPartitions), l -> l)
+			.flatMap(new CountingMapFunction(numSources));
+		addFailingPipeline(minCheckpoints, slotSharing, deduplicated);
+	}
+
+	private static DataStreamSink<Long> addFailingPipeline(long minCheckpoints, boolean slotSharing, DataStream<Long> combinedSource) {
+		return combinedSource
 			// shifts records from one partition to another evenly to retain order
 			.partitionCustom(new ShiftingPartitioner(), l -> l)
-			.map(new FailingMapper(state -> state.completedCheckpoints >= minCheckpoints / 4 && state.runNumber == 0
+			.map(new FailingMapper(
+				state -> state.completedCheckpoints >= minCheckpoints / 4 && state.runNumber == 0
 					|| state.completedCheckpoints >= minCheckpoints * 3 / 4 && state.runNumber == 2,
 				state -> state.completedCheckpoints >= minCheckpoints / 2 && state.runNumber == 1,
 				state -> state.runNumber == 3,
 				state -> state.runNumber == 4))
+			.name("failing-map").uid("failing-map")
 			.slotSharingGroup(slotSharing ? "default" : "map")
-			.partitionCustom(new DistributingPartitioner(), l -> l)
-			.addSink(new VerifyingSink(minCheckpoints))
+			.partitionCustom(new ChunkDistributingPartitioner(), l -> l)
+			.addSink(new StrictOrderVerifyingSink(minCheckpoints))
+			.name("sink").uid("sink")
 			.slotSharingGroup(slotSharing ? "default" : "sink");
 	}
 
-	private static class LongSource implements Source<Long, LongSource.LongSplit, List<LongSource.LongSplit>> {
-		private final long minCheckpoints;
-		private final int numSplits;
-
-		private LongSource(long minCheckpoints, int numSplits) {
-			this.minCheckpoints = minCheckpoints;
-			this.numSplits = numSplits;
-		}
-
+	/**
+	 * Shifts the partitions one up.
+	 */
+	protected static class ShiftingPartitioner implements Partitioner<Long> {
 		@Override
-		public Boundedness getBoundedness() {
-			return Boundedness.CONTINUOUS_UNBOUNDED;
-		}
-
-		@Override
-		public SourceReader<Long, LongSplit> createReader(SourceReaderContext readerContext) {
-			return new LongSourceReader(minCheckpoints);
-		}
-
-		@Override
-		public SplitEnumerator<LongSplit, List<LongSource.LongSplit>> createEnumerator(SplitEnumeratorContext<LongSplit> enumContext) {
-			List<LongSplit> splits = IntStream.range(0, numSplits)
-				.mapToObj(i -> new LongSplit(i, numSplits, 0))
-				.collect(Collectors.toList());
-			return new LongSplitSplitEnumerator(enumContext, splits);
-		}
-
-		@Override
-		public SplitEnumerator<LongSplit, List<LongSource.LongSplit>> restoreEnumerator(SplitEnumeratorContext<LongSplit> enumContext, List<LongSource.LongSplit> checkpoint) {
-			return new LongSplitSplitEnumerator(enumContext, checkpoint);
-		}
-
-		@Override
-		public SimpleVersionedSerializer<LongSplit> getSplitSerializer() {
-			return new SplitVersionedSerializer();
-		}
-
-		@Override
-		public SimpleVersionedSerializer<List<LongSplit>> getEnumeratorCheckpointSerializer() {
-			return new EnumeratorVersionedSerializer();
-		}
-
-		private static class LongSourceReader implements SourceReader<Long, LongSplit> {
-
-			private final long minCheckpoints;
-			private final LongCounter numInputsCounter = new LongCounter();
-			private LongSplit split;
-
-			public LongSourceReader(final long minCheckpoints) {
-				// there is currently no way to know when a checkpoint succeeded in sources, so add #expected failures
-				this.minCheckpoints = minCheckpoints + EXPECTED_FAILURES;
-			}
-
-			private void info(String description, Object... args) {
-				LOG.info(description + " @ {} subtask (? attempt)",
-					ArrayUtils.addAll(args, split.nextNumber % split.increment));
-			}
-
-			@Override
-			public void start() {
-			}
-
-			@Override
-			public InputStatus pollNext(ReaderOutput<Long> output) {
-				if (split == null) {
-					return InputStatus.NOTHING_AVAILABLE;
-				}
-
-				output.collect(split.nextNumber);
-				split.nextNumber += split.increment;
-				return split.numCompletedCheckpoints >= minCheckpoints ? InputStatus.END_OF_INPUT : InputStatus.MORE_AVAILABLE;
-			}
-
-			@Override
-			public List<LongSplit> snapshotState(long checkpointId) {
-				if (split == null) {
-					return Collections.emptyList();
-				}
-				info("Snapshotted next input {}", split.nextNumber);
-				split.numCompletedCheckpoints++;
-				return singletonList(split);
-			}
-
-			@Override
-			public CompletableFuture<Void> isAvailable() {
-				return FutureUtils.completedVoidFuture();
-			}
-
-			@Override
-			public void addSplits(List<LongSplit> splits) {
-				split = Iterables.getOnlyElement(splits);
-			}
-
-			@Override
-			public void notifyNoMoreSplits() {}
-
-			@Override
-			public void close() throws Exception {
-				numInputsCounter.add(split.nextNumber / split.increment);
-			}
-		}
-
-		private static class LongSplit implements SourceSplit {
-			private final int increment;
-			private long nextNumber;
-			private long numCompletedCheckpoints;
-
-			public LongSplit(long nextNumber, int increment, long numCompletedCheckpoints) {
-				this.nextNumber = nextNumber;
-				this.increment = increment;
-				this.numCompletedCheckpoints = numCompletedCheckpoints;
-			}
-
-			@Override
-			public String splitId() {
-				return String.valueOf(increment);
-			}
-		}
-
-		private static class LongSplitSplitEnumerator implements SplitEnumerator<LongSplit, List<LongSplit>> {
-			private final SplitEnumeratorContext<LongSplit> context;
-			private final List<LongSplit> unassignedSplits;
-
-			private LongSplitSplitEnumerator(SplitEnumeratorContext<LongSplit> context, List<LongSplit> unassignedSplits) {
-				this.context = context;
-				this.unassignedSplits = new ArrayList<>(unassignedSplits);
-			}
-
-			@Override
-			public void start() {
-			}
-
-			@Override
-			public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {}
-
-			@Override
-			public void addSplitsBack(List<LongSplit> splits, int subtaskId) {
-				unassignedSplits.addAll(splits);
-			}
-
-			@Override
-			public void addReader(int subtaskId) {
-				if (context.registeredReaders().size() == context.currentParallelism()) {
-					int numReaders = context.registeredReaders().size();
-					Map<Integer, List<LongSplit>> assignment = new HashMap<>();
-					for (int i = 0; i < unassignedSplits.size(); i++) {
-						assignment
-							.computeIfAbsent(i % numReaders, t -> new ArrayList<>())
-							.add(unassignedSplits.get(i));
-					}
-					context.assignSplits(new SplitsAssignment<>(assignment));
-					unassignedSplits.clear();
-				}
-			}
-
-			@Override
-			public List<LongSplit> snapshotState() throws Exception {
-				return unassignedSplits;
-			}
-
-			@Override
-			public void close() throws IOException {
-			}
-		}
-
-		private static class EnumeratorVersionedSerializer implements SimpleVersionedSerializer<List<LongSplit>> {
-			@Override
-			public int getVersion() {
-				return 0;
-			}
-
-			@Override
-			public byte[] serialize(List<LongSplit> splits) throws IOException {
-				final byte[] bytes = new byte[20 * splits.size()];
-				for (final LongSplit split : splits) {
-					ByteBuffer.wrap(bytes).putLong(split.nextNumber).putInt(split.increment).putLong(split.numCompletedCheckpoints);
-				}
-				return bytes;
-			}
-
-			@Override
-			public List<LongSplit> deserialize(int version, byte[] serialized) {
-				final ByteBuffer byteBuffer = ByteBuffer.wrap(serialized);
-				final ArrayList<LongSplit> splits = new ArrayList<>();
-				while (byteBuffer.hasRemaining()) {
-					splits.add(new LongSplit(byteBuffer.getLong(), byteBuffer.getInt(), byteBuffer.getLong()));
-				}
-				return splits;
-			}
-		}
-
-		private static class SplitVersionedSerializer implements SimpleVersionedSerializer<LongSplit> {
-			@Override
-			public int getVersion() {
-				return 0;
-			}
-
-			@Override
-			public byte[] serialize(LongSplit split) {
-				final byte[] bytes = new byte[20];
-				ByteBuffer.wrap(bytes).putLong(split.nextNumber).putInt(split.increment).putLong(split.numCompletedCheckpoints);
-				return bytes;
-			}
-
-			@Override
-			public LongSplit deserialize(int version, byte[] serialized) {
-				final ByteBuffer byteBuffer = ByteBuffer.wrap(serialized);
-				return new LongSplit(byteBuffer.getLong(), byteBuffer.getInt(), byteBuffer.getLong());
-			}
+		public int partition(Long key, int numPartitions) {
+			return (int) ((key + 1) % numPartitions);
 		}
 	}
 
-	static void info(RuntimeContext runtimeContext, String description, Object[] args) {
-		LOG.info(description + " @ {} subtask ({} attempt)",
-				ArrayUtils.addAll(args, runtimeContext.getIndexOfThisSubtask(), runtimeContext.getAttemptNumber()));
+	/**
+	 * Distributes chunks of the size of numPartitions in a round robin fashion.
+	 */
+	protected static class ChunkDistributingPartitioner implements Partitioner<Long> {
+		@Override
+		public int partition(Long key, int numPartitions) {
+			return (int) ((key / numPartitions) % numPartitions);
+		}
 	}
 
-	private static class VerifyingSink extends RichSinkFunction<Long> implements CheckpointedFunction, CheckpointListener {
-		private final LongCounter numOutputCounter = new LongCounter();
-		private final LongCounter outOfOrderCounter = new LongCounter();
-		private final LongCounter lostCounter = new LongCounter();
-		private final LongCounter duplicatesCounter = new LongCounter();
-		private final IntCounter numFailures = new IntCounter();
-		private static final ListStateDescriptor<State> STATE_DESCRIPTOR =
-				new ListStateDescriptor<>("state", State.class);
-		private ListState<State> stateList;
-		private State state;
-		private final long minCheckpoints;
+	/**
+	 * A sink that checks if the members arrive in the expected order without any missing values.
+	 */
+	protected static class StrictOrderVerifyingSink extends VerifyingSinkBase<StrictOrderVerifyingSink.State> {
 		private Random random = new Random();
+		protected boolean backpressure;
 
-		private VerifyingSink(long minCheckpoints) {
-			this.minCheckpoints = minCheckpoints;
+		protected StrictOrderVerifyingSink(long minCheckpoints) {
+			super(minCheckpoints);
 		}
 
 		@Override
-		public void open(Configuration parameters) throws Exception {
-			super.open(parameters);
-			random = new Random();
-			getRuntimeContext().addAccumulator(NUM_OUTPUTS, numOutputCounter);
-			getRuntimeContext().addAccumulator(NUM_OUT_OF_ORDER, outOfOrderCounter);
-			getRuntimeContext().addAccumulator(NUM_DUPLICATES, duplicatesCounter);
-			getRuntimeContext().addAccumulator(NUM_LOST, lostCounter);
-			getRuntimeContext().addAccumulator(NUM_FAILURES, numFailures);
+		protected State createState() {
+			return new State(getRuntimeContext().getNumberOfParallelSubtasks());
 		}
 
 		@Override
 		public void initializeState(FunctionInitializationContext context) throws Exception {
-			stateList = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
-			state = getOnlyElement(stateList.get(), new State(getRuntimeContext().getNumberOfParallelSubtasks()));
-			info("Initialized last snapshotted records {}", Arrays.asList(state.lastRecordInPartitions));
+			super.initializeState(context);
+			backpressure = false;
 		}
 
 		@Override
 		public void snapshotState(FunctionSnapshotContext context) throws Exception {
-			stateList.clear();
-			stateList.add(state);
-			info("Last snapshotted records {}", Arrays.asList(state.lastRecordInPartitions));
-		}
-
-		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
-			state.completedCheckpoints++;
-		}
-
-		@Override
-		public void close() throws Exception {
-			numOutputCounter.add(state.numOutput);
-			outOfOrderCounter.add(state.numOutOfOrderness);
-			duplicatesCounter.add(state.numDuplicates);
-			lostCounter.add(state.numLostValues);
-			if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
-				numFailures.add(getRuntimeContext().getAttemptNumber());
-			}
-			info("Last received records {}", Arrays.asList(state.lastRecordInPartitions));
-			super.close();
+			super.snapshotState(context);
+			backpressure = state.completedCheckpoints < minCheckpoints;
 		}
 
 		@Override
@@ -519,40 +271,39 @@ public class UnalignedCheckpointITCase extends TestLogger {
 			long lastRecord = state.lastRecordInPartitions[partition];
 			if (value < lastRecord) {
 				state.numOutOfOrderness++;
-				info("Out of order records current={} and last={}", value, lastRecord);
+				LOG.debug(
+					"Out of order records current={} and last={} @ {} subtask ({} attempt)",
+					value,
+					lastRecord,
+					getRuntimeContext().getIndexOfThisSubtask(),
+					getRuntimeContext().getAttemptNumber());
 			} else if (value == lastRecord) {
 				state.numDuplicates++;
-				info("Duplicate record {}", value);
+				LOG.debug(
+					"Duplicate record {} @ {} subtask ({} attempt)",
+					value,
+					getRuntimeContext().getIndexOfThisSubtask(),
+					getRuntimeContext().getAttemptNumber());
 			} else if (lastRecord != -1) {
 				long expectedValue = lastRecord + parallelism * parallelism;
 				if (value != expectedValue) {
 					state.numLostValues++;
-					info("Lost records {}-{}", expectedValue, value);
 				}
 			}
 			state.lastRecordInPartitions[partition] = value;
 			state.numOutput++;
 
-			if (state.completedCheckpoints < minCheckpoints) {
+			if (backpressure) {
 				// induce backpressure until enough checkpoints have been written
-				if (random.nextInt(1000) == 42) {
-					Thread.sleep(1);
+				if (random.nextInt(100) == 42) {
+					Thread.sleep(0, 100_000);
 				}
 			}
 			// after all checkpoints have been completed, the remaining data should be flushed out fairly quickly
 		}
 
-		private void info(String description, Object... args) {
-			UnalignedCheckpointITCase.info(getRuntimeContext(), description, args);
-		}
-
-		private static class State {
-			private long numOutOfOrderness;
-			private long numLostValues;
-			private long numDuplicates;
-			private long numOutput = 0;
+		static class State extends VerifyingSinkStateBase {
 			private final long[] lastRecordInPartitions;
-			private long completedCheckpoints;
 
 			private State(int numberOfParallelSubtasks) {
 				lastRecordInPartitions = new long[numberOfParallelSubtasks];
@@ -561,97 +312,92 @@ public class UnalignedCheckpointITCase extends TestLogger {
 		}
 	}
 
-	private static class ShiftingPartitioner implements Partitioner<Long> {
-		@Override
-		public int partition(Long key, int numPartitions) {
-			return (int) ((key + 1) % numPartitions);
-		}
-	}
-
-	private static class DistributingPartitioner implements Partitioner<Long> {
-		@Override
-		public int partition(Long key, int numPartitions) {
-			return (int) ((key / numPartitions) % numPartitions);
-		}
-	}
-
-	private static class FailingMapperState {
-		private long completedCheckpoints;
-		private long runNumber;
-
-		private FailingMapperState(long completedCheckpoints, long runNumber) {
-			this.completedCheckpoints = completedCheckpoints;
-			this.runNumber = runNumber;
-		}
-	}
-
-	private static class FailingMapper extends RichMapFunction<Long, Long> implements CheckpointedFunction, CheckpointListener {
-		private static final ListStateDescriptor<FailingMapperState> FAILING_MAPPER_STATE_DESCRIPTOR =
-				new ListStateDescriptor<>("state", FailingMapperState.class);
-		private ListState<FailingMapperState> listState;
-		private FailingMapperState state;
-		private final FilterFunction<FailingMapperState> failDuringMap;
-		private final FilterFunction<FailingMapperState> failDuringSnapshot;
-		private final FilterFunction<FailingMapperState> failDuringRecovery;
-		private final FilterFunction<FailingMapperState> failDuringClose;
-		private long lastValue;
-
-		private FailingMapper(
-				FilterFunction<FailingMapperState> failDuringMap,
-				FilterFunction<FailingMapperState> failDuringSnapshot,
-				FilterFunction<FailingMapperState> failDuringRecovery,
-				FilterFunction<FailingMapperState> failDuringClose) {
-			this.failDuringMap = failDuringMap;
-			this.failDuringSnapshot = failDuringSnapshot;
-			this.failDuringRecovery = failDuringRecovery;
-			this.failDuringClose = failDuringClose;
-		}
-
-		@Override
-		public Long map(Long value) throws Exception {
-			lastValue = value;
-			checkFail(failDuringMap, "map");
-			return value;
-		}
-
-		public void checkFail(FilterFunction<FailingMapperState> failFunction, String description) throws Exception {
-			if (getRuntimeContext().getIndexOfThisSubtask() == 0 && failFunction.filter(state)) {
-				failMapper(description);
-			}
-		}
-
-		private void failMapper(String description) throws Exception {
-			throw new Exception("Failing " + description + " @ " + state.completedCheckpoints + " (" + state.runNumber + " attempt); last value " + lastValue);
-		}
-
-		@Override
-		public void notifyCheckpointComplete(long checkpointId) {
-			state.completedCheckpoints++;
-		}
-
-		@Override
-		public void notifyCheckpointAborted(long checkpointId) {
-		}
+	private static class MinEmittingFunction extends RichCoFlatMapFunction<Long, Long, Long> implements CheckpointedFunction {
+		private ListState<State> stateList;
+		private State state;
 
 		@Override
 		public void snapshotState(FunctionSnapshotContext context) throws Exception {
-			checkFail(failDuringSnapshot, "snapshotState");
-			listState.clear();
-			listState.add(state);
-		}
-
-		@Override
-		public void close() throws Exception {
-			checkFail(failDuringClose, "close");
-			super.close();
+			stateList.clear();
+			stateList.add(state);
 		}
 
 		@Override
 		public void initializeState(FunctionInitializationContext context) throws Exception {
-			listState = context.getOperatorStateStore().getListState(FAILING_MAPPER_STATE_DESCRIPTOR);
-			state = getOnlyElement(listState.get(), new FailingMapperState(0, 0));
-			state.runNumber = getRuntimeContext().getAttemptNumber();
-			checkFail(failDuringRecovery, "initializeState");
+			stateList = context.getOperatorStateStore().getListState(new ListStateDescriptor<>("state", State.class));
+			this.state = getOnlyElement(stateList.get(), new State());
+		}
+
+		@Override
+		public void flatMap1(Long value, Collector<Long> out) {
+			state.lastLeft = value;
+			if (state.lastRight >= value) {
+				out.collect(value);
+			}
+		}
+
+		@Override
+		public void flatMap2(Long value, Collector<Long> out) {
+			state.lastRight = value;
+			if (state.lastLeft >= value) {
+				out.collect(value);
+			}
+		}
+
+		private static class State {
+			private long lastLeft = Long.MIN_VALUE;
+			private long lastRight = Long.MIN_VALUE;
+		}
+	}
+
+	private static class KeyedIdentityFunction extends KeyedProcessFunction<Long, Long, Long> {
+		ValueState<Long> state;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			state = getRuntimeContext().getState(new ValueStateDescriptor<>("keyedState", BasicTypeInfo.LONG_TYPE_INFO));
+		}
+
+		@Override
+		public void processElement(Long value, Context ctx, Collector<Long> out) {
+			out.collect(value);
+		}
+	}
+
+	private static class CountingMapFunction extends RichFlatMapFunction<Long, Long> implements CheckpointedFunction {
+		private BitSet seenRecords;
+
+		private final int withdrawnCount;
+
+		private ListState<BitSet> stateList;
+
+		public CountingMapFunction(int numSources) {
+			this.withdrawnCount = numSources - 1;
+		}
+
+		@Override
+		public void flatMap(Long value, Collector<Long> out) throws Exception {
+			final int offset = StrictMath.toIntExact(value * withdrawnCount);
+			for (int index = 0; index < withdrawnCount; index++) {
+				if (!seenRecords.get(index + offset)) {
+					seenRecords.set(index + offset);
+					return;
+				}
+			}
+			out.collect(value);
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			stateList.clear();
+			stateList.add(seenRecords);
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			stateList = context.getOperatorStateStore().getListState(new ListStateDescriptor<>("state", BitSet.class));
+			this.seenRecords = getOnlyElement(stateList.get(), new BitSet());
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -1,0 +1,658 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.accumulators.LongCounter;
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.TriConsumer;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterables.getOnlyElement;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.fail;
+
+/**
+ * Base class for tests related to unaligned checkpoints.
+ */
+public abstract class UnalignedCheckpointTestBase extends TestLogger {
+	protected static final Logger LOG = LoggerFactory.getLogger(UnalignedCheckpointTestBase.class);
+	protected static final String NUM_OUTPUTS = "outputs";
+	protected static final String NUM_OUT_OF_ORDER = "outOfOrder";
+	protected static final String NUM_FAILURES = "failures";
+	protected static final String NUM_DUPLICATES = "duplicates";
+	protected static final String NUM_LOST = "lost";
+
+	@Rule
+	public final TemporaryFolder temp = new TemporaryFolder();
+
+	@Rule
+	public final Timeout timeout = Timeout.builder()
+		.withTimeout(300, TimeUnit.SECONDS)
+		.build();
+
+	@Rule
+	public ErrorCollector collector = new ErrorCollector();
+
+	@Nullable
+	protected File execute(UnalignedSettings settings) throws Exception {
+		final File checkpointDir = temp.newFolder();
+		StreamExecutionEnvironment env = settings.createEnvironment(checkpointDir);
+
+		int minCheckpoints = 10;
+		settings.dagCreator.accept(env, minCheckpoints, settings.slotSharing);
+		try {
+			final JobExecutionResult result = env.execute();
+
+			collector.checkThat("NUM_OUT_OF_ORDER", result.<Long>getAccumulatorResult(NUM_OUT_OF_ORDER), equalTo(0L));
+			collector.checkThat("NUM_DUPLICATES", result.<Long>getAccumulatorResult(NUM_DUPLICATES), equalTo(0L));
+			collector.checkThat("NUM_LOST", result.<Long>getAccumulatorResult(NUM_LOST), equalTo(0L));
+			collector.checkThat("NUM_FAILURES", result.<Integer>getAccumulatorResult(NUM_FAILURES), equalTo(settings.expectedFailures));
+		} catch (Exception e) {
+			if (settings.generateCheckpoint) {
+				return Files.find(checkpointDir.toPath(), 2, (file, attr) -> attr.isDirectory() && file.getFileName().toString().startsWith("chk"))
+					.findFirst()
+					.map(Path::toFile)
+					.orElseThrow(() -> new IllegalStateException("Cannot generate checkpoint", e));
+			}
+			throw e;
+		}
+		if (settings.generateCheckpoint) {
+			fail("Could not generate checkpoint");
+		}
+		return null;
+	}
+
+	/**
+	 * A source that generates longs in a fixed number of splits.
+	 */
+	protected static class LongSource
+			implements Source<Long, UnalignedCheckpointTestBase.LongSource.LongSplit, List<UnalignedCheckpointTestBase.LongSource.LongSplit>> {
+		private final long minCheckpoints;
+		private final int numSplits;
+
+		protected LongSource(long minCheckpoints, int numSplits) {
+			this.minCheckpoints = minCheckpoints;
+			this.numSplits = numSplits;
+		}
+
+		@Override
+		public Boundedness getBoundedness() {
+			return Boundedness.CONTINUOUS_UNBOUNDED;
+		}
+
+		@Override
+		public SourceReader<Long, LongSplit> createReader(SourceReaderContext readerContext) {
+			return new LongSourceReader(minCheckpoints);
+		}
+
+		@Override
+		public SplitEnumerator<LongSplit, List<UnalignedCheckpointTestBase.LongSource.LongSplit>> createEnumerator(SplitEnumeratorContext<LongSplit> enumContext) {
+			List<LongSplit> splits = IntStream.range(0, numSplits)
+				.mapToObj(i -> new LongSplit(i, numSplits, 0))
+				.collect(Collectors.toList());
+			return new LongSplitSplitEnumerator(enumContext, splits);
+		}
+
+		@Override
+		public SplitEnumerator<LongSplit, List<UnalignedCheckpointTestBase.LongSource.LongSplit>> restoreEnumerator(
+			SplitEnumeratorContext<LongSplit> enumContext,
+			List<UnalignedCheckpointTestBase.LongSource.LongSplit> checkpoint) {
+			return new LongSplitSplitEnumerator(enumContext, checkpoint);
+		}
+
+		@Override
+		public SimpleVersionedSerializer<LongSplit> getSplitSerializer() {
+			return new SplitVersionedSerializer();
+		}
+
+		@Override
+		public SimpleVersionedSerializer<List<LongSplit>> getEnumeratorCheckpointSerializer() {
+			return new EnumeratorVersionedSerializer();
+		}
+
+		private static class LongSourceReader implements SourceReader<Long, LongSplit> {
+
+			private final long minCheckpoints;
+			private final LongCounter numInputsCounter = new LongCounter();
+			private LongSplit split;
+
+			public LongSourceReader(final long minCheckpoints) {
+				this.minCheckpoints = minCheckpoints;
+			}
+
+			@Override
+			public void start() {
+			}
+
+			@Override
+			public InputStatus pollNext(ReaderOutput<Long> output) {
+				if (split == null) {
+					return InputStatus.NOTHING_AVAILABLE;
+				}
+
+				output.collect(split.nextNumber, split.nextNumber);
+				split.nextNumber += split.increment;
+				return split.numCompletedCheckpoints >= minCheckpoints ? InputStatus.END_OF_INPUT : InputStatus.MORE_AVAILABLE;
+			}
+
+			@Override
+			public List<LongSplit> snapshotState(long checkpointId) {
+				if (split == null) {
+					return Collections.emptyList();
+				}
+				LOG.info("Snapshotted next input {} @ {} subtask (? attempt)", split.nextNumber, split.nextNumber % split.increment);
+				return singletonList(split);
+			}
+
+			@Override
+			public void notifyCheckpointComplete(long checkpointId) {
+				if (split != null) {
+					split.numCompletedCheckpoints++;
+				}
+			}
+
+			@Override
+			public CompletableFuture<Void> isAvailable() {
+				return FutureUtils.completedVoidFuture();
+			}
+
+			@Override
+			public void addSplits(List<LongSplit> splits) {
+				split = Iterables.getOnlyElement(splits);
+			}
+
+			@Override
+			public void notifyNoMoreSplits() {
+			}
+
+			@Override
+			public void handleSourceEvents(SourceEvent sourceEvent) {
+			}
+
+			@Override
+			public void close() throws Exception {
+				if (split != null) {
+					numInputsCounter.add(split.nextNumber / split.increment);
+				}
+			}
+		}
+
+		private static class LongSplit implements SourceSplit {
+			private final int increment;
+			private long nextNumber;
+			private long numCompletedCheckpoints;
+
+			public LongSplit(long nextNumber, int increment, long numCompletedCheckpoints) {
+				this.nextNumber = nextNumber;
+				this.increment = increment;
+				this.numCompletedCheckpoints = numCompletedCheckpoints;
+			}
+
+			@Override
+			public String splitId() {
+				return String.valueOf(increment);
+			}
+		}
+
+		private static class LongSplitSplitEnumerator implements SplitEnumerator<LongSplit, List<LongSplit>> {
+			private final SplitEnumeratorContext<LongSplit> context;
+			private final List<LongSplit> unassignedSplits;
+
+			private LongSplitSplitEnumerator(SplitEnumeratorContext<LongSplit> context, List<LongSplit> unassignedSplits) {
+				this.context = context;
+				this.unassignedSplits = new ArrayList<>(unassignedSplits);
+			}
+
+			@Override
+			public void start() {
+			}
+
+			@Override
+			public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+			}
+
+			@Override
+			public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+			}
+
+			@Override
+			public void addSplitsBack(List<LongSplit> splits, int subtaskId) {
+				unassignedSplits.addAll(splits);
+			}
+
+			@Override
+			public void addReader(int subtaskId) {
+				if (context.registeredReaders().size() == context.currentParallelism()) {
+					int numReaders = context.registeredReaders().size();
+					Map<Integer, List<LongSplit>> assignment = new HashMap<>();
+					for (int i = 0; i < unassignedSplits.size(); i++) {
+						assignment
+							.computeIfAbsent(i % numReaders, t -> new ArrayList<>())
+							.add(unassignedSplits.get(i));
+					}
+					context.assignSplits(new SplitsAssignment<>(assignment));
+					unassignedSplits.clear();
+				}
+			}
+
+			@Override
+			public List<LongSplit> snapshotState() throws Exception {
+				return unassignedSplits;
+			}
+
+			@Override
+			public void close() throws IOException {
+			}
+		}
+
+		private static class EnumeratorVersionedSerializer implements SimpleVersionedSerializer<List<LongSplit>> {
+			@Override
+			public int getVersion() {
+				return 0;
+			}
+
+			@Override
+			public byte[] serialize(List<LongSplit> splits) {
+				final byte[] bytes = new byte[20 * splits.size()];
+				for (final LongSplit split : splits) {
+					ByteBuffer.wrap(bytes).putLong(split.nextNumber).putInt(split.increment).putLong(split.numCompletedCheckpoints);
+				}
+				return bytes;
+			}
+
+			@Override
+			public List<LongSplit> deserialize(int version, byte[] serialized) {
+				final ByteBuffer byteBuffer = ByteBuffer.wrap(serialized);
+				final ArrayList<LongSplit> splits = new ArrayList<>();
+				while (byteBuffer.hasRemaining()) {
+					splits.add(new LongSplit(byteBuffer.getLong(), byteBuffer.getInt(), byteBuffer.getLong()));
+				}
+				return splits;
+			}
+		}
+
+		private static class SplitVersionedSerializer implements SimpleVersionedSerializer<LongSplit> {
+			@Override
+			public int getVersion() {
+				return 0;
+			}
+
+			@Override
+			public byte[] serialize(LongSplit split) {
+				final byte[] bytes = new byte[20];
+				ByteBuffer.wrap(bytes).putLong(split.nextNumber).putInt(split.increment).putLong(split.numCompletedCheckpoints);
+				return bytes;
+			}
+
+			@Override
+			public LongSplit deserialize(int version, byte[] serialized) {
+				final ByteBuffer byteBuffer = ByteBuffer.wrap(serialized);
+				return new LongSplit(byteBuffer.getLong(), byteBuffer.getInt(), byteBuffer.getLong());
+			}
+		}
+	}
+
+
+	/**
+	 * Builder-like interface for all relevant unaligned settings.
+	 */
+	protected static class UnalignedSettings {
+		private int parallelism;
+		private int slotsPerTaskManager = 1;
+		private boolean slotSharing = true;
+		@Nullable
+		private File restoreCheckpoint;
+		private boolean generateCheckpoint = false;
+		private int numSlots;
+		private int numBuffers;
+		private int expectedFailures = 0;
+		private final TriConsumer<StreamExecutionEnvironment, Integer, Boolean> dagCreator;
+
+		public UnalignedSettings(TriConsumer<StreamExecutionEnvironment, Integer, Boolean> dagCreator) {
+			this.dagCreator = dagCreator;
+		}
+
+		public UnalignedSettings setParallelism(int parallelism) {
+			this.parallelism = parallelism;
+			return this;
+		}
+
+		public UnalignedSettings setSlotsPerTaskManager(int slotsPerTaskManager) {
+			this.slotsPerTaskManager = slotsPerTaskManager;
+			return this;
+		}
+
+		public UnalignedSettings setSlotSharing(boolean slotSharing) {
+			this.slotSharing = slotSharing;
+			return this;
+		}
+
+		public UnalignedSettings setRestoreCheckpoint(File restoreCheckpoint) {
+			this.restoreCheckpoint = restoreCheckpoint;
+			return this;
+		}
+
+		public UnalignedSettings setGenerateCheckpoint(boolean generateCheckpoint) {
+			this.generateCheckpoint = generateCheckpoint;
+			return this;
+		}
+
+		public UnalignedSettings setNumSlots(int numSlots) {
+			this.numSlots = numSlots;
+			return this;
+		}
+
+		public UnalignedSettings setNumBuffers(int numBuffers) {
+			this.numBuffers = numBuffers;
+			return this;
+		}
+
+		public UnalignedSettings setExpectedFailures(int expectedFailures) {
+			this.expectedFailures = expectedFailures;
+			return this;
+		}
+
+		public StreamExecutionEnvironment createEnvironment(File checkpointDir) {
+			Configuration conf = new Configuration();
+
+			conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+			conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, .9f);
+			final int taskManagers = (numSlots + slotsPerTaskManager - 1) / slotsPerTaskManager;
+			conf.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, taskManagers);
+			conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
+			conf.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse(numBuffers * 4 + "kb"));
+
+			conf.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+			conf.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+			if (restoreCheckpoint != null) {
+				conf.set(SavepointConfigOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
+			}
+
+			conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 1);
+			conf.set(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, slotsPerTaskManager);
+
+			final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);
+			env.enableCheckpointing(100);
+			env.setParallelism(parallelism);
+			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(generateCheckpoint ? expectedFailures / 2 : expectedFailures, Time.milliseconds(100)));
+			env.getCheckpointConfig().enableUnalignedCheckpoints(true);
+			// for custom partitioner
+			env.getCheckpointConfig().setForceUnalignedCheckpoints(true);
+			if (generateCheckpoint) {
+				env.getCheckpointConfig().enableExternalizedCheckpoints(CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+			}
+			return env;
+		}
+
+		@Override
+		public String toString() {
+			return "UnalignedSettings{" +
+				"parallelism=" + parallelism +
+				", slotsPerTaskManager=" + slotsPerTaskManager +
+				", slotSharing=" + slotSharing +
+				", restoreCheckpoint=" + restoreCheckpoint +
+				", generateCheckpoint=" + generateCheckpoint +
+				", numSlots=" + numSlots +
+				", expectedFailures=" + expectedFailures +
+				", dagCreator=" + dagCreator +
+				'}';
+		}
+	}
+
+	/**
+	 * A mapper that fails in particular situations/attempts.
+	 */
+	protected static class FailingMapper extends RichMapFunction<Long, Long> implements CheckpointedFunction, CheckpointListener {
+		private static final ListStateDescriptor<FailingMapperState> FAILING_MAPPER_STATE_DESCRIPTOR =
+			new ListStateDescriptor<>("state", FailingMapperState.class);
+		private ListState<FailingMapperState> listState;
+		@Nullable
+		private transient FailingMapperState state;
+		private final FilterFunction<FailingMapperState> failDuringMap;
+		private final FilterFunction<FailingMapperState> failDuringSnapshot;
+		private final FilterFunction<FailingMapperState> failDuringRecovery;
+		private final FilterFunction<FailingMapperState> failDuringClose;
+		private long lastValue;
+
+		protected FailingMapper(
+				FilterFunction<FailingMapperState> failDuringMap,
+				FilterFunction<FailingMapperState> failDuringSnapshot,
+				FilterFunction<FailingMapperState> failDuringRecovery,
+				FilterFunction<FailingMapperState> failDuringClose) {
+			this.failDuringMap = failDuringMap;
+			this.failDuringSnapshot = failDuringSnapshot;
+			this.failDuringRecovery = failDuringRecovery;
+			this.failDuringClose = failDuringClose;
+		}
+
+		@Override
+		public Long map(Long value) throws Exception {
+			lastValue = value;
+			checkFail(failDuringMap, "map");
+			return value;
+		}
+
+		public void checkFail(FilterFunction<FailingMapperState> failFunction, String description) throws Exception {
+			if (state != null && failFunction.filter(state)) {
+				failMapper(description);
+			}
+		}
+
+		private void failMapper(String description) throws Exception {
+			throw new Exception("Failing " + description + " @ " + state.completedCheckpoints + " (" + state.runNumber + " attempt); last value " + lastValue);
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			if (state != null) {
+				state.completedCheckpoints++;
+			}
+		}
+
+		@Override
+		public void notifyCheckpointAborted(long checkpointId) {
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			checkFail(failDuringSnapshot, "snapshotState");
+			listState.clear();
+			if (state != null) {
+				listState.add(state);
+			}
+		}
+
+		@Override
+		public void close() throws Exception {
+			checkFail(failDuringClose, "close");
+			super.close();
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			listState = context.getOperatorStateStore().getListState(FAILING_MAPPER_STATE_DESCRIPTOR);
+			if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				state = Iterables.get(listState.get(), 0, new FailingMapperState(0, 0));
+				state.runNumber = getRuntimeContext().getAttemptNumber();
+			}
+			checkFail(failDuringRecovery, "initializeState");
+		}
+
+		/**
+		 * State for {@link FailingMapper}.
+		 */
+		protected static class FailingMapperState {
+			protected long completedCheckpoints;
+			protected long runNumber;
+
+			protected FailingMapperState(long completedCheckpoints, long runNumber) {
+				this.completedCheckpoints = completedCheckpoints;
+				this.runNumber = runNumber;
+			}
+		}
+	}
+
+	/**
+	 * Base for state of the a specific {@link VerifyingSinkBase}.
+	 */
+	public static class VerifyingSinkStateBase {
+		protected long numOutOfOrderness;
+		protected long numLostValues;
+		protected long numDuplicates;
+		protected long numOutput = 0;
+		protected long completedCheckpoints;
+
+		@Override
+		public String toString() {
+			return "StateBase{" +
+				"numOutOfOrderness=" + numOutOfOrderness +
+				", numLostValues=" + numLostValues +
+				", numDuplicates=" + numDuplicates +
+				", numOutput=" + numOutput +
+				", completedCheckpoints=" + completedCheckpoints +
+				'}';
+		}
+	}
+
+	/**
+	 * A sink that checks if the members arrive in the expected order without any missing values.
+	 */
+	protected abstract static class VerifyingSinkBase<State extends VerifyingSinkStateBase> extends RichSinkFunction<Long>
+			implements CheckpointedFunction, CheckpointListener {
+		private final LongCounter numOutputCounter = new LongCounter();
+		private final LongCounter outOfOrderCounter = new LongCounter();
+		private final LongCounter lostCounter = new LongCounter();
+		private final LongCounter duplicatesCounter = new LongCounter();
+		private final IntCounter numFailures = new IntCounter();
+		private ListState<State> stateList;
+		protected transient State state;
+		protected final long minCheckpoints;
+
+		protected VerifyingSinkBase(long minCheckpoints) {
+			this.minCheckpoints = minCheckpoints;
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			getRuntimeContext().addAccumulator(NUM_OUTPUTS, numOutputCounter);
+			getRuntimeContext().addAccumulator(NUM_OUT_OF_ORDER, outOfOrderCounter);
+			getRuntimeContext().addAccumulator(NUM_DUPLICATES, duplicatesCounter);
+			getRuntimeContext().addAccumulator(NUM_LOST, lostCounter);
+			getRuntimeContext().addAccumulator(NUM_FAILURES, numFailures);
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			final State state = createState();
+			stateList = context.getOperatorStateStore().getListState(new ListStateDescriptor<>("state", (Class<State>) state.getClass()));
+			this.state = getOnlyElement(stateList.get(), state);
+			LOG.info("Init state {} @ {} subtask ({} attempt)", state, getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getAttemptNumber());
+		}
+
+		protected abstract State createState();
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			LOG.info("Snapshot state {} @ {} subtask ({} attempt)", state, getRuntimeContext().getIndexOfThisSubtask(),	getRuntimeContext().getAttemptNumber());
+			stateList.clear();
+			stateList.add(state);
+		}
+
+		@Override
+		public void notifyCheckpointComplete(long checkpointId) {
+			state.completedCheckpoints++;
+		}
+
+		@Override
+		public void close() throws Exception {
+			numOutputCounter.add(state.numOutput);
+			outOfOrderCounter.add(state.numOutOfOrderness);
+			duplicatesCounter.add(state.numDuplicates);
+			lostCounter.add(state.numLostValues);
+			if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+				numFailures.add(getRuntimeContext().getAttemptNumber());
+			}
+			LOG.info("Last state {} @ {} subtask ({} attempt)", state, getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getAttemptNumber());
+			super.close();
+		}
+
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This commit fixes a range of smaller bugs introduced in #13228. They all affect the (priority) availability of InputGate and trigger various kinds of preconditions that have been in embedded into the network stack.

## Brief change log

- Double-check if gate still has priority buffer when enqueuing in UnionInputGate. Since notification is not atomic in respect to gate enqueuing, priority event may already polled by task thread when netty enqueues the gate.
- Ignore double notification in StreamTwoInputProcessor.
- Make sure to use unaligned checkpointing in all tests. 
- Fix FileBasedBufferIterator#read.

## Verifying this change

Refactored UnalignedCheckpointITCase and added new tests for union and two-input operator. Note that the base class is used for separate rescaling tests in the future (factored out of rescaling PR).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
