### PR TITLE
[FLINK-20035][tests] Fix wrong config key in JobGraphRunningUtil

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/JobGraphRunningUtil.java
@@ -40,7 +40,7 @@ public class JobGraphRunningUtil {
 			int numTaskManagers,
 			int numSlotsPerTaskManager) throws Exception {
 		configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
-		configuration.setString(RestOptions.BIND_ADDRESS, "0");
+		configuration.setString(RestOptions.BIND_PORT, "0");
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)


### PR DESCRIPTION
## What is the purpose of the change

Fix wrong config key in JobGraphRunningUtil, we should use RestOptions.BIND_PORT instead of RestOptions.BIND_ADDRESS.

## Brief change log

  - Fix wrong config key in JobGraphRunningUtil, use RestOptions.BIND_PORT instead of RestOptions.BIND_ADDRESS.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
