### PR TITLE
[FLINK-20287][docs] Add documentation of how to switch memory allocator in Flink docker image

### DIFF
--- a/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/deployment/resource-providers/standalone/docker.md
@@ -268,6 +268,17 @@ The `ENABLE_BUILT_IN_PLUGINS` should contain a list of plugin jar file names sep
 
 There are also more [advanced ways](#advanced-customization) for customizing the Flink image.
 
+### Switch memory allocator
+
+Flink introduced `jemalloc` as default memory allocator to resolve memory fragmentation problem (please refer to [FLINK-19125](https://issues.apache.org/jira/browse/FLINK-19125)).
+
+You could switch back to use `glibc` as memory allocator to restore the old behavior or if any unexpected memory consumption or problem observed
+(and please report the issue via JIRA or mailing list if you found any), by passing `disable-jemalloc` parameter:
+
+```sh
+    docker run <jobmanager|standalone-job|taskmanager> disable-jemalloc
+```
+
 ### Advanced customization
 
 There are several ways in which you can further customize the Flink image:

--- a/docs/deployment/resource-providers/standalone/docker.zh.md
+++ b/docs/deployment/resource-providers/standalone/docker.zh.md
@@ -268,6 +268,17 @@ The `ENABLE_BUILT_IN_PLUGINS` should contain a list of plugin jar file names sep
 
 There are also more [advanced ways](#advanced-customization) for customizing the Flink image.
 
+### Switch memory allocator
+
+Flink introduced `jemalloc` as default memory allocator to resolve memory fragmentation problem (please refer to [FLINK-19125](https://issues.apache.org/jira/browse/FLINK-19125)).
+
+You could switch back to use `glibc` as memory allocator to restore the old behavior or if any unexpected memory consumption or problem observed
+(and please report the issue via JIRA or mailing list if you found any), by passing `disable-jemalloc` parameter:
+
+```sh
+    docker run <jobmanager|standalone-job|taskmanager> disable-jemalloc
+```
+
 ### Advanced customization
 
 There are several ways in which you can further customize the Flink image:


### PR DESCRIPTION

## What is the purpose of the change

Add documentation of how to switch memory allocator in Flink docker image


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable