### PR TITLE
[FLINK-20271][FLINK-20272][table] Fix ArrayIndexOutOfBounds and wrong result for TopN

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -160,13 +160,14 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			inputs.add(input);
 			dataState.put(sortKey, inputs);
 		} else {
+			final boolean stateRemoved;
 			// emit updates first
 			if (outputRankNumber || hasOffset()) {
 				// the without-number-algorithm can't handle topN with offset,
 				// so use the with-number-algorithm to handle offset
-				retractRecordWithRowNumber(sortedMap, sortKey, input, out);
+				stateRemoved = retractRecordWithRowNumber(sortedMap, sortKey, input, out);
 			} else {
-				retractRecordWithoutRowNumber(sortedMap, sortKey, input, out);
+				stateRemoved = retractRecordWithoutRowNumber(sortedMap, sortKey, input, out);
 			}
 
 			// and then update sortedMap
@@ -190,6 +191,19 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 				}
 			}
 
+			if (!stateRemoved) {
+				// the input record has not been removed from state
+				// should update the data state
+				List<RowData> inputs = dataState.get(sortKey);
+				if (inputs != null) {
+					inputs.remove(input);
+					if (inputs.isEmpty()) {
+						dataState.remove(sortKey);
+					} else {
+						dataState.put(sortKey, inputs);
+					}
+				}
+			}
 		}
 		treeMap.update(sortedMap);
 	}
@@ -298,7 +312,11 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 		}
 	}
 
-	private void retractRecordWithRowNumber(
+	/**
+	 * Retract the input record and emit updated records. This works for outputting with row_number.
+	 * @return true if the input record has been removed from {@link #dataState}.
+	 */
+	private boolean retractRecordWithRowNumber(
 			SortedMap<RowData, Long> sortedMap, RowData sortKey, RowData inputRow, Collector<RowData> out)
 			throws Exception {
 		Iterator<Map.Entry<RowData, Long>> iterator = sortedMap.entrySet().iterator();
@@ -358,9 +376,15 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			// there is no enough elements in Top-N, emit DELETE message for the retract record.
 			collectDelete(out, prevRow, currentRank);
 		}
+
+		return findsSortKey;
 	}
 
-	private void retractRecordWithoutRowNumber(
+	/**
+	 * Retract the input record and emit updated records. This works for outputting without row_number.
+	 * @return true if the input record has been removed from {@link #dataState}.
+	 */
+	private boolean retractRecordWithoutRowNumber(
 			SortedMap<RowData, Long> sortedMap, RowData sortKey, RowData inputRow, Collector<RowData> out)
 			throws Exception {
 		Iterator<Map.Entry<RowData, Long>> iterator = sortedMap.entrySet().iterator();
@@ -418,5 +442,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 				nextRank += entry.getValue();
 			}
 		}
+
+		return findsSortKey;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -196,7 +196,14 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 				// should update the data state
 				List<RowData> inputs = dataState.get(sortKey);
 				if (inputs != null) {
-					inputs.remove(input);
+					// comparing record by equaliser
+					Iterator<RowData> inputsIter = inputs.iterator();
+					while (inputsIter.hasNext()) {
+						if (equaliser.equals(inputsIter.next(), input)) {
+							inputsIter.remove();
+							break;
+						}
+					}
 					if (inputs.isEmpty()) {
 						dataState.remove(sortKey);
 					} else {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -399,4 +399,52 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
+
+	@Test
+	public void testConstantRankRangeWithoutRowNumber() throws Exception {
+		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false,
+			false);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(insertRecord("a", 1L, 1));
+		testHarness.processElement(insertRecord("a", 2L, 2));
+		testHarness.processElement(insertRecord("a", 3L, 2));
+		testHarness.processElement(insertRecord("a", 4L, 2));
+		testHarness.processElement(insertRecord("a", 5L, 3));
+		testHarness.processElement(insertRecord("a", 6L, 4));
+		testHarness.processElement(updateBeforeRecord("a", 2L, 2));
+		testHarness.close();
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(insertRecord("a", 1L, 1));
+		expectedOutput.add(insertRecord("a", 2L, 2));
+		expectedOutput.add(insertRecord("a", 3L, 2));
+		expectedOutput.add(deleteRecord("a", 2L, 2));
+		expectedOutput.add(insertRecord("a", 4L, 2));
+		assertorWithoutRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testConstantRankRangeWithRowNumber() throws Exception {
+		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false,
+			true);
+		OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(insertRecord("a", 1L, 1));
+		testHarness.processElement(insertRecord("a", 2L, 2));
+		testHarness.processElement(insertRecord("a", 3L, 2));
+		testHarness.processElement(insertRecord("a", 4L, 2));
+		testHarness.processElement(insertRecord("a", 5L, 3));
+		testHarness.processElement(insertRecord("a", 6L, 4));
+		testHarness.processElement(updateBeforeRecord("a", 2L, 2));
+		testHarness.close();
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(insertRecord("a", 1L, 1, 1L));
+		expectedOutput.add(insertRecord("a", 2L, 2, 2L));
+		expectedOutput.add(insertRecord("a", 3L, 2, 3L));
+		expectedOutput.add(updateAfterRecord("a", 3L, 2, 2L));
+		expectedOutput.add(updateAfterRecord("a", 4L, 2, 3L));
+		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fixes 2 bugs in `RetractableTopNFunction`:
- FLINK-20271: ArrayIndexOutOfBoundsException when retracting a record in the TopN
- FLINK-20272: Wrong result when removing records out of TopN

## Brief change log

- FLINK-20271: Fix the `curRank` cursor in `retractRecordWithoutRowNumber`.
- FLINK-20272: Remove record from state if the record is out of TopN range.


## Verifying this change

- Added unit tests which can reproduce the reported exceptions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

