### PR TITLE
[FLINK-20184][doc] update hive streaming read and temporal table document

### DIFF
--- a/docs/dev/table/connectors/hive/hive_read_write.md
+++ b/docs/dev/table/connectors/hive/hive_read_write.md
@@ -63,22 +63,32 @@ of new files in the folder and read new files incrementally.
         <td>Enable streaming source or not. NOTES: Please make sure that each partition/file should be written atomically, otherwise the reader may get incomplete data.</td>
     </tr>
     <tr>
+        <td><h5>streaming-source.partition.include</h5></td>
+        <td style="word-wrap: break-word;">all</td>
+        <td>String</td>
+        <td>Option to set the partitions to read, the supported option are `all` and `latest`, the `all` means read all partitions; the `latest` means read latest partition in order of 'streaming-source.partition.order', the `latest` only works` when the streaming hive source table used as temporal table. By default the option is `all`.
+            Flink supports temporal join the latest hive partition by enabling 'streaming-source.enable' and setting 'streaming-source.partition.include' to 'latest', at the same time, user can assign the partition compare order and data update interval by configuring following partition-related options.  
+        </td>
+    </tr>     
+    <tr>
         <td><h5>streaming-source.monitor-interval</h5></td>
-        <td style="word-wrap: break-word;">1 m</td>
+        <td style="word-wrap: break-word;">None</td>
         <td>Duration</td>
-        <td>Time interval for consecutively monitoring partition/file.</td>
+        <td>Time interval for consecutively monitoring partition/file.
+            Notes: The default interval for hive streaming reading is '1 m', the default interval for hive streaming temporal join is '60 m', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
     </tr>
     <tr>
-        <td><h5>streaming-source.consume-order</h5></td>
-        <td style="word-wrap: break-word;">create-time</td>
+        <td><h5>streaming-source.partition-order</h5></td>
+        <td style="word-wrap: break-word;">partition-name</td>
         <td>String</td>
-        <td>The consume order of streaming source, support create-time and partition-time. create-time compare partition/file creation time, this is not the partition create time in Hive metaStore, but the folder/file modification time in filesystem; partition-time compare time represented by partition name, if the partition folder somehow gets updated, e.g. add new file into folder, it can affect how the data is consumed. For non-partition table, this value should always be 'create-time'.</td>
+        <td>The partition order of streaming source, support create-time, partition-time and partition-name. create-time compares partition/file creation time, this is not the partition create time in Hive metaStore, but the folder/file modification time in filesystem, if the partition folder somehow gets updated, e.g. add new file into folder, it can affect how the data is consumed. partition-time compares the time extracted from partition name. partition-name compares partition name's alphabetical order. For non-partition table, this value should always be 'create-time'. By default the value is partition-name. The option is equality with deprecated option 'streaming-source.consume-order'.</td>
     </tr>
     <tr>
         <td><h5>streaming-source.consume-start-offset</h5></td>
-        <td style="word-wrap: break-word;">1970-00-00</td>
+        <td style="word-wrap: break-word;">None</td>
         <td>String</td>
-        <td>Start offset for streaming consuming. How to parse and compare offsets depends on your order. For create-time and partition-time, should be a timestamp string (yyyy-[m]m-[d]d [hh:mm:ss]). For partition-time, will use partition time extractor to extract time from partition.</td>
+        <td>Start offset for streaming consuming. How to parse and compare offsets depends on your order. For create-time and partition-time, should be a timestamp string (yyyy-[m]m-[d]d [hh:mm:ss]). For partition-time, will use partition time extractor to extract time from partition.
+         For partition-name, is the partition name string (e.g. pt_year=2020/pt_mon=10/pt_day=01).</td>
     </tr>
   </tbody>
 </table>
@@ -110,46 +120,6 @@ This can be done by either `tableEnv.useCatalog(...)` in Table API or `USE CATAL
 
 2) Hive and Flink SQL have different syntax, e.g. different reserved keywords and literals.
 Make sure the view’s query is compatible with Flink grammar.
