### PR TITLE
[FLINK-20306][table-planner-blink] Throw a meaningful exception when accessing temporal table as of constant timestamp

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSnapshot.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSnapshot.scala
@@ -48,17 +48,16 @@ class FlinkLogicalSnapshot(
   override def isValid(
       litmus: Litmus,
       context: RelNode.Context): Boolean = {
+    val msg = "Temporal table can only be used in temporal join and only supports " +
+      "'FOR SYSTEM_TIME AS OF' left table's time attribute field.\nQuerying a temporal table " +
+      "using 'FOR SYSTEM TIME AS OF' syntax with %s is not supported yet."
     period match {
       case _: RexFieldAccess =>
         // pass
       case lit: RexLiteral =>
-        return litmus.fail(s"Querying a temporal table using " +
-          "'FOR SYSTEM TIME AS OF' syntax with a constant timestamp " +
-          s"'${lit.toString}' is not supported yet.")
+        return litmus.fail(String.format(msg, s"a constant timestamp '${lit.toString}'"))
       case _ =>
-        return litmus.fail(s"Querying a temporal table using " +
-          "'FOR SYSTEM TIME AS OF' syntax with an expression call " +
-          s"'${period.toString}' is not supported yet.")
+        return litmus.fail(String.format(msg, s"an expression call '${period.toString}'"))
     }
     super.isValid(litmus, context)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
@@ -44,20 +44,15 @@ trait CommonTemporalTableJoinRule {
 
     // period specification check
     snapshot.getPeriod match {
-      // it's left table's field, pass
-      case r: RexFieldAccess if r.getReferenceExpr.isInstanceOf[RexCorrelVariable] =>
+      // it should be left table's field and is a time attribute
+      case r: RexFieldAccess
+        if r.getType.isInstanceOf[TimeIndicatorRelDataType] &&
+          r.getReferenceExpr.isInstanceOf[RexCorrelVariable] => // pass
       case _ =>
         throw new TableException("Temporal table join currently only supports " +
-          "'FOR SYSTEM_TIME AS OF' left table's time attribute field, doesn't support 'PROCTIME()'")
+          "'FOR SYSTEM_TIME AS OF' left table's time attribute field.")
     }
 
-    snapshot.getPeriod.getType match {
-      // supports both event-time and processing time
-      case t: TimeIndicatorRelDataType =>
-      case _ =>
-        throw new TableException("Temporal table join currently only supports " +
-          "'FOR SYSTEM_TIME AS OF' left table's time attribute field")
-    }
     true
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -90,8 +90,11 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
     // can't query a dim table directly
     expectExceptionThrown(
       "SELECT * FROM LookupTable FOR SYSTEM_TIME AS OF TIMESTAMP '2017-08-09 14:36:11'",
-      "Cannot generate a valid execution plan for the given query",
-      classOf[TableException]
+      "Temporal table can only be used in temporal join and only supports " +
+        "'FOR SYSTEM_TIME AS OF' left table's time attribute field.\n" +
+        "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with a constant " +
+        "timestamp '2017-08-09 14:36:11' is not supported yet",
+      classOf[AssertionError]
     )
 
     // only support left or inner join

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -1980,11 +1980,14 @@ class FlinkRelMdHandlerTestBase {
   }
 
   protected lazy val flinkLogicalSnapshot: FlinkLogicalSnapshot = {
+    val temporalTableRelType = relBuilder.scan("TemporalTable1").build().getRowType
+    val correlVar = rexBuilder.makeCorrel(temporalTableRelType, new CorrelationId(0))
+    val rowtimeField = rexBuilder.makeFieldAccess(correlVar, 4)
     new FlinkLogicalSnapshot(
       cluster,
       flinkLogicalTraits,
       studentFlinkLogicalScan,
-      relBuilder.call(FlinkSqlOperatorTable.PROCTIME))
+      rowtimeField)
   }
 
   // SELECT * FROM student AS T JOIN TemporalTable

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -102,8 +102,11 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
     // can't query a dim table directly
     expectExceptionThrown(
       "SELECT * FROM LookupTable FOR SYSTEM_TIME AS OF TIMESTAMP '2017-08-09 14:36:11'",
-      "Cannot generate a valid execution plan for the given query",
-      classOf[TableException]
+      "Temporal table can only be used in temporal join and only supports " +
+        "'FOR SYSTEM_TIME AS OF' left table's time attribute field.\n" +
+        "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with a constant " +
+        "timestamp '2017-08-09 14:36:11' is not supported yet",
+      classOf[AssertionError]
     )
 
     // only support left or inner join
@@ -127,9 +130,11 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
     expectExceptionThrown(
       "SELECT * FROM MyTable AS T LEFT JOIN LookupTable " +
         "FOR SYSTEM_TIME AS OF PROCTIME() AS D ON T.a = D.id",
-      "Temporal table join currently only supports 'FOR SYSTEM_TIME AS OF' " +
-        "left table's time attribute field, doesn't support 'PROCTIME()'",
-      classOf[TableException]
+      "Temporal table can only be used in temporal join and only supports " +
+        "'FOR SYSTEM_TIME AS OF' left table's time attribute field.\n" +
+        "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with " +
+        "an expression call 'PROCTIME()' is not supported yet.",
+      classOf[AssertionError]
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -452,6 +452,21 @@ class TemporalJoinTest extends TableTestBase {
       s"Event-Time Temporal Table Join requires both primary key and row time attribute in " +
         s"versioned table, but no row time attribute can be found.",
       classOf[ValidationException])
+
+    val sqlQuery6 = "SELECT * FROM RatesHistory " +
+      "FOR SYSTEM_TIME AS OF TIMESTAMP '2020-11-11 13:12:13'"
+    expectExceptionThrown(
+      sqlQuery6,
+      "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with a constant timestamp " +
+        "'2020-11-11 13:12:13' is not supported yet.",
+      classOf[AssertionError])
+
+    val sqlQuery7 = "SELECT * FROM RatesHistory FOR SYSTEM_TIME AS OF CAST(1 AS TIMESTAMP)"
+    expectExceptionThrown(
+      sqlQuery7,
+      "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with an expression call " +
+        "'CAST(1):TIMESTAMP(6) NOT NULL' is not supported yet.",
+      classOf[AssertionError])
   }
 
   private def expectExceptionThrown(


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the planner throws a cryptic exception message when accessing temporal table with constant timestamp.

```
SELECT * from RatesHistory FOR SYSTEM_TIME AS OF TIMESTAMP '2020-11-11 13:12:13';

org.apache.calcite.plan.RelOptPlanner$CannotPlanException: There are not enough rules to produce a node with desired properties: convention=STREAM_PHYSICAL, FlinkRelDistributionTraitDef=any, MiniBatchIntervalTraitDef=None: 0, ModifyKindSetTraitDef=[NONE], UpdateKindTraitDef=[NONE].
Missing conversion is FlinkLogicalSnapshot[convention: LOGICAL -> STREAM_PHYSICAL]
There is 1 empty subset: rel#987:RelSubset#44.STREAM_PHYSICAL.any.None: 0.[NONE].[NONE], the relevant part of the original plan is as follows
977:FlinkLogicalSnapshot(period=[2020-11-11 13:12:13])
  975:FlinkLogicalCalc(subset=[rel#976:RelSubset#43.LOGICAL.any.None: 0.[NONE].[NONE]], select=[CAST(Reinterpret(CAST(timestamp))) AS currency_time, currency, CAST(rate) AS rate])
    962:FlinkLogicalTableSourceScan(subset=[rel#974:RelSubset#42.LOGICAL.any.None: 0.[NONE].[NONE]], table=[[default_catalog, default_database, RatesHistory, watermark=[CAST($2):TIMESTAMP(3)]]], fields=[currency, rate, timestamp])
```

We can throw a better exception to indicate this is not supported yet. 

## Brief change log

- throw a better exception when constructing `FlinkLogicalSnapshot` via `isValid(...)` interface.

## Verifying this change

- Added validation tests which can reproduce the problem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
