### PR TITLE
[FLINK-20235][hive][parquet] Parquet lack additional dependencies after bumping

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -920,6 +920,8 @@ under the License.
 									<include>org.apache.parquet:parquet-column</include>
 									<include>org.apache.parquet:parquet-common</include>
 									<include>org.apache.parquet:parquet-encoding</include>
+									<include>org.apache.parquet:parquet-format-structures</include>
+									<include>org.apache.parquet:parquet-jackson</include>
 								</includes>
 							</artifactSet>
 							<relocations>

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -10,3 +10,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.parquet:parquet-column:1.11.1
 - org.apache.parquet:parquet-common:1.11.1
 - org.apache.parquet:parquet-encoding:1.11.1
+- org.apache.parquet:parquet-format-structures:1.11.1
+- org.apache.parquet:parquet-jackson:1.11.1

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -63,6 +63,8 @@ under the License.
 									<include>org.apache.parquet:parquet-column</include>
 									<include>org.apache.parquet:parquet-common</include>
 									<include>org.apache.parquet:parquet-encoding</include>
+									<include>org.apache.parquet:parquet-format-structures</include>
+									<include>org.apache.parquet:parquet-jackson</include>
 									<include>org.codehaus.jackson:jackson-core-asl</include>
 									<include>org.codehaus.jackson:jackson-mapper-asl</include>
 									<include>org.apache.commons:commons-compress</include>

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -10,4 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.parquet:parquet-column:1.11.1
 - org.apache.parquet:parquet-common:1.11.1
 - org.apache.parquet:parquet-encoding:1.11.1
+- org.apache.parquet:parquet-format-structures:1.11.1
+- org.apache.parquet:parquet-jackson:1.11.1
 - commons-pool:commons-pool:1.6


### PR DESCRIPTION

## What is the purpose of the change

In FLINK-19137, Bump Parquet from 1.10.0 to 1.11.1, parquet 1.11 needs dependencies:
- parquet-format-structures
- parquet-jackson

## Brief change log

- Shade parquet dependencies in flink-sql-parquet and flink-hive.

## Verifying this change

Manually testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no