### PR TITLE
[FLINK-20267][runtime] The JaasModule didn't support symbolic links.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
@@ -159,12 +159,20 @@ public class JaasModule implements SecurityModule {
 		checkArgument(workingDir != null, "working directory should not be null.");
 		final File jaasConfFile;
 		try {
-			Path path = Files.createDirectories(Paths.get(workingDir));
+			Path path = Paths.get(workingDir);
+			if (Files.notExists(path)) {
+				// We intentionally favored Path.toRealPath over Files.readSymbolicLinks as the latter one might return a
+				// relative path if the symbolic link refers to it. Path.toRealPath resolves the relative path instead.
+				Path parent = path.getParent().toRealPath();
+				Path resolvedPath = Paths.get(parent.toString(), path.getFileName().toString());
+
+				path = Files.createDirectories(resolvedPath);
+			}
 			Path jaasConfPath = Files.createTempFile(path, "jaas-", ".conf");
 			try (InputStream resourceStream = JaasModule.class.getClassLoader().getResourceAsStream(JAAS_CONF_RESOURCE_NAME)) {
 				Files.copy(resourceStream, jaasConfPath, StandardCopyOption.REPLACE_EXISTING);
 			}
-			jaasConfFile = jaasConfPath.toFile();
+			jaasConfFile = new File(workingDir, jaasConfPath.getFileName().toString());
 			jaasConfFile.deleteOnExit();
 		} catch (IOException e) {
 			throw new RuntimeException("unable to generate a JAAS configuration file", e);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
@@ -29,8 +29,12 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.apache.flink.runtime.security.modules.JaasModule.JAVA_SECURITY_AUTH_LOGIN_CONFIG;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -59,10 +63,33 @@ public class JaasModuleTest {
 		testJaasModuleFilePath(file.toPath().toString() + "/tmp");
 	}
 
+	@Test
+	public void testJaasModuleFilePathIfWorkingDirIsSymLink() throws IOException {
+		Path symlink = createSymLinkFolderStructure();
+		testJaasModuleFilePath(symlink.toString());
+	}
+
+	@Test
+	public void testJaasModuleFilePathIfWorkingDirNoPresentAndPathContainsSymLink() throws IOException {
+		Path symlink = createSymLinkFolderStructure();
+		testJaasModuleFilePath(symlink.toString() + "/tmp");
+	}
+
+	private Path createSymLinkFolderStructure() throws IOException {
+		File baseFolder = folder.newFolder();
+		File actualFolder = new File(baseFolder, "actual_folder");
+		assertTrue(actualFolder.mkdirs());
+
+		Path symlink = new File(baseFolder, "symlink").toPath();
+		Files.createSymbolicLink(symlink, actualFolder.toPath());
+
+		return symlink;
+	}
+
 	/**
 	 * Test that the jaas config file is created in the working directory.
 	 */
-	private void testJaasModuleFilePath(String workingDir) {
+	private void testJaasModuleFilePath(String workingDir) throws IOException {
 		Configuration configuration = new Configuration();
 		// set the string for CoreOptions.TMP_DIRS to mock the working directory.
 		configuration.setString(CoreOptions.TMP_DIRS, workingDir);
@@ -79,7 +106,7 @@ public class JaasModuleTest {
 	 * if we do not manually specify it.
 	 */
 	@Test
-	public void testCreateJaasModuleFileInTemporary() {
+	public void testCreateJaasModuleFileInTemporary() throws IOException {
 		Configuration configuration = new Configuration();
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
 		JaasModule module = new JaasModule(sc);
@@ -89,8 +116,12 @@ public class JaasModuleTest {
 		assertJaasFileLocateInRightDirectory(CoreOptions.TMP_DIRS.defaultValue());
 	}
 
-	private void assertJaasFileLocateInRightDirectory(String directory) {
-		assertTrue(System.getProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG).startsWith(directory));
+	private void assertJaasFileLocateInRightDirectory(String directory) throws IOException {
+		String resolvedExpectedPath = new File(directory).toPath().toRealPath().toString();
+		String resolvedActualPathWithFile = new File(System.getProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG)).toPath().toRealPath().toString();
+		assertThat("The resolved configured directory does not match the expected resolved one.", resolvedActualPathWithFile, startsWith(resolvedExpectedPath));
+
+		assertThat("The configured directory does not match the expected one.", System.getProperty(JAVA_SECURITY_AUTH_LOGIN_CONFIG), startsWith(directory));
 	}
 }
 


### PR DESCRIPTION


## What is the purpose of the change

Directory creation was introduced to JaasModule in [FLINK-19252](https://issues.apache.org/jira/browse/FLINK-19252) in case the folder does not exist, yet. Unfortunately, the used logic was not able to deal with symbolic links which caused exception in such cases.

The behavior could be reproduced through a JUnit test and was fixed in this PR. One goal of this change was to have the symbolic link resolution not being exposed outside `generateDefaultConfigFile(String)` to have the passed `workingDir` parameter match the directory path of the returned `File` instance.

## Brief change log

* Utilization of `Path.toRealPath()` logic to resolve symbolic links.
* The change makes sure that the symbolic link resolution happens within the method only. The returned `File` instance uses the path containing symbolic link again. 
* A unit test was added to cover this behavior.

## Verifying this change

This change added tests and can be verified as follows:

* A new test `JaasModuleTest.testJaasModuleFilePathIfWorkingDirIsSymLink` was added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable