### PR TITLE
[FLINK-20186][table-common] Fix error message for conflicting factories

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -186,8 +186,8 @@ public final class FactoryUtil {
 	 *     // in createDynamicTableSource()
 	 *     helper = FactoryUtil.createTableFactoryHelper(this, context);
 	 *
-	 *     keyFormat = helper.discoverEncodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
-	 *     valueFormat = helper.discoverEncodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
+	 *     keyFormat = helper.discoverDecodingFormat(DeserializationFormatFactory.class, KEY_FORMAT);
+	 *     valueFormat = helper.discoverDecodingFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
 	 *
 	 *     helper.validate();
 	 *
@@ -377,7 +377,6 @@ public final class FactoryUtil {
 			Class<?> factoryClass,
 			DefaultDynamicTableContext context,
 			String connectorOption) {
-
 		final DynamicTableFactory factory;
 		try {
 			factory = discoverFactory(context.getClassLoader(), DynamicTableFactory.class, connectorOption);
@@ -395,16 +394,16 @@ public final class FactoryUtil {
 		if (sourceFactoryClass.equals(factoryClass) && sinkFactoryClass.isAssignableFrom(factory.getClass())) {
 			// discovering source, but not found, and this is a sink connector.
 			return new ValidationException(String.format(
-				"Connector '%s' only supports to be used as sink, can't be used as source.",
+				"Connector '%s' can only be used as a sink. It cannot be used as a source.",
 				connectorOption));
 		} else if (sinkFactoryClass.equals(factoryClass) && sourceFactoryClass.isAssignableFrom(factory.getClass())) {
-			// discovering sink, but not found, and this is a a source connector.
+			// discovering sink, but not found, and this is a source connector.
 			return new ValidationException(String.format(
-				"Connector '%s' only supports to be used as source, can't be used as sink.",
+				"Connector '%s' can only be used as a source. It cannot be used as a sink.",
 				connectorOption));
 		} else {
 			return new ValidationException(String.format(
-				"Connector '%s' should at least implements '%s' or '%s' interface.",
+				"Connector '%s' does neither implement the '%s' nor the '%s' interface.",
 				connectorOption,
 				sourceFactoryClass.getName(),
 				sinkFactoryClass.getName()));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -263,7 +263,8 @@ public final class FactoryUtil {
 					factoryIdentifier,
 					factoryClass.getName(),
 					foundFactories.stream()
-						.map(f -> factories.getClass().getName())
+						.filter(f -> f.factoryIdentifier().equals(factoryIdentifier))
+						.map(f -> f.getClass().getName())
 						.sorted()
 						.collect(Collectors.joining("\n"))));
 		}
@@ -383,7 +384,7 @@ public final class FactoryUtil {
 		} catch (ValidationException e) {
 			return new ValidationException(
 				String.format(
-					"Cannot discover a connector using option '%s'.",
+					"Cannot discover a connector using option: %s",
 					stringifyOption(CONNECTOR.key(), connectorOption)),
 				e);
 		}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -234,12 +234,12 @@ public class FactoryUtilTest {
 	}
 
 	@Test
-	public void testAvailableFactoryTipsDependencyJarForConnector() {
+	public void testConnectorErrorHint() {
 		try {
 			createTableSource(Collections.singletonMap("connector", "sink-only"));
 			fail();
 		} catch (Exception e) {
-			String errorMsg = "Connector 'sink-only' only supports to be used as sink, can't be used as source.";
+			String errorMsg = "Connector 'sink-only' can only be used as a sink. It cannot be used as a source.";
 			assertThat(e, containsCause(new ValidationException(errorMsg)));
 		}
 
@@ -247,7 +247,7 @@ public class FactoryUtilTest {
 			createTableSink(Collections.singletonMap("connector", "source-only"));
 			fail();
 		} catch (Exception e) {
-			String errorMsg = "Connector 'source-only' only supports to be used as source, can't be used as sink.";
+			String errorMsg = "Connector 'source-only' can only be used as a source. It cannot be used as a sink.";
 			assertThat(e, containsCause(new ValidationException(errorMsg)));
 		}
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -67,8 +67,19 @@ public class FactoryUtilTest {
 			"Could not find any factory for identifier 'FAIL' that implements '" +
 				DynamicTableFactory.class.getName() + "' in the classpath.\n\n" +
 			"Available factory identifiers are:\n\n" +
-			"sink-only\nsource-only\ntest\ntest-connector");
+			"conflicting\nsink-only\nsource-only\ntest\ntest-connector");
 		testError(options -> options.put("connector", "FAIL"));
+	}
+
+	@Test
+	public void testConflictingConnector() {
+		expectError(
+			"Multiple factories for identifier 'conflicting' that implement '"
+				+ DynamicTableFactory.class.getName() + "' found in the classpath.\n"
+				+ "\n" + "Ambiguous factory classes are:\n" + "\n"
+				+ TestConflictingDynamicTableFactory1.class.getName() + "\n"
+				+ TestConflictingDynamicTableFactory2.class.getName());
+		testError(options -> options.put("connector", TestConflictingDynamicTableFactory1.IDENTIFIER));
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingDynamicTableFactory1.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingDynamicTableFactory1.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * {@link DynamicTableFactory} that conflicts with {@link TestConflictingDynamicTableFactory2}.
+ */
+public class TestConflictingDynamicTableFactory1 implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+	public static final String IDENTIFIER = "conflicting";
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return Collections.emptySet();
+	}
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingDynamicTableFactory2.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestConflictingDynamicTableFactory2.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * {@link DynamicTableFactory} that conflicts with {@link TestConflictingDynamicTableFactory1}.
+ */
+public class TestConflictingDynamicTableFactory2 implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+	@Override
+	public DynamicTableSink createDynamicTableSink(Context context) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public DynamicTableSource createDynamicTableSource(Context context) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String factoryIdentifier() {
+		return TestConflictingDynamicTableFactory1.IDENTIFIER;
+	}
+
+	@Override
+	public Set<ConfigOption<?>> requiredOptions() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Set<ConfigOption<?>> optionalOptions() {
+		return Collections.emptySet();
+	}
+}

--- a/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-common/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -19,3 +19,5 @@ org.apache.flink.table.factories.TestDynamicTableSourceFactory
 org.apache.flink.table.factories.TestDynamicTableSinkFactory
 org.apache.flink.table.factories.TestDynamicTableSinkOnlyFactory
 org.apache.flink.table.factories.TestDynamicTableSourceOnlyFactory
+org.apache.flink.table.factories.TestConflictingDynamicTableFactory1
+org.apache.flink.table.factories.TestConflictingDynamicTableFactory2


### PR DESCRIPTION
## What is the purpose of the change

Improves error messages for connectors.

## Brief change log

- Fixes various typos and grammar mistakes in error messages.
- Fix error message for conflicting factories.

## Verifying this change

This change added tests and can be verified as follows: `FactoryUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
