### PR TITLE
[FLINK-20222][checkpointing] Operator Coordinators are reset with null state when no checkpoint or state available.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 
+import javax.annotation.Nullable;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -52,5 +54,16 @@ public interface OperatorCoordinatorCheckpointContext extends OperatorInfo, Chec
 	@Override
 	default void notifyCheckpointAborted(long checkpointId) {}
 
-	void resetToCheckpoint(byte[] checkpointData) throws Exception;
+	/**
+	 * Resets the coordinator to the checkpoint with the given state.
+	 *
+	 * <p>This method is called with a null state argument in the following situations:
+	 * <ul>
+	 *   <li>There is a recovery and there was no completed checkpoint yet.</li>
+	 *   <li>There is a recovery from a completed checkpoint/savepoint but it contained no state
+	 *       for the coordinator.</li>
+	 * </ul>
+	 * In both cases, the coordinator should reset to an empty (new) state.
+	 */
+	void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -127,6 +127,14 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 	 * to {@code Context} methods. For example, Events being sent by the Coordinator after this method
 	 * returns are assumed to take place after the checkpoint that was restored.
 	 *
+	 * <p>This method is called with a null state argument in the following situations:
+	 * <ul>
+	 *   <li>There is a recovery and there was no completed checkpoint yet.</li>
+	 *   <li>There is a recovery from a completed checkpoint/savepoint but it contained no state
+	 *       for the coordinator.</li>
+	 * </ul>
+	 * In both cases, the coordinator should reset to an empty (new) state.
+	 *
 	 * <h2>Restoring implicitly notifies of Checkpoint Completion</h2>
 	 *
 	 * <p>Restoring to a checkpoint is a way of confirming that the checkpoint is complete.
@@ -137,7 +145,7 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 	 * complete (for example when a system failure happened directly after committing the checkpoint,
 	 * before calling the {@link #notifyCheckpointComplete(long)} method).
 	 */
-	void resetToCheckpoint(byte[] checkpointData) throws Exception;
+	void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception;
 
 	// ------------------------------------------------------------------------
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -226,7 +226,7 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
 		// ideally we would like to check this here, however this method is called early during
 		// execution graph construction, before the main thread executor is set
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -105,7 +105,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(@Nullable byte[] checkpointData) {
 		// First bump up the coordinator epoch to fence out the active coordinator.
 		LOG.info("Resetting coordinator to checkpoint.");
 		// Replace the coordinator variable with a new DeferrableCoordinator instance.
@@ -366,7 +366,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 			internalCoordinator.start();
 		}
 
-		void resetAndStart(byte[] checkpointData, boolean started) {
+		void resetAndStart(@Nullable byte[] checkpointData, boolean started) {
 			if (failed || closed || internalCoordinator == null) {
 				return;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -257,9 +257,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 
 		if (checkpointCoordinator != null) {
 			// check whether we find a valid checkpoint
-			if (!checkpointCoordinator.restoreLatestCheckpointedStateToAll(
-				new HashSet<>(newExecutionGraph.getAllVertices().values()),
-				false)) {
+			if (!checkpointCoordinator.restoreInitialCheckpointIfPresent(
+					new HashSet<>(newExecutionGraph.getAllVertices().values()))) {
 
 				// check whether we can restore from a savepoint
 				tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, jobGraph.getSavepointRestoreSettings());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -223,9 +223,16 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
 		checkState(!started, "The coordinator can only be reset if it was not yet started");
 		assert enumerator == null;
+
+		// the checkpoint data is null if there was no completed checkpoint before
+		// in that case we don't restore here, but let a fresh SplitEnumerator be created
+		// when "start()" is called.
+		if (checkpointData == null) {
+			return;
+		}
 
 		LOG.info("Restoring SplitEnumerator of source {} from checkpoint.", operatorName);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -78,6 +78,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -319,6 +320,17 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 
 		assertArrayEquals("coordinator should have a restored checkpoint",
 				coordinatorState, coordinator.getLastRestoredCheckpointState());
+	}
+
+	@Test
+	public void testGlobalFailureBeforeCheckpointResetsToEmptyState() throws Exception {
+		final DefaultScheduler scheduler = createSchedulerAndDeployTasks();
+		final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
+
+		failGlobalAndRestart(scheduler, new TestException());
+
+		assertSame("coordinator should have null restored state",
+			TestingOperatorCoordinator.NULL_RESTORE_VALUE, coordinator.getLastRestoredCheckpointState());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -35,6 +35,8 @@ import java.util.concurrent.LinkedBlockingQueue;
  */
 class TestingOperatorCoordinator implements OperatorCoordinator {
 
+	public static final byte[] NULL_RESTORE_VALUE = new byte[0];
+
 	private final OperatorCoordinator.Context context;
 
 	private final ArrayList<Integer> failedTasks = new ArrayList<>();
@@ -104,8 +106,10 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) {
-		lastRestoredCheckpointState = checkpointData;
+	public void resetToCheckpoint(@Nullable byte[] checkpointData) {
+		lastRestoredCheckpointState = checkpointData == null
+				? NULL_RESTORE_VALUE
+				: checkpointData;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
@@ -197,10 +197,15 @@ public class CollectSinkOperatorCoordinator implements OperatorCoordinator, Coor
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) throws Exception {
-		ByteArrayInputStream bais = new ByteArrayInputStream(checkpointData);
-		ObjectInputStream ois = new ObjectInputStream(bais);
-		address = (InetSocketAddress) ois.readObject();
+	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
+		if (checkpointData == null) {
+			// restore before any checkpoint completed
+			closeConnection();
+		} else {
+			ByteArrayInputStream bais = new ByteArrayInputStream(checkpointData);
+			ObjectInputStream ois = new ObjectInputStream(bais);
+			address = (InetSocketAddress) ois.readObject();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Previously, an `OperatorCoordinator` (and thus also a Source `SplitEnumerator`) got no signal after a global recovery happened before in these cases:
  - The first successful checkpoint, because there was no checkpoint to restore to. Further mor
  - The Coordinator has not stored any state in the checkpoint.

However, it is important to have a signal in that case, because the coordinators might need to reset their state.

Now, 

## Brief change log

  - Minor adjustment in `CheckpointCoordinator` to differentiate between checkpoint/savepoint restore during JobManager startup (do nothing is no checkpoint or operator state is there) and checkpoint restore after failover (reset to empty state if no checkpoint or operator state available).
  - `CheckpointCoordinator` restores empty state to `OperatorCoordinators` in the case of a restore after a failure.
  - Sources ignore empty restore and let a new `SplitEnumerator` be created. The `RecreateOnResetCoordinator` already handles the creation of a new `SplitEnumerator` on each restore.

## Verifying this change

This adds a unit test to `OperatorCoordinatorSchedulerTest` to verify the changed behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
