### PR TITLE
[FLINK-18545] Introduce `pipeline.name` to allow users to specify job name by configuration

### DIFF
--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -87,6 +87,12 @@
             <td>The program-wide maximum parallelism used for operators which haven't specified a maximum parallelism. The maximum parallelism specifies the upper limit for dynamic scaling and the number of key groups used for partitioned state.</td>
         </tr>
         <tr>
+            <td><h5>pipeline.name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The job name used for printing and logging.</td>
+        </tr>
+        <tr>
             <td><h5>pipeline.object-reuse</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.flink.client;
 
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -30,6 +33,7 @@ import org.junit.Test;
 import java.io.Serializable;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -62,5 +66,36 @@ public class ExecutionEnvironmentTest extends TestLogger implements Serializable
 		} catch (Exception e) {
 			fail("Consecutive #getExecutionPlan calls caused an exception.");
 		}
+	}
+
+	@Test
+	public void testDefaultJobName() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		testJobName("Flink Java Job at", env);
+	}
+
+	@Test
+	public void testUserDefinedJobName() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(config);
+		testJobName(jobName, env);
+	}
+
+	@Test
+	public void testUserDefinedJobNameWithConfigure() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.configure(config, this.getClass().getClassLoader());
+		testJobName(jobName, env);
+	}
+
+	private void testJobName(String prefixOfExpectedJobName, ExecutionEnvironment env) {
+		env.fromElements(1, 2, 3).writeAsText("/dev/null");
+		Plan plan = env.createProgramPlan();
+		assertTrue(plan.getJobName().startsWith(prefixOfExpectedJobName));
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -36,6 +36,16 @@ import static org.apache.flink.configuration.description.TextElement.text;
  */
 @PublicEvolving
 public class PipelineOptions {
+
+	/**
+	 * The job name used for printing and logging.
+	 */
+	public static final ConfigOption<String> NAME =
+		key("pipeline.name")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("The job name used for printing and logging.");
+
 	/**
 	 * A list of jar files that contain the user-defined function (UDF) classes and all classes used from within the UDFs.
 	 */

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -418,6 +418,8 @@ public class ExecutionEnvironment {
 				this.cacheFile.clear();
 				this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
 			});
+		configuration.getOptional(PipelineOptions.NAME)
+			.ifPresent(jobName -> this.getConfiguration().set(PipelineOptions.NAME, jobName));
 		config.configure(configuration, classLoader);
 	}
 
@@ -870,7 +872,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the program executions fails.
 	 */
 	public JobExecutionResult execute() throws Exception {
-		return execute(getDefaultName());
+		return execute(getJobName());
 	}
 
 	/**
@@ -945,7 +947,7 @@ public class ExecutionEnvironment {
 	 */
 	@PublicEvolving
 	public final JobClient executeAsync() throws Exception {
-		return executeAsync(getDefaultName());
+		return executeAsync(getJobName());
 	}
 
 	/**
@@ -998,7 +1000,7 @@ public class ExecutionEnvironment {
 	 * @throws Exception Thrown, if the compiler could not be instantiated.
 	 */
 	public String getExecutionPlan() throws Exception {
-		Plan p = createProgramPlan(getDefaultName(), false);
+		Plan p = createProgramPlan(getJobName(), false);
 		return ExecutionPlanUtil.getExecutionPlanAsJSON(p);
 	}
 
