### PR TITLE
[FLINK-20366][table-planner-blink] ColumnIntervalUtil#getColumnIntervalWithFilter should consider constant predicate

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
@@ -19,8 +19,7 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.planner.plan.stats._
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil.ColumnRelatedVisitor
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil.getLiteralValueByBroadType
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil.{ColumnRelatedVisitor, getLiteralValueByBroadType}
 
 import org.apache.calcite.rex.{RexBuilder, RexCall, RexInputRef, RexLiteral, RexNode, RexUtil}
 import org.apache.calcite.sql.SqlKind
@@ -210,13 +209,24 @@ object ColumnIntervalUtil {
     }
     val interval = relatedSubRexNode match {
       case Some(rexNode) =>
-        val orParts = RexUtil.flattenOr(Vector(RexUtil.toDnf(rexBuilder, rexNode)))
-        orParts.map(or => {
-          val andParts = RexUtil.flattenAnd(Vector(or))
-          val andIntervals = andParts.map(and => columnIntervalOfSinglePredicate(and))
-          val res = andIntervals.filter(_ != null).foldLeft(beginInterval)(ValueInterval.intersect)
-          res
-        }).reduceLeft(ValueInterval.union)
+        if (rexNode.isAlwaysTrue) {
+          beginInterval
+        } else if (rexNode.isAlwaysFalse) {
+          ValueInterval.empty
+        } else if (RexUtil.isConstant(rexNode)) {
+          // this should not happen, just protect the following code
+          ValueInterval.infinite
+        } else {
+          val orParts = RexUtil.flattenOr(Vector(RexUtil.toDnf(rexBuilder, rexNode)))
+          orParts.map(or => {
+            val andParts = RexUtil.flattenAnd(Vector(or))
+            val andIntervals = andParts.map(and => columnIntervalOfSinglePredicate(and))
+            val res = andIntervals
+              .filter(_ != null)
+              .foldLeft(beginInterval)(ValueInterval.intersect)
+            res
+          }).reduceLeft(ValueInterval.union)
+        }
       case _ => beginInterval
     }
     if (interval == ValueInterval.infinite) null else interval


### PR DESCRIPTION
## What is the purpose of the change

*ColumnIntervalUtil#getColumnIntervalWithFilter should consider constant predicate, see the description of [FLINK-20366](https://issues.apache.org/jira/browse/FLINK-20366)*


## Brief change log

  - *Add logic to handler constant predicate in ColumnIntervalUtil#getColumnIntervalWithFilter*


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended ColumnIntervalUtilTest to verify the change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
