### PR TITLE
[FLINK-20295][table][fs-connector] Table File Source lost data when reading from directories with JSON format

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
@@ -263,7 +263,6 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
 
 		private final HiveMapredSplitReader hiveMapredSplitReader;
 		private final RowDataSerializer serializer;
-		private final ArrayResultIterator<RowData> iterator = new ArrayResultIterator<>();
 		private final int[] selectedFields;
 		private long numRead = 0;
 
@@ -287,6 +286,8 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
 			if (num == 0) {
 				return null;
 			}
+
+			ArrayResultIterator<RowData> iterator = new ArrayResultIterator<>();
 			iterator.set(records, num, NO_OFFSET, skipCount);
 			return iterator;
 		}

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonBatchFileSystemITCase.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.formats.json;
 
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.FileUtils;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,5 +62,53 @@ public class JsonBatchFileSystemITCase extends BatchFileSystemITCaseBase {
 			Arrays.asList(
 				Row.of("x5,5,1,1"),
 				Row.of("x5,5,1,1")));
+	}
+
+	@Test
+	public void bigDataTest() throws IOException {
+		int numRecords = 1000;
+		File dir = generateTestData(numRecords);
+
+		env().setParallelism(1);
+
+		String sql = String.format(
+				"CREATE TABLE bigdata_source ( " +
+						"	id INT, " +
+						"	content STRING" +
+						") PARTITIONED by (id) WITH (" +
+						"	'connector' = 'filesystem'," +
+						"	'path' = '%s'," +
+						"	'format' = 'json'" +
+						")", dir);
+		tEnv().executeSql(sql);
+		TableResult result = tEnv().executeSql("select * from bigdata_source");
+		List<String> elements = new ArrayList<>();
+		result.collect().forEachRemaining(r -> elements.add((String) r.getField(1)));
+		Assert.assertEquals(numRecords, elements.size());
+		elements.sort(String::compareTo);
+
+		List<String> expected = new ArrayList<>();
+		for (int i = 0; i < numRecords; i++) {
+			expected.add(String.valueOf(i));
+		}
+		expected.sort(String::compareTo);
+
+		Assert.assertEquals(expected, elements);
+	}
+
+	private static File generateTestData(int numRecords) throws IOException {
+		File tempDir = TEMPORARY_FOLDER.newFolder();
+
+		File root = new File(tempDir, "id=0");
+		root.mkdir();
+
+		File dataFile = new File(root, "testdata");
+		try (PrintWriter writer = new PrintWriter(dataFile)) {
+			for (int i = 0; i < numRecords; ++i) {
+				writer.println(String.format("{\"content\":\"%s\"}", i));
+			}
+		}
+
+		return tempDir;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DeserializationSchemaAdapter.java
@@ -161,7 +161,6 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 	private class Reader implements BulkFormat.Reader<RowData> {
 
 		private final LineBytesInputFormat inputFormat;
-		private final ArrayResultIterator<RowData> iterator = new ArrayResultIterator<>();
 		private long numRead = 0;
 
 		private Reader(Configuration config, FileSourceSplit split) throws IOException {
@@ -173,7 +172,7 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 		@Nullable
 		@Override
 		public RecordIterator<RowData> readBatch() throws IOException {
-			Object[] records = new Object[DEFAULT_SIZE];
+			RowData[] records = new RowData[DEFAULT_SIZE];
 			int num = 0;
 			final long skipCount = numRead;
 			for (int i = 0; i < BATCH_SIZE; i++) {
@@ -187,7 +186,9 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
 				return null;
 			}
 			numRead += num;
-			((ArrayResultIterator) iterator).set(records, num, NO_OFFSET, skipCount);
+
+			ArrayResultIterator<RowData> iterator = new ArrayResultIterator<>();
+			iterator.set(records, num, NO_OFFSET, skipCount);
 			return iterator;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

When testing the compaction functionality of the FileSystemTableSink, I found that when using json format, the produced directories could not be read correctly by the file source, namely only a part of records are read.

By checking the produced directories, the number of the records in it is the same as expected, thus it seems to be the issue of the source side.

The issue only exists for JSON format.

The data is produced by FileCompactionTest and read by  FileCompactionCheckTest . An example directories tar file of 8000 records are also attached.

## Brief change log

It should be due to that `DeserializationSchemaAdapter` always returned the same cached iterator for different batches, thus it might be the data get override before it is fully emitted. Returns different iterators should be able to solve this issue. 

`HiveBulkFormatAdapter` also has this problem.

## Verifying this change

*(Please pick either of the following options)*

`JsonBatchFileSystemITCase.bigDataTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no