### PR TITLE
[FLINK-19878][table-planner-blink] Fix WatermarkAssigner shouldn't be after ChangelogNormalize

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
@@ -39,16 +39,16 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class WatermarkAssignerChangelogNormalizeTransposeRule
 	extends RelRule<WatermarkAssignerChangelogNormalizeTransposeRule.Config> {
 
-	public static final RelOptRule WITH_COMPUTED_COLUMN = Config.EMPTY
-		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithComputedColumn")
+	public static final RelOptRule WITH_CALC = Config.EMPTY
+		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithCalc")
 		.as(Config.class)
-		.withComputedColumnCalc()
+		.withCalc()
 		.toRule();
 
-	public static final RelOptRule WITHOUT_COMPUTED_COLUMN = Config.EMPTY
-		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithoutComputedColumn")
+	public static final RelOptRule WITHOUT_CALC = Config.EMPTY
+		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithoutCalc")
 		.as(Config.class)
-		.withoutComputedColumnCalc()
+		.withoutCalc()
 		.toRule();
 
 	public WatermarkAssignerChangelogNormalizeTransposeRule(Config config) {
@@ -60,7 +60,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 		final StreamExecWatermarkAssigner watermark = call.rel(0);
 		final RelNode node = call.rel(1);
 		if (node instanceof StreamExecCalc) {
-			// with computed column
+			// with calc
 			final StreamExecCalc calc = call.rel(1);
 			final StreamExecChangelogNormalize changelogNormalize = call.rel(2);
 			final StreamExecExchange exchange = call.rel(3);
@@ -73,7 +73,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 				exchange.getInput());
 			call.transformTo(newTree);
 		} else if (node instanceof StreamExecChangelogNormalize) {
-			// without computed column
+			// without calc
 			final StreamExecChangelogNormalize changelogNormalize = call.rel(1);
 			final StreamExecExchange exchange = call.rel(2);
 
@@ -112,7 +112,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 			return new WatermarkAssignerChangelogNormalizeTransposeRule(this);
 		}
 
-		default Config withComputedColumnCalc() {
+		default Config withCalc() {
 			return withOperandSupplier(b0 ->
 				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
 					b1 -> b1.operand(StreamExecCalc.class).oneInput(
@@ -121,7 +121,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 				.as(Config.class);
 		}
 
-		default Config withoutComputedColumnCalc() {
+		default Config withoutCalc() {
 			return withOperandSupplier(b0 ->
 				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
 					b1 -> b1.operand(StreamExecChangelogNormalize.class).oneInput(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecCalc;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecChangelogNormalize;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecWatermarkAssigner;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Transpose {@link StreamExecWatermarkAssigner} past into {@link StreamExecChangelogNormalize}.
+ */
+public class WatermarkAssignerChangelogNormalizeTransposeRule
+	extends RelRule<WatermarkAssignerChangelogNormalizeTransposeRule.Config> {
+
+	public static final RelOptRule WITH_COMPUTED_COLUMN = Config.EMPTY
+		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithComputedColumn")
+		.as(Config.class)
+		.withComputedColumnCalc()
+		.toRule();
+
+	public static final RelOptRule WITHOUT_COMPUTED_COLUMN = Config.EMPTY
+		.withDescription("WatermarkAssignerChangelogNormalizeTransposeRuleWithoutComputedColumn")
+		.as(Config.class)
+		.withoutComputedColumnCalc()
+		.toRule();
+
+	public WatermarkAssignerChangelogNormalizeTransposeRule(Config config) {
+		super(config);
+	}
+
+	@Override
+	public void onMatch(RelOptRuleCall call) {
+		final StreamExecWatermarkAssigner watermark = call.rel(0);
+		final RelNode node = call.rel(1);
+		if (node instanceof StreamExecCalc) {
+			// with computed column
+			final StreamExecCalc calc = call.rel(1);
+			final StreamExecChangelogNormalize changelogNormalize = call.rel(2);
+			final StreamExecExchange exchange = call.rel(3);
+
+			final RelNode newTree = buildTreeInOrder(
+				changelogNormalize,
+				exchange,
+				watermark,
+				calc,
+				exchange.getInput());
+			call.transformTo(newTree);
+		} else if (node instanceof StreamExecChangelogNormalize) {
+			// without computed column
+			final StreamExecChangelogNormalize changelogNormalize = call.rel(1);
+			final StreamExecExchange exchange = call.rel(2);
+
+			final RelNode newTree = buildTreeInOrder(
+				changelogNormalize,
+				exchange,
+				watermark,
+				exchange.getInput());
+			call.transformTo(newTree);
+		} else {
+			throw new IllegalStateException(this.getClass().getName() +
+				" matches a wrong relation tree: " + RelOptUtil.toString(watermark));
+		}
+	}
+
+	/**
+	 * Build a new {@link RelNode} tree in the given nodes order which is in root-down direction.
+	 */
+	private RelNode buildTreeInOrder(RelNode... nodes) {
+		checkArgument(nodes.length >= 2);
+		RelNode root = nodes[nodes.length - 1];
+		for (int i = nodes.length - 2; i >= 0; i--) {
+			RelNode node = nodes[i];
+			root = node.copy(node.getTraitSet(), Collections.singletonList(root));
+		}
+		return root;
+	}
+
+	/**
+	 * Rule configuration.
+	 */
+	public interface Config extends RelRule.Config {
+
+		@Override
+		default WatermarkAssignerChangelogNormalizeTransposeRule toRule() {
+			return new WatermarkAssignerChangelogNormalizeTransposeRule(this);
+		}
+
+		default Config withComputedColumnCalc() {
+			return withOperandSupplier(b0 ->
+				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
+					b1 -> b1.operand(StreamExecCalc.class).oneInput(
+						b2 -> b2.operand(StreamExecChangelogNormalize.class).oneInput(
+							b3 -> b3.operand(StreamExecExchange.class).anyInputs()))))
+				.as(Config.class);
+		}
+
+		default Config withoutComputedColumnCalc() {
+			return withOperandSupplier(b0 ->
+				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
+					b1 -> b1.operand(StreamExecChangelogNormalize.class).oneInput(
+						b2 -> b2.operand(StreamExecExchange.class).anyInputs())))
+				.as(Config.class);
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -179,6 +179,13 @@ object FlinkStreamProgram {
     chainedProgram.addLast(
       PHYSICAL_REWRITE,
       FlinkGroupProgramBuilder.newBuilder[StreamOptimizeContext]
+        // add a HEP program for watermark transpose rules to make this optimization deterministic
+        .addProgram(
+          FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION)
+            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+            .add(FlinkStreamRuleSets.WATERMARK_TRANSPOSE_RULES)
+            .build(), "watermark transpose")
         .addProgram(new FlinkChangelogModeInferenceProgram,
           "Changelog mode inference")
         .addProgram(new FlinkMiniBatchIntervalTraitInitProgram,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -435,8 +435,8 @@ object FlinkStreamRuleSets {
    * RuleSet related to transpose watermark to be close to source
    */
   val WATERMARK_TRANSPOSE_RULES: RuleSet = RuleSets.ofList(
-    WatermarkAssignerChangelogNormalizeTransposeRule.WITH_COMPUTED_COLUMN,
-    WatermarkAssignerChangelogNormalizeTransposeRule.WITHOUT_COMPUTED_COLUMN
+    WatermarkAssignerChangelogNormalizeTransposeRule.WITH_CALC,
+    WatermarkAssignerChangelogNormalizeTransposeRule.WITHOUT_CALC
   )
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -432,10 +432,18 @@ object FlinkStreamRuleSets {
   )
 
   /**
-    * RuleSet related to watermark assignment.
+   * RuleSet related to transpose watermark to be close to source
+   */
+  val WATERMARK_TRANSPOSE_RULES: RuleSet = RuleSets.ofList(
+    WatermarkAssignerChangelogNormalizeTransposeRule.WITH_COMPUTED_COLUMN,
+    WatermarkAssignerChangelogNormalizeTransposeRule.WITHOUT_COMPUTED_COLUMN
+  )
+
+  /**
+    * RuleSet related to mini-batch.
     */
   val MINI_BATCH_RULES: RuleSet = RuleSets.ofList(
-    // watermark interval infer rule
+    // mini-batch interval infer rule
     MiniBatchIntervalInferRule.INSTANCE
   )
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -161,9 +161,9 @@ Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[
    :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
    :     +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency, rowtime], changelogMode=[I])
    +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
-      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I,UA,D])
-         +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
-            +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+      +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
+         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+            +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[UA,D])
                +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
 ]]>
     </Resource>
@@ -540,6 +540,27 @@ Union(all=[true], union=[b, ts, a], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUpsertSourceWithWatermarkPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT id, ts FROM src]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], ts=[$4])
++- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($4, 1000:INTERVAL SECOND)])
+   +- LogicalProject(id=[$0], a=[$1], b=[+($1, 1)], c=[$2], ts=[TO_TIMESTAMP($2)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, Reinterpret(TO_TIMESTAMP(c)) AS ts], changelogMode=[I,UA,D])
++- ChangelogNormalize(key=[id], changelogMode=[I,UA,D])
+   +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id, c], watermark=[-(TO_TIMESTAMP($1), 1000:INTERVAL SECOND)]]], fields=[id, c], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUpsertSourceWithComputedColumnAndWatermark">
     <Resource name="sql">
       <![CDATA[SELECT a, b, c FROM src WHERE a > 1]]>
