### PR TITLE
[FLINK-19852][task] Reuse TempBarrier memory between iterations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableMaterialization;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -51,8 +50,8 @@ import org.apache.flink.runtime.operators.resettable.SpillingResettableMutableOb
 import org.apache.flink.runtime.operators.shipping.OutputCollector;
 import org.apache.flink.runtime.operators.shipping.OutputEmitter;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
-import org.apache.flink.runtime.operators.sort.Sorter;
 import org.apache.flink.runtime.operators.sort.ExternalSorter;
+import org.apache.flink.runtime.operators.sort.Sorter;
 import org.apache.flink.runtime.operators.util.CloseableInputProvider;
 import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.LocalStrategy;
@@ -121,22 +120,22 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	 * The input readers for the configured broadcast variables for this task.
 	 */
 	protected MutableReader<?>[] broadcastInputReaders;
-	
+
 	/**
 	 * The inputs reader, wrapped in an iterator. Prior to the local strategies, etc...
 	 */
 	protected MutableObjectIterator<?>[] inputIterators;
 
 	/**
-	 * The indices of the iterative inputs. Empty, if the task is not iterative. 
+	 * The indices of the iterative inputs. Empty, if the task is not iterative.
 	 */
 	protected int[] iterativeInputs;
-	
+
 	/**
 	 * The indices of the iterative broadcast inputs. Empty, if non of the inputs is iterative.
 	 */
 	protected int[] iterativeBroadcastInputs;
-	
+
 	/**
 	 * The local strategies that are applied on the inputs.
 	 */
@@ -214,7 +213,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	/**
 	 * The accumulator map used in the RuntimeContext.
 	 */
-	protected Map<String, Accumulator<?,?>> accumulatorMap;
+	protected Map<String, Accumulator<?, ?>> accumulatorMap;
 	private OperatorMetricGroup metrics;
 
 	// --------------------------------------------------------------------------------------------
@@ -294,55 +293,55 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				int numInputs = driver.getNumberOfInputs();
 				int numComparators = driver.getNumberOfDriverComparators();
 				int numBroadcastInputs = this.config.getNumBroadcastInputs();
-				
+
 				initInputsSerializersAndComparators(numInputs, numComparators);
 				initBroadcastInputsSerializers(numBroadcastInputs);
-				
+
 				// set the iterative status for inputs and broadcast inputs
 				{
-					List<Integer> iterativeInputs = new ArrayList<Integer>();
-					
+					List<Integer> iterativeInputs = new ArrayList<>();
+
 					for (int i = 0; i < numInputs; i++) {
 						final int numberOfEventsUntilInterrupt = getTaskConfig().getNumberOfEventsUntilInterruptInIterativeGate(i);
-			
+
 						if (numberOfEventsUntilInterrupt < 0) {
 							throw new IllegalArgumentException();
 						}
 						else if (numberOfEventsUntilInterrupt > 0) {
 							this.inputReaders[i].setIterativeReader();
 							iterativeInputs.add(i);
-				
+
 							if (LOG.isDebugEnabled()) {
 								LOG.debug(formatLogString("Input [" + i + "] reads in supersteps with [" +
-										+ numberOfEventsUntilInterrupt + "] event(s) till next superstep."));
+									numberOfEventsUntilInterrupt + "] event(s) till next superstep."));
 							}
 						}
 					}
 					this.iterativeInputs = asArray(iterativeInputs);
 				}
-				
+
 				{
-					List<Integer> iterativeBcInputs = new ArrayList<Integer>();
-					
+					List<Integer> iterativeBcInputs = new ArrayList<>();
+
 					for (int i = 0; i < numBroadcastInputs; i++) {
 						final int numberOfEventsUntilInterrupt = getTaskConfig().getNumberOfEventsUntilInterruptInIterativeBroadcastGate(i);
-						
+
 						if (numberOfEventsUntilInterrupt < 0) {
 							throw new IllegalArgumentException();
 						}
 						else if (numberOfEventsUntilInterrupt > 0) {
 							this.broadcastInputReaders[i].setIterativeReader();
 							iterativeBcInputs.add(i);
-				
+
 							if (LOG.isDebugEnabled()) {
 								LOG.debug(formatLogString("Broadcast input [" + i + "] reads in supersteps with [" +
-										+ numberOfEventsUntilInterrupt + "] event(s) till next superstep."));
+									numberOfEventsUntilInterrupt + "] event(s) till next superstep."));
 							}
 						}
 					}
 					this.iterativeBroadcastInputs = asArray(iterativeBcInputs);
 				}
