### PR TITLE
[FLINK-20284][python] Port Grpc SharedResourceHolder class to flink-python module

### DIFF
--- a/flink-python/src/main/java/org/apache/beam/vendor/grpc/v1p26p0/io/grpc/internal/SharedResourceHolder.java
+++ b/flink-python/src/main/java/org/apache/beam/vendor/grpc/v1p26p0/io/grpc/internal/SharedResourceHolder.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public final class SharedResourceHolder {
-	static final long DESTROY_DELAY_SECONDS = 1;
+	static final long DESTROY_DELAY_SECONDS = 0;
 
 	// The sole holder instance.
 	private static final SharedResourceHolder holder = new SharedResourceHolder(

--- a/flink-python/src/main/java/org/apache/beam/vendor/grpc/v1p26p0/io/grpc/internal/SharedResourceHolder.java
+++ b/flink-python/src/main/java/org/apache/beam/vendor/grpc/v1p26p0/io/grpc/internal/SharedResourceHolder.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2014 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.vendor.grpc.v1p26p0.io.grpc.internal;
+
+import org.apache.beam.vendor.grpc.v1p26p0.com.google.common.base.Preconditions;
+import java.util.IdentityHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * A holder for shared resource singletons.
+ *
+ * <p>Components like client channels and servers need certain resources, e.g. a thread pool, to
+ * run. If the user has not provided such resources, these components will use a default one, which
+ * is shared as a static resource. This class holds these default resources and manages their
+ * life-cycles.
+ *
+ * <p>A resource is identified by the reference of a {@link Resource} object, which is typically a
+ * singleton, provided to the get() and release() methods. Each Resource object (not its class) maps
+ * to an object cached in the holder.
+ *
+ * <p>Resources are ref-counted and shut down after a delay when the ref-count reaches zero.
+ */
+@ThreadSafe
+public final class SharedResourceHolder {
+	static final long DESTROY_DELAY_SECONDS = 1;
+
+	// The sole holder instance.
+	private static final SharedResourceHolder holder = new SharedResourceHolder(
+		new ScheduledExecutorFactory() {
+			@Override
+			public ScheduledExecutorService createScheduledExecutor() {
+				return Executors.newSingleThreadScheduledExecutor(
+					GrpcUtil.getThreadFactory("grpc-shared-destroyer-%d", true));
+			}
+		});
+
+	private final IdentityHashMap<Resource<?>, Instance> instances =
+		new IdentityHashMap<>();
+
+	private final ScheduledExecutorFactory destroyerFactory;
+
+	private ScheduledExecutorService destroyer;
+
+	// Visible to tests that would need to create instances of the holder.
+	SharedResourceHolder(ScheduledExecutorFactory destroyerFactory) {
+		this.destroyerFactory = destroyerFactory;
+	}
+
+	/**
+	 * Try to get an existing instance of the given resource. If an instance does not exist, create a
+	 * new one with the given factory.
+	 *
+	 * @param resource the singleton object that identifies the requested static resource
+	 */
+	public static <T> T get(Resource<T> resource) {
+		return holder.getInternal(resource);
+	}
+
+	/**
+	 * Releases an instance of the given resource.
+	 *
+	 * <p>The instance must have been obtained from {@link #get(Resource)}. Otherwise will throw
+	 * IllegalArgumentException.
+	 *
+	 * <p>Caller must not release a reference more than once. It's advisory that you clear the
+	 * reference to the instance with the null returned by this method.
+	 *
+	 * @param resource the singleton Resource object that identifies the released static resource
+	 * @param instance the released static resource
+	 *
+	 * @return a null which the caller can use to clear the reference to that instance.
+	 */
+	public static <T> T release(final Resource<T> resource, final T instance) {
+		return holder.releaseInternal(resource, instance);
+	}
+
+	/**
+	 * Visible to unit tests.
+	 *
+	 * @see #get(Resource)
+	 */
+	@SuppressWarnings("unchecked")
+	synchronized <T> T getInternal(Resource<T> resource) {
+		Instance instance = instances.get(resource);
+		if (instance == null) {
+			instance = new Instance(resource.create());
+			instances.put(resource, instance);
+		}
+		if (instance.destroyTask != null) {
+			instance.destroyTask.cancel(false);
+			instance.destroyTask = null;
+		}
+		instance.refcount++;
+		return (T) instance.payload;
+	}
+
+	/**
+	 * Visible to unit tests.
+	 */
+	synchronized <T> T releaseInternal(final Resource<T> resource, final T instance) {
+		final Instance cached = instances.get(resource);
+		if (cached == null) {
+			throw new IllegalArgumentException("No cached instance found for " + resource);
+		}
+		Preconditions.checkArgument(instance == cached.payload, "Releasing the wrong instance");
+		Preconditions.checkState(cached.refcount > 0, "Refcount has already reached zero");
+		cached.refcount--;
+		if (cached.refcount == 0) {
+			Preconditions.checkState(cached.destroyTask == null, "Destroy task already scheduled");
+			// Schedule a delayed task to destroy the resource.
+			if (destroyer == null) {
+				destroyer = destroyerFactory.createScheduledExecutor();
+			}
+			cached.destroyTask = destroyer.schedule(new LogExceptionRunnable(new Runnable() {
+				@Override
+				public void run() {
+					synchronized (SharedResourceHolder.this) {
+						// Refcount may have gone up since the task was scheduled. Re-check it.
+						if (cached.refcount == 0) {
+							try {
+								resource.close(instance);
+							} finally {
+								instances.remove(resource);
+								if (instances.isEmpty()) {
+									destroyer.shutdown();
+									destroyer = null;
+								}
+							}
+						}
+					}
+				}
+			}), DESTROY_DELAY_SECONDS, TimeUnit.SECONDS);
+		}
+		// Always returning null
+		return null;
+	}
+
+	/**
+	 * Defines a resource, and the way to create and destroy instances of it.
+	 */
+	public interface Resource<T> {
+		/**
+		 * Create a new instance of the resource.
+		 */
+		T create();
+
+		/**
+		 * Destroy the given instance.
+		 */
+		void close(T instance);
+	}
+
+	interface ScheduledExecutorFactory {
+		ScheduledExecutorService createScheduledExecutor();
+	}
+
+	private static class Instance {
+		final Object payload;
+		int refcount;
+		ScheduledFuture<?> destroyTask;
+
+		Instance(Object payload) {
+			this.payload = payload;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Port Grpc `SharedResourceHolder` class to `flink-python` module and change the `DESTROY_DELAY_SECONDS` to `0`. Setting `DESTROY_DELAY_SECONDS` to 0 does not solve the problem of asynchronous release of `EventLoopGroup` resources from the root cause, but as only the `EventLoopGroup` resources of `ProvisionService` that need to be released, this can avoid the generation of ClassNotFoundError to the greatest extent. Of course, the best way is that Grpc's NettyServer can provide a more complete synchronous `shutdown` interface. This is a very involved issue, so from the perspective of `Pyflink`, we will temporarily adopt the way of setting `DESTROY_DELAY_SECONDS` to `0`.*


## Brief change log

  - *Port Grpc `SharedResourceHolder` class to flink-python module*
  - *Change `DESTROY_DELAY_SECONDS` to `0`*
 
## Verifying this change

This change added tests and can be verified as follows:

  - *Submit a python udf job in standalone cluster and see the TaskManger log*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
