### PR TITLE
[FLINK-20293] Remove the useless constructor of ContinuousFileMonitoringFunction

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -103,19 +103,10 @@ public class ContinuousFileMonitoringFunction<OUT>
 	private transient ListState<Long> checkpointedState;
 
 	public ContinuousFileMonitoringFunction(
-			FileInputFormat<OUT> format,
-			FileProcessingMode watchType,
-			int readerParallelism,
-			long interval) {
-		this(format, watchType, readerParallelism, interval, Long.MIN_VALUE);
-	}
-
-	public ContinuousFileMonitoringFunction(
 		FileInputFormat<OUT> format,
 		FileProcessingMode watchType,
 		int readerParallelism,
-		long interval,
-		long globalModificationTime) {
+		long interval) {
 
 		Preconditions.checkArgument(
 			watchType == FileProcessingMode.PROCESS_ONCE || interval >= MIN_MONITORING_INTERVAL,
@@ -133,7 +124,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 		this.interval = interval;
 		this.watchType = watchType;
 		this.readerParallelism = Math.max(readerParallelism, 1);
-		this.globalModificationTime = globalModificationTime;
+		this.globalModificationTime = Long.MIN_VALUE;
 	}
 
 	@VisibleForTesting


### PR DESCRIPTION

## What is the purpose of the change

*In 1.11, we introduce `ContinuousFileMonitoringFunction` with given `globalModificationTime` to support `HiveTableSource` continuously reading non-partitioned file. While this feature has a bug, see FLINK-20277.
In master, after FLINK-19888 finished, `HiveTableSource` does not depend on `ContinuousFileMonitoringFunction` any more, we can revert the changes of FLINK-17435 about the `ContinuousFileMonitoringFunction` part to avoid such bug.*


## Brief change log

  - *Remove the useless constructor of ContinuousFileMonitoringFunction*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
