### PR TITLE
[FLINK-19969] CLI print run-application help msg

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -176,7 +176,7 @@ public class CliFrontend {
 		final CommandLine commandLine = getCommandLine(commandOptions, args, true);
 
 		if (commandLine.hasOption(HELP_OPTION.getOpt())) {
-			CliFrontendParser.printHelpForRunApplication(getApplicationModeTargetNames());
+			CliFrontendParser.printHelpForRunApplication(customCommandLines);
 			return;
 		}
 
@@ -205,12 +205,6 @@ public class CliFrontend {
 		final ApplicationConfiguration applicationConfiguration =
 				new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
 		deployer.run(effectiveConfiguration, applicationConfiguration);
-	}
-
-	private static String getApplicationModeTargetNames() {
-		return new DefaultClusterClientServiceLoader().getApplicationModeTargetNames()
-				.map(name -> String.format("\"%s\"", name))
-				.collect(Collectors.joining(", "));
 	}
 
 	/**
@@ -959,7 +953,7 @@ public class CliFrontend {
 
 		// check for action
 		if (args.length < 1) {
-			CliFrontendParser.printHelp(customCommandLines, getApplicationModeTargetNames());
+			CliFrontendParser.printHelp(customCommandLines);
 			System.out.println("Please specify an action.");
 			return 1;
 		}
@@ -996,7 +990,7 @@ public class CliFrontend {
 					return 0;
 				case "-h":
 				case "--help":
-					CliFrontendParser.printHelp(customCommandLines, getApplicationModeTargetNames());
+					CliFrontendParser.printHelp(customCommandLines);
 					return 0;
 				case "-v":
 				case "--version":

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -176,7 +176,7 @@ public class CliFrontend {
 		final CommandLine commandLine = getCommandLine(commandOptions, args, true);
 
 		if (commandLine.hasOption(HELP_OPTION.getOpt())) {
-			CliFrontendParser.printHelpForRun(customCommandLines);
+			CliFrontendParser.printHelpForRunApplication(getApplicationModeTargetNames());
 			return;
 		}
 
@@ -205,6 +205,12 @@ public class CliFrontend {
 		final ApplicationConfiguration applicationConfiguration =
 				new ApplicationConfiguration(programOptions.getProgramArgs(), programOptions.getEntryPointClassName());
 		deployer.run(effectiveConfiguration, applicationConfiguration);
+	}
+
+	private static String getApplicationModeTargetNames() {
+		return new DefaultClusterClientServiceLoader().getApplicationModeTargetNames()
+				.map(name -> String.format("\"%s\"", name))
+				.collect(Collectors.joining(", "));
 	}
 
 	/**
@@ -953,7 +959,7 @@ public class CliFrontend {
 
 		// check for action
 		if (args.length < 1) {
-			CliFrontendParser.printHelp(customCommandLines);
+			CliFrontendParser.printHelp(customCommandLines, getApplicationModeTargetNames());
 			System.out.println("Please specify an action.");
 			return 1;
 		}
@@ -990,7 +996,7 @@ public class CliFrontend {
 					return 0;
 				case "-h":
 				case "--help":
-					CliFrontendParser.printHelp(customCommandLines);
+					CliFrontendParser.printHelp(customCommandLines, getApplicationModeTargetNames());
 					return 0;
 				case "-v":
 				case "--version":

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -31,6 +31,8 @@ import org.apache.commons.cli.ParseException;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A simple command line parser (based on Apache Commons CLI) that extracts command
@@ -341,13 +343,13 @@ public class CliFrontendParser {
 	/**
 	 * Prints the help for the client.
 	 */
-	public static void printHelp(Collection<CustomCommandLine> customCommandLines, String availableApplicationModeTargets) {
+	public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
 		System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
 		System.out.println();
 		System.out.println("The following actions are available:");
 
 		printHelpForRun(customCommandLines);
-		printHelpForRunApplication(availableApplicationModeTargets);
+		printHelpForRunApplication(customCommandLines);
 		printHelpForInfo();
 		printHelpForList(customCommandLines);
 		printHelpForStop(customCommandLines);
@@ -372,15 +374,23 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForRunApplication(String availableApplicationModeTargets) {
+	public static void printHelpForRunApplication(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
 
 		System.out.println("\nAction \"run-application\" runs an application in Application Mode.");
-		System.out.println("\n  Syntax: run-application -t [" + availableApplicationModeTargets + "] [OPTIONS] <jar-file> <arguments>");
+		System.out.println("\n  Syntax: run-application [OPTIONS] <jar-file> <arguments>");
 		formatter.setSyntaxPrefix("  \"run-application\" action options:");
-		formatter.printHelp(" ", new Options().addOption(DynamicPropertiesUtil.DYNAMIC_PROPERTIES));
+
+		// Only GenericCLI works with application mode, the other CLIs will be phased out
+		// in the future
+		List<CustomCommandLine> filteredCommandLines = customCommandLines
+				.stream()
+				.filter((cli) -> cli instanceof GenericCLI)
+				.collect(Collectors.toList());
+
+		printCustomCliOptions(filteredCommandLines, formatter, true);
 		System.out.println();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -341,12 +341,13 @@ public class CliFrontendParser {
 	/**
 	 * Prints the help for the client.
 	 */
-	public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelp(Collection<CustomCommandLine> customCommandLines, String availableApplicationModeTargets) {
 		System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
 		System.out.println();
 		System.out.println("The following actions are available:");
 
 		printHelpForRun(customCommandLines);
+		printHelpForRunApplication(availableApplicationModeTargets);
 		printHelpForInfo();
 		printHelpForList(customCommandLines);
 		printHelpForStop(customCommandLines);
@@ -368,6 +369,18 @@ public class CliFrontendParser {
 
 		printCustomCliOptions(customCommandLines, formatter, true);
 
+		System.out.println();
+	}
+
+	public static void printHelpForRunApplication(String availableApplicationModeTargets) {
+		HelpFormatter formatter = new HelpFormatter();
+		formatter.setLeftPadding(5);
+		formatter.setWidth(80);
+
+		System.out.println("\nAction \"run-application\" runs an application in Application Mode.");
+		System.out.println("\n  Syntax: run-application -t [" + availableApplicationModeTargets + "] [OPTIONS] <jar-file> <arguments>");
+		formatter.setSyntaxPrefix("  \"run-application\" action options:");
+		formatter.printHelp(" ", new Options().addOption(DynamicPropertiesUtil.DYNAMIC_PROPERTIES));
 		System.out.println();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -54,8 +54,7 @@ public class GenericCLI implements CustomCommandLine {
 	private final Option targetOption = new Option("t", "target", true,
 			"The deployment target for the given application, which is equivalent " +
 					"to the \"" + DeploymentOptions.TARGET.key() + "\" config option. The " +
-					"currently available targets are: " + getExecutorFactoryNames() +
-					", \"yarn-application\" and \"kubernetes-application\".");
+					"currently available targets are: " + getExecutorFactoryNames() + ".");
 
 	private final Configuration configuration;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
@@ -53,8 +54,9 @@ public class GenericCLI implements CustomCommandLine {
 
 	private final Option targetOption = new Option("t", "target", true,
 			"The deployment target for the given application, which is equivalent " +
-					"to the \"" + DeploymentOptions.TARGET.key() + "\" config option. The " +
-					"currently available targets are: " + getExecutorFactoryNames() + ".");
+					"to the \"" + DeploymentOptions.TARGET.key() + "\" config option. For the \"run\" action the " +
+					"currently available targets are: " + getExecutorFactoryNames() + ". For the \"run-application\" action"
+					+ " the currently available targets are: " + getApplicationModeTargetNames() + ".");
 
 	private final Configuration configuration;
 
@@ -111,6 +113,12 @@ public class GenericCLI implements CustomCommandLine {
 
 	private static String getExecutorFactoryNames() {
 		return new DefaultExecutorServiceLoader().getExecutorNames()
+				.map(name -> String.format("\"%s\"", name))
+				.collect(Collectors.joining(", "));
+	}
+
+	private static String getApplicationModeTargetNames() {
+		return new DefaultClusterClientServiceLoader().getApplicationModeTargetNames()
 				.map(name -> String.format("\"%s\"", name))
 				.collect(Collectors.joining(", "));
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.Configuration;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
+
 /**
  * A factory containing all the necessary information for creating clients to Flink clusters.
  */
@@ -62,4 +64,13 @@ public interface ClusterClientFactory<ClusterID> {
 	 * @return the corresponding {@link ClusterSpecification} for a new Flink cluster
 	 */
 	ClusterSpecification getClusterSpecification(Configuration configuration);
+
+	/**
+	 * Returns the option to be used when trying to execute an application in Application Mode
+	 * using this cluster client factory, or an {@link Optional#empty()} if the environment of
+	 * this cluster client factory does not support Application Mode.
+	 */
+	default Optional<String> getApplicationTargetName() {
+		return Optional.empty();
+	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientServiceLoader.java
@@ -20,6 +20,8 @@ package org.apache.flink.client.deployment;
 
 import org.apache.flink.configuration.Configuration;
 
+import java.util.stream.Stream;
+
 /**
  * An interface used to discover the appropriate {@link ClusterClientFactory cluster client factory} based on the
  * provided {@link Configuration}.
@@ -33,4 +35,10 @@ public interface ClusterClientServiceLoader {
 	 * @return the appropriate {@link ClusterClientFactory}.
 	 */
 	<ClusterID> ClusterClientFactory<ClusterID> getClusterClientFactory(final Configuration configuration);
+
+	/**
+	 * Loads and returns a stream of the names of all available
+	 * execution target names for {@code Application Mode}.
+	 */
+	Stream<String> getApplicationModeTargetNames();
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientServiceLoader.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientServiceLoader.java
@@ -23,6 +23,8 @@ import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 
+import java.util.stream.Stream;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -40,5 +42,10 @@ public class DummyClusterClientServiceLoader<ClusterID> implements ClusterClient
 	public <C> ClusterClientFactory<C> getClusterClientFactory(final Configuration configuration) {
 		checkNotNull(configuration);
 		return new DummyClusterClientFactory<>(clusterClient);
+	}
+
+	@Override
+	public Stream<String> getApplicationModeTargetNames() {
+		return Stream.empty();
 	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -64,6 +66,11 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 	public String getClusterId(Configuration configuration) {
 		checkNotNull(configuration);
 		return configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+	}
+
+	@Override
+	public Optional<String> getApplicationTargetName() {
+		return Optional.of(KubernetesDeploymentTarget.APPLICATION.getName());
 	}
 
 	private String generateClusterId() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -67,6 +69,11 @@ public class YarnClusterClientFactory extends AbstractContainerizedClusterClient
 		checkNotNull(configuration);
 		final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
 		return clusterId != null ? ConverterUtils.toApplicationId(clusterId) : null;
+	}
+
+	@Override
+	public Optional<String> getApplicationTargetName() {
+		return Optional.of(YarnDeploymentTarget.APPLICATION.getName());
 	}
 
 	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {


### PR DESCRIPTION
## What is the purpose of the change

Adds a help message for the `run-application` CLI command.

## Brief change log

The main change is in the `CliFrontendParser.printHelpForRunApplication()`.

## Verifying this change

Build Flink and run from the CLI: `run-application -h`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
