### PR TITLE
[FLINK-17691][Connectors/Kafka] Fix transactionId kafka string length bug

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -149,7 +149,7 @@ public class FlinkKafkaProducer<IN>
 	 * Number of characters to truncate the taskName to for the Kafka transactionalId.
 	 * The maximum this can possibly be set to is 32,767 - (length of operatorUniqueId).
 	 */
-	private static final short maxTaskNameSize = 10_000;
+	private static final short maxTaskNameSize = 1_000;
 
 	/**
 	 * This coefficient determines what is the safe scale down factor.
@@ -1095,6 +1095,7 @@ public class FlinkKafkaProducer<IN>
 		// so we truncate here if necessary to a more reasonable length string.
 		if (taskName.length() > maxTaskNameSize) {
 			taskName = taskName.substring(0, maxTaskNameSize);
+			LOG.warn("Truncated task name for Kafka TransactionalId from {} to {}.", getRuntimeContext().getTaskName(), taskName);
 		}
 		transactionalIdsGenerator = new TransactionalIdsGenerator(
 			taskName + "-" + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID(),

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -146,6 +146,12 @@ public class FlinkKafkaProducer<IN>
 	private static final long serialVersionUID = 1L;
 
 	/**
+	 * Number of characters to truncate the taskName to for the Kafka transactionalId.
+	 * The maximum this can possibly be set to is 32,767 - (length of operatorUniqueId).
+	 */
+	private static final short maxTaskNameSize = 10_000;
+
+	/**
 	 * This coefficient determines what is the safe scale down factor.
 	 *
 	 * <p>If the Flink application previously failed before first checkpoint completed or we are starting new batch
@@ -1084,8 +1090,14 @@ public class FlinkKafkaProducer<IN>
 			migrateNextTransactionalIdHindState(context);
 		}
 
+		String taskName = getRuntimeContext().getTaskName();
+		// Kafka transactional IDs are limited in length to be less than the max value of a short,
+		// so we truncate here if necessary to a more reasonable length string.
+		if (taskName.length() > maxTaskNameSize) {
+			taskName = taskName.substring(0, maxTaskNameSize);
+		}
 		transactionalIdsGenerator = new TransactionalIdsGenerator(
-			getRuntimeContext().getTaskName() + "-" + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID(),
+			taskName + "-" + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID(),
 			getRuntimeContext().getIndexOfThisSubtask(),
 			getRuntimeContext().getNumberOfParallelSubtasks(),
 			kafkaProducersPoolSize,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The purpose of this change is to prevent Flink from failing to produce records in the case where the taskName exceeds 32,000 characters in length which is larger than the max transactionId kafka supports. 


## Brief change log

Truncate taskName to length 10_000 when constructing the transactionalIdGenerator.

## Verifying this change

create a sink kafka job in Semantic.EXACTLY_ONCE mode
make the operatorName's length large than 32767 (or a large sql operator, which sql string's length is larger than 32767)
```
FlinkKafkaProducer011 init TransactionalIdsGenerator prefix
 getRuntimeContext().getTaskName() + "-" + ((StreamingRuntimeContext) getRuntimeContext()).getOperatorUniqueID()
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) (No) 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) (No)
  - The serializers: (yes / no / don't know) (No) 
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) (No) 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) (No) 
  - The S3 file system connector: (yes / no / don't know) (No) 

## Documentation

  - Does this pull request introduce a new feature? (yes / no) (No)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
