### PR TITLE
[FLINK-20252] Test Job for Approximate Local Recovery

### DIFF
--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -314,13 +314,39 @@ under the License.
 							<archive>
 								<manifestEntries>
 									<program-class>org.apache.flink.streaming.examples.wordcount.WordCount</program-class>
+									<program-class>org.apache.flink.streaming.examples.wordcount.ApproximateFailover</program-class>
 								</manifestEntries>
 							</archive>
 
 							<includes>
 								<include>org/apache/flink/streaming/examples/wordcount/WordCount.class</include>
 								<include>org/apache/flink/streaming/examples/wordcount/WordCount$*.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/ApproximateFailover.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/ApproximateFailover$*.class</include>
 								<include>org/apache/flink/streaming/examples/wordcount/util/WordCountData.class</include>
+							</includes>
+						</configuration>
+					</execution>
+
+					<!-- ApproximateFailover -->
+					<execution>
+						<id>ApproximateFailover</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>ApproximateFailover</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>org.apache.flink.streaming.examples.wordcount.ApproximateFailover</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>org/apache/flink/streaming/examples/wordcount/ApproximateFailover.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/ApproximateFailover$*.class</include>
 							</includes>
 						</configuration>
 					</execution>
@@ -546,6 +572,7 @@ under the License.
 								<copy file="${project.basedir}/target/flink-examples-streaming_${scala.binary.version}-${project.version}-WindowJoin.jar" tofile="${project.basedir}/target/WindowJoin.jar" />
 								<copy file="${project.basedir}/target/flink-examples-streaming_${scala.binary.version}-${project.version}-WordCount.jar" tofile="${project.basedir}/target/WordCount.jar" />
 								<copy file="${project.basedir}/target/flink-examples-streaming_${scala.binary.version}-${project.version}-SocketWindowWordCount.jar" tofile="${project.basedir}/target/SocketWindowWordCount.jar" />
+								<copy file="${project.basedir}/target/flink-examples-streaming_${scala.binary.version}-${project.version}-ApproximateFailover.jar" tofile="${project.basedir}/target/ApproximateFailover.jar" />
 							</target>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/ApproximateFailover.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/ApproximateFailover.java
@@ -1,0 +1,168 @@
+package org.apache.flink.streaming.examples.wordcount;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+/** ApproximateFailover Manual Test.*/
+public class ApproximateFailover {
+	public static void main(String[] args) throws Exception {
+		final int failAfterElements = 150;
+
+		// Checking input parameters
+		final MultipleParameterTool params = MultipleParameterTool.fromArgs(args);
+
+		// set up the execution environment
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		// make parameters available in the web interface
+		env.getConfig().setGlobalJobParameters(params);
+
+		// get input data
+		System.out.println("Executing Failover Manual Test.");
+
+		env
+			.setParallelism(1)
+			.setBufferTimeout(0)
+			.setMaxParallelism(128)
+			.disableOperatorChaining()
+			.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+		env.getCheckpointConfig().enableApproximateLocalRecovery(true);
+
+		DataStream<InvertedKeyTuple>  event = env.addSource(new AppSourceFunction())
+			.slotSharingGroup("source")
+			.map(new FailingMapper<>(failAfterElements))
+			.slotSharingGroup("map");
+
+		FailingMapper.failedBefore = false;
+
+		// emit result
+		System.out.println("Printing result to stdout. Use --output to specify output path.");
+		event.print();
+
+		// execute program
+		env.execute("Streaming WordCount");
+	}
+
+	private static class AppSourceFunction extends RichParallelSourceFunction<InvertedKeyTuple> {
+		private final String shortString = "I am a very long string to test partial records hohoho hahaha ";
+		private final String longOrShortString;
+		private final int maxParallelism;
+		private final int numberOfChannels;
+		private final int[] keys;
+		private int index = 0;
+		private volatile boolean running = true;
+
+		// short-length string
+		AppSourceFunction() {
+			this.longOrShortString = shortString;
+			this.maxParallelism = 128;
+			this.numberOfChannels = 1;
+			this.keys = initKeys(numberOfChannels);
+		}
+
+		@Override
+		public void run(SourceContext<InvertedKeyTuple> ctx) throws Exception{
+			while (running) {
+				synchronized (ctx.getCheckpointLock()) {
+					if (index % 100 == 0) {
+						Thread.sleep(50);
+					}
+					int selectedChannel = index % numberOfChannels;
+					int key = keys[selectedChannel];
+					ctx.collect(new InvertedKeyTuple(index, key, selectedChannel, longOrShortString));
+				}
+				index++;
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+
+		// Find the first key which falls into the key group of each downstream channel
+		private int[] initKeys(int numberOfChannels) {
+			int[] keys = new int[numberOfChannels];
+
+			for (int i = 0; i < numberOfChannels; i++) {
+				int key = 0;
+				while (key < 1000 && selectedChannel(key) != i) {
+					key++;
+				}
+				assert key < 1000 : "Can not find a key within number 1000";
+				keys[i] = key;
+			}
+
+			return keys;
+		}
+
+		private int selectedChannel(int key) {
+			return KeyGroupRangeAssignment.assignKeyToParallelOperator(key, maxParallelism, numberOfChannels);
+		}
+	}
+
+	/** Fails once the first map instance reaches failCount. */
+	private static class FailingMapper<T> extends RichMapFunction<T, T> {
+		private static final long serialVersionUID = 6334389850158703L;
+
+		private static volatile boolean failedBefore;
+
+		private final int failCount;
+		private int numElementsTotal;
+
+		private boolean failer;
+
+		FailingMapper(int failCount) {
+			this.failCount = failCount;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
+		}
+
+		@Override
+		public T map(T value) throws Exception {
+			numElementsTotal++;
+
+			if (!failedBefore) {
+				Thread.sleep(10);
+
+				if (failer && numElementsTotal >= failCount) {
+					failedBefore = true;
+					throw new Exception("Artificial Test Failure");
+				}
+			}
+
+			return value;
+		}
+	}
+
+	private static class InvertedKeyTuple {
+		int index;
+		/** Key based on which the tuple is partitioned. */
+		int key;
+		/** The selected channel of this tuple after key-partitioned. */
+		int selectedChannel;
+		String longOrShortString;
+
+		InvertedKeyTuple(int index, int key, int selectedChannel, String longOrShortString) {
+			this.index = index;
+			this.key = key;
+			this.selectedChannel = selectedChannel;
+			this.longOrShortString = longOrShortString;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("index:%d; key:%d; selectedChannel:%d; longOrShortString:%s",
+				index, key, selectedChannel, longOrShortString);
+		}
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
