### PR TITLE
[FLINK-19795][table-blink] Fix Flink SQL throws exception when changelog source contains duplicate change events

### DIFF
--- a/docs/_includes/generated/execution_config_configuration.html
+++ b/docs/_includes/generated/execution_config_configuration.html
@@ -83,6 +83,12 @@ By default no operator is disabled.</td>
             <td>The maximal fan-in for external merge sort. It limits the number of file handles per operator. If it is too small, may cause intermediate merging. But if it is too large, it will cause too many files opened at the same time, consume memory and lead to random reading.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.source.cdc-events-duplicate</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Indicates whether the CDC (Change Data Capture) sources in the job will produce duplicate change events that requires the framework to deduplicate and get consistent result. CDC source refers to the source that produces full change events, including INSERT/UPDATE_BEFORE/UPDATE_AFTER/DELETE, for example Kafka source with Debezium format. The value of this configuration is false by default.<br /><br />However, it's a common case that there are duplicate change events. Because usually the CDC tools (e.g. Debezium) work in at-least-once delivery when failover happens. Thus, in the abnormal situations Debezium may deliver duplicate change events to Kafka and Flink will get the duplicate events. This may cause Flink query to get wrong results or unexpected exceptions.<br /><br />Therefore, it is recommended to turn on this configuration if your CDC tool is at-least-once delivery. Enabling this configuration requires to define PRIMARY KEY on the CDC sources. The primary key will be used to deduplicate change events and generate normalized changelog stream at the cost of an additional stateful operator.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.source.idle-timeout</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -15,12 +15,6 @@
             <td>If configured, Flink will add this key to the resource profile of container request to Yarn. The value will be set to the value of external-resource.&lt;resource_name&gt;.amount.</td>
         </tr>
         <tr>
-            <td><h5>yarn.security.kerberos.additionalFileSystems</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>List&lt;String&gt;</td>
-            <td>A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.</td>
-        </tr>
-        <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
@@ -127,6 +121,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
             <td>A semicolon-separated list of provided lib directories. They should be pre-uploaded and world-readable. Flink will use them to exclude the local Flink jars(e.g. flink-dist, lib/, plugins/)uploading to accelerate the job submission process. Also YARN will cache them on the nodes so that they doesn't need to be downloaded every time for each application. An example could be hdfs://$namenode_address/path/of/flink/lib</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.security.kerberos.additionalFileSystems</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.</td>
         </tr>
         <tr>
             <td><h5>yarn.security.kerberos.localized-keytab-path</h5></td>

--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -221,6 +221,17 @@ Format Options
     </tbody>
 </table>
 
