### PR TITLE
[FLINK-20314][planner] Add rule to remove empty calc

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalCalcRemoveRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkLogicalCalcRemoveRule.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+
+import org.apache.calcite.rel.rules.CalcRemoveRule;
+
+import static org.apache.calcite.rel.rules.CalcRemoveRule.Config;
+
+/**
+ * Rule to remove trivial {@link FlinkLogicalCalc}.
+ */
+public class FlinkLogicalCalcRemoveRule {
+	public static final CalcRemoveRule INSTANCE = Config.DEFAULT.withOperandSupplier(
+			b -> b.operand(FlinkLogicalCalc.class)
+					.predicate(calc -> calc.getProgram().isTrivial())
+					.anyInputs())
+			.as(Config.class).toRule();
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -376,6 +376,8 @@ object FlinkBatchRuleSets {
     PythonCorrelateSplitRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
+    // remove trivial calc
+    FlinkLogicalCalcRemoveRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -376,8 +376,6 @@ object FlinkBatchRuleSets {
     PythonCorrelateSplitRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
-    // remove trivial calc
-    FlinkLogicalCalcRemoveRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -365,6 +365,8 @@ object FlinkStreamRuleSets {
     PythonCorrelateSplitRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
+    // remove trivial calc
+    FlinkLogicalCalcRemoveRule.INSTANCE,
     //Rule that rewrites temporal join with extracted primary key
     TemporalJoinRewriteWithUniqueKeyRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -365,7 +365,9 @@ object FlinkStreamRuleSets {
     PythonCorrelateSplitRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
-    // remove trivial calc
+    // remove the trivial calc that is produced by PushWatermarkIntoTableSourceScanAcrossCalcRule.
+    // because [[PushWatermarkIntoTableSourceScanAcrossCalcRule]] will push the rowtime computed
+    // column into the source. After FlinkCalcMergeRule applies, it may produces a trivial calc.
     FlinkLogicalCalcRemoveRule.INSTANCE,
     //Rule that rewrites temporal join with extracted primary key
     TemporalJoinRewriteWithUniqueKeyRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -16,6 +16,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testSimpleWatermarkPushDown">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c FROM VirtualTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2, 5000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testWatermarkWithUdf">
     <Resource name="sql">
       <![CDATA[SELECT a - b FROM UdfTable]]>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Remove the empty calc node in the logical rewrite phase.*

The empty calc is produced by the rule `PushWatermarkIntoTableSourceScanAcrossCalcRule`. However, it's difficult to eliminate the empty calc in the `PushWatermarkIntoTableSourceScanAcrossCalcRule`.  Let me explain why it may get trivial calc.  For example,

```
CREATE TABLE SimpleTable(
   a INT,
   b INT,
   c TIMESTAMP(3),
   d AS c + INTERVAL '5' SECOND,
  WATERMARK FOR d AS d - INTERVAL '5' SECOND
) WITH (
 ...
)
```
With the query `SELECT a, b, c FROM SimpleTable`, we have the following plan after logical phase before logical rewrite phase

```
FlinkLogicalCalc(select=[a, b, c])
+- FlinkLogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)])
   +- FlinkLogicalCalc(select=[a, b, c, +(c, 5000:INTERVAL SECOND) AS d])
      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable]], fields=[a, b, c])
```
After `PushWatermarkIntoTableSourceScanAcrossCalcRule` applies, we will get the plan

```
FlinkLogicalCalc(select=[a, b, c])
+- FlinkLogicalCalc(select=[a, b, c, +(c, 5000:INTERVAL SECOND) AS d])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable]], fields=[a, b, c], watermark=[-($3, 5000:INTERVAL SECOND)])
```
After calc merge rule applies, we will have the following plan

```
FlinkLogicalCalc(select=[a, b, c])
+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable]], fields=[a, b, c], watermark=[-($3, 5000:INTERVAL SECOND)])
```

Now we has the trivial calc. It's out of scope for the push-watermark-down rule to prune the trivial calc. Therefore, we'd better to keep the push-watermark-down rule unchanged and add a new rule to remove the empty calc.


## Brief change log

  - *Add `FlinkLogicalCalcRemoveRule` to remove empty calc*

## Verifying this change


This change added tests and can be verified as follows:

  - *Add unit test and itcase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
