### PR TITLE
[FLINK-20365][python] The native k8s cluster could not be unregistered when executing Python DataStream application in attach mode

### DIFF
--- a/flink-python/pyflink/util/exceptions.py
+++ b/flink-python/pyflink/util/exceptions.py
@@ -146,6 +146,9 @@ def capture_java_exception(f):
         try:
             return f(*a, **kw)
         except Py4JJavaError as e:
+            from pyflink.java_gateway import get_gateway
+            get_gateway().jvm.org.apache.flink.client.python.PythonEnvUtils\
+                .setPythonException(e.java_exception)
             s = e.java_exception.toString()
             stack_trace = '\n\t at '.join(map(lambda x: x.toString(),
                                               e.java_exception.getStackTrace()))

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -33,7 +33,6 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 /**
  * A main class used to launch Python applications. It executes python as a
@@ -42,7 +41,7 @@ import java.util.concurrent.ExecutionException;
 public final class PythonDriver {
 	private static final Logger LOG = LoggerFactory.getLogger(PythonDriver.class);
 
-	public static void main(String[] args) throws ExecutionException, InterruptedException {
+	public static void main(String[] args) throws Exception {
 		// The python job needs at least 2 args.
 		// e.g. py a.py [user args]
 		// e.g. pym a.b [user args]
@@ -106,9 +105,11 @@ public final class PythonDriver {
 		} catch (Throwable e) {
 			LOG.error("Run python process failed", e);
 
-			// throw ProgramAbortException if the caller is interested in the program plan,
-			// there is no harm to throw ProgramAbortException even if it is not the case.
-			throw new ProgramAbortException();
+			if (PythonEnvUtils.capturedJavaException != null) {
+				throw PythonEnvUtils.capturedJavaException;
+			} else {
+				throw new ProgramAbortException();
+			}
 		} finally {
 			PythonEnvUtils.setGatewayServer(null);
 			gatewayServer.shutdown();

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.client.python;
 
+import org.apache.flink.client.deployment.application.UnsuccessfulExecutionException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.OperatingSystem;
@@ -72,6 +74,8 @@ final class PythonEnvUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(PythonEnvUtils.class);
 
 	static final String PYFLINK_CLIENT_EXECUTABLE = "PYFLINK_CLIENT_EXECUTABLE";
+
+	static volatile Exception capturedJavaException = null;
 
 	/**
 	 * Wraps Python exec environment.
@@ -374,5 +378,11 @@ final class PythonEnvUtils {
 		pythonEnv.systemEnv.put("PYFLINK_GATEWAY_PORT", String.valueOf(gatewayServer.getListeningPort()));
 		// start the python process.
 		return PythonEnvUtils.startPythonProcess(pythonEnv, commands, redirectToPipe);
+	}
+
+	public static void setPythonException(Exception pythonException) {
+		if (ExceptionUtils.findThrowable(pythonException, UnsuccessfulExecutionException.class).isPresent()) {
+			capturedJavaException = pythonException;
+		}
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The native k8s cluster could not be unregistered when executing Python DataStream application attachedly.

## Brief change log

- *Catch  the UnsuccessfulExecutionException in Py4JJavaError and throw UnsuccessfulExecutionException when python process exited.*

## Verifying this change

- This change has test case covered by test_kubernetes_pyflink_application.sh

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( not documented)