+Caveats
+----------------
+
+### Duplicate change events
+
+Under normal operating scenarios, the Canal application delivers every change event **exactly-once**. Flink works pretty well when consuming Canal produced events in this situation.
+However, Canal application works in **at-least-once** delivery if any failover happens.
+That means, in the abnormal situations, Canal may deliver duplicate change events to message queues and Flink will get the duplicate events.
+This may cause Flink query to get wrong results or unexpected exceptions. Thus, it is recommended to set job configuration [`table.exec.source.cdc-events-duplicate`]({% link dev/table/config.md %}#table-exec-source-cdc-events-duplicate) to `true` and define PRIMARY KEY on the source in this situation.
+Framework will generate an additional stateful operator, and use the primary key to deduplicate the change events and produce a normalized changelog stream.
+
 Data Type Mapping
 ----------------
 

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -219,6 +219,17 @@ Format 参数
     </tbody>
 </table>
 
+注意事项
+----------------
+
+### 重复的变更事件
+
+在正常的操作环境下，Canal 应用能以 **exactly-once** 的语义投递每条变更事件。在这种情况下，Flink 消费 Canal 产生的变更事件能够工作得很好。
+然而，当有故障发生时，Canal 应用只能保证 **at-least-once** 的投递语义。
+这也意味着，在非正常情况下，Canal 可能会投递重复的变更事件到消息队列中，当 Flink 从消息队列中消费的时候就会得到重复的事件。
+这可能会导致 Flink query 的运行得到错误的结果或者非预期的异常。因此，建议在这种情况下，建议在这种情况下，将作业参数 [`table.exec.source.cdc-events-duplicate`]({% link dev/table/config.zh.md %}#table-exec-source-cdc-events-duplicate) 设置成 `true`，并在该 source 上定义 PRIMARY KEY。
+框架会生成一个额外的有状态算子，使用该 primary key 来对变更事件去重并生成一个规范化的 changelog 流。
+
 数据类型映射
 ----------------
 

--- a/docs/dev/table/connectors/formats/debezium.zh.md
+++ b/docs/dev/table/connectors/formats/debezium.zh.md
@@ -364,6 +364,14 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
 注意事项
 ----------------
 
+### 重复的变更事件
+
+在正常的操作环境下，Debezium 应用能以 **exactly-once** 的语义投递每条变更事件。在这种情况下，Flink 消费 Debezium 产生的变更事件能够工作得很好。
+然而，当有故障发生时，Debezium 应用只能保证 **at-least-once** 的投递语义。可以查看 [Debezium 官方文档](https://debezium.io/documentation/faq/#what_happens_when_an_application_stops_or_crashes) 了解更多关于 Debezium 的消息投递语义。
+这也意味着，在非正常情况下，Debezium 可能会投递重复的变更事件到 Kafka 中，当 Flink 从 Kafka 中消费的时候就会得到重复的事件。
+这可能会导致 Flink query 的运行得到错误的结果或者非预期的异常。因此，建议在这种情况下，将作业参数 [`table.exec.source.cdc-events-duplicate`]({% link dev/table/config.zh.md %}#table-exec-source-cdc-events-duplicate) 设置成 `true`，并在该 source 上定义 PRIMARY KEY。
+框架会生成一个额外的有状态算子，使用该 primary key 来对变更事件去重并生成一个规范化的 changelog 流。
+
 ### 消费 Debezium Postgres Connector 产生的数据
 
 如果你正在使用 [Debezium PostgreSQL Connector](https://debezium.io/documentation/reference/1.2/connectors/postgresql.html) 捕获变更到 Kafka，请确保被监控表的 [REPLICA IDENTITY](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY) 已经被配置成 `FULL` 了，默认值是 `DEFAULT`。

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -70,6 +70,33 @@ public class ExecutionConfigOptions {
 				"watermarks from this source while it is idle. " +
 				"Default value is 0, which means detecting source idleness is not enabled.");
 
+	@Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+	public static final ConfigOption<Boolean> TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE =
+		key("table.exec.source.cdc-events-duplicate")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription(Description.builder()
+				.text("Indicates whether the CDC (Change Data Capture) sources " +
+					"in the job will produce duplicate change events that requires the " +
+					"framework to deduplicate and get consistent result. CDC source refers to the " +
+					"source that produces full change events, including INSERT/UPDATE_BEFORE/" +
+					"UPDATE_AFTER/DELETE, for example Kafka source with Debezium format. " +
+					"The value of this configuration is false by default.")
+				.linebreak().linebreak()
+				.text("However, it's a common case that there are duplicate change events. " +
+					"Because usually the CDC tools (e.g. Debezium) work in at-least-once delivery " +
+					"when failover happens. Thus, in the abnormal situations Debezium may deliver " +
+					"duplicate change events to Kafka and Flink will get the duplicate events. " +
+					"This may cause Flink query to get wrong results or unexpected exceptions.")
+				.linebreak().linebreak()
+				.text("Therefore, it is recommended to turn on this configuration if your CDC tool " +
+					"is at-least-once delivery. Enabling this configuration requires to define " +
+					"PRIMARY KEY on the CDC sources. The primary key will be used to deduplicate " +
+					"change events and generate normalized changelog stream at the cost of " +
+					"an additional stateful operator.")
+				.build()
+			);
+
 	// ------------------------------------------------------------------------
 	//  Sink Options
 	// ------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
@@ -102,7 +102,8 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
 			schemaTable.getTableIdentifier(),
 			catalogTable,
 			tableSource,
-			schemaTable.isStreamingMode());
+			schemaTable.isStreamingMode(),
+			context.getTableConfig());
 
 		// 2. push table scan
 		pushTableScan(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -313,6 +313,14 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
   }
 
   def areColumnsUnique(
+      rel: StreamExecDropUpdateBefore,
+      mq: RelMetadataQuery,
+      columns: ImmutableBitSet,
+      ignoreNulls: Boolean): JBoolean = {
+    mq.areColumnsUnique(rel.getInput, columns, ignoreNulls)
+  }
+
+  def areColumnsUnique(
       rel: Aggregate,
       mq: RelMetadataQuery,
       columns: ImmutableBitSet,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -226,6 +226,12 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
   }
 
   def getRelModifiedMonotonicity(
+      rel: StreamExecDropUpdateBefore,
+      mq: RelMetadataQuery): RelModifiedMonotonicity = {
+    getMonotonicity(rel.getInput, mq, rel.getRowType.getFieldCount)
+  }
+
+  def getRelModifiedMonotonicity(
       rel: StreamExecWatermarkAssigner,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
     getMonotonicity(rel.getInput, mq, rel.getRowType.getFieldCount)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -321,6 +321,13 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
   }
 
   def getUniqueKeys(
+      rel: StreamExecDropUpdateBefore,
+      mq: RelMetadataQuery,
+      ignoreNulls: Boolean): JSet[ImmutableBitSet] = {
+    mq.getUniqueKeys(rel.getInput, ignoreNulls)
+  }
+
+  def getUniqueKeys(
       rel: Aggregate,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): JSet[ImmutableBitSet] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDropUpdateBefore.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDropUpdateBefore.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.streaming.api.operators.StreamFilter
+import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+import org.apache.flink.table.runtime.operators.misc.DropUpdateBeforeFunction
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+ * Stream physical RelNode which will drop the UPDATE_BEFORE messages.
+ * This is usually used as an optimization for the downstream operators that doesn't need
+ * the UPDATE_BEFORE messages, but the upstream operator can't drop it by itself (e.g. the source).
+ */
+class StreamExecDropUpdateBefore(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode)
+  extends SingleRel(cluster, traitSet, input)
+  with StreamPhysicalRel
+  with StreamExecNode[RowData] {
+
+  override def requireWatermark: Boolean = false
+
+  override def deriveRowType(): RelDataType = getInput.getRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecDropUpdateBefore(
+      cluster,
+      traitSet,
+      inputs.get(0))
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
+    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  }
+
+  override def replaceInputNode(
+    ordinalInParent: Int,
+    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+
+  override protected def translateToPlanInternal(
+      planner: StreamPlanner): Transformation[RowData] = {
+
+    // sanity check
+    if (ChangelogPlanUtils.generateUpdateBefore(this)) {
+      throw new IllegalStateException(s"${this.getClass.getSimpleName} is required to emit " +
+        s"UPDATE_BEFORE messages. This should never happen." )
+    }
+
+    val inputTransform = getInputNodes.get(0).translateToPlan(planner)
+      .asInstanceOf[Transformation[RowData]]
+    val rowTypeInfo = inputTransform.getOutputType.asInstanceOf[InternalTypeInfo[RowData]]
+    val operator = new StreamFilter[RowData](new DropUpdateBeforeFunction)
+
+    new OneInputTransformation(
+      inputTransform,
+      getRelDetailedDescription,
+      operator,
+      rowTypeInfo,
+      inputTransform.getParallelism)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/ChangelogModeInferenceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/ChangelogModeInferenceTest.xml
@@ -143,9 +143,10 @@ Calc(select=[amount, currency, rowtime, PROCTIME_MATERIALIZE(proctime) AS procti
    :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
    :     +- Calc(select=[amount, currency, rowtime, PROCTIME() AS proctime], changelogMode=[I])
    :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, Orders, source: [CollectionTableSource(amount, currency, rowtime)]]], fields=[amount, currency, rowtime], changelogMode=[I])
-   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UB,UA,D])
-      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I,UB,UA,D])
-         +- TableSourceScan(table=[[default_catalog, default_database, ratesChangelogStream]], fields=[currency, rate, rowtime], changelogMode=[I,UB,UA,D])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I,UA,D])
+         +- DropUpdateBefore(changelogMode=[I,UA,D])
+            +- TableSourceScan(table=[[default_catalog, default_database, ratesChangelogStream]], fields=[currency, rate, rowtime], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -80,6 +80,31 @@ GroupAggregate(groupBy=[a], select=[a, COUNT_RETRACT(*) AS EXPR$1, MAX_RETRACT(t
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testChangelogSourceWithEventsDuplicate">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c FROM src WHERE a > 1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$1], b=[$2], c=[$3])
++- LogicalFilter(condition=[>($1, 1)])
+   +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($4, 1000:INTERVAL SECOND)])
+      +- LogicalProject(id=[$0], a=[$1], b=[+($1, 1)], c=[$2], ts=[TO_TIMESTAMP($2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, c], where=[>(a, 1)], changelogMode=[I,UB,UA,D])
++- ChangelogNormalize(key=[id], changelogMode=[I,UB,UA,D])
+   +- Exchange(distribution=[hash[id]], changelogMode=[I,UA,D])
+      +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1000:INTERVAL SECOND)], changelogMode=[I,UA,D])
+         +- Calc(select=[id, a, +(a, 1) AS b, c, TO_TIMESTAMP(c) AS ts], changelogMode=[I,UA,D])
+            +- DropUpdateBefore(changelogMode=[I,UA,D])
+               +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[id, a, c], changelogMode=[I,UB,UA,D])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testDataStreamScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM DataStreamTable]]>
@@ -130,41 +155,6 @@ LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
 +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testEventTimeTemporalJoinOnUpsertSource">
