### PR TITLE
[FLINK-20391] Set FORWARD_EDGES_PIPELINED for BATCH ExecutionMode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -284,7 +284,7 @@ public class StreamGraphGenerator {
 				checkpointConfig.disableCheckpointing();
 			}
 
-			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED);
+			graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED);
 			graph.setScheduleMode(ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST);
 			setDefaultBufferTimeout(-1);
 			setBatchStateBackendAndTimerService(graph);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -126,7 +126,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 		assertThat(
 				streamGraph,
 				hasProperties(
-						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
+						GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
 						false));
 	}
@@ -189,7 +189,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 		assertThat(
 				graph,
 				hasProperties(
-						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
+						GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
 						false));
 	}
@@ -238,7 +238,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 		assertThat(
 				graph,
 				hasProperties(
-						GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
+						GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
 						ScheduleMode.LAZY_FROM_SOURCES_WITH_BATCH_SLOT_REQUEST,
 						false));
 
@@ -298,6 +298,18 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 						.appendText("' and scheduleMode='")
 						.appendValue(scheduleMode)
 						.appendText("'");
+			}
+
+			@Override
+			protected void describeMismatchSafely(
+					StreamGraph item,
+					Description mismatchDescription) {
+				mismatchDescription.appendText("was ")
+					.appendText("a StreamGraph with exchangeMode='")
+					.appendValue(item.getGlobalDataExchangeMode())
+					.appendText("' and scheduleMode='")
+					.appendValue(item.getScheduleMode())
+					.appendText("'");
 			}
 		};
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
@@ -93,6 +94,8 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -108,6 +111,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator.areOperatorsChainable;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -611,6 +615,51 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		// UNDEFINED shuffle mode is translated into PIPELINED_BOUNDED result partition by default
 		assertEquals(ResultPartitionType.PIPELINED_BOUNDED,
 			sourceAndMapVertex.getProducedDataSets().get(0).getResultType());
+	}
+
+	@Test
+	public void testPartitionTypesInBatchMode() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+		env.setParallelism(4);
+		env.disableOperatorChaining();
+		DataStream<Integer> source = env.fromElements(1);
+		source
+			// set the same parallelism as the source to make it a FORWARD SHUFFLE
+			.map(value -> value).setParallelism(1)
+			.rescale()
+			.map(value -> value)
+			.rebalance()
+			.map(value -> value)
+			.keyBy(value -> value)
+			.map(value -> value)
+			.addSink(new DiscardingSink<>());
+
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+		List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
+		assertThat(verticesSorted.get(0) /* source - forward */,
+			hasOutputPartitionType(ResultPartitionType.PIPELINED_BOUNDED));
+		assertThat(verticesSorted.get(1) /* rescale */,
+			hasOutputPartitionType(ResultPartitionType.BLOCKING));
+		assertThat(verticesSorted.get(2) /* rebalance */,
+			hasOutputPartitionType(ResultPartitionType.BLOCKING));
+		assertThat(verticesSorted.get(3) /* keyBy */,
+			hasOutputPartitionType(ResultPartitionType.BLOCKING));
+		assertThat(verticesSorted.get(4) /* forward - sink */,
+			hasOutputPartitionType(ResultPartitionType.PIPELINED_BOUNDED));
+	}
+
+	private Matcher<JobVertex> hasOutputPartitionType(ResultPartitionType partitionType) {
+		return new FeatureMatcher<JobVertex, ResultPartitionType>(
+			equalTo(partitionType),
+			"output partition type",
+			"output partition type"
+		) {
+			@Override
+			protected ResultPartitionType featureValueOf(JobVertex actual) {
+				return actual.getProducedDataSets().get(0).getResultType();
+			}
+		};
 	}
 
 	@Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
## What is the purpose of the change

Change the GlobalDataExchangeMode to `FORWARD_EDGES_PIPELINED` in `BATCH` mode to enable `rescale` operation to be blocking and thus make it a pipelined region border.

## Verifying this change

Added test:
* testPartitionTypesInBatchMode

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
