### PR TITLE
[FLINK-20221] DelimitedInputFormat does not restore compressed splits

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -300,14 +300,14 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	// --------------------------------------------------------------------------------------------
 	//  Runtime methods
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
-	public void open(FileInputSplit split) throws IOException {
-		super.open(split);
+	public void initializeSplit(FileInputSplit split, Long offset) throws IOException {
+		super.initializeSplit(split, offset);
 
 		// instantiate the parsers
 		FieldParser<?>[] parsers = new FieldParser<?>[fieldTypes.length];
-		
+
 		for (int i = 0; i < fieldTypes.length; i++) {
 			if (fieldTypes[i] != null) {
 				Class<? extends FieldParser<?>> parserType = FieldParser.getParserForType(fieldTypes[i]);
@@ -330,9 +330,9 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 			}
 		}
 		this.fieldParsers = parsers;
-		
+
 		// skip the first line, if we are at the beginning of a file and have the option set
-		if (this.skipFirstLineAsHeader && this.splitStart == 0) {
+		if (this.skipFirstLineAsHeader && ((offset == null && split.getStart() == 0) || (offset != null && offset == 0))) {
 			readLine(); // read and ignore
 		}
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvInputFormat.java
@@ -50,8 +50,8 @@ public abstract class CsvInputFormat<OUT> extends GenericCsvInputFormat<OUT> {
 	}
 
 	@Override
-	public void open(FileInputSplit split) throws IOException {
-		super.open(split);
+	public void initializeSplit(FileInputSplit split, Long offset) throws IOException {
+		super.initializeSplit(split, offset);
 
 		@SuppressWarnings("unchecked")
 		FieldParser<Object>[] fieldParsers = (FieldParser<Object>[]) getFieldParsers();

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/PojoCsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/PojoCsvInputFormat.java
@@ -156,8 +156,8 @@ public class PojoCsvInputFormat<OUT> extends CsvInputFormat<OUT> {
 	}
 
 	@Override
-	public void open(FileInputSplit split) throws IOException {
-		super.open(split);
+	public void initializeSplit(FileInputSplit split, Long offset) throws IOException {
+		super.initializeSplit(split, offset);
 
 		pojoFields = new Field[pojoFieldNames.length];
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/PrimitiveInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/PrimitiveInputFormat.java
@@ -56,8 +56,8 @@ public class PrimitiveInputFormat<OT> extends DelimitedInputFormat<OT> {
 	}
 
 	@Override
-	public void open(FileInputSplit split) throws IOException {
-		super.open(split);
+	public void initializeSplit(FileInputSplit split, Long offset) throws IOException {
+		super.initializeSplit(split, offset);
 		Class<? extends FieldParser<OT>> parserType = FieldParser.getParserForType(primitiveClass);
 		if (parserType == null) {
 			throw new IllegalArgumentException("The type '" + primitiveClass.getName() + "' is not supported for the primitive input format.");

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/RowCsvInputFormatTest.java
@@ -290,8 +290,8 @@ public class RowCsvInputFormatTest {
 			BasicTypeInfo.STRING_TYPE_INFO};
 
 		RowCsvInputFormat format = new RowCsvInputFormat(PATH, fieldTypes, "\n", "|");
-		format.configure(new Configuration());
 		format.enableQuotedStringParsing('@');
+		format.configure(new Configuration());
 		format.open(split);
 
 		Row result = new Row(3);

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/TextInputFormatTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.io;
 
+import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileSystem;
@@ -31,9 +32,11 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -192,6 +195,67 @@ public class TextInputFormatTest extends TestLogger {
 			result = inputFormat.nextRecord("");
 			assertNotNull("Expecting first record here", result);
 			assertEquals(content, result);
+		}
+	}
+
+	@Test
+	public void testCompressedRead() throws IOException {
+		TextInputFormat.registerInflaterInputStreamFactory(
+			"compressed",
+			new InflaterInputStreamFactory<InputStream>() {
+				@Override
+				public InputStream create(InputStream in) {
+					return in;
+				}
+
+				@Override
+				public Collection<String> getCommonFileExtensions() {
+					return Collections.singletonList("compressed");
+				}
+			});
+
+		final String first = "First line";
+		final String second = "Second line";
+
+		// create input file
+		File tempFile = File.createTempFile("TextInputFormatTest", ".compressed", temporaryFolder.getRoot());
+		tempFile.setWritable(true);
+
+		try (PrintStream ps = new PrintStream(tempFile)) {
+			ps.println(first);
+			ps.println(second);
+		}
+
+		TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+		Configuration parameters = new Configuration();
+		inputFormat.configure(parameters);
+
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertThat("expected at least one input split", splits.length, greaterThanOrEqualTo(1));
+
+		inputFormat.open(splits[0]);
+		try {
+			assertFalse(inputFormat.reachedEnd());
+			String result = inputFormat.nextRecord("");
+			assertNotNull("Expecting first record here", result);
+			assertEquals(first, result);
+			assertFalse(inputFormat.reachedEnd());
+
+			Long currentOffset = inputFormat.getCurrentState();
+			inputFormat.close();
+
+			inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			inputFormat.configure(parameters);
+			inputFormat.reopen(splits[0], currentOffset);
+
+			assertFalse(inputFormat.reachedEnd());
+			result = inputFormat.nextRecord(result);
+			assertNotNull("Expecting second record here", result);
+			assertEquals(second, result);
+
+			assertTrue(inputFormat.reachedEnd() || null == inputFormat.nextRecord(result));
+		} finally {
+			inputFormat.close();
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/io/RichInputOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/RichInputOutputITCase.java
@@ -78,13 +78,13 @@ public class RichInputOutputITCase extends JavaProgramTestBase {
 		}
 
 		@Override
-		public void open(FileInputSplit split) throws IOException{
+		public void initializeSplit(FileInputSplit split, Long offset) throws IOException {
 			try {
 				getRuntimeContext().addAccumulator("DATA_SOURCE_ACCUMULATOR", counter);
 			} catch (UnsupportedOperationException e){
 				// the accumulator is already added
 			}
-			super.open(split);
+			super.initializeSplit(split, offset);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

Fix bug where DelimitedInputFormat does not restore full file input splits. This happens for example every time when we read compressed files.

The bug was caused by a faulty *if* condition but fixing it uncovered another problem with the open/reopen mechanism where the reopen function would call open all the time which would often lead to problems with backward seeking the input split stream.

This happens because the open method already fills the read buffer to discard partial rows at the beginning of splits which can cause the stream to be read beyond the checkpoint offset. After this the reopen would seek to the checkpoint offset (potentially backward) and fill the buffers and start reading again.

To avoid this I separated open and reopen in the DelimitedInputFormat properly and make sure that initialization logic placed in subclasses to the open method is moved to a common initializeSplit method.

## Brief change log

*(for example:)*
  - *Fix restore logic in DelimitedInputFormat#reopen for full file splits (length == -1)*  
  - *Separate open/reopen DelimitedInputFormat and refactor initialization logic to another method *
  - *Added new tests for coverage*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Extended CsvInputFormatTest to cover compressed files*
  - *Extended TextInputFormatTest to cover compressed files*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (it changes open/reopen methods but not the signature)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
