### PR TITLE
[FLINK-20304] Introduce the BroadcastStateTransformation.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -57,8 +57,8 @@ import static java.util.Objects.requireNonNull;
 public class BroadcastConnectedStream<IN1, IN2> {
 
 	private final StreamExecutionEnvironment environment;
-	private final DataStream<IN1> inputStream1;
-	private final BroadcastStream<IN2> inputStream2;
+	private final DataStream<IN1> nonBroadcastStream;
+	private final BroadcastStream<IN2> broadcastStream;
 	private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
 
 	protected BroadcastConnectedStream(
@@ -67,8 +67,8 @@ public class BroadcastConnectedStream<IN1, IN2> {
 			final BroadcastStream<IN2> input2,
 			final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors) {
 		this.environment = requireNonNull(env);
-		this.inputStream1 = requireNonNull(input1);
-		this.inputStream2 = requireNonNull(input2);
+		this.nonBroadcastStream = requireNonNull(input1);
+		this.broadcastStream = requireNonNull(input2);
 		this.broadcastStateDescriptors = requireNonNull(broadcastStateDescriptors);
 	}
 
@@ -82,7 +82,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	 * @return The stream which, by convention, is not broadcasted.
 	 */
 	public DataStream<IN1> getFirstInput() {
-		return inputStream1;
+		return nonBroadcastStream;
 	}
 
 	/**
@@ -91,7 +91,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	 * @return The stream which, by convention, is the broadcast one.
 	 */
 	public BroadcastStream<IN2> getSecondInput() {
-		return inputStream2;
+		return broadcastStream;
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	 * @return The type of the first input
 	 */
 	public TypeInformation<IN1> getType1() {
-		return inputStream1.getType();
+		return nonBroadcastStream.getType();
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 	 * @return The type of the second input
 	 */
 	public TypeInformation<IN2> getType2() {
-		return inputStream2.getType();
+		return broadcastStream.getType();
 	}
 
 	/**
@@ -155,7 +155,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 			final TypeInformation<OUT> outTypeInfo) {
 
 		Preconditions.checkNotNull(function);
-		Preconditions.checkArgument(inputStream1 instanceof KeyedStream,
+		Preconditions.checkArgument(nonBroadcastStream instanceof KeyedStream,
 				"A KeyedBroadcastProcessFunction can only be used on a keyed stream.");
 
 		TwoInputStreamOperator<IN1, IN2, OUT> operator =
@@ -204,7 +204,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 			final TypeInformation<OUT> outTypeInfo) {
 
 		Preconditions.checkNotNull(function);
-		Preconditions.checkArgument(!(inputStream1 instanceof KeyedStream),
+		Preconditions.checkArgument(!(nonBroadcastStream instanceof KeyedStream),
 				"A BroadcastProcessFunction can only be used on a non-keyed stream.");
 
 		TwoInputStreamOperator<IN1, IN2, OUT> operator =
@@ -219,19 +219,19 @@ public class BroadcastConnectedStream<IN1, IN2> {
 			final TwoInputStreamOperator<IN1, IN2, OUT> operator) {
 
 		// read the output type of the input Transforms to coax out errors about MissingTypeInfo
-		inputStream1.getType();
-		inputStream2.getType();
+		nonBroadcastStream.getType();
+		broadcastStream.getType();
 
 		TwoInputTransformation<IN1, IN2, OUT> transform = new TwoInputTransformation<>(
-				inputStream1.getTransformation(),
-				inputStream2.getTransformation(),
+				nonBroadcastStream.getTransformation(),
+				broadcastStream.getTransformation(),
 				functionName,
 				operator,
 				outTypeInfo,
 				environment.getParallelism());
 
-		if (inputStream1 instanceof KeyedStream) {
-			KeyedStream<IN1, ?> keyedInput1 = (KeyedStream<IN1, ?>) inputStream1;
+		if (nonBroadcastStream instanceof KeyedStream) {
+			KeyedStream<IN1, ?> keyedInput1 = (KeyedStream<IN1, ?>) nonBroadcastStream;
 			TypeInformation<?> keyType1 = keyedInput1.getKeyType();
 			transform.setStateKeySelectors(keyedInput1.getKeySelector(), null);
 			transform.setStateKeyType(keyType1);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -27,10 +27,11 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
-import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
 import org.apache.flink.util.Preconditions;
 
 import java.util.List;
@@ -222,27 +223,39 @@ public class BroadcastConnectedStream<IN1, IN2> {
 		nonBroadcastStream.getType();
 		broadcastStream.getType();
 
-		TwoInputTransformation<IN1, IN2, OUT> transform = new TwoInputTransformation<>(
-				nonBroadcastStream.getTransformation(),
-				broadcastStream.getTransformation(),
-				functionName,
-				operator,
-				outTypeInfo,
-				environment.getParallelism());
+		final BroadcastStateTransformation<IN1, IN2, OUT> transformation =
+				getBroadcastStateTransformation(functionName, outTypeInfo, operator);
+
+		@SuppressWarnings({"unchecked", "rawtypes"})
+		final SingleOutputStreamOperator<OUT> returnStream =
+				new SingleOutputStreamOperator(environment, transformation);
+
+		getExecutionEnvironment().addOperator(transformation);
+		return returnStream;
+	}
+
+	private <OUT> BroadcastStateTransformation<IN1, IN2, OUT> getBroadcastStateTransformation(
+			final String functionName,
+			final TypeInformation<OUT> outTypeInfo,
+			final TwoInputStreamOperator<IN1, IN2, OUT> operator) {
 
 		if (nonBroadcastStream instanceof KeyedStream) {
-			KeyedStream<IN1, ?> keyedInput1 = (KeyedStream<IN1, ?>) nonBroadcastStream;
-			TypeInformation<?> keyType1 = keyedInput1.getKeyType();
-			transform.setStateKeySelectors(keyedInput1.getKeySelector(), null);
-			transform.setStateKeyType(keyType1);
+			return new BroadcastStateTransformation<>(
+					functionName,
+					(KeyedStream<IN1, ?>) nonBroadcastStream,
+					broadcastStream,
+					SimpleOperatorFactory.of(operator),
+					outTypeInfo,
+					environment.getParallelism());
+		} else {
+			return new BroadcastStateTransformation<>(
+					functionName,
+					nonBroadcastStream,
+					broadcastStream,
+					SimpleOperatorFactory.of(operator),
+					outTypeInfo,
+					environment.getParallelism());
 		}
-
-		@SuppressWarnings({ "unchecked", "rawtypes" })
-		SingleOutputStreamOperator<OUT> returnStream = new SingleOutputStreamOperator(environment, transform);
-
-		getExecutionEnvironment().addOperator(transform);
-
-		return returnStream;
 	}
 
 	protected <F> F clean(F f) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -240,7 +240,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 			final TwoInputStreamOperator<IN1, IN2, OUT> operator) {
 
 		if (nonBroadcastStream instanceof KeyedStream) {
-			return new BroadcastStateTransformation<>(
+			return BroadcastStateTransformation.forKeyedStream(
 					functionName,
 					(KeyedStream<IN1, ?>) nonBroadcastStream,
 					broadcastStream,
@@ -248,7 +248,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 					outTypeInfo,
 					environment.getParallelism());
 		} else {
-			return new BroadcastStateTransformation<>(
+			return BroadcastStateTransformation.forNonKeyedStream(
 					functionName,
 					nonBroadcastStream,
 					broadcastStream,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
@@ -78,7 +78,7 @@ public class BroadcastStream<T> {
 		return inputStream.getTransformation();
 	}
 
-	public List<MapStateDescriptor<?, ?>> getBroadcastStateDescriptor() {
+	public List<MapStateDescriptor<?, ?>> getBroadcastStateDescriptors() {
 		return broadcastStateDescriptors;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -274,7 +274,7 @@ public class DataStream<T> {
 				environment,
 				this,
 				Preconditions.checkNotNull(broadcastStream),
-				broadcastStream.getBroadcastStateDescriptor());
+				broadcastStream.getBroadcastStateDescriptors());
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionInternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
+import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
 import org.apache.flink.streaming.api.transformations.CoFeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.FeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
@@ -53,6 +54,7 @@ import org.apache.flink.streaming.api.transformations.TimestampsAndWatermarksTra
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
+import org.apache.flink.streaming.runtime.translators.BroadcastStateTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySinkTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySourceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.MultiInputTransformationTranslator;
@@ -167,6 +169,7 @@ public class StreamGraphGenerator {
 		tmp.put(SideOutputTransformation.class, new SideOutputTransformationTranslator<>());
 		tmp.put(ReduceTransformation.class, new ReduceTransformationTranslator<>());
 		tmp.put(TimestampsAndWatermarksTransformation.class, new TimestampsAndWatermarksTransformationTranslator<>());
+		tmp.put(BroadcastStateTransformation.class, new BroadcastStateTransformationTranslator<>());
 		translatorMap = Collections.unmodifiableMap(tmp);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
@@ -40,8 +40,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * to all the elements that belong to the non-keyed, broadcasted side, as this is kept in Flink's
  * state.
  *
- * <p>For more information see
- * <a href="https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/broadcast_state.html">.
+ * <p>For more information see the
+ * <a href="https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/broadcast_state.html">
+ *     Broadcast State Pattern documentation page</a>.
  *
  * @param <IN1> The type of the elements in the non-broadcasted input.
  * @param <IN2> The type of the elements in the broadcasted input.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This is the transformation for the Broadcast State pattern. In a nutshell, this transformation
+ * allows to take a broadcasted (non-keyed) stream, connect it with another keyed or non-keyed
+ * stream, and apply a function on the resulting connected stream. This function will have access
+ * to all the elements that belong to the non-keyed, broadcasted side, as this is kept in Flink's
+ * state.
+ *
+ * <p>For more information see
+ * <a href="https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/broadcast_state.html">.
+ *
+ * @param <IN1> The type of the elements in the non-broadcasted input.
+ * @param <IN2> The type of the elements in the broadcasted input.
+ * @param <OUT> The type of the elements that result from this transformation.
+ */
+@Internal
+public class BroadcastStateTransformation<IN1, IN2, OUT> extends PhysicalTransformation<OUT> {
+
+	private final DataStream<IN1> inputStream;
+
+	private final BroadcastStream<IN2> broadcastStream;
+
+	private final StreamOperatorFactory<OUT> operatorFactory;
+
+	private final TypeInformation<?> stateKeyType;
+
+	private final KeySelector<IN1, ?> keySelector;
+
+	public BroadcastStateTransformation(
+			final String name,
+			final DataStream<IN1> inputStream,
+			final BroadcastStream<IN2> broadcastStream,
+			final StreamOperatorFactory<OUT> operatorFactory,
+			final TypeInformation<OUT> outTypeInfo,
+			final int parallelism) {
+		this(
+				name,
+				checkNotNull(inputStream),
+				broadcastStream,
+				operatorFactory,
+				null,
+				null,
+				outTypeInfo,
+				parallelism);
+	}
+
+	public BroadcastStateTransformation(
+			final String name,
+			final KeyedStream<IN1, ?> inputStream,
+			final BroadcastStream<IN2> broadcastStream,
+			final StreamOperatorFactory<OUT> operatorFactory,
+			final TypeInformation<OUT> outTypeInfo,
+			final int parallelism) {
+		this(
+				name,
+				checkNotNull(inputStream),
+				broadcastStream,
+				operatorFactory,
+				inputStream.getKeyType(),
+				inputStream.getKeySelector(),
+				outTypeInfo,
+				parallelism);
+	}
+
+	private BroadcastStateTransformation(
+			final String name,
+			final DataStream<IN1> inputStream,
+			final BroadcastStream<IN2> broadcastStream,
+			final StreamOperatorFactory<OUT> operatorFactory,
+			final TypeInformation<?> keyType,
+			final KeySelector<IN1, ?> keySelector,
+			final TypeInformation<OUT> outTypeInfo,
+			final int parallelism) {
+		super(name, outTypeInfo, parallelism);
+		this.inputStream = checkNotNull(inputStream);
+		this.broadcastStream = checkNotNull(broadcastStream);
+		this.operatorFactory = checkNotNull(operatorFactory);
+
+		this.stateKeyType = keyType;
+		this.keySelector = keySelector;
+		updateManagedMemoryStateBackendUseCase(keySelector != null);
+	}
+
+	public BroadcastStream<IN2> getBroadcastStream() {
+		return broadcastStream;
+	}
+
+	public DataStream<IN1> getNonBroadcastStream() {
+		return inputStream;
+	}
+
+	public StreamOperatorFactory<OUT> getOperatorFactory() {
+		return operatorFactory;
+	}
+
+	public TypeInformation<?> getStateKeyType() {
+		return stateKeyType;
+	}
+
+	public KeySelector<IN1, ?> getKeySelector() {
+		return keySelector;
+	}
+
+	@Override
+	public void setChainingStrategy(ChainingStrategy strategy) {
+		this.operatorFactory.getChainingStrategy();
+	}
+
+	@Override
+	public List<Transformation<?>> getTransitivePredecessors() {
+		final List<Transformation<?>> predecessors = new ArrayList<>();
+		predecessors.add(this);
+		predecessors.add(inputStream.getTransformation());
+		predecessors.add(broadcastStream.getTransformation());
+		return predecessors;
+	}
+
+	@Override
+	public List<Transformation<?>> getInputs() {
+		final List<Transformation<?>> predecessors = new ArrayList<>();
+		predecessors.add(inputStream.getTransformation());
+		predecessors.add(broadcastStream.getTransformation());
+		return predecessors;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
@@ -42,6 +42,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 abstract class AbstractOneInputTransformationTranslator<IN, OUT, OP extends Transformation<OUT>>
 		extends SimpleTransformationTranslator<OUT, OP> {
+
 	protected Collection<Integer> translateInternal(
 			final Transformation<OUT> transformation,
 			final StreamOperatorFactory<OUT> operatorFactory,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractTwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractTwoInputTransformationTranslator.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A base class with functionality used during translating
+ * {@link Transformation transformations} with two inputs.
+ */
+@Internal
+public abstract class AbstractTwoInputTransformationTranslator<IN1, IN2, OUT, OP extends Transformation<OUT>>
+		extends SimpleTransformationTranslator<OUT, OP> {
+
+	protected Collection<Integer> translateInternal(
+			final Transformation<OUT> transformation,
+			final Transformation<IN1> firstInputTransformation,
+			final Transformation<IN2> secondInputTransformation,
+			final StreamOperatorFactory<OUT> operatorFactory,
+			@Nullable final TypeInformation<?> keyTypeInfo,
+			@Nullable final KeySelector<IN1, ?> firstKeySelector,
+			@Nullable final KeySelector<IN2, ?> secondKeySelector,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(firstInputTransformation);
+		checkNotNull(secondInputTransformation);
+		checkNotNull(operatorFactory);
+		checkNotNull(context);
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addCoOperator(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				operatorFactory,
+				firstInputTransformation.getOutputType(),
+				secondInputTransformation.getOutputType(),
+				transformation.getOutputType(),
+				transformation.getName());
+
+		if (firstKeySelector != null || secondKeySelector != null) {
+			checkState(keyTypeInfo != null, "Keyed Transformation without provided key type information.");
+
+			final TypeSerializer<?> keySerializer = keyTypeInfo.createSerializer(executionConfig);
+			streamGraph.setTwoInputStateKey(
+					transformationId,
+					firstKeySelector,
+					secondKeySelector,
+					keySerializer);
+		}
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		for (Integer inputId: context.getStreamNodeIds(firstInputTransformation)) {
+			streamGraph.addEdge(inputId, transformationId, 1);
+		}
+
+		for (Integer inputId: context.getStreamNodeIds(secondInputTransformation)) {
+			streamGraph.addEdge(inputId, transformationId, 2);
+		}
+
+		return Collections.singleton(transformationId);
+
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link TransformationTranslator} for the {@link BroadcastStateTransformation}.
+ *
+ * @param <IN1> The type of the elements in the non-broadcasted input of the {@link BroadcastStateTransformation}.
+ * @param <IN2> The type of the elements in the broadcasted input of the {@link BroadcastStateTransformation}.
+ * @param <OUT> The type of the elements that result from the {@link BroadcastStateTransformation}.
+ */
+@Internal
+public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
+		extends SimpleTransformationTranslator<OUT, BroadcastStateTransformation<IN1, IN2, OUT>>  {
+
+	@Override
+	protected Collection<Integer> translateForBatchInternal(
+			final BroadcastStateTransformation<IN1, IN2, OUT> transformation,
+			final Context context) {
+		throw new UnsupportedOperationException("The Broadcast State Pattern is not support in BATCH execution mode.");
+	}
+
+	@Override
+	protected Collection<Integer> translateForStreamingInternal(
+			final BroadcastStateTransformation<IN1, IN2, OUT> transformation,
+			final Context context) {
+		checkNotNull(transformation);
+		checkNotNull(context);
+
+		final TypeInformation<IN1> nonBroadcastTypeInfo =
+				transformation.getNonBroadcastStream().getType();
+		final TypeInformation<IN2> broadcastTypeInfo =
+				transformation.getBroadcastStream().getType();
+
+		final StreamGraph streamGraph = context.getStreamGraph();
+		final String slotSharingGroup = context.getSlotSharingGroup();
+		final int transformationId = transformation.getId();
+		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+
+		streamGraph.addCoOperator(
+				transformationId,
+				slotSharingGroup,
+				transformation.getCoLocationGroupKey(),
+				transformation.getOperatorFactory(),
+				nonBroadcastTypeInfo,
+				broadcastTypeInfo,
+				transformation.getOutputType(),
+				transformation.getName());
+
+		if (transformation.getKeySelector() != null) {
+			final TypeSerializer<?> keySerializer =
+					transformation.getStateKeyType().createSerializer(executionConfig);
+
+			streamGraph.setTwoInputStateKey(
+					transformationId,
+					transformation.getKeySelector(),
+					null,
+					keySerializer);
+		}
+
+		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
+				? transformation.getParallelism()
+				: executionConfig.getParallelism();
+		streamGraph.setParallelism(transformationId, parallelism);
+		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
+
+		for (Integer inputId: context.getStreamNodeIds(transformation.getNonBroadcastStream().getTransformation())) {
+			streamGraph.addEdge(inputId, transformationId, 1);
+		}
+
+		for (Integer inputId: context.getStreamNodeIds(transformation.getBroadcastStream().getTransformation())) {
+			streamGraph.addEdge(inputId, transformationId, 2);
+		}
+
+		return Collections.singleton(transformationId);
+
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
@@ -58,9 +58,9 @@ public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
 		checkNotNull(context);
 
 		final TypeInformation<IN1> nonBroadcastTypeInfo =
-				transformation.getNonBroadcastStream().getType();
+				transformation.getNonBroadcastStream().getOutputType();
 		final TypeInformation<IN2> broadcastTypeInfo =
-				transformation.getBroadcastStream().getType();
+				transformation.getBroadcastStream().getOutputType();
 
 		final StreamGraph streamGraph = context.getStreamGraph();
 		final String slotSharingGroup = context.getSlotSharingGroup();
@@ -94,11 +94,11 @@ public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
 		streamGraph.setParallelism(transformationId, parallelism);
 		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
-		for (Integer inputId: context.getStreamNodeIds(transformation.getNonBroadcastStream().getTransformation())) {
+		for (Integer inputId: context.getStreamNodeIds(transformation.getNonBroadcastStream())) {
 			streamGraph.addEdge(inputId, transformationId, 1);
 		}
 
-		for (Integer inputId: context.getStreamNodeIds(transformation.getBroadcastStream().getTransformation())) {
+		for (Integer inputId: context.getStreamNodeIds(transformation.getBroadcastStream())) {
 			streamGraph.addEdge(inputId, transformationId, 2);
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -19,15 +19,10 @@
 package org.apache.flink.streaming.runtime.translators;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
-import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -40,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class TwoInputTransformationTranslator<IN1, IN2, OUT>
-		extends SimpleTransformationTranslator<OUT, TwoInputTransformation<IN1, IN2, OUT>> {
+		extends AbstractTwoInputTransformationTranslator<IN1, IN2, OUT, TwoInputTransformation<IN1, IN2, OUT>> {
 
 	@Override
 	protected Collection<Integer> translateForBatchInternal(
@@ -68,44 +63,14 @@ public class TwoInputTransformationTranslator<IN1, IN2, OUT>
 		checkNotNull(transformation);
 		checkNotNull(context);
 
-		final StreamGraph streamGraph = context.getStreamGraph();
-		final String slotSharingGroup = context.getSlotSharingGroup();
-		final int transformationId = transformation.getId();
-		final ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
-
-		streamGraph.addCoOperator(
-				transformationId,
-				slotSharingGroup,
-				transformation.getCoLocationGroupKey(),
+		return translateInternal(
+				transformation,
+				transformation.getInput1(),
+				transformation.getInput2(),
 				transformation.getOperatorFactory(),
-				transformation.getInputType1(),
-				transformation.getInputType2(),
-				transformation.getOutputType(),
-				transformation.getName());
-
-		if (transformation.getStateKeySelector1() != null || transformation.getStateKeySelector2() != null) {
-			final TypeSerializer<?> keySerializer = transformation.getStateKeyType().createSerializer(executionConfig);
-			streamGraph.setTwoInputStateKey(
-					transformationId,
-					transformation.getStateKeySelector1(),
-					transformation.getStateKeySelector2(),
-					keySerializer);
-		}
-
-		final int parallelism = transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
-				? transformation.getParallelism()
-				: executionConfig.getParallelism();
-		streamGraph.setParallelism(transformationId, parallelism);
-		streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
-
-		for (Integer inputId: context.getStreamNodeIds(transformation.getInput1())) {
-			streamGraph.addEdge(inputId, transformationId, 1);
-		}
-
-		for (Integer inputId: context.getStreamNodeIds(transformation.getInput2())) {
-			streamGraph.addEdge(inputId, transformationId, 2);
-		}
-
-		return Collections.singleton(transformationId);
+				transformation.getStateKeyType(),
+				transformation.getStateKeySelector1(),
+				transformation.getStateKeySelector2(),
+				context);
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -34,7 +34,9 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.Collector;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
 
@@ -44,12 +46,14 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * ITCase for the {@link org.apache.flink.api.common.state.BroadcastState}.
  */
 public class BroadcastStateITCase extends AbstractTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testKeyedWithBroadcastTranslation() throws Exception {
@@ -184,12 +188,10 @@ public class BroadcastStateITCase extends AbstractTestBase {
 					}
 				});
 
-		try {
-			env.execute();
-			fail("Execution should have failed during job graph creation.");
-		} catch (UnsupportedOperationException e) {
-			assertEquals(e.getMessage(), "The Broadcast State Pattern is not support in BATCH execution mode.");
-		}
+		thrown.expect(UnsupportedOperationException.class);
+		thrown.expectMessage("The Broadcast State Pattern is not support in BATCH execution mode.");
+
+		env.execute();
 	}
 
 	private static class TestSink extends RichSinkFunction<String> {


### PR DESCRIPTION
## What is the purpose of the change

So far the Broadcast State pattern was a TwoInputTransformation.
This did not allow for special handling when it comes to
translating it for Batch or Streaming execution. This commit
introduces a special transformation just for this.

## Brief change log

We introduce the `BroadcastStateTransformation` and the corresponding `BroadcastStateTransformationTranslator` that throws an `UnsupportedOperationException` when called for execution in `BATCH` mode.

## Verifying this change

The `STREAMING` translation is covered by existing tests while I added the `BroadcastStateITCase.testBroadcastBatchTranslationThrowsException()` for the `BATCH`case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
