### PR TITLE
[FLINK-20338] Make the `StatefulSinkWriterOperator` load `StreamingFileSink`'s state.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperator.java
@@ -31,7 +31,12 @@ import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.CollectionUtil;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Runtime {@link org.apache.flink.streaming.api.operators.StreamOperator} for executing {@link
@@ -54,18 +59,28 @@ final class StatefulSinkWriterOperator<InputT, CommT, WriterStateT> extends Abst
 	/** The writer operator's state serializer. */
 	private final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer;
 
+	/** The previous sink operator's state name. */
+	@Nullable
+	private final String previousSinkStateName;
+
 	// ------------------------------- runtime fields ---------------------------------------
+
+	/** The previous sink operator's state. */
+	@Nullable
+	private ListState<WriterStateT> previousSinkState;
 
 	/** The operator's state. */
 	private ListState<WriterStateT> writerState;
 
 	StatefulSinkWriterOperator(
+			@Nullable final String previousSinkStateName,
 			final ProcessingTimeService processingTimeService,
 			final Sink<InputT, CommT, WriterStateT, ?> sink,
 			final SimpleVersionedSerializer<WriterStateT> writerStateSimpleVersionedSerializer) {
 		super(processingTimeService);
 		this.sink = sink;
 		this.writerStateSimpleVersionedSerializer = writerStateSimpleVersionedSerializer;
+		this.previousSinkStateName = previousSinkStateName;
 	}
 
 	@Override
@@ -74,17 +89,40 @@ final class StatefulSinkWriterOperator<InputT, CommT, WriterStateT> extends Abst
 
 		final ListState<byte[]> rawState = context.getOperatorStateStore().getListState(WRITER_RAW_STATES_DESC);
 		writerState = new SimpleVersionedListState<>(rawState, writerStateSimpleVersionedSerializer);
+
+		if (previousSinkStateName != null) {
+			final ListStateDescriptor<byte[]> preSinkStateDesc = new ListStateDescriptor<>(
+					previousSinkStateName,
+					BytePrimitiveArraySerializer.INSTANCE);
+
+			final ListState<byte[]> preRawState = context
+					.getOperatorStateStore()
+					.getListState(preSinkStateDesc);
+			this.previousSinkState = new SimpleVersionedListState<>(
+					preRawState,
+					writerStateSimpleVersionedSerializer);
+		}
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public void snapshotState(StateSnapshotContext context) throws Exception {
 		writerState.update((List<WriterStateT>) sinkWriter.snapshotState());
+		if (previousSinkState != null) {
+			previousSinkState.clear();
+		}
 	}
 
 	@Override
 	SinkWriter<InputT, CommT, WriterStateT> createWriter() throws Exception {
-		final List<WriterStateT> committables = CollectionUtil.iterableToList(writerState.get());
-		return sink.createWriter(createInitContext(), committables);
+		final List<WriterStateT> writerStates = CollectionUtil.iterableToList(writerState.get());
+		final List<WriterStateT> states = new ArrayList<>(writerStates);
+		if (previousSinkStateName != null) {
+			checkNotNull(previousSinkState);
+			final List<WriterStateT> previousSinkStates = CollectionUtil.iterableToList(
+					previousSinkState.get());
+			states.addAll(previousSinkStates);
+		}
+		return sink.createWriter(createInitContext(), states);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorFactory.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link org.apache.flink.streaming.api.operators.StreamOperatorFactory} for {@link
  * StatefulSinkWriterOperator}.
@@ -35,13 +37,27 @@ public final class StatefulSinkWriterOperatorFactory<InputT, CommT, WriterStateT
 
 	private final Sink<InputT, CommT, WriterStateT, ?> sink;
 
+	@Nullable
+	private final String previousSinkStateName;
+
 	public StatefulSinkWriterOperatorFactory(Sink<InputT, CommT, WriterStateT, ?> sink) {
+		this(sink, null);
+	}
+
+	public StatefulSinkWriterOperatorFactory(
+			Sink<InputT, CommT, WriterStateT, ?> sink,
+			@Nullable String previousSinkStateName) {
 		this.sink = sink;
+		this.previousSinkStateName = previousSinkStateName;
 	}
 
 	@Override
 	AbstractSinkWriterOperator<InputT, CommT> createWriterOperator(ProcessingTimeService processingTimeService) {
-		return new StatefulSinkWriterOperator<>(processingTimeService, sink, sink.getWriterStateSerializer().get());
+		return new StatefulSinkWriterOperator<>(
+				previousSinkStateName,
+				processingTimeService,
+				sink,
+				sink.getWriterStateSerializer().get());
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/StatefulSinkWriterOperatorTest.java
@@ -18,18 +18,31 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TestHarnessUtil;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -90,6 +103,70 @@ public class StatefulSinkWriterOperatorTest extends SinkWriterOperatorTestBase {
 						new StreamRecord<>(Tuple3.of(2, initialTime + 2, initialTime).toString())));
 	}
 
