### PR TITLE
 [FLINK-16443][checkpointing] Make sure that CheckpointException are also serialized in DeclineCheckpoint.

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -36,14 +36,12 @@ import org.junit.Test;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.LinkedList;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
@@ -161,8 +159,7 @@ public class CassandraSinkBaseTest {
 
 				Assert.fail();
 			} catch (Exception e) {
-				Optional<IOException> exCause = findSerializedThrowable(e, IOException.class, ClassLoader.getSystemClassLoader());
-				Assert.assertTrue(exCause.isPresent());
+				Assert.assertTrue(e.getCause() instanceof IOException);
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -45,7 +45,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
+import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
@@ -156,7 +156,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 		}
 		catch (Exception ex) {
 			// testHarness1 will be fenced off after creating and closing testHarness2
-			if (!findSerializedThrowable(ex, ProducerFencedException.class, ClassLoader.getSystemClassLoader()).isPresent()) {
+			if (!findThrowable(ex, ProducerFencedException.class).isPresent()) {
 				throw ex;
 			}
 		}
@@ -662,7 +662,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 	}
 
 	private boolean isCausedBy(FlinkKafkaErrorCode expectedErrorCode, Throwable ex) {
-		Optional<FlinkKafkaException> cause = findSerializedThrowable(ex, FlinkKafkaException.class, ClassLoader.getSystemClassLoader());
+		Optional<FlinkKafkaException> cause = findThrowable(ex, FlinkKafkaException.class);
 		if (cause.isPresent()) {
 			return cause.get().getErrorCode().equals(expectedErrorCode);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointException.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.SerializedThrowable;
 
 /**
  * Base class for checkpoint related exceptions.
@@ -41,20 +40,12 @@ public class CheckpointException extends Exception {
 	}
 
 	public CheckpointException(CheckpointFailureReason failureReason, Throwable cause) {
-		// Defensively replace the cause with a SerializedThrowable in case it's a user-defined exception
-		// that doesn't exist on the JobManager's default classpath.
-		super(
-			failureReason.message(),
-			cause == null ? null : new SerializedThrowable(cause));
+		super(failureReason.message(), cause);
 		this.checkpointFailureReason = Preconditions.checkNotNull(failureReason);
 	}
 
 	public CheckpointException(String message, CheckpointFailureReason failureReason, Throwable cause) {
-		// Defensively replace the cause with a SerializedThrowable in case it's a user-defined exception
-		// that doesn't exist on the JobManager's default classpath.
-		super(
-			message + " Failure reason: " + failureReason.message(),
-			cause == null ? null : new SerializedThrowable(cause));
+		super(message + " Failure reason: " + failureReason.message(), cause);
 		this.checkpointFailureReason = Preconditions.checkNotNull(failureReason);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -19,9 +19,10 @@
 package org.apache.flink.runtime.messages.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.SerializedThrowable;
+
+import javax.annotation.Nullable;
 
 /**
  * This message is sent from the {@link org.apache.flink.runtime.taskexecutor.TaskExecutor} to the
@@ -34,21 +35,18 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
 	private static final long serialVersionUID = 2094094662279578953L;
 
 	/** The reason why the checkpoint was declined. */
-	private final Throwable reason;
+	@Nullable
+	private final SerializedThrowable reason;
 
 	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId) {
 		this(job, taskExecutionId, checkpointId, null);
 	}
 
-	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, Throwable reason) {
+	public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, @Nullable Throwable reason) {
 		super(job, taskExecutionId, checkpointId);
 
-		if (reason == null || reason instanceof CheckpointException) {
-			this.reason = reason;
-		} else {
-			// some other exception. replace with a serialized throwable, to be on the safe side
-			this.reason = new SerializedThrowable(reason);
-		}
+		// some other exception. replace with a serialized throwable, to be on the safe side
+		this.reason = reason == null ? null : new SerializedThrowable(reason);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -58,7 +56,7 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
 	 *
 	 * @return The reason why the checkpoint was declined
 	 */
-	public Throwable getReason() {
+	public SerializedThrowable getReason() {
 		return reason;
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunctionTest.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.flink.util.ExceptionUtils.findSerializedThrowable;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -145,7 +144,7 @@ public class TwoPhaseCommitSinkFunctionTest {
 			harness.snapshot(2, 5);
 			fail("something should fail");
 		} catch (Exception ex) {
-			if (!findSerializedThrowable(ex, ContentDump.NotWritableException.class, ClassLoader.getSystemClassLoader()).isPresent()) {
+			if (!(ex.getCause() instanceof ContentDump.NotWritableException)) {
 				throw ex;
 			}
 			// ignore


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The problem of having exceptions that are only in the user code classloader was fixed by proactively serializing them inside the CheckpointException. That means all consumers of CheckpointException now need to be aware of that and unwrap the serializable exception.

I believe the right way to fix this would have been to use a SerializedException in the DeclineCheckpoint message instead, which would have localized the change to the actual problem: RPC transport.

## Brief change log

- Use a SerializedException in the DeclineCheckpoint message
- Revert https://github.com/apache/flink/pull/9742

## Verifying this change

It's a rather minor change, where proper testing would require a rather complicated setup.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