-    <Resource name="sql">
-      <![CDATA[
-SELECT o.currency, o.amount, r.rate, o.amount * r.rate
-FROM orders AS o LEFT JOIN rates_history FOR SYSTEM_TIME AS OF o.rowtime AS r
-ON o.currency = r.currency
-]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(currency=[$1], amount=[$0], rate=[$4], EXPR$3=[*($0, $4)])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1, 2}])
-   :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
-   :  +- LogicalTableScan(table=[[default_catalog, default_database, orders]])
-   +- LogicalFilter(condition=[=($cor0.currency, $0)])
-      +- LogicalSnapshot(period=[$cor0.rowtime])
-         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
-            +- LogicalTableScan(table=[[default_catalog, default_database, rates_history]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[I])
-+- TemporalJoin(joinType=[LeftOuterJoin], where=[AND(=(currency, currency0), __TEMPORAL_JOIN_CONDITION(rowtime, rowtime0, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0), __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, rowtime, currency0, rate, rowtime0], changelogMode=[I])
-   :- Exchange(distribution=[hash[currency]], changelogMode=[I])
-   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
-   :     +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency, rowtime], changelogMode=[I])
-   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
-      +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
-         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
-            +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[UA,D])
-               +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>
@@ -241,6 +231,71 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
 WatermarkAssigner(rowtime=[d], watermark=[-(d, 1:INTERVAL SECOND)])
 +- Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
    +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinOnChangelogSourceWithEventsDuplicate">
