### PR TITLE
[FLINK-20344][dist] Modify the default value of the flink-conf savepoint folder to distinguish the checkpoint folder

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -121,7 +121,7 @@ parallelism.default: 1
 
 # Default target directory for savepoints, optional.
 #
-# state.savepoints.dir: hdfs://namenode-host:port/flink-checkpoints
+# state.savepoints.dir: hdfs://namenode-host:port/flink-savepoints
 
 # Flag to enable/disable incremental checkpoints for backends that
 # support incremental checkpoints (like the RocksDB state backend). 


### PR DESCRIPTION
Should savepoints in the flink-conf.yml file be specified as the end of flink-savepoint instead of the default and the same as the configuration of flink-checkpoints

 

state.**checkpoints**.dir: hdfs://namenode-host:port/flink-**checkpoints**

state.**savepoints**.dir: hdfs://namenode-host:port/flink-**checkpoints**

 

after modification

state.**savepoints**.dir: hdfs://namenode-host:port/flink-**savepoints**