### PR TITLE
[FLINK-20283][python] Provide a meaningful exception message when managed memory fraction of Python worker process is invalid

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -252,7 +252,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 		if (memoryManager != null && config.isUsingManagedMemory()) {
 			Preconditions.checkArgument(managedMemoryFraction > 0 && managedMemoryFraction <= 1.0,
 				"The configured managed memory fraction for Python worker process must be within (0, 1], was: %s. " +
-				"Please refer to the config option \"taskmanager.memory.managed.consumer-weights\" for more details.",
+				"It maybe because the consumer type \"Python\" was missing or set to 0 for the config option \"taskmanager.memory.managed.consumer-weights\"." +
 				managedMemoryFraction);
 
 			final LongFunctionWithException<PythonSharedResources, Exception> initializer = (size) ->

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -252,7 +252,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 		if (memoryManager != null && config.isUsingManagedMemory()) {
 			Preconditions.checkArgument(managedMemoryFraction > 0 && managedMemoryFraction <= 1.0,
 				"The configured managed memory fraction for Python worker process must be within (0, 1], was: %s. " +
-				"It maybe because the consumer type \"Python\" was missing or set to 0 for the config option \"taskmanager.memory.managed.consumer-weights\"." +
+				"It may be because the consumer type \"Python\" was missing or set to 0 for the config option \"taskmanager.memory.managed.consumer-weights\"." +
 				managedMemoryFraction);
 
 			final LongFunctionWithException<PythonSharedResources, Exception> initializer = (size) ->

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -250,7 +250,10 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 		Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);
 
 		if (memoryManager != null && config.isUsingManagedMemory()) {
-			Preconditions.checkArgument(managedMemoryFraction > 0 && managedMemoryFraction <= 1.0);
+			Preconditions.checkArgument(managedMemoryFraction > 0 && managedMemoryFraction <= 1.0,
+				"The configured managed memory fraction for Python worker process must be within (0, 1], was: %s. " +
+				"Please refer to the config option \"taskmanager.memory.managed.consumer-weights\" for more details.",
+				managedMemoryFraction);
 
 			final LongFunctionWithException<PythonSharedResources, Exception> initializer = (size) ->
 				new PythonSharedResources(createJobBundleFactory(pipelineOptions), createPythonExecutionEnvironment(size));


### PR DESCRIPTION

## What is the purpose of the change

*This pull request improves the exception message when managed memory fraction of Python worker process is invalid*



## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
