### PR TITLE
[FLINK-20262] Building flink-dist docker image does not work without python2

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -66,7 +66,7 @@ function start_file_server() {
 
     command -v python3 >/dev/null 2>&1
     if [[ $? -eq 0 ]]; then
-      python ${TEST_INFRA_DIR}/python3_fileserver.py &
+      python3 ${TEST_INFRA_DIR}/python3_fileserver.py &
       return
     fi
 

--- a/flink-end-to-end-tests/test-scripts/python3_fileserver.py
+++ b/flink-end-to-end-tests/test-scripts/python3_fileserver.py
@@ -22,7 +22,7 @@ import socketserver
 handler = http.server.SimpleHTTPRequestHandler
 
 # azure says that ports are still in use if this is not set
-SocketServer.TCPServer.allow_reuse_address = True
+socketserver.TCPServer.allow_reuse_address = True
 httpd = socketserver.TCPServer(("", 9999), handler)
 
 try:


### PR DESCRIPTION
## What is the purpose of the change
Fix the script for building docker image with flink-dist on a system with only python3 installed.


## Brief change log

* call the correct method when there is no link for `python` in the system.
* fix the python3 object name in a fileserver script

## Verifying this change
Run e.g. `test_docker-embedded_job.sh` or any other that uses the `build_image` utility method on a system with `python3` but without `python`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
