### PR TITLE
[FLINK-20270][connector/common] Add support for ExternallyInducedSour…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Optional;
+
+/**
+ * Sources that implement this interface do not trigger checkpoints when receiving a
+ * trigger message from the checkpoint coordinator, but when their input data/events
+ * indicate that a checkpoint should be triggered.
+ *
+ * <p>The ExternallyInducedSourceReader tells the Flink runtime that a checkpoint needs to
+ * be made by returning a checkpointId when shouldTriggerCheckpoint() is invoked.
+ *
+ * <p>The implementations typically works together with the SplitEnumerator which informs
+ * the external system to trigger a checkpoint.
+ *
+ * @param <T>        The type of records produced by the source.
+ * @param <SplitT>   The type of splits handled by the source.
+ */
+@PublicEvolving
+public interface ExternallyInducedSourceReader<T, SplitT extends SourceSplit>
+		extends SourceReader<T, SplitT> {
+
+	/**
+	 * A method that informs the Flink runtime whether a checkpoint should be triggered on
+	 * this Source.
+	 *
+	 * <p>This method is invoked when the previous {@link #pollNext(ReaderOutput)}
+	 * returns {@link org.apache.flink.core.io.InputStatus#NOTHING_AVAILABLE}, to check
+	 * if the source needs to be checkpointed.
+	 *
+	 * <p>If a CheckpointId is returned, a checkpoint will be triggered on this source reader.
+	 * Otherwise, Flink runtime will continue to process the records.
+	 *
+	 * @return An optional checkpoint ID that Flink runtime should take a checkpoint for.
+	 */
+	Optional<Long> shouldTriggerCheckpoint();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/ExternallyInducedSourceReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 
 import java.util.Optional;
@@ -31,11 +32,17 @@ import java.util.Optional;
  * be made by returning a checkpointId when shouldTriggerCheckpoint() is invoked.
  *
  * <p>The implementations typically works together with the SplitEnumerator which informs
- * the external system to trigger a checkpoint.
+ * the external system to trigger a checkpoint. The external system also needs to forward
+ * the Checkpoint ID to the source, so the source knows which checkpoint to trigger.
+ *
+ * <p><b>Important:</b> It is crucial that all parallel source tasks trigger
+ * their checkpoints at roughly the same time. Otherwise this leads to performance
+ * issues due to long checkpoint alignment phases or large alignment data snapshots.
  *
  * @param <T>        The type of records produced by the source.
  * @param <SplitT>   The type of splits handled by the source.
  */
+@Experimental
 @PublicEvolving
 public interface ExternallyInducedSourceReader<T, SplitT extends SourceSplit>
 		extends SourceReader<T, SplitT> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -139,9 +139,27 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 		this.emitProgressiveWatermarks = emitProgressiveWatermarks;
 	}
 
-	@Override
-	public void open() throws Exception {
+	/**
+	 * Initializes the reader. The code from this method should ideally happen in the
+	 * constructor or in the operator factory even. It has to happen here at a slightly
+	 * later stage, because of the lazy metric initialization.
+	 *
+	 * <p>Calling this method explicitly is an optional way to have the reader
+	 * initialization a bit earlier than in open(), as needed by the
+	 * {@link org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask}
+	 *
+	 * <p>This code should move to the constructor once the metric groups are available
+	 * at task setup time.
+	 */
+	public void initReader() throws Exception {
+		if (sourceReader != null) {
+			return;
+		}
+
 		final MetricGroup metricGroup = getMetricGroup();
+		assert metricGroup != null;
+
+		final int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
 
 		final SourceReaderContext context = new SourceReaderContext() {
 			@Override
@@ -161,7 +179,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 
 			@Override
 			public int getIndexOfSubtask() {
-				return getRuntimeContext().getIndexOfThisSubtask();
+				return subtaskIndex;
 			}
 
 			@Override
@@ -175,21 +193,26 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 			}
 		};
 
+		sourceReader = readerFactory.apply(context);
+	}
+
+	@Override
+	public void open() throws Exception {
+		initReader();
+
 		// in the future when we this one is migrated to the "eager initialization" operator
 		// (StreamOperatorV2), then we should evaluate this during operator construction.
 		if (emitProgressiveWatermarks) {
 			eventTimeLogic = TimestampsAndWatermarks.createProgressiveEventTimeLogic(
 					watermarkStrategy,
-					metricGroup,
+					getMetricGroup(),
 					getProcessingTimeService(),
 					getExecutionConfig().getAutoWatermarkInterval());
 		} else {
 			eventTimeLogic = TimestampsAndWatermarks.createNoOpEventTimeLogic(
 					watermarkStrategy,
-					metricGroup);
+					getMetricGroup());
 		}