+    <Resource name="sql">
+      <![CDATA[
+SELECT o.currency_name, o.amount, r.rate, o.amount * r.rate
+FROM orders AS o JOIN rates_history AS r
+ON o.currency_id = r.currency_id AND o.currency_name = r.currency_name
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(currency_name=[$2], amount=[$0], rate=[$5], EXPR$3=[*($0, $5)])
++- LogicalJoin(condition=[AND(=($1, $3), =($2, $4))], joinType=[inner])
+   :- LogicalTableScan(table=[[default_catalog, default_database, orders]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, rates_history]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[currency_name, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[I,UB,UA,D])
++- Join(joinType=[InnerJoin], where=[AND(=(currency_id, currency_id0), =(currency_name, currency_name0))], select=[amount, currency_id, currency_name, currency_id0, currency_name0, rate], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UB,UA,D])
+   :- Exchange(distribution=[hash[currency_id, currency_name]], changelogMode=[I])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency_id, currency_name], changelogMode=[I])
+   +- Exchange(distribution=[hash[currency_id, currency_name]], changelogMode=[I,UB,UA,D])
+      +- ChangelogNormalize(key=[currency_id], changelogMode=[I,UB,UA,D])
+         +- Exchange(distribution=[hash[currency_id]], changelogMode=[I,UA])
+            +- DropUpdateBefore(changelogMode=[I,UA])
+               +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency_id, currency_name, rate], changelogMode=[I,UB,UA])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testEventTimeTemporalJoinOnUpsertSource">
+    <Resource name="sql">
+      <![CDATA[
+SELECT o.currency, o.amount, r.rate, o.amount * r.rate
+FROM orders AS o LEFT JOIN rates_history FOR SYSTEM_TIME AS OF o.rowtime AS r
+ON o.currency = r.currency
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(currency=[$1], amount=[$0], rate=[$4], EXPR$3=[*($0, $4)])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{1, 2}])
+   :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, orders]])
+   +- LogicalFilter(condition=[=($cor0.currency, $0)])
+      +- LogicalSnapshot(period=[$cor0.rowtime])
+         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+            +- LogicalTableScan(table=[[default_catalog, default_database, rates_history]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[I])
++- TemporalJoin(joinType=[LeftOuterJoin], where=[AND(=(currency, currency0), __TEMPORAL_JOIN_CONDITION(rowtime, rowtime0, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0), __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, rowtime, currency0, rate, rowtime0], changelogMode=[I])
+   :- Exchange(distribution=[hash[currency]], changelogMode=[I])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency, rowtime], changelogMode=[I])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
+      +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
+         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+            +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[UA,D])
+               +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>
@@ -444,8 +499,9 @@ LogicalProject(b=[$2], a=[$1], ts=[$0])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Calc(select=[b, a, ts], changelogMode=[I,UB,UA,D])
-+- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
+Calc(select=[b, a, ts], changelogMode=[I,UA,D])
++- DropUpdateBefore(changelogMode=[I,UA,D])
+   +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
 ]]>
     </Resource>
   </TestCase>
