### PR TITLE
[FLINK-19940][task] Improve naming of multi-input transformation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -86,6 +86,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -370,7 +371,7 @@ public class StreamingJobGraphGenerator {
 						chainEntryPoints);
 			}
 
-			chainedNames.put(currentNodeId, createChainedName(currentNodeId, chainableOutputs));
+			chainedNames.put(currentNodeId, createChainedName(currentNodeId, chainableOutputs, Optional.ofNullable(chainEntryPoints.get(currentNodeId))));
 			chainedMinResources.put(currentNodeId, createChainedMinResources(currentNodeId, chainableOutputs));
 			chainedPreferredResources.put(currentNodeId, createChainedPreferredResources(currentNodeId, chainableOutputs));
 
@@ -429,8 +430,10 @@ public class StreamingJobGraphGenerator {
 			.computeIfAbsent(startNodeId, k -> new InputOutputFormatContainer(Thread.currentThread().getContextClassLoader()));
 	}
 
-	private String createChainedName(Integer vertexID, List<StreamEdge> chainedOutputs) {
-		String operatorName = streamGraph.getStreamNode(vertexID).getOperatorName();
+	private String createChainedName(Integer vertexID, List<StreamEdge> chainedOutputs, Optional<OperatorChainInfo> operatorChainInfo) {
+		final String operatorName = nameWithChainedSourcesInfo(
+			streamGraph.getStreamNode(vertexID).getOperatorName(),
+			operatorChainInfo.map(chain -> chain.getChainedSources().values()).orElse(Collections.emptyList()));
 		if (chainedOutputs.size() > 1) {
 			List<String> outputChainedNames = new ArrayList<>();
 			for (StreamEdge chainable : chainedOutputs) {
@@ -1168,6 +1171,15 @@ public class StreamingJobGraphGenerator {
 			serializedHooks);
 
 		jobGraph.setSnapshotSettings(settings);
+	}
+
+	private static String nameWithChainedSourcesInfo(String operatorName, Collection<ChainedSourceInfo> chainedSourceInfos) {
+		return chainedSourceInfos.isEmpty() ? operatorName :
+			String.format("%s [%s]", operatorName, chainedSourceInfos
+				.stream()
+				.map(chainedSourceInfo -> chainedSourceInfo.getOperatorConfig().getOperatorName())
+				.collect(Collectors.joining(", "))
+			);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -29,7 +29,9 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.operators.util.UserCodeWrapper;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
@@ -64,6 +66,7 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.CoordinatedOperatorFactory;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
@@ -74,12 +77,14 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
+import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.util.TestAnyModeReadingStreamOperator;
 import org.apache.flink.util.Collector;
@@ -964,6 +969,49 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
 		// vertices in different regions should be in different slot sharing groups
 		assertDistinctSharingGroups(source1Vertex, source2Vertex, map2Vertex);
+	}
+
+	@Test
+	public void testNamingOfChainedMultipleInputs() {
+		String[] sources = new String[]{"source-1", "source-2", "source-3"};
+		JobGraph graph = createGraphWithMultipleInputs(true, sources);
+		JobVertex head = graph.getVerticesSortedTopologicallyFromSources().iterator().next();
+		Arrays.stream(sources).forEach(source -> assertTrue(head.getName().contains(source)));
+	}
+
+	@Test
+	public void testNamingOfNonChainedMultipleInputs() {
+		String[] sources = new String[]{"source-1", "source-2", "source-3"};
+		JobGraph graph = createGraphWithMultipleInputs(false, sources);
+		JobVertex head = Iterables.find(graph.getVertices(), vertex -> vertex.getInvokableClassName().equals(MultipleInputStreamTask.class.getName()));
+		assertFalse(head.getName(), head.getName().contains("source-1"));
+	}
+
+	public JobGraph createGraphWithMultipleInputs(boolean chain, String ...inputNames) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		MultipleInputTransformation<Long> transform = new MultipleInputTransformation<>("mit", new UnusedOperatorFactory(), Types.LONG, env.getParallelism());
+		Arrays.stream(inputNames)
+			.map(name -> env.fromSource(new NumberSequenceSource(1, 2), WatermarkStrategy.noWatermarks(), name).getTransformation())
+			.forEach(transform::addInput);
+		transform.setChainingStrategy(chain ? ChainingStrategy.HEAD_WITH_SOURCES : ChainingStrategy.NEVER);
+
+		env.addOperator(transform);
+
+		return StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+	}
+
+	private static final class UnusedOperatorFactory extends AbstractStreamOperatorFactory<Long> {
+
+		@Override
+		public <T extends StreamOperator<Long>> T createStreamOperator(StreamOperatorParameters<Long> parameters) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			throw new UnsupportedOperationException();
+		}
 	}
 
 	private static List<JobVertex> getExpectedVerticesList(List<JobVertex> vertices) {


### PR DESCRIPTION
## What is the purpose of the change

When chained with `MultipleInputTransformation`, source names don't appear in the UI (unless added by "client code", e.g. blink execution plan).
With this change,` [src1, srcN]` is appended to the `JobVertex` name if it has any chained sources. 

## Verifying this change

- Added `testNamingOfChainedMultipleInputs` / `testNamingOfNonChainedMultipleInputs` to `StreamingJobGraphGeneratorTest` (unit test)
- Checked manually in logs and web ui

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
