### PR TITLE
[FLINK-19535][connector/common] Avoid failing job multiple times in SourceCoordinator

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -278,6 +279,36 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 			new EventWithSubtask(new TestOperatorEvent(2), 0),
 			new EventWithSubtask(new TestOperatorEvent(3), 0)
 		));
+	}
+
+	@Test
+	public void testFailingJobMultipleTimesNotCauseCascadingJobFailure() throws Exception {
+		Function<OperatorCoordinator.Context, OperatorCoordinator> coordinatorProvider =
+			context -> new TestingOperatorCoordinator(context) {
+				@Override
+				public void handleEventFromOperator(int subtask, OperatorEvent event) {
+					context.failJob(new RuntimeException("Artificial Exception"));
+				}
+			};
+		final TestEventSender sender = new TestEventSender();
+		final OperatorCoordinatorHolder holder = createCoordinatorHolder(sender, coordinatorProvider);
+
+		holder.handleEventFromOperator(0, new TestOperatorEvent());
+		assertNotNull(globalFailure);
+		final Throwable firstGlobalFailure = globalFailure;
+
+		holder.handleEventFromOperator(1, new TestOperatorEvent());
+		assertEquals("The global failure should be the same instance because the context"
+						 + "should only take the first request from the coordinator to fail the"
+						 + "job.",
+			firstGlobalFailure, globalFailure);
+
+		holder.resetToCheckpoint(new byte[0]);
+		holder.handleEventFromOperator(1, new TestOperatorEvent());
+		assertNotEquals("The new failures should be propagated after the coordinator "
+							+ "is reset.", firstGlobalFailure, globalFailure);
+		// Reset global failure to null to make the after method check happy.
+		globalFailure = null;
 	}
 
 	/**


### PR DESCRIPTION
…ourceCoordinator.

## What is the purpose of the change
Currently the when the `SourceCoordinator` fails the job by calling `OperatorCoordinatorContext.failJob()`, it enqueues a task to the scheduler thread. That means an `SourceCoordinator` instance may fail the job multiple times, which is unnecessary and sometimes can cause infinite cascading job failures.

This patch fixes the issue by only failing the job once in `OperatorCoordinatorHolder` unless the `OperatorCoordinatorHolder` is reset to checkpoint.

## Brief change log
- Add a failed flag in the OperatorCoordinator to avoid failing the job multiple times.


## Verifying this change
The following unit test was added to verify the change.
`OperatorCoordinatorHolderTest.testFailingJobMultipleTimesNotCauseCascadingJobFailure`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