-				
+
 				initLocalStrategies(numInputs);
 			}
 			catch (Exception e) {
@@ -360,7 +359,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			// pre main-function initialization
 			initialize();
 
-			// read the broadcast variables. they will be released in the finally clause 
+			// read the broadcast variables. they will be released in the finally clause
 			for (int i = 0; i < this.config.getNumBroadcastInputs(); i++) {
 				final String name = this.config.getBroadcastInputName(i);
 				readAndSetBroadcastInput(i, name, this.runtimeUdfContext, 1 /* superstep one for the start */);
@@ -419,7 +418,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			throw new Exception("The driver setup for '" + this.getEnvironment().getTaskInfo().getTaskName() +
 				"' , caused an error: " + t.getMessage(), t);
 		}
-		
+
 		// instantiate the UDF
 		try {
 			final Class<? super S> userCodeFunctionType = this.driver.getStubType();
@@ -432,33 +431,32 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 					(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 		}
 	}
-	
+
 	protected <X> void readAndSetBroadcastInput(int inputNum, String bcVarName, DistributedRuntimeUDFContext context, int superstep) throws IOException {
-		
+
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(formatLogString("Setting broadcast variable '" + bcVarName + "'" + 
+			LOG.debug(formatLogString("Setting broadcast variable '" + bcVarName + "'" +
 				(superstep > 1 ? ", superstep " + superstep : "")));
 		}
-		
+
 		@SuppressWarnings("unchecked")
 		final TypeSerializerFactory<X> serializerFactory =  (TypeSerializerFactory<X>) this.broadcastInputSerializers[inputNum];
-		
+
 		final MutableReader<?> reader = this.broadcastInputReaders[inputNum];
 
 		BroadcastVariableMaterialization<X, ?> variable = getEnvironment().getBroadcastVariableManager().materializeBroadcastVariable(bcVarName, superstep, this, reader, serializerFactory);
 		context.setBroadcastVariable(bcVarName, variable);
 	}
-	
+
 	protected void releaseBroadcastVariables(String bcVarName, int superstep, DistributedRuntimeUDFContext context) {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(formatLogString("Releasing broadcast variable '" + bcVarName + "'" + 
+			LOG.debug(formatLogString("Releasing broadcast variable '" + bcVarName + "'" +
 				(superstep > 1 ? ", superstep " + superstep : "")));
 		}
-		
+
 		getEnvironment().getBroadcastVariableManager().releaseReference(bcVarName, superstep, this);
 		context.clearBroadcastVariable(bcVarName);
 	}
-	
 
 	protected void run() throws Exception {
 		// ---------------------------- Now, the actual processing starts ------------------------
@@ -526,7 +524,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 					// do nothing
 				}
 			}
-			
+
 			// if resettable driver invoke teardown
 			if (this.driver instanceof ResettableDriver) {
 				final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
@@ -546,7 +544,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				throw ex;
 			}
 			else if (this.running) {
-				// throw only if task was not cancelled. in the case of canceling, exceptions are expected 
+				// throw only if task was not cancelled. in the case of canceling, exceptions are expected
 				BatchTask.logAndThrowException(ex, this);
 			}
 		}
@@ -556,19 +554,19 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	}
 
 	protected void closeLocalStrategiesAndCaches() {
-		
+
 		// make sure that all broadcast variable references held by this task are released
 		if (LOG.isDebugEnabled()) {
 			LOG.debug(formatLogString("Releasing all broadcast variables."));
 		}
-		
+
 		getEnvironment().getBroadcastVariableManager().releaseAllReferencesFromTask(this);
 		if (runtimeUdfContext != null) {
 			runtimeUdfContext.clearAllBroadcastVariables();
 		}
-		
-		// clean all local strategies and caches/pipeline breakers. 
-		
+
+		// clean all local strategies and caches/pipeline breakers.
+
 		if (this.localStrategies != null) {
 			for (int i = 0; i < this.localStrategies.length; i++) {
 				if (this.localStrategies[i] != null) {
@@ -619,8 +617,8 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 	/**
 	 * Sets the last output {@link Collector} of the collector chain of this {@link BatchTask}.
-	 * <p>
-	 * In case of chained tasks, the output collector of the last {@link ChainedDriver} is set. Otherwise it is the
+	 *
+	 * <p>In case of chained tasks, the output collector of the last {@link ChainedDriver} is set. Otherwise it is the
 	 * single collector of the {@link BatchTask}.
 	 *
 	 * @param newOutputCollector new output collector to set as last collector
@@ -647,7 +645,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			S stub = config.<S>getStubWrapper(userCodeClassLoader).getUserCodeObject(stubSuperClass, userCodeClassLoader);
 			// check if the class is a subclass, if the check is required
 			if (stubSuperClass != null && !stubSuperClass.isAssignableFrom(stub.getClass())) {
-				throw new RuntimeException("The class '" + stub.getClass().getName() + "' is not a subclass of '" + 
+				throw new RuntimeException("The class '" + stub.getClass().getName() + "' is not a subclass of '" +
 						stubSuperClass.getName() + "' as is required.");
 			}
 			FunctionUtils.setFunctionRuntimeContext(stub, this.runtimeUdfContext);
@@ -660,7 +658,6 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 	/**
 	 * Creates the record readers for the number of inputs as defined by {@link #getNumTaskInputs()}.
-	 *
 	 * This method requires that the task configuration, the driver, and the user-code class loader are set.
 	 */
 	protected void initInputReaders() throws Exception {
@@ -676,7 +673,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 			if (groupSize == 1) {
 				// non-union case
-				inputReaders[i] = new MutableRecordReader<IOReadableWritable>(
+				inputReaders[i] = new MutableRecordReader<>(
 						getEnvironment().getInputGate(currentReaderOffset),
 						getEnvironment().getTaskManagerInfo().getTmpDirectories());
 			} else if (groupSize > 1){
@@ -685,7 +682,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				for (int j = 0; j < groupSize; ++j) {
 					readers[j] = getEnvironment().getInputGate(currentReaderOffset + j);
 				}
-				inputReaders[i] = new MutableRecordReader<IOReadableWritable>(
+				inputReaders[i] = new MutableRecordReader<>(
 						new UnionInputGate(readers),
 						getEnvironment().getTaskManagerInfo().getTmpDirectories());
 			} else {
@@ -704,7 +701,6 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 	/**
 	 * Creates the record readers for the extra broadcast inputs as configured by {@link TaskConfig#getNumBroadcastInputs()}.
-	 *
 	 * This method requires that the task configuration, the driver, and the user-code class loader are set.
 	 */
 	protected void initBroadcastInputReaders() throws Exception {
@@ -719,7 +715,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			final int groupSize = this.config.getBroadcastGroupSize(i);
 			if (groupSize == 1) {
 				// non-union case
-				broadcastInputReaders[i] = new MutableRecordReader<IOReadableWritable>(
+				broadcastInputReaders[i] = new MutableRecordReader<>(
 						getEnvironment().getInputGate(currentReaderOffset),
 						getEnvironment().getTaskManagerInfo().getTmpDirectories());
 			} else if (groupSize > 1){
@@ -728,7 +724,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				for (int j = 0; j < groupSize; ++j) {
 					readers[j] = getEnvironment().getInputGate(currentReaderOffset + j);
 				}
-				broadcastInputReaders[i] = new MutableRecordReader<IOReadableWritable>(
+				broadcastInputReaders[i] = new MutableRecordReader<>(
 						new UnionInputGate(readers),
 						getEnvironment().getTaskManagerInfo().getTmpDirectories());
 			} else {
@@ -739,39 +735,39 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		}
 		this.broadcastInputReaders = broadcastInputReaders;
 	}
-	
+
 	/**
 	 * Creates all the serializers and comparators.
 	 */
-	protected void initInputsSerializersAndComparators(int numInputs, int numComparators) throws Exception {
+	protected void initInputsSerializersAndComparators(int numInputs, int numComparators) {
 		this.inputSerializers = new TypeSerializerFactory<?>[numInputs];
 		this.inputComparators = numComparators > 0 ? new TypeComparator<?>[numComparators] : null;
 		this.inputIterators = new MutableObjectIterator<?>[numInputs];
 
 		ClassLoader userCodeClassLoader = getUserCodeClassLoader();
-		
+
 		for (int i = 0; i < numInputs; i++) {
-			
+
 			final TypeSerializerFactory<?> serializerFactory = this.config.getInputSerializer(i, userCodeClassLoader);
 			this.inputSerializers[i] = serializerFactory;
-			
+
 			this.inputIterators[i] = createInputIterator(this.inputReaders[i], this.inputSerializers[i]);
 		}
-		
+
 		//  ---------------- create the driver's comparators ---------------------
 		for (int i = 0; i < numComparators; i++) {
-			
+
 			if (this.inputComparators != null) {
 				final TypeComparatorFactory<?> comparatorFactory = this.config.getDriverComparator(i, userCodeClassLoader);
 				this.inputComparators[i] = comparatorFactory.createComparator();
 			}
 		}
 	}
-	
+
 	/**
 	 * Creates all the serializers and iterators for the broadcast inputs.
 	 */
-	protected void initBroadcastInputsSerializers(int numBroadcastInputs) throws Exception {
+	protected void initBroadcastInputsSerializers(int numBroadcastInputs) {
 		this.broadcastInputSerializers = new TypeSerializerFactory<?>[numBroadcastInputs];
 
 		ClassLoader userCodeClassLoader = getUserCodeClassLoader();
@@ -784,7 +780,6 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	}
 
 	/**
-	 *
 	 * NOTE: This method must be invoked after the invocation of {@code #initInputReaders()} and
 	 * {@code #initInputSerializersAndComparators(int)}!
 	 */
@@ -976,7 +971,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 					throw new RuntimeException("Initializing the user code and the configuration failed" +
 							(e.getMessage() == null ? "." : ": " + e.getMessage()), e);
 				}
-				
+
 				if (!(localStub instanceof GroupCombineFunction)) {
 					throw new IllegalStateException("Performing combining sort outside a reduce task!");
 				}
@@ -1016,7 +1011,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		}
 		return compFact.createComparator();
 	}
-	
+
 	protected MutableObjectIterator<?> createInputIterator(MutableReader<?> inputReader, TypeSerializerFactory<?> serializerFactory) {
 		@SuppressWarnings("unchecked")
 		MutableReader<DeserializationDelegate<?>> reader = (MutableReader<DeserializationDelegate<?>>) inputReader;
@@ -1034,8 +1029,8 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	 * The output collector applies the configured shipping strategies for each writer.
 	 */
 	protected void initOutputs() throws Exception {
-		this.chainedTasks = new ArrayList<ChainedDriver<?, ?>>();
-		this.eventualOutputs = new ArrayList<RecordWriter<?>>();
+		this.chainedTasks = new ArrayList<>();
+		this.eventualOutputs = new ArrayList<>();
 
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 
@@ -1134,7 +1129,6 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		}
 	}
 
-
 	@Override
 	public <X> TypeSerializerFactory<X> getInputSerializer(int index) {
 		if (index < 0 || index >= this.driver.getNumberOfInputs()) {
@@ -1145,7 +1139,6 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		final TypeSerializerFactory<X> serializerFactory = (TypeSerializerFactory<X>) this.inputSerializers[index];
 		return serializerFactory;
 	}
-
 
 	@Override
 	public <X> TypeComparator<X> getDriverComparator(int index) {
@@ -1234,8 +1227,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	 * @return The OutputCollector that data produced in this task is submitted to.
 	 */
 	public static <T> Collector<T> getOutputCollector(AbstractInvokable task, TaskConfig config, ClassLoader cl,
-			List<RecordWriter<?>> eventualOutputs, int outputOffset, int numOutputs) throws Exception
-	{
+			List<RecordWriter<?>> eventualOutputs, int outputOffset, int numOutputs) throws Exception {
 		if (numOutputs == 0) {
 			return null;
 		}
@@ -1245,8 +1237,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		final List<RecordWriter<SerializationDelegate<T>>> writers = new ArrayList<>(numOutputs);
 
 		// create a writer for each output
-		for (int i = 0; i < numOutputs; i++)
-		{
+		for (int i = 0; i < numOutputs; i++) {
 			// create the OutputEmitter from output ship strategy
 			final ShipStrategyType strategy = config.getOutputShipStrategy(i);
 			final int indexInSubtaskGroup = task.getIndexInSubtaskGroup();
@@ -1254,14 +1245,14 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 			final ChannelSelector<SerializationDelegate<T>> oe;
 			if (compFactory == null) {
-				oe = new OutputEmitter<T>(strategy, indexInSubtaskGroup);
+				oe = new OutputEmitter<>(strategy, indexInSubtaskGroup);
 			}
 			else {
 				final DataDistribution dataDist = config.getOutputDataDistribution(i, cl);
 				final Partitioner<?> partitioner = config.getOutputPartitioner(i, cl);
 
 				final TypeComparator<T> comparator = compFactory.createComparator();
-				oe = new OutputEmitter<T>(strategy, indexInSubtaskGroup, comparator, partitioner, dataDist);
+				oe = new OutputEmitter<>(strategy, indexInSubtaskGroup, comparator, partitioner, dataDist);
 			}
 
 			final RecordWriter<SerializationDelegate<T>> recordWriter = new RecordWriterBuilder()
@@ -1276,7 +1267,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		if (eventualOutputs != null) {
 			eventualOutputs.addAll(writers);
 		}
-		return new OutputCollector<T>(writers, serializerFactory.getSerializer());
+		return new OutputCollector<>(writers, serializerFactory.getSerializer());
 	}
 
 	/**
@@ -1291,7 +1282,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			List<ChainedDriver<?, ?>> chainedTasksTarget,
 			List<RecordWriter<?>> eventualOutputs,
 			ExecutionConfig executionConfig,
-			Map<String, Accumulator<?,?>> accumulatorMap) throws Exception {
+			Map<String, Accumulator<?, ?>> accumulatorMap) throws Exception {
 		final int numOutputs = config.getNumOutputs();
 
 		// check whether we got any chained tasks
@@ -1305,8 +1296,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			// instantiate each task
 			@SuppressWarnings("rawtypes")
 			Collector previous = null;
-			for (int i = numChained - 1; i >= 0; --i)
-			{
+			for (int i = numChained - 1; i >= 0; --i) {
 				// get the task first
 				final ChainedDriver<?, ?> ct;
 				try {
@@ -1343,19 +1333,19 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		// instantiate the output collector the default way from this configuration
 		return getOutputCollector(containingTask , config, cl.asClassLoader(), eventualOutputs, 0, numOutputs);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//                                  User Code LifeCycle
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Opens the given stub using its {@link org.apache.flink.api.common.functions.RichFunction#open(Configuration)} method. If the open call produces
 	 * an exception, a new exception with a standard error message is created, using the encountered exception
 	 * as its cause.
-	 * 
+	 *
 	 * @param stub The user code instance to be opened.
 	 * @param parameters The parameters supplied to the user code.
-	 * 
+	 *
 	 * @throws Exception Thrown, if the user code's open method produces an exception.
 	 */
 	public static void openUserCode(Function stub, Configuration parameters) throws Exception {
@@ -1365,14 +1355,14 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			throw new Exception("The user defined 'open(Configuration)' method in " + stub.getClass().toString() + " caused an exception: " + t.getMessage(), t);
 		}
 	}
-	
+
 	/**
 	 * Closes the given stub using its {@link org.apache.flink.api.common.functions.RichFunction#close()} method. If the close call produces
 	 * an exception, a new exception with a standard error message is created, using the encountered exception
 	 * as its cause.
-	 * 
+	 *
 	 * @param stub The user code instance to be closed.
-	 * 
+	 *
 	 * @throws Exception Thrown, if the user code's close method produces an exception.
 	 */
 	public static void closeUserCode(Function stub) throws Exception {
@@ -1382,79 +1372,77 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			throw new Exception("The user defined 'close()' method caused an exception: " + t.getMessage(), t);
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//                               Chained Task LifeCycle
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Opens all chained tasks, in the order as they are stored in the array. The opening process
 	 * creates a standardized log info message.
-	 * 
+	 *
 	 * @param tasks The tasks to be opened.
 	 * @param parent The parent task, used to obtain parameters to include in the log message.
 	 * @throws Exception Thrown, if the opening encounters an exception.
 	 */
 	public static void openChainedTasks(List<ChainedDriver<?, ?>> tasks, AbstractInvokable parent) throws Exception {
 		// start all chained tasks
-		for (int i = 0; i < tasks.size(); i++) {
-			final ChainedDriver<?, ?> task = tasks.get(i);
+		for (ChainedDriver<?, ?> task : tasks) {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug(constructLogString("Start task code", task.getTaskName(), parent));
 			}
 			task.openTask();
 		}
 	}
-	
+
 	/**
 	 * Closes all chained tasks, in the order as they are stored in the array. The closing process
 	 * creates a standardized log info message.
-	 * 
+	 *
 	 * @param tasks The tasks to be closed.
 	 * @param parent The parent task, used to obtain parameters to include in the log message.
 	 * @throws Exception Thrown, if the closing encounters an exception.
 	 */
 	public static void closeChainedTasks(List<ChainedDriver<?, ?>> tasks, AbstractInvokable parent) throws Exception {
-		for (int i = 0; i < tasks.size(); i++) {
-			final ChainedDriver<?, ?> task = tasks.get(i);
+		for (ChainedDriver<?, ?> task : tasks) {
 			task.closeTask();
-			
+
 			if (LOG.isDebugEnabled()) {
 				LOG.debug(constructLogString("Finished task code", task.getTaskName(), parent));
 			}
 		}
 	}
-	
+
 	/**
 	 * Cancels all tasks via their {@link ChainedDriver#cancelTask()} method. Any occurring exception
 	 * and error is suppressed, such that the canceling method of every task is invoked in all cases.
-	 * 
+	 *
 	 * @param tasks The tasks to be canceled.
 	 */
 	public static void cancelChainedTasks(List<ChainedDriver<?, ?>> tasks) {
-		for (int i = 0; i < tasks.size(); i++) {
+		for (ChainedDriver<?, ?> task : tasks) {
 			try {
-				tasks.get(i).cancelTask();
+				task.cancelTask();
 			} catch (Throwable t) {
 				// do nothing
 			}
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//                                     Miscellaneous Utilities
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Instantiates a user code class from is definition in the task configuration.
 	 * The class is instantiated without arguments using the null-ary constructor. Instantiation
 	 * will fail if this constructor does not exist or is not public.
-	 * 
+	 *
 	 * @param <T> The generic type of the user code class.
 	 * @param config The task configuration containing the class description.
 	 * @param cl The class loader to be used to load the class.
 	 * @param superClass The super class that the user code class extends or implements, for type checking.
-	 * 
+	 *
 	 * @return An instance of the user code class.
 	 */
 	public static <T> T instantiateUserCode(TaskConfig config, ClassLoader cl, Class<? super T> superClass) {
@@ -1462,7 +1450,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			T stub = config.<T>getStubWrapper(cl).getUserCodeObject(superClass, cl);
 			// check if the class is a subclass, if the check is required
 			if (superClass != null && !superClass.isAssignableFrom(stub.getClass())) {
-				throw new RuntimeException("The class '" + stub.getClass().getName() + "' is not a subclass of '" + 
+				throw new RuntimeException("The class '" + stub.getClass().getName() + "' is not a subclass of '" +
 						superClass.getName() + "' as is required.");
 			}
 			return stub;
@@ -1471,10 +1459,10 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 			throw new RuntimeException("The UDF class is not a proper subclass of " + superClass.getName(), ccex);
 		}
 	}
-	
+
 	private static int[] asArray(List<Integer> list) {
 		int[] a = new int[list.size()];
-		
+
 		int i = 0;
 		for (int val : list) {
 			a[i++] = val;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/TempBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/TempBarrier.java
@@ -16,11 +16,7 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.runtime.operators;
-
-import java.io.IOException;
-import java.util.ArrayList;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerFactory;
@@ -36,44 +32,51 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.util.CloseableInputProvider;
 import org.apache.flink.util.MutableObjectIterator;
 
+import java.io.IOException;
+import java.util.ArrayList;
+
 /**
- * 
+ * This class facilitates JVM-local exchange between stages of a batch job.
  */
 public class TempBarrier<T> implements CloseableInputProvider<T> {
-	
+
 	private final SpillingBuffer buffer;
-	
+
 	private final TypeSerializer<T> serializer;
-	
+
 	private final TempWritingThread tempWriter;
-	
+
 	private final MemoryManager memManager;
-	
+
 	private final Object lock = new Object();
-	
+
 	private volatile Throwable exception;
-	
+
 	private final ArrayList<MemorySegment> memory;
-	
+
 	private volatile boolean writingDone;
-	
+
 	private volatile boolean closed;
 
 	// --------------------------------------------------------------------------------------------
-	
-	public TempBarrier(AbstractInvokable owner, MutableObjectIterator<T> input, TypeSerializerFactory<T> serializerFactory,
-			MemoryManager memManager, IOManager ioManager, int numPages) throws MemoryAllocationException
-	{
+
+	public TempBarrier(
+			AbstractInvokable owner,
+			MutableObjectIterator<T> input,
+			TypeSerializerFactory<T> serializerFactory,
+			MemoryManager memManager,
+			IOManager ioManager,
+			int numPages) throws MemoryAllocationException {
 		this.serializer = serializerFactory.getSerializer();
 		this.memManager = memManager;
-		
-		this.memory = new ArrayList<MemorySegment>(numPages);
+
+		this.memory = new ArrayList<>(numPages);
 		memManager.allocatePages(owner, this.memory, numPages);
-		
+
 		this.buffer = new SpillingBuffer(ioManager, new ListMemorySegmentSource(this.memory), memManager.getPageSize());
 		this.tempWriter = new TempWritingThread(input, serializerFactory.getSerializer(), this.buffer);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 
 	public void startReading() {
@@ -81,9 +84,7 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 	}
 
 	/**
-	 * 
 	 * This method resets the input!
-	 * 
 	 * @see org.apache.flink.runtime.operators.util.CloseableInputProvider#getIterator()
 	 */
 	@Override
@@ -93,17 +94,16 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 				this.lock.wait(5000);
 			}
 		}
-		
+
 		if (this.exception != null) {
 			throw new RuntimeException("An error occurred creating the temp table.", this.exception);
 		} else if (this.writingDone) {
 			final DataInputView in = this.buffer.flip();
-			return new InputViewIterator<T>(in, this.serializer);
+			return new InputViewIterator<>(in, this.serializer);
 		} else {
 			return null;
 		}
 	}
-
 
 	@Override
 	public void close() throws IOException {
@@ -116,18 +116,18 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 			}
 			this.lock.notifyAll();
 		}
-		
+
 		try {
 			this.tempWriter.shutdown();
 			this.tempWriter.join();
 		} catch (InterruptedException iex) {
 			throw new IOException("Interrupted");
 		}
-		
+
 		this.memManager.release(this.buffer.close());
 		this.memManager.release(this.memory);
 	}
-	
+
 	private void setException(Throwable t) {
 		synchronized (this.lock) {
 			this.exception = t;
@@ -135,57 +135,59 @@ public class TempBarrier<T> implements CloseableInputProvider<T> {
 		}
 		try {
 			close();
-		} catch (Throwable ex) {}
+		} catch (Throwable ex) {
+			// ignored
+		}
 	}
-	
-	private void writingDone() throws IOException {
+
+	private void writingDone() {
 		synchronized (this.lock) {
 			this.writingDone = true;
 			this.lock.notifyAll();
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	private final class TempWritingThread extends Thread {
-		
+
 		private final MutableObjectIterator<T> input;
-		
+
 		private final TypeSerializer<T> serializer;
-		
+
 		private final SpillingBuffer buffer;
-		
+
 		private volatile boolean running = true;
-		
+
 		private TempWritingThread(MutableObjectIterator<T> input, TypeSerializer<T> serializer, SpillingBuffer buffer) {
 			super("Temp writer");
 			setDaemon(true);
-			
+
 			this.input = input;
 			this.serializer = serializer;
 			this.buffer = buffer;
 		}
-		
+
 		@Override
 		public void run() {
 			final MutableObjectIterator<T> input = this.input;
 			final TypeSerializer<T> serializer = this.serializer;
 			final SpillingBuffer buffer = this.buffer;
-			
+
 			try {
 				T record = serializer.createInstance();
-				
+
 				while (this.running && ((record = input.next(record)) != null)) {
 					serializer.serialize(record, buffer);
 				}
-				
+
 				TempBarrier.this.writingDone();
 			}
 			catch (Throwable t) {
 				TempBarrier.this.setException(t);
 			}
 		}
-		
+
 		public void shutdown() {
 			this.running = false;
 			this.interrupt();


### PR DESCRIPTION
## What is the purpose of the change

Reuse allocated memory segments between the iterations of an iterative job.

## Brief change log

  - fix checkstyle and IDE warnings
  - introduce a method to close `TempBarrier` without releasing memory
  - add `TempBarrier` constructor argument to use preallocated memory
  - use new method/argument in `BatchTask.resetAllInputs`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
