### PR TITLE
[FLINK-20285][runtime] LazyFromSourcesSchedulingStrategy checks vertex's state right before scheduling it

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -42,7 +42,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
 	private final InputDependencyConstraint inputDependencyConstraint;
 
-	private final ExecutionState executionState;
+	private ExecutionState executionState;
 
 	public TestingSchedulingExecutionVertex(
 			JobVertexID jobVertexId,
@@ -66,6 +66,10 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 	@Override
 	public ExecutionState getState() {
 		return executionState;
+	}
+
+	public void setState(ExecutionState state) {
+		this.executionState = state;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

LazyFromSourcesSchedulingStrategy is possible to schedule vertices which are not in CREATED state. This will lead result in unexpected check failure and result in fatal error (see attached error).

The reason is that the status of a vertex to schedule was changed in LazyFromSourcesSchedulingStrategy#allocateSlotsAndDeployExecutionVertices() during the invocation of schedulerOperations.allocateSlotsAndDeploy(...) on other vertices.

This PR is to fix it by checking vertex's state right before scheduling it.

## Verifying this change

  - *Added UT*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
