### PR TITLE
[FLINK-20328][tests] Fixed buffer calculation in UnalignedCheckpointITCase.

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -110,12 +110,12 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 	}
 
 	private static UnalignedSettings createPipelineSettings(int parallelism, int slotsPerTaskManager, boolean slotSharing) {
-		int numShuffles = 5;
+		int numShuffles = 4;
 		return new UnalignedSettings(UnalignedCheckpointITCase::createPipeline)
 			.setParallelism(parallelism)
 			.setSlotSharing(slotSharing)
 			.setNumSlots(slotSharing ? parallelism : parallelism * numShuffles)
-			.setNumBuffers(3 * slotsPerTaskManager * parallelism * numShuffles)
+			.setNumBuffers(getNumBuffers(parallelism, numShuffles))
 			.setSlotsPerTaskManager(slotsPerTaskManager)
 			.setExpectedFailures(5);
 	}
@@ -126,7 +126,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 			.setParallelism(parallelism)
 			.setSlotSharing(true)
 			.setNumSlots(parallelism * numShuffles)
-			.setNumBuffers(3 * parallelism * parallelism * numShuffles)
+			.setNumBuffers(getNumBuffers(parallelism, numShuffles))
 			.setSlotsPerTaskManager(parallelism)
 			.setExpectedFailures(5);
 	}
@@ -137,9 +137,15 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 			.setParallelism(parallelism)
 			.setSlotSharing(true)
 			.setNumSlots(parallelism * numShuffles)
-			.setNumBuffers(3 * parallelism * parallelism * numShuffles)
+			.setNumBuffers(getNumBuffers(parallelism, numShuffles))
 			.setSlotsPerTaskManager(parallelism)
 			.setExpectedFailures(5);
+	}
+
+	private static int getNumBuffers(int parallelism, int numShuffles) {
+		int buffersPerSubtask =	parallelism + 1 + // output side
+			2 * BUFFER_PER_CHANNEL * parallelism; // input side including recovery (=local channels count fully)
+		return buffersPerSubtask * parallelism * numShuffles;
 	}
 
 	private final UnalignedSettings settings;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -98,6 +98,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 	protected static final String NUM_FAILURES = "failures";
 	protected static final String NUM_DUPLICATES = "duplicates";
 	protected static final String NUM_LOST = "lost";
+	public static final int BUFFER_PER_CHANNEL = 1;
 
 	@Rule
 	public final TemporaryFolder temp = new TemporaryFolder();
@@ -445,7 +446,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 				conf.set(SavepointConfigOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
 			}
 
-			conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 1);
+			conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, BUFFER_PER_CHANNEL);
 			conf.set(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, slotsPerTaskManager);
 
 			final LocalStreamEnvironment env = StreamExecutionEnvironment.createLocalEnvironment(parallelism, conf);


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For low parallelism, recovery competed with regular task creation for the buffers.

## Brief change log

- Fixed calculation.

## Verifying this change

Fixes test instability.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
