### PR TITLE
[FLINK-20349][table-planner-blink] Fix checking for deadlock caused by exchange

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
@@ -169,7 +169,7 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 	@Override
 	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
 		throw new IllegalStateException(
-			"A conflict is detected. This is a bug. Please consider filing an issue.\n" +
+			"A conflict is detected. This is a bug. Please file an issue.\n" +
 				"To work around this bug, please set " +
 				OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED.key() +
 				" to false to disable multiple input operator.");

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.processors.utils;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.planner.plan.nodes.exec.AbstractExecNodeExactlyOnceVisitor;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
@@ -167,6 +168,10 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 
 	@Override
 	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
-		throw new IllegalStateException("A conflict is detected. This is unexpected.");
+		throw new IllegalStateException(
+			"A conflict is detected. This is a bug. Please consider filing an issue.\n" +
+				"To work around this bug, please set " +
+				OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED.key() +
+				" to false to disable multiple input operator.");
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGenerator.java
@@ -156,7 +156,7 @@ public abstract class InputPriorityGraphGenerator {
 	private void addTopologyEdges(ExecNode<?, ?> node, int higherInput, int lowerInput) {
 		ExecNode<?, ?> higherNode = node.getInputNodes().get(higherInput);
 		ExecNode<?, ?> lowerNode = node.getInputNodes().get(lowerInput);
-		List<ExecNode<?, ?>> lowerAncestors = calculateAncestors(lowerNode);
+		List<ExecNode<?, ?>> lowerAncestors = calculatePipelinedAncestors(lowerNode);
 
 		List<Tuple2<ExecNode<?, ?>, ExecNode<?, ?>>> linkedEdges = new ArrayList<>();
 		for (ExecNode<?, ?> ancestor : lowerAncestors) {
@@ -177,7 +177,7 @@ public abstract class InputPriorityGraphGenerator {
 	 * Find the ancestors by going through PIPELINED edges.
 	 */
 	@VisibleForTesting
-	List<ExecNode<?, ?>> calculateAncestors(ExecNode<?, ?> node) {
+	List<ExecNode<?, ?>> calculatePipelinedAncestors(ExecNode<?, ?> node) {
 		List<ExecNode<?, ?>> ret = new ArrayList<>();
 		AbstractExecNodeExactlyOnceVisitor ancestorVisitor = new AbstractExecNodeExactlyOnceVisitor() {
 			@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public class InputPriorityGraphGeneratorTest {
 
 	@Test
-	public void testCalculateAncestors() {
+	public void testCalculatePipelinedAncestors() {
 		// P = ExecEdge.DamBehavior.PIPELINED, E = ExecEdge.DamBehavior.END_INPUT
 		//
 		// 0 ------P----> 1 -E--> 2
@@ -59,14 +59,14 @@ public class InputPriorityGraphGeneratorTest {
 			Collections.singletonList(nodes[2]),
 			Collections.emptySet(),
 			ExecEdge.DamBehavior.END_INPUT);
-		List<ExecNode<?, ?>> ancestors = resolver.calculateAncestors(nodes[2]);
+		List<ExecNode<?, ?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
 		Assert.assertEquals(2, ancestors.size());
 		Assert.assertTrue(ancestors.contains(nodes[0]));
 		Assert.assertTrue(ancestors.contains(nodes[5]));
 	}
 
 	@Test
-	public void testCalculateBoundedAncestors() {
+	public void testCalculateBoundedPipelinedAncestors() {
 		// P = ExecEdge.DamBehavior.PIPELINED, E = ExecEdge.DamBehavior.END_INPUT
 		//
 		// 0 -P-> 1 -P-> 2
@@ -84,7 +84,7 @@ public class InputPriorityGraphGeneratorTest {
 			Collections.singletonList(nodes[2]),
 			new HashSet<>(Collections.singleton(nodes[1])),
 			ExecEdge.DamBehavior.END_INPUT);
-		List<ExecNode<?, ?>> ancestors = resolver.calculateAncestors(nodes[2]);
+		List<ExecNode<?, ?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
 		Assert.assertEquals(1, ancestors.size());
 		Assert.assertTrue(ancestors.contains(nodes[1]));
 	}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.xml
@@ -460,6 +460,44 @@ HashJoin(joinType=[InnerJoin], where=[=(b, e0)], select=[a, b, d, e, a0, b0, d0,
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSubplanReuse_DeadlockCausedByReusingExchangeInAncestor">
+    <Resource name="sql">
+      <![CDATA[
+WITH T1 AS (
+  SELECT x1.*, x2.a AS k, (x1.b + x2.b) AS v
+  FROM x x1 LEFT JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0)
+SELECT x.a, x.b, T1.* FROM x LEFT JOIN T1 ON x.a = T1.k WHERE x.a > 0 AND T1.v = 0
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$3], b0=[$4], c=[$5], k=[$6], v=[$7])
++- LogicalFilter(condition=[AND(>($0, 0), =($7, 0))])
+   +- LogicalJoin(condition=[=($0, $6)], joinType=[left])
+      :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], k=[$3], v=[+($1, $4)])
+         +- LogicalFilter(condition=[>($3, 0)])
+            +- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+               :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, a0, b0, c, k, CAST(0:BIGINT) AS v])
++- HashJoin(joinType=[InnerJoin], where=[=(a, k)], select=[a, b, a0, b0, c, k], build=[right])
+   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+   :  +- Calc(select=[a, b], where=[>(a, 0)], reuse_id=[2])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], reuse_id=[1])
+   +- Calc(select=[a, b, c, a0 AS k])
+      +- HashJoin(joinType=[InnerJoin], where=[AND(=(a, a0), =(+(b, b0), 0:BIGINT))], select=[a, b, c, a0, b0], build=[right])
+         :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+         :  +- Reused(reference_id=[1])
+         +- Exchange(distribution=[hash[a]])
+            +- Reused(reference_id=[2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSubplanReuse_SetExchangeAsBatch_OverAgg">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
@@ -405,6 +405,78 @@ Union(all=[true], union=[a, EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDeadlockCausedByExchangeInAncestor[shuffleMode: ALL_EDGES_BLOCKING]">
+    <Resource name="sql">
+      <![CDATA[
+WITH T1 AS (
+  SELECT x1.*, x2.a AS k, (x1.b + x2.b) AS v
+  FROM x x1 LEFT JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0)
+SELECT x.a, x.b, T1.* FROM x LEFT JOIN T1 ON x.a = T1.k WHERE x.a > 0 AND T1.v = 0
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$4], b0=[$5], c=[$6], nx=[$7], k=[$8], v=[$9])
++- LogicalFilter(condition=[AND(>($0, 0), =($9, 0))])
+   +- LogicalJoin(condition=[=($0, $8)], joinType=[left])
+      :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], nx=[$3], k=[$4], v=[+($1, $5)])
+         +- LogicalFilter(condition=[>($4, 0)])
+            +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+               :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, a0, b0, c, nx, k, CAST(0:BIGINT) AS v])
++- MultipleInput(readOrder=[2,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[=(a, k)], select=[a, b, a0, b0, c, nx, k], build=[right])\n:- [#1] Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])\n+- Calc(select=[a, b, c, nx, a0 AS k])\n   +- HashJoin(joinType=[InnerJoin], where=[AND(=(a, a0), =(+(b, b0), 0:BIGINT))], select=[a, b, c, nx, a0, b0], build=[right])\n      :- [#2] Exchange(distribution=[hash[a]])\n      +- [#3] Exchange(distribution=[hash[a]])\n])
+   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+   :  +- Calc(select=[a, b], where=[>(a, 0)], reuse_id=[2])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Reused(reference_id=[1])
+   +- Exchange(distribution=[hash[a]])
+      +- Reused(reference_id=[2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeadlockCausedByExchangeInAncestor[shuffleMode: ALL_EDGES_PIPELINED]">
+    <Resource name="sql">
+      <![CDATA[
+WITH T1 AS (
+  SELECT x1.*, x2.a AS k, (x1.b + x2.b) AS v
+  FROM x x1 LEFT JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0)
+SELECT x.a, x.b, T1.* FROM x LEFT JOIN T1 ON x.a = T1.k WHERE x.a > 0 AND T1.v = 0
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], a0=[$4], b0=[$5], c=[$6], nx=[$7], k=[$8], v=[$9])
++- LogicalFilter(condition=[AND(>($0, 0), =($9, 0))])
+   +- LogicalJoin(condition=[=($0, $8)], joinType=[left])
+      :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], nx=[$3], k=[$4], v=[+($1, $5)])
+         +- LogicalFilter(condition=[>($4, 0)])
+            +- LogicalJoin(condition=[=($0, $4)], joinType=[left])
+               :- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, a0, b0, c, nx, k, CAST(0:BIGINT) AS v])
++- MultipleInput(readOrder=[2,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[=(a, k)], select=[a, b, a0, b0, c, nx, k], build=[right])\n:- [#1] Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])\n+- Calc(select=[a, b, c, nx, a0 AS k])\n   +- HashJoin(joinType=[InnerJoin], where=[AND(=(a, a0), =(+(b, b0), 0:BIGINT))], select=[a, b, c, nx, a0, b0], build=[right])\n      :- [#2] Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])\n      +- [#3] Exchange(distribution=[hash[a]])\n])
+   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+   :  +- Calc(select=[a, b], where=[>(a, 0)], reuse_id=[2])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx], reuse_id=[1])
+   :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
+   :  +- Reused(reference_id=[1])
+   +- Exchange(distribution=[hash[a]])
+      +- Reused(reference_id=[2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNoPriorityConstraint[shuffleMode: ALL_EDGES_BLOCKING]">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DeadlockBreakupTest.scala
@@ -231,4 +231,22 @@ class DeadlockBreakupTest extends TableTestBase {
          |""".stripMargin
     util.verifyPlan(sqlQuery)
   }
+
+  @Test
+  def testSubplanReuse_DeadlockCausedByReusingExchangeInAncestor(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED, true)
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED, false)
+    util.tableEnv.getConfig.getConfiguration.setString(
+      ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,SortMergeJoin")
+    val sqlQuery =
+      """
+        |WITH T1 AS (
+        |  SELECT x1.*, x2.a AS k, (x1.b + x2.b) AS v
+        |  FROM x x1 LEFT JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0)
+        |SELECT x.a, x.b, T1.* FROM x LEFT JOIN T1 ON x.a = T1.k WHERE x.a > 0 AND T1.v = 0
+        |""".stripMargin
+    util.verifyPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
@@ -170,6 +170,18 @@ class MultipleInputITCase(shuffleMode: String) extends BatchTestBase {
     )
   }
 
+  @Test
+  def testDeadlockCausedByExchangeInAncestor(): Unit = {
+    checkMultipleInputResult(
+      """
+        |WITH T1 AS (
+        |  SELECT x1.*, x2.a AS k, (x1.b + x2.b) AS v
+        |  FROM x x1 LEFT JOIN x x2 ON x1.a = x2.a WHERE x2.a > 0)
+        |SELECT x.a, x.b, T1.* FROM x LEFT JOIN T1 ON x.a = T1.k WHERE x.a > 0 AND T1.v = 0
+        |""".stripMargin
+    )
+  }
+
   def checkMultipleInputResult(sql: String): Unit = {
     tEnv.getConfig.getConfiguration.setBoolean(
       OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED, false)


### PR DESCRIPTION
## What is the purpose of the change

This is the bug fix for FLINK-20349, where the checking for deadlock caused by exchange in the deadlock break-up algorithm does not work for some cases.

## Brief change log

- Fix checking for deadlock caused by exchange

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
