### PR TITLE
[FLINK-20384][doc] Fix Wrong Links in Some Chinese Docs

### DIFF
--- a/docs/deployment/filesystems/plugins.zh.md
+++ b/docs/deployment/filesystems/plugins.zh.md
@@ -70,7 +70,7 @@ possible across Flink core, plugins, and user code.
 
 ## File Systems
 
-All [file systems]({%link deployment/filesystems/index.md %}) **except MapR** are pluggable. That means they can and should
+All [file systems]({%link deployment/filesystems/index.zh.md %}) **except MapR** are pluggable. That means they can and should
 be used as plugins. To use a pluggable file system, copy the corresponding JAR file from the `opt`
 directory to a directory under `plugins` directory of your Flink distribution before starting Flink,
 e.g.
@@ -116,7 +116,7 @@ Furthermore, loggers are whitelisted, so that they are configured properly.
 
 ## Metric Reporters
 
-All [metric reporters]({% link deployment/metric_reporters.md %}) that Flink provides can be used as plugins.
-See the [metrics]({% link ops/metrics.md %}) documentation for more details.
+All [metric reporters]({% link deployment/metric_reporters.zh.md %}) that Flink provides can be used as plugins.
+See the [metrics]({% link ops/metrics.zh.md %}) documentation for more details.
 
 {% top %}

--- a/docs/deployment/ha/kubernetes_ha.zh.md
+++ b/docs/deployment/ha/kubernetes_ha.zh.md
@@ -24,7 +24,7 @@ under the License.
 -->
 
 ## Kubernetes Cluster High Availability
-Kubernetes high availability service could support both [standalone Flink on Kubernetes]({% link deployment/resource-providers/standalone/kubernetes.md %}) and [native Kubernetes integration]({% link deployment/resource-providers/native_kubernetes.md %}).
+Kubernetes high availability service could support both [standalone Flink on Kubernetes]({% link deployment/resource-providers/standalone/kubernetes.zh.md %}) and [native Kubernetes integration]({% link deployment/resource-providers/native_kubernetes.zh.md %}).
 
 When running Flink JobManager as a Kubernetes deployment, the replica count should be configured to 1 or greater.
 * The value `1` means that a new JobManager will be launched to take over leadership if the current one terminates exceptionally.
@@ -38,9 +38,9 @@ high-availability.storageDir: hdfs:///flink/recovery
 {% endhighlight %}
 
 #### Example: Highly Available Standalone Flink Cluster on Kubernetes
-Both session and job/application clusters support using the Kubernetes high availability service. Users just need to add the following Flink config options to [flink-configuration-configmap.yaml]({% link deployment/resource-providers/standalone/kubernetes.md %}#common-cluster-resource-definitions). All other yamls do not need to be updated.
+Both session and job/application clusters support using the Kubernetes high availability service. Users just need to add the following Flink config options to [flink-configuration-configmap.yaml]({% link deployment/resource-providers/standalone/kubernetes.zh.md %}#common-cluster-resource-definitions). All other yamls do not need to be updated.
 
-<span class="label label-info">Note</span> The filesystem which corresponds to the scheme of your configured HA storage directory must be available to the runtime. Refer to [custom Flink image]({% link deployment/resource-providers/standalone/docker.md %}#customize-flink-image) and [enable plugins]({% link deployment/resource-providers/standalone/docker.md %}#using-plugins) for more information.
+<span class="label label-info">Note</span> The filesystem which corresponds to the scheme of your configured HA storage directory must be available to the runtime. Refer to [custom Flink image]({% link deployment/resource-providers/standalone/docker.zh.md %}#customize-flink-image) and [enable plugins]({% link deployment/resource-providers/standalone/docker.zh.md %}#using-plugins) for more information.
 
 {% highlight yaml %}
 apiVersion: v1

--- a/docs/deployment/metric_reporters.zh.md
+++ b/docs/deployment/metric_reporters.zh.md
@@ -23,7 +23,7 @@ under the License.
 -->
 
 Flink allows reporting metrics to external systems.
-For more information about Flink's metric system go to the [metric system documentation]({% link ops/metrics.md %}).
+For more information about Flink's metric system go to the [metric system documentation]({% link ops/metrics.zh.md %}).
 
 * This will be replaced by the TOC
 {:toc}
@@ -61,7 +61,7 @@ metrics.reporter.my_other_reporter.port: 10000
 {% endhighlight %}
 
 **Important:** The jar containing the reporter must be accessible when Flink is started. Reporters that support the
- `factory.class` property can be loaded as [plugins]({% link deployment/filesystems/plugins.md %}). Otherwise the jar must be placed
+ `factory.class` property can be loaded as [plugins]({% link deployment/filesystems/plugins.zh.md %}). Otherwise the jar must be placed
  in the /lib folder. Reporters that are shipped with Flink (i.e., all reporters documented on this page) are available
  by default.
 

--- a/docs/dev/python/table-api-users-guide/metrics.zh.md
+++ b/docs/dev/python/table-api-users-guide/metrics.zh.md
@@ -199,7 +199,7 @@ function_context
 
 您可以参考Java的指标文档，以获取关于以下部分的更多详细信息：
 
-*    [Reporter]({% link deployment/metric_reporters.md %}) 。
+*    [Reporter]({% link deployment/metric_reporters.zh.md %}) 。
 *    [系统指标]({% link ops/metrics.zh.md %}#system-metrics) 。
 *    [延迟跟踪]({% link ops/metrics.zh.md %}#latency-tracking) 。
 *    [REST API集成]({% link ops/metrics.zh.md %}#rest-api-integration) 。

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -555,7 +555,7 @@ counter = getRuntimeContext()
 
 ## Reporter
 
-For information on how to set up Flink's metric reporters please take a look at the [metric reporters documentation]({% link deployment/metric_reporters.md %}).
+For information on how to set up Flink's metric reporters please take a look at the [metric reporters documentation]({% link deployment/metric_reporters.zh.md %}).
 
 ## System metrics
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix wrong links in some Chinese docs*


## Brief change log

  - *Fix wrong links in `plugins.zh.md`*
  - *Fix wrong links in `kubernetes_ha.zh.md`*
  - *Fix wrong links in `metric_reporters.zh.md`*
  - *Fix wrong links in `plugins.zh.md`*
  - *Fix wrong links in `metrics.zh.md`*
  - *Fix wrong links in `metrics.zh.md`*

## Verifying this change 

-*Executing the script `build_docs.sh`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
