### PR TITLE
[FLINK-19775][tests] Fix SystemProcessingTimeServiceTest.testImmediateShutdown

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -352,6 +352,9 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 			}
 		} while (interruptCallerThread.isAlive());
 
+		// clear the interrupted flag in case join didn't do it
+		final boolean ignored = Thread.interrupted();
+
 		blockUntilTriggered.trigger();
 		Assert.assertTrue(timeService.shutdownServiceUninterruptible(timeoutMs));
 		Assert.assertTrue(timerFinished.get());


### PR DESCRIPTION
## What is the purpose of the change

The test SystemProcessingTimeServiceTest.testImmediateShutdown was unstable because the
test case testShutdownServiceUninterruptible was not properly clearing the isInterrupted
flag it sets during its run. Consequently, the subsequent execution of testImmediateShutdown
could fail with an InterruptedException.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
