### PR TITLE
[FLINK-20327][doc] The Hive's read/write page should redirect to SQL Fileystem connector

### DIFF
--- a/docs/dev/table/connectors/hive/hive_read_write.md
+++ b/docs/dev/table/connectors/hive/hive_read_write.md
@@ -351,8 +351,7 @@ overwrite is not supported for streaming write.
 The below shows how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
 and runs a batch query to read that data back out. 
 
-Please see the [StreamingFileSink]({% link dev/connectors/streamfile_sink.md %}) for 
-a full list of available configurations. 
+Please see the [streaming sink]({% link dev/table/connectors/filesystem.md %}#streaming-sink) for a full list of available configurations.
 
 {% highlight sql %}
 

--- a/docs/dev/table/connectors/hive/hive_read_write.zh.md
+++ b/docs/dev/table/connectors/hive/hive_read_write.zh.md
@@ -351,8 +351,7 @@ overwrite is not supported for streaming write.
 The below shows how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
 and runs a batch query to read that data back out. 
 
-Please see the [StreamingFileSink]({% link dev/connectors/streamfile_sink.zh.md %}) for 
-a full list of available configurations. 
+Please see the [streaming sink]({% link dev/table/connectors/filesystem.zh.md %}#streaming-sink) for a full list of available configurations. 
 
 {% highlight sql %}
 


### PR DESCRIPTION
## What is the purpose of the change

* The streaming-sink link in Hive's read/write page should redirect to SQL Fileystem connector.


## Brief change log

  - update the link in Hive's read/write page


## Verifying this change

This change is a document PR without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
