### PR TITLE
[FLINK-20316][doc] update the deduplication section of query page

### DIFF
--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -1100,7 +1100,7 @@ WHERE rownum = 1
 
 - `ROW_NUMBER()`: Assigns an unique, sequential number to each row, starting with one.
 - `PARTITION BY col1[, col2...]`: Specifies the partition columns, i.e. the deduplicate key.
-- `ORDER BY time_attr [asc|desc]`: Specifies the ordering column, it must be a [time attribute]({{ site.baseurl }}/dev/table/streaming/time_attributes.html). Currently only support [proctime attribute]({{ site.baseurl }}/dev/table/streaming/time_attributes.html#processing-time). [Rowtime atttribute]({{ site.baseurl }}/dev/table/streaming/time_attributes.html#event-time) will be supported in the future. Ordering by ASC means keeping the first row, ordering by DESC means keeping the last row.
+- `ORDER BY time_attr [asc|desc]`: Specifies the ordering column, it must be a [time attribute]({% link dev/table/streaming/time_attributes.md %}). Currently Flink supports [processing time attribute]({% link dev/table/streaming/time_attributes.md %}#processing-time) and [event time atttribute]({% link dev/table/streaming/time_attributes.md %}#event-time). Ordering by ASC means keeping the first row, ordering by DESC means keeping the last row.
 - `WHERE rownum = 1`: The `rownum = 1` is required for Flink to recognize this query is deduplication.
 
 The following examples show how to specify SQL queries with Deduplication on streaming tables.
@@ -1154,6 +1154,9 @@ val result1 = tableEnv.sqlQuery(
 </div>
 
 {% top %}
+
+Deduplication can keep the time attribute of input stream, this is very helpful when the downstream operation is window aggregation or join operation.
+Both processing-time deduplication and event-time deduplication supports working on mini-batch mode, this is friendly to performance, please see also [mini-batch configuration]({% link dev/table/config.md %}#table-exec-mini-batch-enabled) for more information.
 
 ### Group Windows
 

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -1156,7 +1156,7 @@ val result1 = tableEnv.sqlQuery(
 {% top %}
 
 Deduplication can keep the time attribute of input stream, this is very helpful when the downstream operation is window aggregation or join operation.
-Both processing-time deduplication and event-time deduplication supports working on mini-batch mode, this is friendly to performance, please see also [mini-batch configuration]({% link dev/table/config.md %}#table-exec-mini-batch-enabled) for more information.
+Both processing-time deduplication and event-time deduplication support working on mini-batch mode, this is more performance friendly, please see also [mini-batch configuration]({% link dev/table/config.md %}#table-exec-mini-batch-enabled) for how to enable mini-batch mode..
 
 ### Group Windows
 

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -1096,7 +1096,7 @@ WHERE rownum = 1
 
 - `ROW_NUMBER()`: 从第一行开始，依次为每一行分配一个唯一且连续的号码。
 - `PARTITION BY col1[, col2...]`: 指定分区的列，例如去重的键。
-- `ORDER BY time_attr [asc|desc]`: 指定排序的列。所制定的列必须为 [时间属性]({{ site.baseurl }}/zh/dev/table/streaming/time_attributes.html)。目前仅支持 [proctime attribute]({{ site.baseurl }}/zh/dev/table/streaming/time_attributes.html#processing-time)，在未来版本中将会支持 [Rowtime atttribute]({{ site.baseurl }}/zh/dev/table/streaming/time_attributes.html#event-time) 。升序（ ASC ）排列指只保留第一行，而降序排列（ DESC ）则指保留最后一行。
+- `ORDER BY time_attr [asc|desc]`: 指定排序的列。所指定的列必须为 [时间属性]({% link dev/table/streaming/time_attributes.zh.md %}), 目前 Flink 支持 [处理时间属性]({% link dev/table/streaming/time_attributes.zh.md %}#处理时间) 和 [事件时间属性]({% link dev/table/streaming/time_attributes.zh.md %}#事件时间) 。升序（ ASC ）排列指只保留第一行，而降序排列（ DESC ）则指保留最后一行。
 - `WHERE rownum = 1`: Flink 需要 `rownum = 1` 以确定该查询是否为去重查询。
 
 以下的例子描述了如何指定 SQL 查询以在一个流计算表中进行去重操作。
@@ -1148,6 +1148,9 @@ val result1 = tableEnv.sqlQuery(
 </div>
 
 {% top %}
+
+去重能够保留输入流的时间属性，当下游操作是 window 聚合 或 join 关联操作时非常有用。
+基于处理时间的去重和基于事件时间的去重都支持 mini-batch 模式，这对性能很友好, 查看 [mini-batch 配置]({% link dev/table/config.zh.md %}#table-exec-mini-batch-enabled) 了解更多信息。
 
 ### 分组窗口
 

--- a/docs/dev/table/sql/queries.zh.md
+++ b/docs/dev/table/sql/queries.zh.md
@@ -1150,7 +1150,7 @@ val result1 = tableEnv.sqlQuery(
 {% top %}
 
 去重能够保留输入流的时间属性，当下游操作是 window 聚合 或 join 关联操作时非常有用。
-基于处理时间的去重和基于事件时间的去重都支持 mini-batch 模式，这对性能很友好, 查看 [mini-batch 配置]({% link dev/table/config.zh.md %}#table-exec-mini-batch-enabled) 了解更多信息。
+基于处理时间的去重和基于事件时间的去重都支持 mini-batch 模式，这对性能更加友好, 查看 [mini-batch 配置]({% link dev/table/config.zh.md %}#table-exec-mini-batch-enabled) 了解如何开启 mini-batch 模式。
 
 ### 分组窗口
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request aims to update the deduplication section of query page.


## Brief change log

  - Update that Flink SQL has supported both proctime and rowtime deduplication but he document is still support only proctime
  - Update that both proctime and rowtime deduplication support working on `mini-batch` mode

## Verifying this change

This change is a document PR without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
