### PR TITLE
[FLINK-20351] Correct the logging of the location of a task failure on the JM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1606,15 +1606,13 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				LOG.info("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState);
 			} else {
 				if (LOG.isInfoEnabled()) {
-					final String locationInformation = getAssignedResource() != null ? getAssignedResource().toString() : "not deployed";
-
 					LOG.info(
 						"{} ({}) switched from {} to {} on {}.",
 						getVertex().getTaskNameWithSubtaskIndex(),
 						getAttemptId(),
 						currentState,
 						targetState,
-						locationInformation,
+						getLocationInformation(),
 						error);
 				}
 			}
@@ -1635,6 +1633,14 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			return true;
 		} else {
 			return false;
+		}
+	}
+
+	private String getLocationInformation() {
+		if (assignedResource != null) {
+			return assignedResource.getTaskManagerLocation().toString();
+		} else {
+			return "not deployed";
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This commit logs the TaskManagerLocation.toString instead of the LogicalSlot.toString
when logging an Execution failure.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
