### PR TITLE
[FLINK-20256][table-common] Allow errors when extracting the data type a DataView

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -228,7 +228,7 @@ public final class DataTypeExtractor {
 		// main work
 		DataType dataType = extractDataTypeOrRawWithTemplate(template, typeHierarchy, resolvedType);
 		// handle data views
-		dataType =  handleDataViewHints(dataType, clazz);
+		dataType = handleDataViewHints(dataType, clazz);
 		// final work
 		return closestBridging(dataType, clazz);
 	}
@@ -548,12 +548,6 @@ public final class DataTypeExtractor {
 				final DataType fieldDataType = extractDataTypeOrRaw(fieldTemplate, fieldTypeHierarchy, fieldType);
 				fieldDataTypes.put(field.getName(), fieldDataType);
 			} catch (Throwable t) {
-				// special case for fields of data views which are skipped in case of an error
-				if (DataView.class.isAssignableFrom(field.getDeclaringClass())) {
-					fieldDataTypes.put(field.getName(), DataTypes.NULL());
-					continue;
-				}
-
 				throw extractionError(
 					t,
 					"Error in field '%s' of class '%s'.",

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -437,6 +437,15 @@ public class DataTypeExtractorTest {
 
 			TestSpec
 				.forType(
+					"Data view with invalid list element",
+					AccumulatorWithInvalidDefaultDataView.class)
+				.expectErrorMessage(
+					"Could not extract a data type from '" + ListView.class.getName()
+						+ "<" + Object.class.getName() + ">'. "
+						+ "Please pass the required data type manually or allow RAW types."),
+
+			TestSpec
+				.forType(
 					"Data view with default extraction",
 					AccumulatorWithDefaultDataView.class)
 				.lookupExpects(Object.class)
@@ -1104,6 +1113,13 @@ public class DataTypeExtractorTest {
 	}
 
 	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Accumulator with invalid default extraction for data view.
+	 */
+	public static class AccumulatorWithInvalidDefaultDataView {
+		public ListView<Object> listView;
+	}
 
 	/**
 	 * Accumulator with default extraction for data view.


### PR DESCRIPTION
## What is the purpose of the change

Avoids swallowing exceptions caused by `DataView`s. I cannot remember why we added this logic. I removed it and all tests pass. It seems a mistake in the original PR.

## Brief change log

Remove swallowing of exception and add more tests.

## Verifying this change

This change added tests and can be verified as follows: `FunctionITCase` and `DataTypeExtractorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
