### PR TITLE
[FLINK-20114][connector/kafka,common] Fix a few issues reported in Kafka Source release testing.

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -79,6 +79,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     .build();
  * }</pre>
  *
+ * <p>Users can also set more properties via {@link #setProperty(String, String)} and
+ * {@link #setProperties(Properties)}. The valid configurations can be found in
+ * {@link KafkaSourceOptions} and {@link ConsumerConfig configurations for KafkaConsumer}.
+ *
  * <p>Check the Java docs of each individual methods to learn more about the settings to
  * build a KafkaSource.
  */

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -441,6 +441,7 @@ public class KafkaSourceBuilder<OUT> {
 		maybeOverride(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName(), true);
 		maybeOverride(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName(), true);
 		maybeOverride(ConsumerConfig.GROUP_ID_CONFIG, "KafkaSource-" + new Random().nextLong(), false);
+		maybeOverride(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false", false);
 		maybeOverride(
 				ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
 				startingOffsetsInitializer.getAutoOffsetResetStrategy().name().toLowerCase(),

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -44,6 +44,14 @@ public class KafkaSourceOptions {
 					.withDescription("The interval in milliseconds for the Kafka source to discover " +
 							"the new partitions. A non-positive value disables the partition discovery.");
 
+	public static final ConfigOption<Integer> PARTITION_DISCOVERY_TIMEOUT_MS =
+			ConfigOptions
+					.key("partition.discovery.timeout.ms")
+					.intType()
+					.defaultValue(30000)
+					.withDescription("The max time to wait for partition discovery. The job " +
+							"will be fail if the partition cannot be discovered before timeout.");
+
 	public static final ConfigOption<Long> CLOSE_TIMEOUT_MS =
 			ConfigOptions
 					.key("close.timeout.ms")

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -52,13 +52,6 @@ public class KafkaSourceOptions {
 					.withDescription("The max time to wait for partition discovery. The job " +
 							"will be fail if the partition cannot be discovered before timeout.");
 
-	public static final ConfigOption<Long> CLOSE_TIMEOUT_MS =
-			ConfigOptions
-					.key("close.timeout.ms")
-					.longType()
-					.defaultValue(10000L)
-					.withDescription("The max time to wait when closing components.");
-
 	@SuppressWarnings("unchecked")
 	public static <T> T getOption(Properties props, ConfigOption configOption, Function<String, T> parser) {
 		String value = props.getProperty(configOption.key());

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -131,7 +131,14 @@ public class KafkaSourceEnumerator implements SplitEnumerator<KafkaPartitionSpli
 			LOG.info("Starting the KafkaSourceEnumerator for consumer group {} " +
 				"without periodic partition discovery.", consumerGroupId);
 			context.callAsync(
-					this::discoverAndInitializePartitionSplit,
+					() -> {
+						try {
+							return discoverAndInitializePartitionSplit();
+						} finally {
+							// Close the admin client early because we won't use it anymore.
+							adminClient.close();
+						}
+					},
 					this::handlePartitionSplitChanges);
 		}
 	}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -361,7 +361,11 @@ public class KafkaSourceEnumerator implements SplitEnumerator<KafkaPartitionSpli
 						.partitionsToOffsetAndMetadata()
 						.thenApply(result -> {
 							Map<TopicPartition, Long> offsets = new HashMap<>();
-							result.forEach((tp, oam) -> offsets.put(tp, oam.offset()));
+							result.forEach((tp, oam) -> {
+								if (oam != null) {
+									offsets.put(tp, oam.offset());
+								}
+							});
 							return offsets;
 						}).get();
 			} catch (InterruptedException e) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -61,6 +61,13 @@ class SpecifiedOffsetsInitializer implements OffsetsInitializer {
 			}
 		}
 		if (!toLookup.isEmpty()) {
+			// First check the committed offsets.
+			Map<TopicPartition, Long> committedOffsets = partitionOffsetsRetriever.committedOffsets(toLookup);
+			offsets.putAll(committedOffsets);
+			toLookup.removeAll(committedOffsets.keySet());
+		}
+		if (!toLookup.isEmpty()) {
+			// Fall back to the offset reset strategy.
 			switch (offsetResetStrategy) {
 				case EARLIEST:
 					offsets.putAll(partitionOffsetsRetriever.beginningOffsets(toLookup));

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
@@ -49,7 +49,10 @@ public interface KafkaSubscriber extends Serializable {
 	 * @param currentAssignment the partitions that are currently assigned to the source readers.
 	 * @return The partition changes compared with the currently assigned partitions.
 	 */
-	PartitionChange getPartitionChanges(AdminClient adminClient, Set<TopicPartition> currentAssignment);
+	PartitionChange getPartitionChanges(
+			AdminClient adminClient,
+			Set<TopicPartition> currentAssignment,
+			int timeoutMs);
 
 	/**
 	 * A container class to hold the newly added partitions and removed partitions.

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.connector.kafka.source.enumerator.subscriber;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
@@ -32,7 +34,6 @@ import java.util.Set;
  * The base implementations of {@link KafkaSubscriber}.
  */
 class KafkaSubscriberUtils {
-
 	private KafkaSubscriberUtils() {}
 
 	static void updatePartitionChanges(
@@ -48,10 +49,16 @@ class KafkaSubscriberUtils {
 		}
 	}
 
-	static Map<String, TopicDescription> getTopicMetadata(AdminClient adminClient) {
+	static Map<String, TopicDescription> getTopicMetadata(AdminClient adminClient, int timeoutMs) {
 		try {
-			Set<String> topicNames = adminClient.listTopics().names().get();
-			return adminClient.describeTopics(topicNames).all().get();
+			Set<String> topicNames = adminClient
+				.listTopics(new ListTopicsOptions().timeoutMs(timeoutMs))
+				.names()
+				.get();
+			return adminClient
+				.describeTopics(topicNames, new DescribeTopicsOptions().timeoutMs(timeoutMs))
+				.all()
+				.get();
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to get topic metadata.", e);
 		}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
@@ -46,11 +46,12 @@ class PartitionSetSubscriber implements KafkaSubscriber {
 	@Override
 	public PartitionChange getPartitionChanges(
 			AdminClient adminClient,
-			Set<TopicPartition> currentAssignment) {
+			Set<TopicPartition> currentAssignment,
+			int timeout) {
 		Set<TopicPartition> newPartitions = new HashSet<>();
 		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
 
-		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient);
+		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient, timeout);
 		for (TopicPartition tp : partitions) {
 			TopicDescription topicDescription = topicMetadata.get(tp.topic());
 			if (topicDescription != null && topicDescription.partitions().size() > tp.partition()) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kafka.source.enumerator.subscriber;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
@@ -49,13 +50,15 @@ class TopicListSubscriber implements KafkaSubscriber {
 	@Override
 	public PartitionChange getPartitionChanges(
 			AdminClient adminClient,
-			Set<TopicPartition> currentAssignment) {
+			Set<TopicPartition> currentAssignment,
+			int timeoutMs) {
 		Set<TopicPartition> newPartitions = new HashSet<>();
 		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
 
 		Map<String, TopicDescription> topicMetadata;
 		try {
-			topicMetadata = adminClient.describeTopics(topics).all().get();
+			topicMetadata = adminClient.describeTopics(
+				topics, new DescribeTopicsOptions().timeoutMs(timeoutMs)).all().get();
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to get topic metadata.", e);
 		}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -48,11 +48,12 @@ class TopicPatternSubscriber implements KafkaSubscriber {
 	@Override
 	public PartitionChange getPartitionChanges(
 			AdminClient adminClient,
-			Set<TopicPartition> currentAssignment) {
+			Set<TopicPartition> currentAssignment,
+			int timeoutMs) {
 		Set<TopicPartition> newPartitions = new HashSet<>();
 		Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
 
-		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient);
+		Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient, timeoutMs);
 		for (Map.Entry<String, TopicDescription> topicEntry : topicMetadata.entrySet()) {
 			String topic = topicEntry.getKey();
 			if (topicPattern.matcher(topic).matches()) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -91,9 +91,13 @@ public class KafkaSourceReader<T>
 				offsetsToCommit.computeIfAbsent(checkpointId, id -> new HashMap<>());
 			// Put the offsets of the active splits.
 			for (KafkaPartitionSplit split : splits) {
-				offsetsMap.put(
-						split.getTopicPartition(),
-						new OffsetAndMetadata(split.getStartingOffset(), null));
+				// If the checkpoint is triggered before the partition starting offsets
+				// is retrieved, do not commit the offsets for those partitions.
+				if (split.getStartingOffset() >= 0) {
+					offsetsMap.put(
+							split.getTopicPartition(),
+							new OffsetAndMetadata(split.getStartingOffset(), null));
+				}
 			}
 			// Put offsets of all the finished splits.
 			offsetsMap.putAll(offsetsOfFinishedSplits);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -107,7 +107,7 @@ public class KafkaSourceReader<T>
 
 	@Override
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-		LOG.info("Committing offsets for checkpoint {}", checkpointId);
+		LOG.debug("Committing offsets for checkpoint {}", checkpointId);
 		((KafkaSourceFetcherManager<T>) splitFetcherManager).commitOffsets(
 				offsetsToCommit.get(checkpointId),
 				(ignored, e) -> {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaDeserializationSchemaWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.deserializer;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.IOException;
+
+/**
+ * A wrapper class that wraps a {@link org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema}
+ * to deserialize {@link ConsumerRecord ConsumerRecords}.
+ *
+ * @param <T> the type of the deserialized records.
+ */
+class KafkaDeserializationSchemaWrapper<T> implements KafkaRecordDeserializer<T> {
+	private static final long serialVersionUID = 3239435655135705790L;
+	private final KafkaDeserializationSchema<T> kafkaDeserializationSchema;
+
+	KafkaDeserializationSchemaWrapper(KafkaDeserializationSchema<T> kafkaDeserializationSchema) {
+		this.kafkaDeserializationSchema = kafkaDeserializationSchema;
+	}
+
+	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		kafkaDeserializationSchema.open(context);
+	}
+
+	@Override
+	public void deserialize(
+		ConsumerRecord<byte[], byte[]> message,
+		Collector<T> out) throws IOException {
+		try {
+			kafkaDeserializationSchema.deserialize(message, out);
+		} catch (Exception exception) {
+			throw new IOException(
+				String.format("Failed to deserialize consumer record %s.", message), exception);
+		}
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return kafkaDeserializationSchema.getProducedType();
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializationSchemaWrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.deserializer;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.IOException;
+
+/**
+ * A class that wraps a {@link DeserializationSchema} as the value deserializer for a
+ * {@link ConsumerRecord}.
+ *
+ * @param <T> the return type of the deserialization.
+ */
+class KafkaValueOnlyDeserializationSchemaWrapper<T> implements KafkaRecordDeserializer<T> {
+	private static final long serialVersionUID = -3962448817248263667L;
+	private final DeserializationSchema<T> deserializationSchema;
+
+	KafkaValueOnlyDeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {
+		this.deserializationSchema = deserializationSchema;
+	}
+
+	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		deserializationSchema.open(context);
+	}
+
+	@Override
+	public void deserialize(
+			ConsumerRecord<byte[], byte[]> message,
+			Collector<T> out) throws IOException {
+		deserializationSchema.deserialize(message.value(), out);
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return deserializationSchema.getProducedType();
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -18,19 +18,25 @@
 
 package org.apache.flink.connector.kafka.source;
 
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.ListAccumulator;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Collector;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -101,6 +107,46 @@ public class KafkaSourceITCase {
 		}
 	}
 
+	@Test
+	public void testTimestamp() throws Throwable {
+		final String topic = "testTimestamp";
+		KafkaSourceTestEnv.createTestTopic(topic, 1, 1);
+		KafkaSourceTestEnv.produceToKafka(Arrays.asList(
+			new ProducerRecord<>(topic, 0, 1L, "key0", 0),
+			new ProducerRecord<>(topic, 0, 2L, "key1", 1),
+			new ProducerRecord<>(topic, 0, 3L, "key2", 2)
+		));
+
+		KafkaSource<PartitionAndValue> source = KafkaSource
+				.<PartitionAndValue>builder()
+				.setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+				.setGroupId("testTimestampAndWatermark")
+				.setTopics(topic)
+				.setDeserializer(new TestingKafkaRecordDeserializer())
+				.setStartingOffsets(OffsetsInitializer.earliest())
+				.setBounded(OffsetsInitializer.latest())
+				.build();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		DataStream<PartitionAndValue> stream = env.fromSource(
+			source,
+			WatermarkStrategy.noWatermarks(),
+			"testTimestamp");
+
+		// verify the timestamp and watermark are working fine.
+		stream.transform(
+			"timestampVerifier",
+			TypeInformation.of(PartitionAndValue.class),
+			new WatermarkVerifyingOperator(v -> v));
+		stream.addSink(new DiscardingSink<>());
+		JobExecutionResult result = env.execute();
+
+		assertEquals(Arrays.asList(1L, 2L, 3L), result.getAccumulatorResult("timestamp"));
+	}
+
+	// ----------------------------------
+
 	private void testBasicRead(
 			KafkaSource<PartitionAndValue> source,
 			String sourceNameAndGroupId) throws Exception {
@@ -146,6 +192,24 @@ public class KafkaSourceITCase {
 		@Override
 		public TypeInformation<PartitionAndValue> getProducedType() {
 			return TypeInformation.of(PartitionAndValue.class);
+		}
+	}
+
+	private static class WatermarkVerifyingOperator extends StreamMap<PartitionAndValue, PartitionAndValue> {
+
+		public WatermarkVerifyingOperator(MapFunction<PartitionAndValue, PartitionAndValue> mapper) {
+			super(mapper);
+		}
+
+		private static final long serialVersionUID = 2868223355944228209L;
+		@Override
+		public void open() throws Exception {
+			getRuntimeContext().addAccumulator("timestamp", new ListAccumulator<Long>());
+		}
+
+		@Override
+		public void processElement(StreamRecord<PartitionAndValue> element) throws Exception {
+			getRuntimeContext().getAccumulator("timestamp").add(element.getTimestamp());
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -38,6 +38,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,7 +134,7 @@ public class KafkaSourceITCase {
 		@Override
 		public void deserialize(
 				ConsumerRecord<byte[], byte[]> record,
-				Collector<PartitionAndValue> collector) throws Exception {
+				Collector<PartitionAndValue> collector) throws IOException {
 			if (deserializer == null) {
 				deserializer = new IntegerDeserializer();
 			}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
+import org.apache.flink.streaming.connectors.kafka.KafkaConsumerTestBase;
+import org.apache.flink.streaming.connectors.kafka.KafkaProducerTestBase;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * An IT case class that runs all the IT cases of the legacy
+ * {@link org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer} with the
+ * new {@link KafkaSource}.
+ */
+public class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
+
+	public KafkaSourceLegacyITCase() throws Exception {
+		super(true);
+	}
+
+	@BeforeClass
+	public static void prepare() throws Exception {
+		KafkaProducerTestBase.prepare();
+		((KafkaTestEnvironmentImpl) kafkaServer).setProducerSemantic(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
+	}
+
+	@Test(timeout = 120000)
+	public void testFailOnNoBroker() throws Exception {
+		runFailOnNoBrokerTest();
+	}
+
+	@Test(timeout = 60000)
+	public void testConcurrentProducerConsumerTopology() throws Exception {
+		runSimpleConcurrentProducerConsumerTopology();
+	}
+
+	@Test(timeout = 60000)
+	public void testKeyValueSupport() throws Exception {
+		runKeyValueTest();
+	}
+
+	// --- canceling / failures ---
+
+	@Test(timeout = 60000)
+	public void testCancelingEmptyTopic() throws Exception {
+		runCancelingOnEmptyInputTest();
+	}
+
+	@Test(timeout = 60000)
+	public void testCancelingFullTopic() throws Exception {
+		runCancelingOnFullInputTest();
+	}
+
+	// --- source to partition mappings and exactly once ---
+
+	@Test(timeout = 60000)
+	public void testOneToOneSources() throws Exception {
+		runOneToOneExactlyOnceTest();
+	}
+
+	@Test(timeout = 60000)
+	public void testOneSourceMultiplePartitions() throws Exception {
+		runOneSourceMultiplePartitionsExactlyOnceTest();
+	}
+
+	@Test(timeout = 60000)
+	public void testMultipleSourcesOnePartition() throws Exception {
+		runMultipleSourcesOnePartitionExactlyOnceTest();
+	}
+
+	// --- broker failure ---
+
+	@Test(timeout = 60000)
+	public void testBrokerFailure() throws Exception {
+		runBrokerFailureTest();
+	}
+
+	// --- special executions ---
+
+	@Test(timeout = 60000)
+	public void testBigRecordJob() throws Exception {
+		runBigRecordTestTopology();
+	}
+
+	@Test(timeout = 60000)
+	public void testMultipleTopicsWithLegacySerializer() throws Exception {
+		runProduceConsumeMultipleTopics(true);
+	}
+
+	@Test(timeout = 60000)
+	public void testMultipleTopicsWithKafkaSerializer() throws Exception {
+		runProduceConsumeMultipleTopics(false);
+	}
+
+	@Test(timeout = 60000)
+	public void testAllDeletes() throws Exception {
+		runAllDeletesTest();
+	}
+
+	// --- startup mode ---
+
+	@Test(timeout = 60000)
+	public void testStartFromEarliestOffsets() throws Exception {
+		runStartFromEarliestOffsets();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromLatestOffsets() throws Exception {
+		runStartFromLatestOffsets();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromGroupOffsets() throws Exception {
+		runStartFromGroupOffsets();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromSpecificOffsets() throws Exception {
+		runStartFromSpecificOffsets();
+	}
+
+	@Test(timeout = 60000)
+	public void testStartFromTimestamp() throws Exception {
+		runStartFromTimestamp();
+	}
+
+	// --- offset committing ---
+
+	@Test(timeout = 60000)
+	public void testCommitOffsetsToKafka() throws Exception {
+		runCommitOffsetsToKafka();
+	}
+
+	@Test(timeout = 60000)
+	public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+		runAutoOffsetRetrievalAndCommitToKafka();
+	}
+
+	@Test(timeout = 60000)
+	public void testCollectingSchema() throws Exception {
+		runCollectingSchemaTest();
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -43,12 +43,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class OffsetsInitializerTest {
 	private static final String TOPIC = "topic";
+	private static final String TOPIC2 = "topic2";
 	private static KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl retriever;
 
 	@BeforeClass
 	public static void setup() throws Throwable {
 		KafkaSourceTestEnv.setup();
 		KafkaSourceTestEnv.setupTopic(TOPIC, true, true);
+		KafkaSourceTestEnv.setupTopic(TOPIC2, false, false);
 		retriever = new KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl(
 				KafkaSourceTestEnv.getConsumer(),
 				KafkaSourceTestEnv.getAdminClient(),
@@ -119,19 +121,29 @@ public class OffsetsInitializerTest {
 		Map<TopicPartition, Long> specifiedOffsets = new HashMap<>();
 		List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
 		Map<TopicPartition, OffsetAndMetadata> committedOffsets = KafkaSourceTestEnv.getCommittedOffsets(partitions);
-		committedOffsets.forEach((tp, oam) -> specifiedOffsets.put(tp, oam.offset()));
+		partitions.forEach(tp -> specifiedOffsets.put(tp, (long) tp.partition()));
 		// Remove the specified offsets for partition 0.
-		TopicPartition missingPartition = new TopicPartition(TOPIC, 0);
-		specifiedOffsets.remove(missingPartition);
+		TopicPartition partitionSetToCommitted = new TopicPartition(TOPIC, 0);
+		specifiedOffsets.remove(partitionSetToCommitted);
 		OffsetsInitializer initializer = OffsetsInitializer.offsets(specifiedOffsets);
 
 		assertEquals(OffsetResetStrategy.EARLIEST, initializer.getAutoOffsetResetStrategy());
+		// The partition without committed offset should fallback to offset reset strategy.
+		TopicPartition partitionSetToEarliest = new TopicPartition(TOPIC2, 0);
+		partitions.add(partitionSetToEarliest);
 
 		Map<TopicPartition, Long> offsets =
 				initializer.getPartitionOffsets(partitions, retriever);
 		for (TopicPartition tp : partitions) {
 			Long offset = offsets.get(tp);
-			long expectedOffset = tp.equals(missingPartition) ? 0L : committedOffsets.get(tp).offset();
+			long expectedOffset;
+			if (tp.equals(partitionSetToCommitted)) {
+				expectedOffset = committedOffsets.get(tp).offset();
+			} else if (tp.equals(partitionSetToEarliest)) {
+				expectedOffset = 0L;
+			} else {
+				expectedOffset = specifiedOffsets.get(tp);
+			}
 			assertEquals(String.format("%s has incorrect offset.", tp), expectedOffset, (long) offset);
 		}
 	}
@@ -139,6 +151,6 @@ public class OffsetsInitializerTest {
 	@Test(expected = IllegalStateException.class)
 	public void testSpecifiedOffsetsInitializerWithoutOffsetResetStrategy() {
 		OffsetsInitializer initializer = OffsetsInitializer.offsets(Collections.emptyMap(), OffsetResetStrategy.NONE);
-		initializer.getPartitionOffsets(KafkaSourceTestEnv.getPartitionsForTopic(TOPIC), retriever);
+		initializer.getPartitionOffsets(KafkaSourceTestEnv.getPartitionsForTopic(TOPIC2), retriever);
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
@@ -68,7 +68,7 @@ public class KafkaSubscriberTest {
 		KafkaSubscriber subscriber =
 				KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2));
 		KafkaSubscriber.PartitionChange change =
-				subscriber.getPartitionChanges(adminClient, currentAssignment);
+				subscriber.getPartitionChanges(adminClient, currentAssignment, 30000);
 		Set<TopicPartition> expectedNewPartitions = new HashSet<>(KafkaSourceTestEnv.getPartitionsForTopics(topics));
 		expectedNewPartitions.remove(assignedPartition1);
 		expectedNewPartitions.remove(assignedPartition2);
@@ -80,7 +80,7 @@ public class KafkaSubscriberTest {
 	public void testTopicPatternSubscriber() {
 		KafkaSubscriber subscriber = KafkaSubscriber.getTopicPatternSubscriber(Pattern.compile("pattern.*"));
 		KafkaSubscriber.PartitionChange change =
-				subscriber.getPartitionChanges(adminClient, currentAssignment);
+				subscriber.getPartitionChanges(adminClient, currentAssignment, 30000);
 
 		Set<TopicPartition> expectedNewPartitions = new HashSet<>();
 		for (int i = 0; i < KafkaSourceTestEnv.NUM_PARTITIONS; i++) {
@@ -103,7 +103,7 @@ public class KafkaSubscriberTest {
 
 		KafkaSubscriber subscriber = KafkaSubscriber.getPartitionSetSubscriber(partitions);
 		KafkaSubscriber.PartitionChange change =
-				subscriber.getPartitionChanges(adminClient, currentAssignment);
+				subscriber.getPartitionChanges(adminClient, currentAssignment, 3000);
 
 		Set<TopicPartition> expectedNewPartitions = new HashSet<>(partitions);
 		expectedNewPartitions.remove(assignedPartition1);

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -183,6 +183,20 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
 		}
 	}
 
+	@Test
+	public void testNotCommitOffsetsForUninitializedSplits() throws Exception {
+		final long checkpointId = 1234L;
+		try (KafkaSourceReader<Integer> reader = (KafkaSourceReader<Integer>) createReader()) {
+			KafkaPartitionSplit split = new KafkaPartitionSplit(
+				new TopicPartition(TOPIC, 0),
+				KafkaPartitionSplit.EARLIEST_OFFSET);
+			reader.addSplits(Collections.singletonList(split));
+			reader.snapshotState(checkpointId);
+			assertEquals(1, reader.getOffsetsToCommit().size());
+			assertTrue(reader.getOffsetsToCommit().get(checkpointId).isEmpty());
+		}
+	}
+
 	// ------------------------------------------
 
 	@Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader.deserializer;
+
+import org.apache.flink.formats.json.JsonNodeDeserializationSchema;
+import org.apache.flink.streaming.util.serialization.JSONKeyValueDeserializationSchema;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for KafkaRecordDeserializers.
+ */
+public class KafkaRecordDeserializerTest {
+
+	@Test
+	public void testKafkaDeserializationSchemaWrapper() throws IOException {
+		final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
+		KafkaRecordDeserializer<ObjectNode> schema =
+			KafkaRecordDeserializer.of(new JSONKeyValueDeserializationSchema(true));
+		SimpleCollector<ObjectNode> collector = new SimpleCollector<>();
+		schema.deserialize(consumerRecord, collector);
+
+		assertEquals(1, collector.list.size());
+		ObjectNode deserializedValue = collector.list.get(0);
+
+		assertEquals(4, deserializedValue.get("key").get("index").asInt());
+		assertEquals("world", deserializedValue.get("value").get("word").asText());
+		assertEquals("topic#1", deserializedValue.get("metadata").get("topic").asText());
+		assertEquals(4, deserializedValue.get("metadata").get("offset").asInt());
+		assertEquals(3, deserializedValue.get("metadata").get("partition").asInt());
+	}
+
+	@Test
+	public void testKafkaValueDeserializationSchemaWrapper() throws IOException {
+		final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
+		KafkaRecordDeserializer<ObjectNode> schema =
+			KafkaRecordDeserializer.valueOnly(new JsonNodeDeserializationSchema());
+		SimpleCollector<ObjectNode> collector = new SimpleCollector<>();
+		schema.deserialize(consumerRecord, collector);
+
+		assertEquals(1, collector.list.size());
+		ObjectNode deserializedValue = collector.list.get(0);
+
+		assertEquals("world", deserializedValue.get("word").asText());
+		assertNull(deserializedValue.get("key"));
+		assertNull(deserializedValue.get("metadata"));
+	}
+
+	@Test
+	public void testKafkaValueDeserializerWrapper() throws IOException {
+		final String topic = "Topic";
+		byte[] value = new StringSerializer().serialize(topic, "world");
+		final ConsumerRecord<byte[], byte[]> consumerRecord =
+			new ConsumerRecord<>(topic, 0, 0L, null, value);
+		KafkaRecordDeserializer<String> schema =
+			KafkaRecordDeserializer.valueOnly(StringDeserializer.class);
+
+		SimpleCollector<String> collector = new SimpleCollector<>();
+		schema.deserialize(consumerRecord, collector);
+
+		assertEquals(1, collector.list.size());
+		assertEquals("world", collector.list.get(0));
+	}
+
+	// ----------------
+
+	private ConsumerRecord<byte[], byte[]> getConsumerRecord() throws JsonProcessingException {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode initialKey = mapper.createObjectNode();
+		initialKey.put("index", 4);
+		byte[] serializedKey = mapper.writeValueAsBytes(initialKey);
+
+		ObjectNode initialValue = mapper.createObjectNode();
+		initialValue.put("word", "world");
+		byte[] serializedValue = mapper.writeValueAsBytes(initialValue);
+
+		return new ConsumerRecord<>("topic#1", 3, 4L, serializedKey, serializedValue);
+	}
+
+	// ----------------
+
+	private static class SimpleCollector<T> implements Collector<T> {
+
+		private final List<T> list = new ArrayList<>();
+
+		@Override
+		public void collect(T record) {
+			list.add(record);
+		}
+
+		@Override
+		public void close() {
+			// do nothing
+		}
+	}
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -149,6 +150,20 @@ public abstract class KafkaTestEnvironment {
 	}
 
 	public abstract <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KafkaDeserializationSchema<T> readSchema, Properties props);
+
+	public <T> KafkaSourceBuilder<T> getSourceBuilder(List<String> topics, DeserializationSchema<T> deserializationSchema, Properties props) {
+		return getSourceBuilder(topics, new KafkaDeserializationSchemaWrapper<T>(deserializationSchema), props);
+	}
+
+	public <T> KafkaSourceBuilder<T> getSourceBuilder(String topic, KafkaDeserializationSchema<T> readSchema, Properties props) {
+		return getSourceBuilder(Collections.singletonList(topic), readSchema, props);
+	}
+
+	public <T> KafkaSourceBuilder<T> getSourceBuilder(String topic, DeserializationSchema<T> deserializationSchema, Properties props) {
+		return getSourceBuilder(Collections.singletonList(topic), deserializationSchema, props);
+	}
+
+	public abstract <T> KafkaSourceBuilder<T> getSourceBuilder(List<String> topics, KafkaDeserializationSchema<T> readSchema, Properties props);
 
 	public abstract <K, V> Collection<ConsumerRecord<K, V>> getAllRecordsFromTopic(
 			Properties properties,

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/GenericDeserializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/GenericDeserializationSchema.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.serialization;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Collector;
+
+import java.io.IOException;
+
+/**
+ * The deserialization schema interface that deserialize a generic record
+ * read from the source. Unlike the {@link DeserializationSchema}, this class
+ * allows the record to be deserialized in a generic type instead of fixed
+ * to byte[].
+ *
+ * @param <M> the type of the messages to be deserialized.
+ * @param <T> the type of the deserialized messages.
+ */
+public interface GenericDeserializationSchema<M, T> {
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	@PublicEvolving
+	default void open(DeserializationSchema.InitializationContext context) throws Exception {}
+
+	/**
+	 * Deserializes the byte message.
+	 *
+	 * <p>Can output multiple records through the {@link Collector}. Note that number and size of the
+	 * produced records should be relatively small. Depending on the source implementation records
+	 * can be buffered in memory or collecting records might delay emitting checkpoint barrier.
+	 *
+	 * @param message The message, as a byte array.
+	 * @param out The collector to put the resulting messages.
+	 */
+	@PublicEvolving
+	void deserialize(M message, Collector<T> out) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -73,7 +73,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	@Override
 	public void close() throws Exception {
 		closed = true;
-		coordinator.closeAsync(closingTimeoutMs);
+		coordinator.closeAsync(closingTimeoutMs).get();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -23,8 +23,10 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 
 import org.junit.Test;
 
@@ -34,11 +36,14 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.getSplitsAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyException;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -157,8 +162,10 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 				DataInputStream in = new DataInputStream(bais)) {
 			restoredContext = new SourceCoordinatorContext<>(
 					coordinatorExecutor,
+					Executors.newScheduledThreadPool(
+						1,
+						new ExecutorThreadFactory(coordinatorThreadFactory.getCoordinatorThreadName() + "-worker")),
 					coordinatorThreadFactory,
-					1,
 					operatorCoordinatorContext,
 					new MockSourceSplitSerializer(),
 					restoredTracker);
@@ -168,6 +175,45 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 		assertEquals(splitSplitAssignmentTracker.uncheckpointedAssignments(), restoredTracker.uncheckpointedAssignments());
 		assertEquals(splitSplitAssignmentTracker.assignmentsByCheckpointId(), restoredTracker.assignmentsByCheckpointId());
 
+	}
+
+	@Test
+	public void testCallableInterruptedDuringShutdownDoNotFailJob() throws InterruptedException {
+		AtomicReference<Throwable> expectedError = new AtomicReference<>(null);
+
+		ManuallyTriggeredScheduledExecutorService manualWorkerExecutor =
+			new ManuallyTriggeredScheduledExecutorService();
+		ManuallyTriggeredScheduledExecutorService manualCoordinatorExecutor =
+			new ManuallyTriggeredScheduledExecutorService();
+
+		SourceCoordinatorContext<MockSourceSplit> testingContext = new SourceCoordinatorContext<>(
+			manualCoordinatorExecutor,
+			manualWorkerExecutor,
+			new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
+				TEST_OPERATOR_ID.toHexString(),
+				getClass().getClassLoader()),
+			operatorCoordinatorContext,
+			new MockSourceSplitSerializer(),
+			splitSplitAssignmentTracker);
+
+		testingContext.callAsync(
+			() -> {
+				throw new InterruptedException();
+			},
+			(ignored, e) -> {
+				if (e != null) {
+					expectedError.set(e);
+					throw new RuntimeException(e);
+				}
+			}
+		);
+
+		manualWorkerExecutor.triggerAll();
+		testingContext.close();
+		manualCoordinatorExecutor.triggerAll();
+
+		assertTrue(expectedError.get() instanceof InterruptedException);
+		assertFalse(operatorCoordinatorContext.isJobFailed());
 	}
 
 	// ------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumerator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,8 +67,10 @@ public abstract class SourceCoordinatorTestBase {
 		coordinatorExecutor = Executors.newSingleThreadExecutor(coordinatorThreadFactory);
 		context = new SourceCoordinatorContext<>(
 				coordinatorExecutor,
+				Executors.newScheduledThreadPool(
+					1,
+					new ExecutorThreadFactory(coordinatorThreadFactory.getCoordinatorThreadName() + "-worker")),
 				coordinatorThreadFactory,
-				1,
 				operatorCoordinatorContext,
 				new MockSourceSplitSerializer(),
 				splitSplitAssignmentTracker);


### PR DESCRIPTION
# What is the purpose of the change
This PR fixes a few issues reported during Kafka Source release testing.
- Do not commit offsets for partitions whose offsets has not been initialized.
- Do not log and fail the job again if exception is received by the UncaughtExceptionHandler in SourceCoordinatorContext.
- Report numRecordsOut from the SourceOperator.
- Close admin client early when periodic partition discovery is disabled.
- Close the OperatorCoordinators synchronously to avoid ClassNotFoundException.

## Brief change log
- Do not commit offsets for partitions whose offsets has not been initialized.
- Do not log and fail the job again if exception is received by the UncaughtExceptionHandler in SourceCoordinatorContext.
- Report numRecordsOut from the SourceOperator.
- Close admin client early when periodic partition discovery is disabled.
- Close the OperatorCoordinators synchronously to avoid ClassNotFoundException.

## Verifying this change
Two unit tests have been added to verify the following two commits.
- Do not commit offsets for partitions whose offsets has not been initialized.
- Do not log and fail the job again if exception is received by the UncaughtExceptionHandler in SourceCoordinatorContext.

Verified via the WebUI that the metrics of records out is correctly reported.
Used the `StateMachineExample` to start/cancel/resume jobs and did not see dangling `AdminClients` / `ClassNotFoundException`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