-
-### Temporal Table Join
-
-You can use a Hive table as a temporal table and join streaming data with it. Please follow
-the [example]({% link dev/table/streaming/temporal_tables.md %}#temporal-table) to find
-out how to join a temporal table.
-
-When performing the join, the Hive table will be cached in Slot memory and each record from
-the stream is joined against the table by key to decide whether a match is found. Using a Hive
-table as a temporal table does not require any additional configuration. Optionally, you can
-configure the TTL of the Hive table cache with the following property. After the cache expires,
-the Hive table will be scanned again to load the latest data.
-
-<table class="table table-bordered">
-  <thead>
-    <tr>
-        <th class="text-left" style="width: 20%">Key</th>
-        <th class="text-left" style="width: 15%">Default</th>
-        <th class="text-left" style="width: 10%">Type</th>
-        <th class="text-left" style="width: 55%">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><h5>lookup.join.cache.ttl</h5></td>
-        <td style="word-wrap: break-word;">60 min</td>
-        <td>Duration</td>
-        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes.</td>
-    </tr>
-  </tbody>
-</table>
-
-**Notes**:
-
--  Each joining subtask needs to keep its own cache of the Hive table. Please ensure the Hive table can fit into
-the memory of a TM task slot.
-- It is encouraged to set a relatively large value for `lookup.join.cache.ttl`. Otherwise, Jobs
-are prone to performance issues as the table needs to be updated and reloaded too frequently. 
-- Currently, Flink simply loads the whole Hive table whenever the cache needs to be refreshed.
-There is no way to differentiate new data from old.
 
 ### Vectorized Optimization upon Read
 
@@ -197,6 +167,155 @@ following parameters in `TableConfig` (note that these parameters affect all sou
     </tr>
   </tbody>
 </table>
+
+## Temporal Table Join
+
+You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 
+Please see [temporal join]({% link dev/table/streaming/joins.md %}#temporal-joins) for more information about the temporal join.
+
+Flink supports processing-time temporal join Hive Table, the processing-time temporal join always joins the latest version of temporal table.
+Flink supports temporal join both partitioned table and Hive non-partitioned table, for partitioned table, Flink supports tracking the latest partition of Hive table automatically.
+
+**NOTE**: Flink does not support event-time temporal join Hive table yet.
+
+### Temporal Join The Latest Partition
+
+For a partitioned table which is changing over time, we can read it out as an unbounded stream, the partition can be acted as a version of the temporal table if every partition contains complete data of a version,
+the version of temporal table keeps the data of the partition.
+ 
+Flink support tracking the latest partition(version) of temporal table automatically in processing time temporal join, the latest partition(version) is defined by 'streaming-source.partition-order' option,
+This is the most common user cases that use Hive table as dimension table in a Flink stream application job.
+
+**NOTE:** This feature is only support in Flink `STREAMING` Mode.
+
+The following demo shows a classical business pipeline, the dimension table comes from Hive and it's updated once every day by a batch pipeline job or a Flink job, the kafka stream comes from real time online business data or log and need to join with the dimension table to enrich stream. 
+
+{% highlight sql %}
+-- Assume the data in hive table is updated per day, every day contains the latest and complete dimension data
+SET table.sql-dialect=hive;
+CREATE TABLE dimension_table (
+  product_id STRING,
+  product_name STRING,
+  unit_price DECIMAL(10, 4),
+  pv_count BIGINT,
+  like_count BIGINT,
+  comment_count BIGINT,
+  update_time TIMESTAMP(3),
+  update_user STRING,
+  ...
+) PARTITIONED BY (pt_year STRING, pt_month STRING, pt_day STRING) TBLPROPERTIES (
+  -- using default partition-name order to load the latest partition every 12h (the most recommended and convenient way)
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.monitor-interval' = '12 h',
+  'streaming-source.partition-order' = 'partition-name',  -- option with default value, can be ignored.
+
+  -- using partition file create-time order to load the latest partition every 12h
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.partition-order' = 'create-time',
+  'streaming-source.monitor-interval' = '12 h'
+
+  -- using partition-time order to load the latest partition every 12h
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.monitor-interval' = '12 h',
+  'streaming-source.partition-order' = 'partition-time',
+  'partition.time-extractor.kind' = 'default',
+  'partition.time-extractor.timestamp-pattern' = '$pt_year-$pt_month-$pt_day 00:00:00' 
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE orders_table (
+  order_id STRING,
+  order_amount DOUBLE,
+  product_id STRING,
+  log_ts TIMESTAMP(3),
+  proctime as PROCTIME()
+) WITH (...);
+
+
+-- streaming sql, kafka temporal join a hive dimension table. Flink will automatically reload data from the
+-- configured latest partition in the interval of 'streaming-source.monitor-interval'.
+
+SELECT * FROM orders_table AS order 
+JOIN dimension_table FOR SYSTEM_TIME AS OF o.proctime AS dim
+ON order.product_id = dim.product_id;
+
+{% endhighlight %}
+
+### Temporal Join The Latest Table
+ 
+For a Hive table, we can read it out as a bounded stream. In this case, the Hive table can only track its latest version at the time when we query.
+The latest version of table keep all data of the Hive table. 
+
+When performing the temporal join the latest Hive table, the Hive table will be cached in Slot memory and each record from the stream is joined against the table by key to decide whether a match is found. 
+Using the latest Hive table as a temporal table does not require any additional configuration. Optionally, you can configure the TTL of the Hive table cache with the following property. After the cache expires, the Hive table will be scanned again to load the latest data.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+        <th class="text-left" style="width: 20%">Key</th>
+        <th class="text-left" style="width: 15%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 55%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><h5>lookup.join.cache.ttl</h5></td>
+        <td style="word-wrap: break-word;">60 min</td>
+        <td>Duration</td>
+        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
+       </td>
+    </tr>
+  </tbody>
+</table>
+
+The following demo shows load all data of hive table as a temporal table.
+
+{% highlight sql %}
+-- Assume the data in hive table is overwrite by batch pipeline.
+SET table.sql-dialect=hive;
+CREATE TABLE dimension_table (
+  product_id STRING,
+  product_name STRING,
+  unit_price DECIMAL(10, 4),
+  pv_count BIGINT,
+  like_count BIGINT,
+  comment_count BIGINT,
+  update_time TIMESTAMP(3),
+  update_user STRING,
+  ...
+) TBLPROPERTIES (
+  'streaming-source.enable' = 'false',           -- option with default value, can be ignored.
+  'streaming-source.partition.include' = 'all',  -- option with default value, can be ignored.
+  'lookup.join.cache.ttl' = '12 h'
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE orders_table (
+  order_id STRING,
+  order_amount DOUBLE,
+  product_id STRING,
+  log_ts TIMESTAMP(3),
+  proctime as PROCTIME()
+) WITH (...);
+
+
+-- streaming sql, kafka join a hive dimension table. Flink will reload all data from dimension_table after cache ttl is expired.
+
+SELECT * FROM orders_table AS order 
+JOIN dimension_table FOR SYSTEM_TIME AS OF o.proctime AS dim
+ON order.product_id = dim.product_id;
+
+{% endhighlight %}
+
+**Note**:
+1. Each joining subtask needs to keep its own cache of the Hive table. Please make sure the Hive table can fit into the memory of a TM task slot.
+2. It is encouraged to set a relatively large value both for `streaming-source.monitor-interval`(latest partition as temporal table) or `lookup.join.cache.ttl`(all partitions as temporal table). Otherwise, Jobs are prone to performance issues as the table needs to be updated and reloaded too frequently.
+3. Currently we simply load the whole Hive table whenever the cache needs refreshing. There's no way to differentiate
+new data from the old.
 
 ## Writing
 

--- a/docs/dev/table/connectors/hive/hive_read_write.zh.md
+++ b/docs/dev/table/connectors/hive/hive_read_write.zh.md
@@ -63,22 +63,32 @@ of new files in the folder and read new files incrementally.
         <td>Enable streaming source or not. NOTES: Please make sure that each partition/file should be written atomically, otherwise the reader may get incomplete data.</td>
     </tr>
     <tr>
+        <td><h5>streaming-source.partition.include</h5></td>
+        <td style="word-wrap: break-word;">all</td>
+        <td>String</td>
+        <td>Option to set the partitions to read, the supported option are `all` and `latest`, the `all` means read all partitions; the `latest` means read latest partition in order of 'streaming-source.partition.order', the `latest` only works` when the streaming hive source table used as temporal table. By default the option is `all`.
+            Flink supports temporal join the latest hive partition by enabling 'streaming-source.enable' and setting 'streaming-source.partition.include' to 'latest', at the same time, user can assign the partition compare order and data update interval by configuring following partition-related options.  
+        </td>
+    </tr>     
+    <tr>
         <td><h5>streaming-source.monitor-interval</h5></td>
-        <td style="word-wrap: break-word;">1 m</td>
+        <td style="word-wrap: break-word;">None</td>
         <td>Duration</td>
-        <td>Time interval for consecutively monitoring partition/file.</td>
+        <td>Time interval for consecutively monitoring partition/file.
+            Notes: The default interval for hive streaming reading is '1 m', the default interval for hive streaming temporal join is '60 m', this is because there's one framework limitation that every TM will visit the Hive metaStore in current hive streaming temporal join implementation which may produce pressure to metaStore, this will improve in the future.</td>
     </tr>
     <tr>
-        <td><h5>streaming-source.consume-order</h5></td>
-        <td style="word-wrap: break-word;">create-time</td>
+        <td><h5>streaming-source.partition-order</h5></td>
+        <td style="word-wrap: break-word;">partition-name</td>
         <td>String</td>
-        <td>The consume order of streaming source, support create-time and partition-time. create-time compare partition/file creation time, this is not the partition create time in Hive metaStore, but the folder/file modification time in filesystem; partition-time compare time represented by partition name, if the partition folder somehow gets updated, e.g. add new file into folder, it can affect how the data is consumed. For non-partition table, this value should always be 'create-time'.</td>
+        <td>The partition order of streaming source, support create-time, partition-time and partition-name. create-time compares partition/file creation time, this is not the partition create time in Hive metaStore, but the folder/file modification time in filesystem, if the partition folder somehow gets updated, e.g. add new file into folder, it can affect how the data is consumed. partition-time compares the time extracted from partition name. partition-name compares partition name's alphabetical order. For non-partition table, this value should always be 'create-time'. By default the value is partition-name. The option is equality with deprecated option 'streaming-source.consume-order'.</td>
     </tr>
     <tr>
         <td><h5>streaming-source.consume-start-offset</h5></td>
-        <td style="word-wrap: break-word;">1970-00-00</td>
+        <td style="word-wrap: break-word;">None</td>
         <td>String</td>
-        <td>Start offset for streaming consuming. How to parse and compare offsets depends on your order. For create-time and partition-time, should be a timestamp string (yyyy-[m]m-[d]d [hh:mm:ss]). For partition-time, will use partition time extractor to extract time from partition.</td>
+        <td>Start offset for streaming consuming. How to parse and compare offsets depends on your order. For create-time and partition-time, should be a timestamp string (yyyy-[m]m-[d]d [hh:mm:ss]). For partition-time, will use partition time extractor to extract time from partition.
+         For partition-name, is the partition name string (e.g. pt_year=2020/pt_mon=10/pt_day=01).</td>
     </tr>
   </tbody>
 </table>
@@ -110,46 +120,6 @@ This can be done by either `tableEnv.useCatalog(...)` in Table API or `USE CATAL
 
 2) Hive and Flink SQL have different syntax, e.g. different reserved keywords and literals.
 Make sure the view’s query is compatible with Flink grammar.
-
-### Temporal Table Join
-
-You can use a Hive table as a temporal table and join streaming data with it. Please follow
-the [example]({% link dev/table/streaming/temporal_tables.zh.md %}#temporal-table) to find
-out how to join a temporal table.
-
-When performing the join, the Hive table will be cached in Slot memory and each record from
-the stream is joined against the table by key to decide whether a match is found. Using a Hive
-table as a temporal table does not require any additional configuration. Optionally, you can
-configure the TTL of the Hive table cache with the following property. After the cache expires,
-the Hive table will be scanned again to load the latest data.
-
-<table class="table table-bordered">
-  <thead>
-    <tr>
-        <th class="text-left" style="width: 20%">Key</th>
-        <th class="text-left" style="width: 15%">Default</th>
-        <th class="text-left" style="width: 10%">Type</th>
-        <th class="text-left" style="width: 55%">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-        <td><h5>lookup.join.cache.ttl</h5></td>
-        <td style="word-wrap: break-word;">60 min</td>
-        <td>Duration</td>
-        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes.</td>
-    </tr>
-  </tbody>
-</table>
-
-**Notes**:
-
--  Each joining subtask needs to keep its own cache of the Hive table. Please ensure the Hive table can fit into
-the memory of a TM task slot.
-- It is encouraged to set a relatively large value for `lookup.join.cache.ttl`. Otherwise, Jobs
-are prone to performance issues as the table needs to be updated and reloaded too frequently. 
-- Currently, Flink simply loads the whole Hive table whenever the cache needs to be refreshed.
-There is no way to differentiate new data from old.
 
 ### Vectorized Optimization upon Read
 
@@ -198,6 +168,155 @@ following parameters in `TableConfig` (note that these parameters affect all sou
   </tbody>
 </table>
 
+## Temporal Table Join
+
+You can use a Hive table as a temporal table, and then a stream can correlate the Hive table by temporal join. 
+Please see [temporal join]({% link dev/table/streaming/joins.zh.md %}#时间区间-join) for more information about the temporal join.
+
+Flink supports processing-time temporal join Hive Table, the processing-time temporal join always joins the latest version of temporal table.
+Flink supports temporal join both partitioned table and Hive non-partitioned table, for partitioned table, Flink supports tracking the latest partition of Hive table automatically.
+
+**NOTE**: Flink does not support event-time temporal join Hive table yet.
+
+### Temporal Join The Latest Partition
+
+For a partitioned table which is changing over time, we can read it out as an unbounded stream, the partition can be acted as a version of the temporal table if every partition contains complete data of a version,
+the version of temporal table keeps the data of the partition.
+ 
+Flink support tracking the latest partition(version) of temporal table automatically in processing time temporal join, the latest partition(version) is defined by 'streaming-source.partition-order' option,
+This is the most common user cases that use Hive table as dimension table in a Flink stream application job.
+
+**NOTE:** This feature is only support in Flink `STREAMING` Mode.
+
+The following demo shows a classical business pipeline, the dimension table comes from Hive and it's updated once every day by a batch pipeline job or a Flink job, the kafka stream comes from real time online business data or log and need to join with the dimension table to enrich stream. 
+
+{% highlight sql %}
+-- Assume the data in hive table is updated per day, every day contains the latest and complete dimension data
+SET table.sql-dialect=hive;
+CREATE TABLE dimension_table (
+  product_id STRING,
+  product_name STRING,
+  unit_price DECIMAL(10, 4),
+  pv_count BIGINT,
+  like_count BIGINT,
+  comment_count BIGINT,
+  update_time TIMESTAMP(3),
+  update_user STRING,
+  ...
+) PARTITIONED BY (pt_year STRING, pt_month STRING, pt_day STRING) TBLPROPERTIES (
+  -- using default partition-name order to load the latest partition every 12h (the most recommended and convenient way)
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.monitor-interval' = '12 h',
+  'streaming-source.partition-order' = 'partition-name',  -- option with default value, can be ignored.
+
+  -- using partition file create-time order to load the latest partition every 12h
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.partition-order' = 'create-time',
+  'streaming-source.monitor-interval' = '12 h'
+
+  -- using partition-time order to load the latest partition every 12h
+  'streaming-source.enable' = 'true',
+  'streaming-source.partition.include' = 'latest',
+  'streaming-source.monitor-interval' = '12 h',
+  'streaming-source.partition-order' = 'partition-time',
+  'partition.time-extractor.kind' = 'default',
+  'partition.time-extractor.timestamp-pattern' = '$pt_year-$pt_month-$pt_day 00:00:00' 
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE orders_table (
+  order_id STRING,
+  order_amount DOUBLE,
+  product_id STRING,
+  log_ts TIMESTAMP(3),
+  proctime as PROCTIME()
+) WITH (...);
+
+
+-- streaming sql, kafka temporal join a hive dimension table. Flink will automatically reload data from the
+-- configured latest partition in the interval of 'streaming-source.monitor-interval'.
+
+SELECT * FROM orders_table AS order 
+JOIN dimension_table FOR SYSTEM_TIME AS OF o.proctime AS dim
+ON order.product_id = dim.product_id;
+
+{% endhighlight %}
+
+### Temporal Join The Latest Table
+ 
+For a Hive table, we can read it out as a bounded stream. In this case, the Hive table can only track its latest version at the time when we query.
+The latest version of table keep all data of the Hive table. 
+
+When performing the temporal join the latest Hive table, the Hive table will be cached in Slot memory and each record from the stream is joined against the table by key to decide whether a match is found. 
+Using the latest Hive table as a temporal table does not require any additional configuration. Optionally, you can configure the TTL of the Hive table cache with the following property. After the cache expires, the Hive table will be scanned again to load the latest data.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+        <th class="text-left" style="width: 20%">Key</th>
+        <th class="text-left" style="width: 15%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 55%">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+        <td><h5>lookup.join.cache.ttl</h5></td>
+        <td style="word-wrap: break-word;">60 min</td>
+        <td>Duration</td>
+        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
+       </td>
+    </tr>
+  </tbody>
+</table>
+
+The following demo shows load all data of hive table as a temporal table.
+
+{% highlight sql %}
+-- Assume the data in hive table is overwrite by batch pipeline.
+SET table.sql-dialect=hive;
+CREATE TABLE dimension_table (
+  product_id STRING,
+  product_name STRING,
+  unit_price DECIMAL(10, 4),
+  pv_count BIGINT,
+  like_count BIGINT,
+  comment_count BIGINT,
+  update_time TIMESTAMP(3),
+  update_user STRING,
+  ...
+) TBLPROPERTIES (
+  'streaming-source.enable' = 'false',           -- option with default value, can be ignored.
+  'streaming-source.partition.include' = 'all',  -- option with default value, can be ignored.
+  'lookup.join.cache.ttl' = '12 h'
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE orders_table (
+  order_id STRING,
+  order_amount DOUBLE,
+  product_id STRING,
+  log_ts TIMESTAMP(3),
+  proctime as PROCTIME()
+) WITH (...);
+
+
+-- streaming sql, kafka join a hive dimension table. Flink will reload all data from dimension_table after cache ttl is expired.
+
+SELECT * FROM orders_table AS order 
+JOIN dimension_table FOR SYSTEM_TIME AS OF o.proctime AS dim
+ON order.product_id = dim.product_id;
+
+{% endhighlight %}
+
+**Note**:
+1. Each joining subtask needs to keep its own cache of the Hive table. Please make sure the Hive table can fit into the memory of a TM task slot.
+2. It is encouraged to set a relatively large value both for `streaming-source.monitor-interval`(latest partition as temporal table) or `lookup.join.cache.ttl`(all partitions as temporal table). Otherwise, Jobs are prone to performance issues as the table needs to be updated and reloaded too frequently.
+3. Currently we simply load the whole Hive table whenever the cache needs refreshing. There's no way to differentiate
+new data from the old.
+
 ## Writing
 
 Flink supports writing data from Hive in both `BATCH` and `STREAMING` modes. When run as a `BATCH`
@@ -212,7 +331,7 @@ Flink SQL> INSERT INTO mytable SELECT 'Tom', 25;
 Flink SQL> INSERT OVERWRITE mytable SELECT 'Tom', 25;
 {% endhighlight %}
 
-Data can also be inserted into a particular partitions. 
+Data can also be inserted into particular partitions. 
 
 {% highlight sql %}
 # ------ Insert with static partition ------ 
@@ -303,4 +422,3 @@ Flink's Hive integration has been tested against the following file formats:
 - SequenceFile
 - ORC
 - Parquet
-


### PR DESCRIPTION
## What is the purpose of the change

* This pull request  update the outdate section of hive streaming read and temporal table document.


## Brief change log

  - update file `docs/dev/table/hive/hive_read_write.md` and `docs/dev/table/hive/hive_read_write.zh.md`

- local web page as following:
![image](https://user-images.githubusercontent.com/5163645/100203360-78bb8d80-2f3d-11eb-8c22-9cc35cfca858.png)
![image](https://user-images.githubusercontent.com/5163645/100203468-9ab51000-2f3d-11eb-91b5-7ba50a0ace41.png)

![image](https://user-images.githubusercontent.com/5163645/100201480-11044300-2f3b-11eb-84fb-ff0a0bfb9223.png)

## Verifying this change

This change is a document PR without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
