### PR TITLE
[FLINK-20175][bp-1.11] Avro Confluent Registry SQL format does not support adding nullable columns

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -181,9 +181,9 @@ public class AvroRowDataDeSerializationSchemaTest {
 		byte[] input = byteArrayOutputStream.toByteArray();
 
 		DataType dataType = ROW(
-				FIELD("type_timestamp_millis", TIMESTAMP(3)),
-				FIELD("type_date", DATE()),
-				FIELD("type_time_millis", TIME(3)));
+				FIELD("type_timestamp_millis", TIMESTAMP(3).notNull()),
+				FIELD("type_date", DATE().notNull()),
+				FIELD("type_time_millis", TIME(3).notNull()));
 		final RowType rowType = (RowType) dataType.getLogicalType();
 		final TypeInformation<RowData> typeInfo = new RowDataTypeInfo(rowType);
 		AvroRowDataSerializationSchema serializationSchema = new AvroRowDataSerializationSchema(rowType);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -22,17 +22,27 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.generated.User;
+import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.DecoderFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -52,6 +62,44 @@ public class AvroSchemaConverterTest {
 	public void testAvroSchemaConversion() {
 		final String schema = User.getClassSchema().toString(true);
 		validateUserSchema(AvroSchemaConverter.convertToTypeInfo(schema));
+	}
+
+	@Test
+	public void testAddingOptionalField() throws IOException {
+		Schema oldSchema = SchemaBuilder.record("record")
+			.fields()
+			.requiredLong("category_id")
+			.optionalString("name")
+			.endRecord();
+
+		Schema newSchema = AvroSchemaConverter.convertToSchema(
+			DataTypes.ROW(
+				DataTypes.FIELD("category_id", DataTypes.BIGINT().notNull()),
+				DataTypes.FIELD("name", DataTypes.STRING().nullable()),
+				DataTypes.FIELD("description", DataTypes.STRING().nullable())
+			).getLogicalType()
+		);
+
+		byte[] serializedRecord = AvroTestUtils.writeRecord(
+			new GenericRecordBuilder(oldSchema)
+				.set("category_id", 1L)
+				.set("name", "test")
+				.build(),
+			oldSchema
+		);
+		GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<>(
+			oldSchema,
+			newSchema);
+		GenericRecord newRecord = datumReader.read(
+			null,
+			DecoderFactory.get().binaryDecoder(serializedRecord, 0, serializedRecord.length, null));
+		assertThat(
+			newRecord,
+			equalTo(new GenericRecordBuilder(newSchema)
+				.set("category_id", 1L)
+				.set("name", "test")
+				.set("description", null)
+				.build()));
 	}
 
 	@Test
@@ -97,48 +145,55 @@ public class AvroSchemaConverterTest {
 				DataTypes.FIELD("row3", DataTypes.ROW(DataTypes.FIELD("c", DataTypes.STRING())))))
 			.build().toRowDataType().getLogicalType();
 		Schema schema = AvroSchemaConverter.convertToSchema(rowType);
-		assertEquals("{\n" +
-			"  \"type\" : \"record\",\n" +
-			"  \"name\" : \"record\",\n" +
-			"  \"fields\" : [ {\n" +
-			"    \"name\" : \"record_row1\",\n" +
-			"    \"type\" : {\n" +
-			"      \"type\" : \"record\",\n" +
-			"      \"name\" : \"record_row1\",\n" +
-			"      \"fields\" : [ {\n" +
-			"        \"name\" : \"record_row1_a\",\n" +
-			"        \"type\" : [ \"string\", \"null\" ]\n" +
-			"      } ]\n" +
-			"    }\n" +
-			"  }, {\n" +
-			"    \"name\" : \"record_row2\",\n" +
-			"    \"type\" : {\n" +
-			"      \"type\" : \"record\",\n" +
-			"      \"name\" : \"record_row2\",\n" +
-			"      \"fields\" : [ {\n" +
-			"        \"name\" : \"record_row2_b\",\n" +
-			"        \"type\" : [ \"string\", \"null\" ]\n" +
-			"      } ]\n" +
-			"    }\n" +
-			"  }, {\n" +
-			"    \"name\" : \"record_row3\",\n" +
-			"    \"type\" : {\n" +
-			"      \"type\" : \"record\",\n" +
-			"      \"name\" : \"record_row3\",\n" +
-			"      \"fields\" : [ {\n" +
-			"        \"name\" : \"record_row3_row3\",\n" +
-			"        \"type\" : {\n" +
-			"          \"type\" : \"record\",\n" +
-			"          \"name\" : \"record_row3_row3\",\n" +
-			"          \"fields\" : [ {\n" +
-			"            \"name\" : \"record_row3_row3_c\",\n" +
-			"            \"type\" : [ \"string\", \"null\" ]\n" +
-			"          } ]\n" +
-			"        }\n" +
-			"      } ]\n" +
-			"    }\n" +
-			"  } ]\n" +
-			"}", schema.toString(true));
+		assertEquals("{\n"
+			+ "  \"type\" : \"record\",\n"
+			+ "  \"name\" : \"record\",\n"
+			+ "  \"fields\" : [ {\n"
+			+ "    \"name\" : \"row1\",\n"
+			+ "    \"type\" : {\n"
+			+ "      \"type\" : \"record\",\n"
+			+ "      \"name\" : \"record_row1\",\n"
+			+ "      \"fields\" : [ {\n"
+			+ "        \"name\" : \"a\",\n"
+			+ "        \"type\" : [ \"null\", \"string\" ],\n"
+			+ "        \"default\" : null\n"
+			+ "      } ]\n"
+			+ "    },\n"
+			+ "    \"default\" : null\n"
+			+ "  }, {\n"
+			+ "    \"name\" : \"row2\",\n"
+			+ "    \"type\" : {\n"
+			+ "      \"type\" : \"record\",\n"
+			+ "      \"name\" : \"record_row2\",\n"
+			+ "      \"fields\" : [ {\n"
+			+ "        \"name\" : \"b\",\n"
+			+ "        \"type\" : [ \"null\", \"string\" ],\n"
+			+ "        \"default\" : null\n"
+			+ "      } ]\n"
+			+ "    },\n"
+			+ "    \"default\" : null\n"
+			+ "  }, {\n"
+			+ "    \"name\" : \"row3\",\n"
+			+ "    \"type\" : {\n"
+			+ "      \"type\" : \"record\",\n"
+			+ "      \"name\" : \"record_row3\",\n"
+			+ "      \"fields\" : [ {\n"
+			+ "        \"name\" : \"row3\",\n"
+			+ "        \"type\" : {\n"
+			+ "          \"type\" : \"record\",\n"
+			+ "          \"name\" : \"record_row3_row3\",\n"
+			+ "          \"fields\" : [ {\n"
+			+ "            \"name\" : \"c\",\n"
+			+ "            \"type\" : [ \"null\", \"string\" ],\n"
+			+ "            \"default\" : null\n"
+			+ "          } ]\n"
+			+ "        },\n"
+			+ "        \"default\" : null\n"
+			+ "      } ]\n"
+			+ "    },\n"
+			+ "    \"default\" : null\n"
+			+ "  } ]\n"
+			+ "}", schema.toString(true));
 	}
 
 	private void validateUserSchema(TypeInformation<?> actual) {


### PR DESCRIPTION
## What is the purpose of the change

* Backports the fix for nullable columns in Avro format. efc12ca13743c2562d297a511d82cbdccc718cd0
* Backports the nested record names f570d04885aa1c63c9b9c0d1ad702f49aa0b75a3


## Verifying this change

Added test: `testAddingOptionalField`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
