### PR TITLE
[FLINK-17424][e2e] Further stabilize Elasticsearch in test_sql_client.sh

### DIFF
--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -34,12 +34,24 @@ function setup_elasticsearch {
     fi
 
     # start downloading Elasticsearch
-    echo "Downloading Elasticsearch from $downloadUrl ..."
-    curl "$downloadUrl" --retry 10 --retry-max-time 120 --output $TEST_DATA_DIR/elasticsearch.tar.gz
-
     local elasticsearchDir=$TEST_DATA_DIR/elasticsearch
     mkdir -p $elasticsearchDir
-    tar xzf $TEST_DATA_DIR/elasticsearch.tar.gz -C $elasticsearchDir --strip-components=1
+    echo "Downloading Elasticsearch from $downloadUrl ..."
+    for i in {1..10};
+    do
+        wget "$downloadUrl" -O $TEST_DATA_DIR/elasticsearch.tar.gz
+        if [ $? -eq 0 ]; then
+            echo "Download successful."
+            echo "Extracting..."
+            tar xzf $TEST_DATA_DIR/elasticsearch.tar.gz -C $elasticsearchDir --strip-components=1
+            if [ $? -eq 0 ]; then
+                break
+            fi
+        fi
+        echo "Attempt $i failed."
+        sleep 5
+    done
+    echo "Extraction successful."
 
     if [ `uname -i` == 'aarch64' ] && [ $elasticsearch_version -ge 6 ]; then
       echo xpack.ml.enabled: false >> $elasticsearchDir/config/elasticsearch.yml

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -26,8 +26,9 @@ CONFLUENT_VERSION="5.0.0"
 CONFLUENT_MAJOR_VERSION="5.0"
 KAFKA_SQL_VERSION="universal"
 ELASTICSEARCH_VERSION=7
-ELASTICSEARCH_MAC_DOWNLOAD_URL='https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.1-darwin-x86_64.tar.gz'
-ELASTICSEARCH_LINUX_DOWNLOAD_URL='https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.5.1-linux-x86_64.tar.gz'
+# we use the smallest version possible
+ELASTICSEARCH_MAC_DOWNLOAD_URL='https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.1-no-jdk-darwin-x86_64.tar.gz'
+ELASTICSEARCH_LINUX_DOWNLOAD_URL='https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.5.1-no-jdk-linux-x86_64.tar.gz'
 
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/kafka_sql_common.sh \


### PR DESCRIPTION
## What is the purpose of the change

Another attempt to improve the error rate when downloading Elasticsearch. If this doesn't help, we need to put a loop around `curl` and retry ourselves. There is a `--retry-all-errors` but this is not available on all machines yet.

## Brief change log

- Continue download at last position if possible.
- Use OSS version

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