@@ -530,11 +586,12 @@ LogicalProject(b=[$2], ts=[$0], a=[$1])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-Union(all=[true], union=[b, ts, a], changelogMode=[I,UB,UA,D])
-:- Calc(select=[b, ts, a], changelogMode=[I,UB,UA,D])
-:  +- TableSourceScan(table=[[default_catalog, default_database, changelog_src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
-+- Calc(select=[b, t AS ts, a], changelogMode=[I,UB,UA])
-   +- GroupAggregate(groupBy=[a], select=[a, MAX(ts) AS t, MAX(b) AS b], changelogMode=[I,UB,UA])
+Union(all=[true], union=[b, ts, a], changelogMode=[I,UA,D])
+:- Calc(select=[b, ts, a], changelogMode=[I,UA,D])
+:  +- DropUpdateBefore(changelogMode=[I,UA,D])
+:     +- TableSourceScan(table=[[default_catalog, default_database, changelog_src]], fields=[ts, a, b], changelogMode=[I,UB,UA,D])
++- Calc(select=[b, t AS ts, a], changelogMode=[I,UA])
+   +- GroupAggregate(groupBy=[a], select=[a, MAX(ts) AS t, MAX(b) AS b], changelogMode=[I,UA])
       +- Exchange(distribution=[hash[a]], changelogMode=[I])
          +- TableSourceScan(table=[[default_catalog, default_database, append_src]], fields=[ts, a, b], changelogMode=[I])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -285,6 +285,15 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testAreColumnsUniqueCountOnStreamExecDropUpdateBefore(): Unit = {
+    assertFalse(mq.areColumnsUnique(streamDropUpdateBefore, ImmutableBitSet.of()))
+    assertTrue(mq.areColumnsUnique(streamDropUpdateBefore, ImmutableBitSet.of(0)))
+    assertTrue(mq.areColumnsUnique(streamDropUpdateBefore, ImmutableBitSet.of(0, 1)))
+    assertTrue(mq.areColumnsUnique(streamDropUpdateBefore, ImmutableBitSet.of(0, 2)))
+    assertFalse(mq.areColumnsUnique(streamDropUpdateBefore, ImmutableBitSet.of(1, 2)))
+  }
+
+  @Test
   def testAreColumnsUniqueOnAggregate(): Unit = {
     Array(logicalAgg, flinkLogicalAgg).foreach { agg =>
       assertTrue(mq.areColumnsUnique(agg, ImmutableBitSet.of(0)))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -723,6 +723,14 @@ class FlinkRelMdHandlerTestBase {
       key)
   }
 
+  protected lazy val streamDropUpdateBefore = {
+    new StreamExecDropUpdateBefore(
+      cluster,
+      streamPhysicalTraits,
+      studentStreamScan
+    )
+  }
+
   // equivalent SQL is
   // select * from (
   //  select id, name, score, age, height, sex, class,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicityTest.scala
@@ -345,5 +345,12 @@ class FlinkRelMdModifiedMonotonicityTest extends FlinkRelMdHandlerTestBase {
       mq.getRelModifiedMonotonicity(streamChangelogNormalize))
   }
 
+  @Test
+  def testGetRelMonotonicityOnDropUpdateBefore(): Unit = {
+    assertEquals(
+      new RelModifiedMonotonicity(Array.fill(7)(CONSTANT)),
+      mq.getRelModifiedMonotonicity(streamDropUpdateBefore))
+  }
+
 }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -165,6 +165,11 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnStreamExecDropUpdateBefore(): Unit = {
+    assertEquals(uniqueKeys(Array(0)), mq.getUniqueKeys(streamDropUpdateBefore).toSet)
+  }
+
+  @Test
   def testGetUniqueKeysOnAggregate(): Unit = {
     Array(logicalAgg, flinkLogicalAgg, batchGlobalAggWithLocal, batchGlobalAggWithoutLocal,
       streamGlobalAggWithLocal, streamGlobalAggWithoutLocal).foreach { agg =>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/ChangelogModeInferenceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/ChangelogModeInferenceTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.table.api.{ExplainDetail, _}
 import org.apache.flink.table.api.config.OptimizerConfigOptions
+import org.apache.flink.table.planner.plan.optimize.program.FlinkChangelogModeInferenceProgram
 import org.apache.flink.table.planner.utils.{AggregatePhaseStrategy, TableTestBase}
 
 import org.junit.{Before, Test}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.stream.sql
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.expressions.utils.Func0
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.MockedLookupTableSource
 import org.apache.flink.table.planner.utils.TableTestBase
@@ -286,6 +287,13 @@ class TableScanTest extends TableTestBase {
   }
 
   @Test
+  def testJoinOnChangelogSourceWithEventsDuplicate(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE, true)
+    verifyJoinOnSource("I,UB,UA")
+  }
+
+  @Test
   def testJoinOnNoUpdateSource(): Unit = {
     verifyJoinOnSource("I,D")
   }
@@ -344,6 +352,29 @@ class TableScanTest extends TableTestBase {
         |)
       """.stripMargin)
     util.verifyPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
+  }
+
+  @Test
+  def testChangelogSourceWithEventsDuplicate(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE, true)
+    util.addTable(
+      """
+        |CREATE TABLE src (
+        |  id STRING,
+        |  a INT,
+        |  b AS a + 1,
+        |  c STRING,
+        |  ts as to_timestamp(c),
+        |  PRIMARY KEY (id) NOT ENFORCED,
+        |  WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+        |) WITH (
+        |  'connector' = 'values',
+        |  'changelog-mode' = 'I,UB,UA,D'
+        |)
+      """.stripMargin)
+    // the last node should keep UB because there is a filter on the changelog stream
+    util.verifyPlan("SELECT a, b, c FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
   }
 
   @Test
@@ -625,6 +656,29 @@ class TableScanTest extends TableTestBase {
     thrown.expectMessage("Table 'default_catalog.default_database.src' produces a " +
       "changelog stream contains UPDATE_AFTER, no UPDATE_BEFORE. " +
       "This requires to define primary key constraint on the table.")
+    util.verifyPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
+  }
+
+  @Test
+  def testMissingPrimaryKeyForEventsDuplicate(): Unit = {
+    util.addTable(
+      """
+        |CREATE TABLE src (
+        |  ts TIMESTAMP(3),
+        |  a INT,
+        |  b DOUBLE
+        |) WITH (
+        |  'connector' = 'values',
+        |  'changelog-mode' = 'I,UB,UA,D'
+        |)
+      """.stripMargin)
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      ExecutionConfigOptions.TABLE_EXEC_SOURCE_CDC_EVENTS_DUPLICATE, true)
+
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Configuration 'table.exec.source.cdc-events-duplicate' is enabled " +
+      "which requires the changelog sources to define a PRIMARY KEY. " +
+      "However, table 'default_catalog.default_database.src' doesn't have a primary key.")
     util.verifyPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -19,20 +19,19 @@
 package org.apache.flink.table.planner.runtime.stream.sql
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.factories.TestValuesTableFactory.getRawResults
-import org.apache.flink.table.planner.factories.TestValuesTableFactory.registerData
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase
-import org.junit._
-import org.junit.Assert.assertEquals
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import java.time.LocalDateTime
-import java.time.format.DateTimeParseException
-
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.factories.TestValuesTableFactory.{getResults, registerData}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.types.Row
+import org.junit.Assert.assertEquals
+import org.junit._
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeParseException
 
 import scala.collection.JavaConversions._
 
@@ -196,7 +195,8 @@ class TemporalJoinITCase(state: StateBackendMode)
          |  currency_no STRING,
          |  amount BIGINT,
          |  order_time TIMESTAMP(3),
-         |  WATERMARK FOR order_time AS order_time
+         |  WATERMARK FOR order_time AS order_time,
+         |  PRIMARY KEY (order_id) NOT ENFORCED
          |) WITH (
          |  'connector' = 'values',
          |  'changelog-mode' = 'I,UA,UB,D',
@@ -455,15 +455,12 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -475,15 +472,12 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency AND o.currency_no = r.currency_no"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -496,13 +490,10 @@ class TemporalJoinITCase(state: StateBackendMode)
       " JOIN v1 FOR SYSTEM_TIME AS OF o.order_time as r " +
       " ON o.currency = r.currency"
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -514,18 +505,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
     tEnv.executeSql(sql).await()
 
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,null,null)",
-      "+I(6,RMB,40,2020-08-16T00:04,null,null)",
-      "-D(6,RMB,40,2020-08-16T00:04,null,null)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,null,null")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -537,30 +523,19 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
     tEnv.executeSql(sql).await()
 
-    val rawResult = getRawResults("rowtime_default_sink")
     // Note: the event time semantics in delete event is when the delete event happened,
     // records "+I(2,US Dollar)" and "+I(3,RMB)" would not correlate the deleted events
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,null,null)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,null,null)",
-      "+I(3,RMB,40,2020-08-15T00:03,null,null)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,null,null)",
-      "+I(6,RMB,40,2020-08-16T00:04,null,null)",
-      "-D(6,RMB,40,2020-08-16T00:04,null,null)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,null,null",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,null,null")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
   def testEventTimeLeftTemporalJoinUpsertSource(): Unit = {
-    // Note: The WatermarkAssigner of upsertSource is followed after ChangelogNormalize,
-    // when the parallelism > 1 and test data doesn't cover all parallelisms, it returns
-    // Long.MaxValue as final watermark until all parallelism finished.
-    // This may leads the test failed because the test data doesn't cover every parallelism.
-    // TODO: Remove the single parallelism once FLINK-19878 has been fixed.
-    env.setParallelism(1)
     val sql = "INSERT INTO rowtime_default_sink " +
       " SELECT o.order_id, o.currency, o.amount, o.order_time, r.rate, r.currency_time " +
       " FROM orders_rowtime AS o LEFT JOIN upsert_currency " +
@@ -568,20 +543,15 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency "
     tEnv.executeSql(sql).await()
 
-    val rawResult = TestValuesTableFactory.getRawResults("rowtime_default_sink")
     // Note: the event time semantics in delete event is when the delete event happened,
     // record "+I(3,RMB)" would not correlate the deleted event
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,null,null)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,104,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,104,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,null,null)",
-      "+I(6,RMB,40,2020-08-16T00:04,null,null)",
-      "-D(6,RMB,40,2020-08-16T00:04,null,null)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,104,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,null,null",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,null,null")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -593,15 +563,12 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency_no = r.currency_no AND o.currency = r.currency"
     tEnv.executeSql(sql).await()
 
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -613,11 +580,10 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency and o.currency_no = r.currency_no " +
       " and o.order_id < 5 and r.rate > 114"
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -632,7 +598,7 @@ class TemporalJoinITCase(state: StateBackendMode)
          |  r_time TIMESTAMP(3),
          |  r1_rate BIGINT,
          |  r1_time TIMESTAMP(3),
-         |  PRIMARY KEY(currency) NOT ENFORCED
+         |  PRIMARY KEY(order_id) NOT ENFORCED
          |""".stripMargin
     ))
     val sql = "INSERT INTO rowtime_sink1 " +
@@ -645,18 +611,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r1.currency"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_sink1")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02,106,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,null,null,null,null)",
-      "+I(6,RMB,40,2020-08-16T00:04,null,null,null,null)",
-      "-D(6,RMB,40,2020-08-16T00:04,null,null,null,null)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,null,null,null,null")
+    assertEquals(expected.sorted, getResults("rowtime_sink1").sorted)
   }
 
   @Test
