### PR TITLE
[FLINK-20382][runtime] Fail hard when JobMaster cannot start scheduling of a job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -932,7 +932,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			);
 		}
 
-		schedulerAssignedFuture.thenRun(this::startScheduling);
+		FutureUtils.assertNoException(schedulerAssignedFuture.thenRun(this::startScheduling));
 	}
 
 	private void startScheduling() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -32,6 +32,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 	private static final Logger LOG = LoggerFactory.getLogger(FatalExitExceptionHandler.class);
 
 	public static final FatalExitExceptionHandler INSTANCE = new FatalExitExceptionHandler();
+	public static final int EXIT_CODE = -17;
 
 	@Override
 	@SuppressWarnings("finally")
@@ -40,7 +41,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 			LOG.error("FATAL: Thread '{}' produced an uncaught exception. Stopping the process...", t.getName(), e);
 		}
 		finally {
-			System.exit(-17);
+			System.exit(EXIT_CODE);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
+import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
@@ -81,7 +82,7 @@ public class JobMasterSchedulerTest extends TestLogger {
 		try {
 			startFuture.join();
 
-			assertThat(trackingSecurityManager.getSystemExitFuture().join(), is(-17));
+			assertThat(trackingSecurityManager.getSystemExitFuture().join(), is(FatalExitExceptionHandler.EXIT_CODE));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(jobMaster, Time.milliseconds(testingTimeout.toMillis()));
 			System.setSecurityManager(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the JobMaster scheduler interaction.
+ */
+public class JobMasterSchedulerTest extends TestLogger {
+
+	@ClassRule
+	public static final TestingRpcServiceResource TESTING_RPC_SERVICE_RESOURCE = new TestingRpcServiceResource();
+
+	private final Duration testingTimeout = Duration.ofSeconds(10L);
+
+
+	/**
+	 * Tests that we fail fatally if we cannot start the scheduling. See FLINK-20382.
+	 */
+	@Test
+	public void testIfStartSchedulingFailsJobMasterFailsFatally() throws Exception {
+		final SystemExitTrackingSecurityManager trackingSecurityManager = new SystemExitTrackingSecurityManager();
+		System.setSecurityManager(trackingSecurityManager);
+
+		final SchedulerNGFactory schedulerFactory = new FailingSchedulerFactory();
+		final JobMaster jobMaster = new JobMasterBuilder(new JobGraph(), TESTING_RPC_SERVICE_RESOURCE
+			.getTestingRpcService())
+			.withSchedulerFactory(schedulerFactory)
+			.createJobMaster();
+
+		final CompletableFuture<Acknowledge> startFuture = jobMaster.start(JobMasterId.generate());
+
+		try {
+			startFuture.join();
+
+			assertThat(trackingSecurityManager.getSystemExitFuture().join(), is(-17));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(jobMaster, Time.milliseconds(testingTimeout.toMillis()));
+			System.setSecurityManager(null);
+		}
+	}
+
+	private static final class FailingSchedulerFactory implements SchedulerNGFactory {
+		@Override
+		public SchedulerNG createInstance(
+			Logger log,
+			JobGraph jobGraph,
+			BackPressureStatsTracker backPressureStatsTracker,
+			Executor ioExecutor,
+			Configuration jobMasterConfiguration,
+			SlotPool slotPool,
+			ScheduledExecutorService futureExecutor,
+			ClassLoader userCodeLoader,
+			CheckpointRecoveryFactory checkpointRecoveryFactory,
+			Time rpcTimeout,
+			BlobWriter blobWriter,
+			JobManagerJobMetricGroup jobManagerJobMetricGroup,
+			Time slotRequestTimeout,
+			ShuffleMaster<?> shuffleMaster,
+			JobMasterPartitionTracker partitionTracker,
+			ExecutionDeploymentTracker executionDeploymentTracker,
+			long initializationTimestamp) {
+			return TestingSchedulerNG.newBuilder()
+				.setStartSchedulingRunnable(() -> {
+					throw new FlinkRuntimeException("Could not start scheduling.");
+				})
+				.build();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -29,10 +29,10 @@ import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTrack
 import org.apache.flink.runtime.io.network.partition.PartitionTrackerFactory;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
-import org.apache.flink.runtime.jobmaster.ExecutionDeploymentReconciler;
 import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentReconciler;
-import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentTracker;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentReconciler;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
@@ -42,8 +42,11 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+
+import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -76,6 +79,9 @@ public class JobMasterBuilder {
 	private PartitionTrackerFactory partitionTrackerFactory = NoOpJobMasterPartitionTracker.FACTORY;
 
 	private ResourceID jmResourceId = ResourceID.generate();
+
+	@Nullable
+	private SchedulerNGFactory schedulerFactory = null;
 
 	private FatalErrorHandler fatalErrorHandler = error -> {
 	};
@@ -157,6 +163,11 @@ public class JobMasterBuilder {
 		return this;
 	}
 
+	public JobMasterBuilder withSchedulerFactory(SchedulerNGFactory schedulerFactory) {
+		this.schedulerFactory = schedulerFactory;
+		return this;
+	}
+
 	public JobMaster createJobMaster() throws Exception {
 		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
 
@@ -173,7 +184,7 @@ public class JobMasterBuilder {
 			onCompletionActions,
 			fatalErrorHandler,
 			JobMasterBuilder.class.getClassLoader(),
-			SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration),
+			schedulerFactory != null ? schedulerFactory : SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration),
 			shuffleMaster,
 			partitionTrackerFactory,
 			executionDeploymentTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -237,6 +237,9 @@ public class TestingSchedulerNG implements SchedulerNG {
 		return new Builder();
 	}
 
+	/**
+	 * Builder for the TestingSchedulerNG.
+	 */
 	public static final class Builder {
 		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
 		private Runnable startSchedulingRunnable = () -> {};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Testing implementation of the {@link SchedulerNG}.
+ */
+public class TestingSchedulerNG implements SchedulerNG {
+	private final CompletableFuture<Void> terminationFuture;
+	private final Runnable startSchedulingRunnable;
+	private final Consumer<Throwable> suspendConsumer;
+
+	public TestingSchedulerNG(
+			CompletableFuture<Void> terminationFuture,
+			Runnable startSchedulingRunnable,
+			Consumer<Throwable> suspendConsumer) {
+		this.terminationFuture = terminationFuture;
+		this.startSchedulingRunnable = startSchedulingRunnable;
+		this.suspendConsumer = suspendConsumer;
+	}
+
+	@Override
+	public void setMainThreadExecutor(ComponentMainThreadExecutor mainThreadExecutor) {}
+
+	@Override
+	public void registerJobStatusListener(JobStatusListener jobStatusListener) {}
+
+	@Override
+	public void startScheduling() {
+		startSchedulingRunnable.run();
+	}
+
+	private void failOperation() {
+		throw new UnsupportedOperationException("This operation is not supported.");
+	}
+
+	@Override
+	public void suspend(Throwable cause) {
+		suspendConsumer.accept(cause);
+	}
+
+	@Override
+	public void cancel() {
+	}
+
+	@Override
+	public CompletableFuture<Void> getTerminationFuture() {
+		return terminationFuture;
+	}
+
+	@Override
+	public void handleGlobalFailure(Throwable cause) {
+	}
+
+	@Override
+	public boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+		failOperation();
+		return false;
+	}
+
+	@Override
+	public SerializedInputSplit requestNextInputSplit(
+		JobVertexID vertexID,
+		ExecutionAttemptID executionAttempt) throws IOException {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public ExecutionState requestPartitionState(
+		IntermediateDataSetID intermediateResultId,
+		ResultPartitionID resultPartitionId) throws PartitionProducerDisposedException {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public void scheduleOrUpdateConsumers(ResultPartitionID partitionID) {
+		failOperation();
+	}
+
+	@Override
+	public ArchivedExecutionGraph requestJob() {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public JobStatus requestJobStatus() {
+		return JobStatus.CREATED;
+	}
+
+	@Override
+	public JobDetails requestJobDetails() {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public KvStateLocation requestKvStateLocation(
+		JobID jobId,
+		String registrationName) {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public void notifyKvStateRegistered(
+		JobID jobId,
+		JobVertexID jobVertexId,
+		KeyGroupRange keyGroupRange,
+		String registrationName,
+		KvStateID kvStateId,
+		InetSocketAddress kvStateServerAddress) {
+		failOperation();
+	}
+
+	@Override
+	public void notifyKvStateUnregistered(
+		JobID jobId,
+		JobVertexID jobVertexId,
+		KeyGroupRange keyGroupRange,
+		String registrationName) {
+		failOperation();
+	}
+
+	@Override
+	public void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+		failOperation();
+	}
+
+	@Override
+	public Optional<OperatorBackPressureStats> requestOperatorBackPressureStats(JobVertexID jobVertexId) {
+		failOperation();
+		return Optional.empty();
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(
+		@Nullable String targetDirectory,
+		boolean cancelJob) {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public void acknowledgeCheckpoint(
+		JobID jobID,
+		ExecutionAttemptID executionAttemptID,
+		long checkpointId,
+		CheckpointMetrics checkpointMetrics,
+		TaskStateSnapshot checkpointState) {
+		failOperation();
+	}
+
+	@Override
+	public void declineCheckpoint(DeclineCheckpoint decline) {
+		failOperation();
+	}
+
+	@Override
+	public CompletableFuture<String> stopWithSavepoint(
+		String targetDirectory,
+		boolean advanceToEndOfEventTime) {
+		failOperation();
+		return null;
+	}
+
+	@Override
+	public void deliverOperatorEventToCoordinator(
+		ExecutionAttemptID taskExecution,
+		OperatorID operator,
+		OperatorEvent evt) {
+		failOperation();
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+		OperatorID operator,
+		CoordinationRequest request) {
+		failOperation();
+		return null;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
+		private Runnable startSchedulingRunnable = () -> {};
+		private Consumer<Throwable> suspendConsumer = ignored -> {};
+
+		public Builder setTerminationFuture(CompletableFuture<Void> terminationFuture) {
+			this.terminationFuture = terminationFuture;
+			return this;
+		}
+
+		public Builder setStartSchedulingRunnable(Runnable startSchedulingRunnable) {
+			this.startSchedulingRunnable = startSchedulingRunnable;
+			return this;
+		}
+
+		public Builder setSuspendConsumer(Consumer<Throwable> suspendConsumer) {
+			this.suspendConsumer = suspendConsumer;
+			return this;
+		}
+
+		public TestingSchedulerNG build() {
+			return new TestingSchedulerNG(
+				terminationFuture,
+				startSchedulingRunnable,
+				suspendConsumer);
+		}
+	}
+}


### PR DESCRIPTION
This commit checks whether the SchedulerNG.startScheduling method failed. If this is
the case, then we fail hard by terminating the process.