### PR TITLE
[FLINK-20223] The RecreateOnResetOperatorCoordinator and SourceCoordi…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -81,11 +81,13 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit> extends Recre
 	 */
 	public static class CoordinatorExecutorThreadFactory implements ThreadFactory {
 		private final String coordinatorThreadName;
+		private final ClassLoader cl;
 		private Thread t;
 
 		CoordinatorExecutorThreadFactory(String coordinatorThreadName) {
 			this.coordinatorThreadName = coordinatorThreadName;
 			this.t = null;
+			this.cl = Thread.currentThread().getContextClassLoader();
 		}
 
 		@Override
@@ -95,6 +97,7 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit> extends Recre
 						"SingleThreadExecutor.");
 			}
 			t = new Thread(r, coordinatorThreadName);
+			t.setContextClassLoader(cl);
 			t.setUncaughtExceptionHandler(FatalExitExceptionHandler.INSTANCE);
 			return t;
 		}


### PR DESCRIPTION
…nator executor thread should use the user class loader.

## What is the purpose of the change
This patch fixes two class loader related problems:

1. Currently the `RecreateOnResetOperatorCoordinator` does not use the user class loader when creating the internal coordinator or calling start. `ClassNotFoundException` could be thrown due to this. The patch fixes this issue by creating and starting the internal operator coordinator using the user class loader.
2. The SourceCoordinator executor thread does not run with user class loader at this point. Because that thread is going to interact with the custom implementation of `SplitEnumerator`, it should run with user class loader as well.


## Brief change log
- Fix `RecreateOnResetOperatorCoordinator` to create and start internal coordinators in user class loader.
- Fix the SourceCoordinator executor thread to run with user class loader.

## Verifying this change
Unit tests have been added / modified to test the change.
- `RecreateOnResetOperatorCoordinatorTest`.
- `SourceCoordinatorProviderTest.testUserClassLoaderInCoordinatorExecutor()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