@@ -669,18 +630,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,114,2020-08-15T00:00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,102,2020-08-15T00:00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,102,2020-08-15T00:00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04)",
-      "+I(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)",
-      "-D(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,102,2020-08-15T00:00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,114,2020-08-15T00:00:01",
+      "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -693,18 +649,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04)",
-      "+I(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)",
-      "-D(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -717,18 +668,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency AND substr(o.currency, 1, 2) = 'US' "
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,null,null)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,null,null)",
-      "+I(4,Euro,14,2020-08-16T00:04,null,null)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "+I(5,RMB,40,2020-08-16T00:03,null,null)",
-      "+I(6,RMB,40,2020-08-16T00:04,null,null)",
-      "-D(6,RMB,40,2020-08-16T00:04,null,null)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,null,null",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,null,null",
+      "4,Euro,14,2020-08-16T00:04,null,null",
+      "5,RMB,40,2020-08-16T00:03,null,null")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   @Test
@@ -748,18 +694,13 @@ class TemporalJoinITCase(state: StateBackendMode)
       " ON o.currency = r.currency"
 
     tEnv.executeSql(sql).await()
-    val rawResult = getRawResults("rowtime_default_sink")
     val expected = List(
-      "+I(1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01)",
-      "+I(2,US Dollar,1,2020-08-15T00:02,102,2020-08-15T00:00:02)",
-      "+I(3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04)",
-      "+I(4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01)",
-      "+I(5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04)",
-      "+I(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)",
-      "+U(2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02)",
-      "-D(6,RMB,40,2020-08-16T00:04,702,2020-08-15T00:00:04)",
-      "-U(2,US Dollar,1,2020-08-16T00:03,106,2020-08-16T00:02)")
-    assertEquals(expected.sorted, rawResult.sorted)
+      "1,Euro,12,2020-08-15T00:01,114,2020-08-15T00:00:01",
+      "2,US Dollar,18,2020-08-16T00:03,106,2020-08-16T00:02",
+      "3,RMB,40,2020-08-15T00:03,702,2020-08-15T00:00:04",
+      "4,Euro,14,2020-08-16T00:04,118,2020-08-16T00:01",
+      "5,RMB,40,2020-08-16T00:03,702,2020-08-15T00:00:04")
+    assertEquals(expected.sorted, getResults("rowtime_default_sink").sorted)
   }
 
   private def createSinkTable(tableName: String, columns: Option[String]): Unit = {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/misc/DropUpdateBeforeFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/misc/DropUpdateBeforeFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.misc;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+/**
+ * A function drops only rows with {@link RowKind#UPDATE_BEFORE} changelog kind.
+ * This is usually used as an optimization for the downstream operators that doesn't need
+ * the {@link RowKind#UPDATE_BEFORE} messages, but the upstream operator can't drop it by itself.
+ */
+public class DropUpdateBeforeFunction implements FilterFunction<RowData> {
+	private static final long serialVersionUID = 1L;
+
+	@Override
+	public boolean filter(RowData value) {
+		return !RowKind.UPDATE_BEFORE.equals(value.getRowKind());
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Usually, CDC tools deliver change events to message queue in an **at-least-once** semantic. There might be duplicate INSERT/UPDATE/DELETE messages for the same primary key. However, when appling TopN query on this created source table, the TopN operator will thrown exception: `Caused by: java.lang.RuntimeException: Can not retract a non-existent record`.

We introduced a configuration `table.exec.source.cdc-events-duplicate=true|false` to indicate whether the cdc source produce duplicate messages that require the framework to deduplicate. By default, the value is false (for backward-compatibility). When it is set to true, it requires to set a primary key on the source, and the framework will this the primary key to deduplicate/normalize the changelog (using the ChangelogNormalize operator). 

This option only take effect on the cdc sources which will produce full changelog, including INSERT/UPDATE_BEFORE/UPDATE_AFTER/DELETE events. So it doesn't affect the upsert sources, because upsert sources always generate a ChangelogNormalize operator after it. 

This pull request also fixes FLINK-20205 to not send `UPDATE_BEFORE` messages if the downstream doesn't need it for CDC sources.

## Brief change log

- Add validation if the configuration is enabled but primary key is not defined.
- Generate ChangelogNormalize node after CDC source if `table.exec.source.cdc-events-duplicate=true`.
- Drop `UPDATE_BEFORE` messages for CDC source if downstream doesn't need it, because `ChangelogNormalize` also doesn't need the before messages.

## Verifying this change

- Added plan tests for the configuration is enabled.
- Added IT cases for the configuration is enabled.
- Added unit tests for metadata handler tests for the new `StreamExecDropUpdateBefore` node.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
