### PR TITLE
[FLINK-20258][runtime] Made the ClusterConfigurationInfoEntry more flexible in terms of data types.

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -462,13 +462,13 @@
       "type" : "array",
       "items" : {
         "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ClusterConfigurationInfoEntry",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ClusterConfigurationInfoEntry<java:lang:Object>",
         "properties" : {
           "key" : {
             "type" : "string"
           },
           "value" : {
-            "type" : "string"
+            "type" : "any"
           }
         }
       }
@@ -984,10 +984,10 @@
                   "type" : "integer"
                 },
                 "processed_data" : {
-                   "type" : "integer"
+                  "type" : "integer"
                 },
                 "persisted_data" : {
-                   "type" : "integer"
+                  "type" : "integer"
                 },
                 "num_subtasks" : {
                   "type" : "integer"
@@ -1081,10 +1081,10 @@
                   "type" : "integer"
                 },
                 "processed_data" : {
-                   "type" : "integer"
+                  "type" : "integer"
                 },
                 "persisted_data" : {
-                   "type" : "integer"
+                  "type" : "integer"
                 },
                 "num_subtasks" : {
                   "type" : "integer"
@@ -1293,10 +1293,10 @@
           "type" : "integer"
         },
         "processed_data" : {
-           "type" : "integer"
+          "type" : "integer"
         },
         "persisted_data" : {
-           "type" : "integer"
+          "type" : "integer"
         },
         "num_subtasks" : {
           "type" : "integer"
@@ -1394,10 +1394,10 @@
           "type" : "integer"
         },
         "processed_data" : {
-           "type" : "integer"
+          "type" : "integer"
         },
         "persisted_data" : {
-           "type" : "integer"
+          "type" : "integer"
         },
         "num_subtasks" : {
           "type" : "integer"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfoEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfoEntry.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * A single key-value pair entry in the {@link ClusterConfigurationInfo} response.
  */
-public class ClusterConfigurationInfoEntry {
+public class ClusterConfigurationInfoEntry<T> {
 
 	public static final String FIELD_NAME_CONFIG_KEY = "key";
 	public static final String FIELD_NAME_CONFIG_VALUE = "value";
@@ -37,12 +37,12 @@ public class ClusterConfigurationInfoEntry {
 	private final String key;
 
 	@JsonProperty(FIELD_NAME_CONFIG_VALUE)
-	private final String value;
+	private final T value;
 
 	@JsonCreator
 	public ClusterConfigurationInfoEntry(
 			@JsonProperty(FIELD_NAME_CONFIG_KEY) String key,
-			@JsonProperty(FIELD_NAME_CONFIG_VALUE) String value) {
+			@JsonProperty(FIELD_NAME_CONFIG_VALUE) T value) {
 		this.key = Preconditions.checkNotNull(key);
 		this.value = Preconditions.checkNotNull(value);
 	}
@@ -51,7 +51,7 @@ public class ClusterConfigurationInfoEntry {
 		return key;
 	}
 
-	public String getValue() {
+	public T getValue() {
 		return value;
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -375,7 +375,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 
 		return clusterConfigurationInfoEntries.stream().collect(Collectors.toMap(
 			ClusterConfigurationInfoEntry::getKey,
-			ClusterConfigurationInfoEntry::getValue));
+			e -> String.valueOf(e.getValue())));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This change shall enable us to return different data types instead of only returning Strings for the cluster configuration endpoint. We use this feature to return long instead of String for memory-related configuration entries. This will make it possible to convert the corresponding values into human-readable values.

## Brief change log

* A generic type is added to `ClusterConfigurationInfoEntry` specifying the value's data type.
* A new factory method `ClusterConfigurationInfo.createClusterConfigurationInfoEntry` for creating entries is introduced that applies custom creation logic for memory-related parameters and falling back to the default approach for any other parameter.

## Verifying this change

This change added tests and can be verified as follows:

* `ClusterConfigurationInfoTest` was adapted accordingly adding more test cases
* `YARNSessionCapacitySchedulerITCase` needed a small refactoring to adapt to the change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