@@ -1051,7 +1053,7 @@ public class ExecutionEnvironment {
 	 */
 	@Internal
 	public Plan createProgramPlan() {
-		return createProgramPlan(getDefaultName());
+		return createProgramPlan(getJobName());
 	}
 
 	/**
@@ -1122,12 +1124,13 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Gets a default job name, based on the timestamp when this method is invoked.
+	 * Gets the job name. If user defined job name is not found in the configuration,
+	 * the default name based on the timestamp when this method is invoked will return.
 	 *
-	 * @return A default job name.
+	 * @return A job name.
 	 */
-	private static String getDefaultName() {
-		return "Flink Java Job at " + Calendar.getInstance().getTime();
+	private String getJobName() {
+		return configuration.getString(PipelineOptions.NAME, "Flink Java Job at " + Calendar.getInstance().getTime());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -786,6 +786,9 @@ public class StreamExecutionEnvironment {
 				this.cacheFile.clear();
 				this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
 			});
+		configuration.getOptional(PipelineOptions.NAME).ifPresent(
+				jobName -> this.getConfiguration().set(PipelineOptions.NAME, jobName)
+		);
 		config.configure(configuration, classLoader);
 		checkpointCfg.configure(configuration);
 	}
@@ -1676,7 +1679,7 @@ public class StreamExecutionEnvironment {
 	 * @throws Exception which occurs during job execution.
 	 */
 	public JobExecutionResult execute() throws Exception {
-		return execute(DEFAULT_JOB_NAME);
+		return execute(getJobName());
 	}
 
 	/**
@@ -1769,7 +1772,7 @@ public class StreamExecutionEnvironment {
 	 */
 	@PublicEvolving
 	public final JobClient executeAsync() throws Exception {
-		return executeAsync(DEFAULT_JOB_NAME);
+		return executeAsync(getJobName());
 	}
 
 	/**
@@ -1836,7 +1839,7 @@ public class StreamExecutionEnvironment {
 	 */
 	@Internal
 	public StreamGraph getStreamGraph() {
-		return getStreamGraph(DEFAULT_JOB_NAME);
+		return getStreamGraph(getJobName());
 	}
 
 	/**
@@ -1891,7 +1894,7 @@ public class StreamExecutionEnvironment {
 	 * @return The execution plan of the program, as a JSON String.
 	 */
 	public String getExecutionPlan() {
-		return getStreamGraph(DEFAULT_JOB_NAME, false).getStreamingPlanAsJSON();
+		return getStreamGraph(getJobName(), false).getStreamingPlanAsJSON();
 	}
 
 	/**
@@ -2186,5 +2189,9 @@ public class StreamExecutionEnvironment {
 			}
 		}
 		return (T) resolvedTypeInfo;
+	}
+
+	private String getJobName() {
+		return configuration.getString(PipelineOptions.NAME, DEFAULT_JOB_NAME);
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -255,6 +257,37 @@ public class StreamExecutionEnvironmentTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	@Test
+	public void testDefaultJobName() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		testJobName(StreamExecutionEnvironment.DEFAULT_JOB_NAME, env);
+	}
+
+	@Test
+	public void testUserDefinedJobName() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		StreamExecutionEnvironment env = new StreamExecutionEnvironment(config);
+		testJobName(jobName, env);
+	}
+
+	@Test
+	public void testUserDefinedJobNameWithConfigure() {
+		String jobName = "MyTestJob";
+		Configuration config = new Configuration();
+		config.set(PipelineOptions.NAME, jobName);
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.configure(config, this.getClass().getClassLoader());
+		testJobName(jobName, env);
+	}
+
+	private void testJobName(String expectedJobName, StreamExecutionEnvironment env) {
+		env.fromElements(1, 2, 3).print();
+		StreamGraph streamGraph = env.getStreamGraph();
+		assertEquals(expectedJobName, streamGraph.getJobName());
 	}
 
 	@Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -699,7 +700,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	public TableResult executeInternal(List<ModifyOperation> operations) {
 		List<Transformation<?>> transformations = translate(operations);
 		List<String> sinkIdentifierNames = extractSinkIdentifierNames(operations);
-		String jobName = "insert-into_" + String.join(",", sinkIdentifierNames);
+		String jobName = getJobName("insert-into_" + String.join(",", sinkIdentifierNames));
 		Pipeline pipeline = execEnv.createPipeline(transformations, tableConfig, jobName);
 		try {
 			JobClient jobClient = execEnv.executeAsync(pipeline);
@@ -731,7 +732,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 				operation
 		);
 		List<Transformation<?>> transformations = translate(Collections.singletonList(sinkOperation));
-		Pipeline pipeline = execEnv.createPipeline(transformations, tableConfig, "collect");
+		String jobName = getJobName("collect");
+		Pipeline pipeline = execEnv.createPipeline(transformations, tableConfig, jobName);
 		try {
 			JobClient jobClient = execEnv.executeAsync(pipeline);
 			tableSink.setJobClient(jobClient);
@@ -1171,6 +1173,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 					}
 				}
 		).collect(Collectors.toList());
+	}
+
+	private String getJobName(String defaultJobName) {
+		return tableConfig.getConfiguration().getString(PipelineOptions.NAME, defaultJobName);
 	}
 
 	/** Get catalog from catalogName or throw a ValidationException if the catalog not exists. */


### PR DESCRIPTION

## What is the purpose of the change

*Users can't specify job name for sql job when using new apis introduced in FLIP-84. As discussion in FLINK-18545, we should introduce pipeline.name in PipelineOptions to support it, which could work for both DataStream jobs and SQL jobs. This pr is cherry pick from https://github.com/apache/flink/pull/14103. Different from https://github.com/apache/flink/pull/14103, in release-1.11, flink-python does not support DataStream api, so the third commit is unnecessary.*


## Brief change log

  - *Introduce pipeline.name to allow users to specify job name by configuration*
  - *Allow users to specify job name by configuration in ExecutionEnvironment*
  - *Specify job name by pipeline.name for sql job*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended StreamExecutionEnvironmentTest & ExecutionEnvironmentTest to verify the job name specified by pipeline.name*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