+	@Test
+	public void loadPreviousSinkState() throws Exception {
+		//1. Build previous sink state
+		final List<String> previousSinkInputs = Arrays.asList("bit", "mention", "thick", "stick", "stir",
+				"easy", "sleep", "forth", "cost", "prompt");
+
+		final OneInputStreamOperatorTestHarness<String, String> previousSink =
+				new OneInputStreamOperatorTestHarness<>(
+						new DummySinkOperator(),
+						StringSerializer.INSTANCE);
+
+		OperatorSubtaskState previousSinkState = TestHarnessUtil.buildSubtaskState(
+				previousSink,
+				previousSinkInputs);
+
+		//2. Load previous sink state and verify the output
+		final OneInputStreamOperatorTestHarness<Integer, String> compatibleWriterOperator =
+				createCompatibleSinkOperator();
+
+		final List<StreamRecord<String>> expectedOutput1 =
+				previousSinkInputs.stream().map(StreamRecord::new).collect(Collectors.toList());
+		expectedOutput1.add(new StreamRecord<>(Tuple3.of(1, 1, Long.MIN_VALUE).toString()));
+
+		// load the state from previous sink
+		compatibleWriterOperator.initializeState(previousSinkState);
+
+		compatibleWriterOperator.open();
+
+		compatibleWriterOperator.processElement(1, 1);
+
+		// this will flush out the committables that were restored from previous sink
+		compatibleWriterOperator.endInput();
+
+		OperatorSubtaskState operatorStateWithoutPreviousState = compatibleWriterOperator.snapshot(
+				1L,
+				1L);
+
+		compatibleWriterOperator.close();
+
+		assertThat(
+				compatibleWriterOperator.getOutput(),
+				containsInAnyOrder(expectedOutput1.toArray()));
+
+		//3. Restore the sink without previous sink's state
+		final OneInputStreamOperatorTestHarness<Integer, String> restoredSinkOperator =
+				createCompatibleSinkOperator();
+		final List<StreamRecord<String>> expectedOutput2 =
+				Arrays.asList(
+						new StreamRecord<>(Tuple3.of(2, 2, Long.MIN_VALUE).toString()),
+						new StreamRecord<>(Tuple3.of(3, 3, Long.MIN_VALUE).toString()));
+
+		restoredSinkOperator.initializeState(operatorStateWithoutPreviousState);
+
+		restoredSinkOperator.open();
+
+		restoredSinkOperator.processElement(2, 2);
+		restoredSinkOperator.processElement(3, 3);
+
+		// this will flush out the committables that were restored
+		restoredSinkOperator.endInput();
+
+		assertThat(restoredSinkOperator.getOutput(), containsInAnyOrder(expectedOutput2.toArray()));
+	}
+
 	/**
 	 * A {@link SinkWriter} buffers elements and snapshots them when asked.
 	 */
@@ -104,5 +181,37 @@ public class StatefulSinkWriterOperatorTest extends SinkWriterOperatorTestBase {
 		void restoredFrom(List<String> states) {
 			this.elements = states;
 		}
+	}
+
+	static class DummySinkOperator extends AbstractStreamOperator<String> implements OneInputStreamOperator<String, String> {
+
+		static final String DUMMY_SINK_STATE_NAME = "dummy_sink_state";
+
+		static final ListStateDescriptor<byte[]> SINK_STATE_DESC = new ListStateDescriptor<>(
+				DUMMY_SINK_STATE_NAME,
+				BytePrimitiveArraySerializer.INSTANCE);
+		ListState<String> sinkState;
+
+		public void initializeState(StateInitializationContext context) throws Exception {
+			super.initializeState(context);
+			sinkState = new SimpleVersionedListState<>(context
+					.getOperatorStateStore()
+					.getListState(SINK_STATE_DESC), TestSink.StringCommittableSerializer.INSTANCE);
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			sinkState.add(element.getValue());
+		}
+	}
+
+	private OneInputStreamOperatorTestHarness<Integer, String> createCompatibleSinkOperator() throws Exception {
+		return new OneInputStreamOperatorTestHarness<>(
+				new StatefulSinkWriterOperatorFactory<>(TestSink
+						.newBuilder()
+						.setWriter(new SnapshottingBufferingSinkWriter())
+						.withWriterState()
+						.build(), DummySinkOperator.DUMMY_SINK_STATE_NAME),
+				IntSerializer.INSTANCE);
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Flink-1.12 introduces the `FileSink` in FLINK-19510, which can guarantee the exactly once semantics both in the streaming and batch execution mode. We need to provide a way for the user who uses `StreamingFileSink` to migrate from `StreamingFileSink` to `FileSink`.

For this purpose we propose to let the new sink writer operator could load the previous StreamingFileSink's state and then the `SinkWriter` could have the opertunity to handle the old state. 



## Brief change log

  - *Make the `StatefuleSinkWriterOperator` load previous sink's state*
  - *SinkTransformationTranslator would create a `StatefulSinkWriterOper`, that load the bucket-state*


## Verifying this change

* `StatefulSinkWriterOperatorTest::loadPreviousSinkState` test load state from previous sink's checkpoint and restore

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