-
-		sourceReader = readerFactory.apply(context);
 
 		// restore the state if necessary.
 		final List<SplitT> splits = CollectionUtil.iterableToList(readerState.get());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskExternallyInducedSourceInput.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.streaming.api.operators.SourceOperator;
+
+import java.util.function.Consumer;
+
+/**
+ * A subclass of {@link StreamTaskSourceInput} for {@link ExternallyInducedSourceReader}.
+ */
+public class StreamTaskExternallyInducedSourceInput<T> extends StreamTaskSourceInput<T> {
+	private final Consumer<Long> checkpointTriggeringHook;
+	private final ExternallyInducedSourceReader<T, ?> sourceReader;
+
+	@SuppressWarnings("unchecked")
+	public StreamTaskExternallyInducedSourceInput(
+			SourceOperator<T, ?> operator,
+			Consumer<Long> checkpointTriggeringHook,
+			int inputGateIndex,
+			int inputIndex) {
+		super(operator, inputGateIndex, inputIndex);
+		this.checkpointTriggeringHook = checkpointTriggeringHook;
+		this.sourceReader = (ExternallyInducedSourceReader<T, ?>) operator.getSourceReader();
+	}
+
+	@Override
+	public InputStatus emitNext(DataOutput<T> output) throws Exception {
+		InputStatus status = super.emitNext(output);
+		if (status == InputStatus.NOTHING_AVAILABLE) {
+			sourceReader.shouldTriggerCheckpoint().ifPresent(checkpointTriggeringHook);
+		}
+		return status;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -39,7 +39,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * unavailable or finished.
  */
 @Internal
-public final class StreamTaskSourceInput<T> implements StreamTaskInput<T>, CheckpointableInput {
+public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, CheckpointableInput {
 
 	private final SourceOperator<T, ?> operator;
 	private final int inputGateIndex;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -19,6 +19,10 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
@@ -26,6 +30,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.AbstractDataOutput;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
+import org.apache.flink.streaming.runtime.io.StreamTaskExternallyInducedSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -35,6 +40,9 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
 import javax.annotation.Nullable;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -42,7 +50,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T, ?>> {
+
 	private AsyncDataOutputToOutput<T> output;
+	private boolean isExternallyInducedSource;
 
 	public SourceOperatorStreamTask(Environment env) throws Exception {
 		super(env);
@@ -57,7 +67,20 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 		// input processors
 		sourceOperator.initReader();
 
-		final StreamTaskInput<T> input = new StreamTaskSourceInput<>(sourceOperator, 0, 0);
+		final SourceReader<T, ?> sourceReader = mainOperator.getSourceReader();
+		final StreamTaskInput<T> input;
+
+		if (sourceReader instanceof ExternallyInducedSourceReader) {
+			isExternallyInducedSource = true;
+
+			input = new StreamTaskExternallyInducedSourceInput<>(
+				sourceOperator,
+				this::triggerCheckpointForExternallyInducedSource,
+				0,
+				0);
+		} else {
+			input = new StreamTaskSourceInput<>(sourceOperator, 0, 0);
+		}
 
 		/**
 		 * {@link SourceOperatorStreamTask} doesn't have any inputs, so there is no need for
@@ -75,6 +98,21 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 	}
 
 	@Override
+	public Future<Boolean> triggerCheckpointAsync(
+			CheckpointMetaData checkpointMetaData,
+			CheckpointOptions checkpointOptions,
+			boolean advanceToEndOfEventTime) {
+		if (!isExternallyInducedSource) {
+			return super.triggerCheckpointAsync(
+				checkpointMetaData,
+				checkpointOptions,
+				advanceToEndOfEventTime);
+		} else {
+			return CompletableFuture.completedFuture(isRunning());
+		}
+	}
+
+	@Override
 	protected void advanceToEndOfEventTime() {
 		output.emitWatermark(Watermark.MAX_WATERMARK);
 	}
@@ -86,6 +124,23 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 		}
 		super.afterInvoke();
 	}
+
+	// --------------------------
+
+	private void triggerCheckpointForExternallyInducedSource(long checkpointId) {
+		final CheckpointOptions checkpointOptions = CheckpointOptions.forCheckpointWithDefaultLocation(
+			configuration.isExactlyOnceCheckpointMode(),
+			configuration.isUnalignedCheckpointsEnabled(),
+			configuration.getAlignmentTimeout());
+		final long timestamp = System.currentTimeMillis();
+
+		final CheckpointMetaData checkpointMetaData =
+			new CheckpointMetaData(checkpointId, timestamp);
+
+		super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions, false);
+	}
+
+	// ---------------------------
 
 	/**
 	 * Implementation of {@link DataOutput} that wraps a specific {@link Output}.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -49,8 +49,16 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 	}
 
 	@Override
-	public void init() {
-		StreamTaskInput<T> input = new StreamTaskSourceInput<>(mainOperator, 0, 0);
+	public void init() throws Exception {
+		final SourceOperator<T, ?> sourceOperator = this.mainOperator;
+		// reader initialization, which cannot happen in the constructor due to the
+		// lazy metric group initialization. We do this here now, rather than
+		// later (in open()) so that we can access the reader when setting up the
+		// input processors
+		sourceOperator.initReader();
+
+		final StreamTaskInput<T> input = new StreamTaskSourceInput<>(sourceOperator, 0, 0);
+
 		/**
 		 * {@link SourceOperatorStreamTask} doesn't have any inputs, so there is no need for
 		 * {@link WatermarkGauge} on the input.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -91,9 +91,7 @@ public class SourceOperatorTest {
 	@After
 	public void cleanUp() throws Exception {
 		operator.close();
-		if (((TestingSourceOperator<Integer>) operator).isReaderCreated()) {
-			assertTrue(mockSourceReader.isClosed());
-		}
+		assertTrue(mockSourceReader.isClosed());
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -43,8 +43,6 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 	private final int subtaskIndex;
 	private final int parallelism;
 
-	private volatile boolean readerCreated;
-
 	public TestingSourceOperator(
 			SourceReader<T, MockSourceSplit> reader,
 			WatermarkStrategy<T> watermarkStrategy,
@@ -85,13 +83,13 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 		this.subtaskIndex = subtaskIndex;
 		this.parallelism = parallelism;
 		this.metrics = UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
-		this.readerCreated = false;
-	}
 
-	@Override
-	public void open() throws Exception {
-		super.open();
-		readerCreated = true;
+		// unchecked wrapping is okay to keep tests simpler
+		try {
+			initReader();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override
@@ -105,9 +103,5 @@ public class TestingSourceOperator<T>  extends SourceOperator<T, MockSourceSplit
 		ExecutionConfig cfg = new ExecutionConfig();
 		cfg.setAutoWatermarkInterval(100);
 		return cfg;
-	}
-
-	public boolean isReaderCreated() {
-		return readerCreated;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -22,10 +22,15 @@ import org.apache.flink.api.common.eventtime.TimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -43,10 +48,13 @@ import org.apache.flink.util.SerializedValue;
 
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -56,6 +64,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for verifying that the {@link SourceOperator} as a task input can be integrated
@@ -125,6 +134,26 @@ public class SourceOperatorStreamTaskTest {
 		}
 	}
 
+	@Test
+	public void testExternallyInducedSource() throws Exception {
+		final int numEventsBeforeCheckpoint = 10;
+		final int totalNumEvents = 20;
+		TestingExternallyInducedSourceReader testingReader =
+			new TestingExternallyInducedSourceReader(numEventsBeforeCheckpoint, totalNumEvents);
+		try (StreamTaskMailboxTestHarness<Integer> testHarness =
+					createTestHarness(new TestingExternallyInducedSource(testingReader), 0, null)) {
+			TestingExternallyInducedSourceReader runtimeTestingReader =
+				(TestingExternallyInducedSourceReader) ((SourceOperator) testHarness.getStreamTask().mainOperator).getSourceReader();
+
+			testHarness.processAll();
+
+			assertEquals(totalNumEvents, runtimeTestingReader.numEmittedEvents);
+			assertTrue(runtimeTestingReader.checkpointed);
+			assertEquals(TestingExternallyInducedSourceReader.CHECKPOINT_ID, runtimeTestingReader.checkpointedId);
+			assertEquals(numEventsBeforeCheckpoint, runtimeTestingReader.checkpointedAt);
+		}
+	}
+
 	private TaskStateSnapshot executeAndWaitForCheckpoint(
 			long checkpointId,
 			TaskStateSnapshot initialSnapshot,
@@ -168,7 +197,7 @@ public class SourceOperatorStreamTaskTest {
 
 		// Wait until the checkpoint finishes.
 		// We have to mark the source reader as available here, otherwise the runMailboxStep() call after
-		// checkpiont is completed will block.
+		// checkpoint is completed will block.
 		getSourceReaderFromTask(testHarness).markAvailable();
 		processUntil(testHarness, checkpointFuture::isDone);
 		waitForAcknowledgeLatch.await();
@@ -187,10 +216,20 @@ public class SourceOperatorStreamTaskTest {
 	private StreamTaskMailboxTestHarness<Integer> createTestHarness(
 			long checkpointId,
 			TaskStateSnapshot snapshot) throws Exception {
+		return createTestHarness(
+			new MockSource(Boundedness.BOUNDED, 1),
+			checkpointId,
+			snapshot
+		);
+	}
+
+	private StreamTaskMailboxTestHarness<Integer> createTestHarness(
+			MockSource source,
+			long checkpointId,
+			TaskStateSnapshot snapshot) throws Exception {
 		// get a source operator.
-		SourceOperatorFactory<Integer> sourceOperatorFactory = new SourceOperatorFactory<>(
-				new MockSource(Boundedness.BOUNDED, 1),
-				WatermarkStrategy.noWatermarks());
+		SourceOperatorFactory<Integer> sourceOperatorFactory =
+			new SourceOperatorFactory<>(source, WatermarkStrategy.noWatermarks());
 
 		// build a test harness.
 		StreamTaskMailboxTestHarnessBuilder<Integer> builder =
@@ -235,5 +274,88 @@ public class SourceOperatorStreamTaskTest {
 
 	private MockSourceReader getSourceReaderFromTask(StreamTaskMailboxTestHarness<Integer> testHarness) {
 		return (MockSourceReader) ((SourceOperator) testHarness.getStreamTask().mainOperator).getSourceReader();
+	}
+
+	// ------------- private testing classes ----------
+
+	private static class TestingExternallyInducedSource extends MockSource {
+		private static final long serialVersionUID = 3078454109555893721L;
+		private final TestingExternallyInducedSourceReader reader;
+
+		private TestingExternallyInducedSource(TestingExternallyInducedSourceReader reader) {
+			super(Boundedness.CONTINUOUS_UNBOUNDED, 1);
+			this.reader = reader;
+		}
+
+		@Override
+		public SourceReader<Integer, MockSourceSplit> createReader(SourceReaderContext readerContext) {
+			return reader;
+		}
+	}
+
+	private static class TestingExternallyInducedSourceReader
+			implements ExternallyInducedSourceReader<Integer, MockSourceSplit>, Serializable {
+		private static final long CHECKPOINT_ID = 1234L;
+		private final int numEventsBeforeCheckpoint;
+		private final int totalNumEvents;
+		private int numEmittedEvents;
+
+		private boolean checkpointed;
+		private int checkpointedAt;
+		private long checkpointedId;
+
+		TestingExternallyInducedSourceReader(int numEventsBeforeCheckpoint, int totalNumEvents) {
+			this.numEventsBeforeCheckpoint = numEventsBeforeCheckpoint;
+			this.totalNumEvents = totalNumEvents;
+			this.numEmittedEvents = 0;
+			this.checkpointed = false;
+			this.checkpointedAt = -1;
+		}
+
+		@Override
+		public Optional<Long> shouldTriggerCheckpoint() {
+			if (numEmittedEvents == numEventsBeforeCheckpoint && !checkpointed) {
+				return Optional.of(CHECKPOINT_ID);
+			} else {
+				return Optional.empty();
+			}
+		}
+
+		@Override
+		public void start() {}
+
+		@Override
+		public InputStatus pollNext(ReaderOutput<Integer> output) throws Exception {
+			numEmittedEvents++;
+			if (numEmittedEvents == numEventsBeforeCheckpoint) {
+				return InputStatus.NOTHING_AVAILABLE;
+			} else if (numEmittedEvents < totalNumEvents) {
+				return InputStatus.MORE_AVAILABLE;
+			} else {
+				return InputStatus.END_OF_INPUT;
+			}
+		}
+
+		@Override
+		public List<MockSourceSplit> snapshotState(long checkpointId) {
+			checkpointed = true;
+			checkpointedAt = numEmittedEvents;
+			checkpointedId = checkpointId;
+			return Collections.emptyList();
+		}
+
+		@Override
+		public CompletableFuture<Void> isAvailable() {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public void addSplits(List<MockSourceSplit> splits) {}
+
+		@Override
+		public void notifyNoMoreSplits() {}
+
+		@Override
+		public void close() throws Exception {}
 	}
 }


### PR DESCRIPTION
…ce based on FLIP-27 to SourceOperatorStreamTask.

## What is the purpose of the change
The current design of FLIP-27 has a regression of not supporting `ExternallyInducedSource` compared with the old `SourceFunction`. This patch fixes that by introducing an `ExternallyInducedSourceReader` interface.

This patch did not add support of `ExternallyInducedSourceReader` for `MultipleInputStreamTask` because it is currently only used by batch jobs and the solution is more intrusive. The implementation that also support `MultipleInputStreamTask` can be found [here](https://github.com/becketqin/flink/tree/FLINK-20270). We will have a separate patch to cover that.

## Brief change log
- Add support for ExternallyInducedSource based on FLIP-27 to SourceOperatorStreamTask.

## Verifying this change
A unit test of `SourceOperatorStreamTask.testExternallyInducedSource()` has been added to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