@@ -556,10 +577,10 @@ LogicalProject(a=[$1], b=[$2], c=[$3])
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, c], where=[>(a, 1)], changelogMode=[I,UB,UA,D])
-+- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1000:INTERVAL SECOND)], changelogMode=[I,UB,UA,D])
-   +- Calc(select=[id, a, +(a, 1) AS b, c, TO_TIMESTAMP(c) AS ts], changelogMode=[I,UB,UA,D])
-      +- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
-         +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
++- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
+   +- Exchange(distribution=[hash[id]], changelogMode=[UA,D])
+      +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1000:INTERVAL SECOND)], changelogMode=[UA,D])
+         +- Calc(select=[id, a, +(a, 1) AS b, c, TO_TIMESTAMP(c) AS ts], changelogMode=[UA,D])
             +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[id, a, c], changelogMode=[UA,D])
 ]]>
     </Resource>


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Cutrrently, for a upsertSource like upsert-kafka, the WatermarkAssigner is followed after ChangelogNormalize node,  it may returns Long.MaxValue as watermark if some parallelism doesn't have data. 

 
```
   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I,UA,D])
         +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
            +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
               +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
 ```

As an improvement, we can move the WatermarkAssigner to be after the SourceScan node and thus the watermark will produce like general Source.

## Brief change log

- Added rules to transpose`StreamExecWatermarkAssigner` past into `StreamExecChangelogNormalize`.
- Added a HEP program for the watermark transpose rules in physical rewrite phase.

## Verifying this change

- The existing tests in `TableScanTest`.
- Added a `testUpsertSourceWithWatermarkPushDown` test to verify this rule works well with watermark pushdown rule. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
