### PR TITLE
[FLINK-20308][doc] Fix wrong links in some Chinese markdown files

### DIFF
--- a/docs/dev/table/connectors/formats/debezium.zh.md
+++ b/docs/dev/table/connectors/formats/debezium.zh.md
@@ -376,5 +376,5 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
 数据类型映射
 ----------------
 
-目前，Debezium Format 使用 JSON Format 进行序列化和反序列化。有关数据类型映射的更多详细信息，请参考 [JSON Format 文档]({% link dev/table/connectors/formats/json.zh.md %}#data-type-mapping) 和 [Confluent Avro Format 文档]({% link dev/table/connectors/formats/avro-confluent.md %}#data-type-mapping)。
+目前，Debezium Format 使用 JSON Format 进行序列化和反序列化。有关数据类型映射的更多详细信息，请参考 [JSON Format 文档]({% link dev/table/connectors/formats/json.zh.md %}#data-type-mapping) 和 [Confluent Avro Format 文档]({% link dev/table/connectors/formats/avro-confluent.zh.md %}#data-type-mapping)。
 

--- a/docs/dev/table/connectors/formats/index.zh.md
+++ b/docs/dev/table/connectors/formats/index.zh.md
@@ -74,7 +74,7 @@ Flink 支持以下格式：
         <tr>
         <td><a href="{% link dev/table/connectors/formats/raw.zh.md %}">Raw</a></td>
         <td><a href="{% link dev/table/connectors/kafka.zh.md %}">Apache Kafka</a>,
-          <a href="{% link dev/table/connectors/kinesis.md %}">Amazon Kinesis Data Streams</a>,
+          <a href="{% link dev/table/connectors/kinesis.zh.md %}">Amazon Kinesis Data Streams</a>,
           <a href="{% link dev/table/connectors/filesystem.zh.md %}">Filesystem</a></td>
         </tr>        
     </tbody>

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -324,11 +324,11 @@ CREATE TABLE MyTable (
 The expression may contain any combination of columns, constants, or functions. The expression cannot
 contain a subquery.
 
-Computed columns are commonly used in Flink for defining [time attributes]({% link dev/table/streaming/time_attributes.md %})
+Computed columns are commonly used in Flink for defining [time attributes]({% link dev/table/streaming/time_attributes.zh.md %})
 in `CREATE TABLE` statements.
-- A [processing time attribute]({% link dev/table/streaming/time_attributes.md %}#processing-time)
+- A [processing time attribute]({% link dev/table/streaming/time_attributes.zh.md %}#processing-time)
 can be defined easily via `proc AS PROCTIME()` using the system's `PROCTIME()` function.
-- An [event time attribute]({% link dev/table/streaming/time_attributes.md %}#event-time) timestamp
+- An [event time attribute]({% link dev/table/streaming/time_attributes.zh.md %}#event-time) timestamp
 can be pre-processed before the `WATERMARK` declaration. For example, the computed column can be used
 if the original field is not `TIMESTAMP(3)` type or is nested in a JSON string.
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix wrong links in `debezium.zh.md`, `index.zh.md` and `create.zh.md`*


## Brief change log

  - *Fix wrong links in `debezium.zh.md`, `index.zh.md` and `create.zh.md`*

## Verifying this change

 -*Executing the script `build_docs.sh`*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
