### PR TITLE
[FLINK-20396][checkpointing] Add a 'subtaskReset()' method to the OperatorCoordinator.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
@@ -1395,8 +1396,10 @@ public class CheckpointCoordinator {
 					LOG.debug("Resetting the master hooks.");
 					MasterHooks.reset(masterHooks.values(), LOG);
 
-					LOG.info("Resetting the Coordinators to an empty state.");
-					restoreStateToCoordinators(Collections.emptyMap());
+					LOG.info("Resetting the Operator Coordinators to an empty state.");
+					restoreStateToCoordinators(
+							OperatorCoordinator.NO_CHECKPOINT,
+							Collections.emptyMap());
 				}
 
 				return OptionalLong.empty();
@@ -1424,7 +1427,7 @@ public class CheckpointCoordinator {
 					LOG);
 
 			if (operatorCoordinatorRestoreBehavior != OperatorCoordinatorRestoreBehavior.SKIP) {
-				restoreStateToCoordinators(operatorStates);
+				restoreStateToCoordinators(latest.getCheckpointID(), operatorStates);
 			}
 
 			// update metrics
@@ -1641,12 +1644,15 @@ public class CheckpointCoordinator {
 			initDelay, baseInterval, TimeUnit.MILLISECONDS);
 	}
 
-	private void restoreStateToCoordinators(final Map<OperatorID, OperatorState> operatorStates) throws Exception {
+	private void restoreStateToCoordinators(
+			final long checkpointId,
+			final Map<OperatorID, OperatorState> operatorStates) throws Exception {
+
 		for (OperatorCoordinatorCheckpointContext coordContext : coordinatorsToCheckpoint) {
 			final OperatorState state = operatorStates.get(coordContext.operatorId());
 			final ByteStreamStateHandle coordinatorState = state == null ? null : state.getCoordinatorState();
 			final byte[] bytes = coordinatorState == null ? null : coordinatorState.getData();
-			coordContext.resetToCheckpoint(bytes);
+			coordContext.resetToCheckpoint(checkpointId, bytes);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
@@ -65,5 +65,5 @@ public interface OperatorCoordinatorCheckpointContext extends OperatorInfo, Chec
 	 * </ul>
 	 * In both cases, the coordinator should reset to an empty (new) state.
 	 */
-	void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception;
+	void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
@@ -66,4 +66,15 @@ public interface OperatorCoordinatorCheckpointContext extends OperatorInfo, Chec
 	 * In both cases, the coordinator should reset to an empty (new) state.
 	 */
 	void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) throws Exception;
+
+	/**
+	 * Called if a task is recovered as part of a <i>partial failover</i>, meaning a failover
+	 * handled by the scheduler's failover strategy (by default recovering a pipelined region).
+	 * The method is invoked for each subtask involved in that partial failover.
+	 *
+	 * <p>In contrast to this method, the {@link #resetToCheckpoint(long, byte[])} method is called in
+	 * the case of a global failover, which is the case when the coordinator (JobManager) is
+	 * recovered.
+	 */
+	void subtaskReset(int subtask, long checkpointId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -126,7 +126,9 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 	 * All subtasks will also have been reset to the same checkpoint.
 	 *
 	 * <p>This method is called in the case of a <i>global failover</i> of the system, which means
-	 * a failover of the coordinator (JobManager).
+	 * a failover of the coordinator (JobManager). This method is not invoked on a <i>partial
+	 * failover</i>; partial failovers call the {@link #subtaskReset(int, long)} method for the
+	 * involved subtasks.
 	 *
 	 * <p>This method is expected to behave synchronously with respect to other method calls and calls
 	 * to {@code Context} methods. For example, Events being sent by the Coordinator after this method
@@ -158,15 +160,21 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 	 * Called when one of the subtasks of the task running the coordinated operator goes
 	 * through a failover (failure / recovery cycle).
 	 *
-	 * <p>This method is called in case of a <i>partial failover</i> meaning a failover handled
-	 * by the scheduler's failover strategy (by default recovering a pipelined region).
+	 * <p>This method is called every time there is a failover of a subtasks, regardless of
+	 * whether there it is a partial failover or a global failover.
+	 */
+	void subtaskFailed(int subtask, @Nullable Throwable reason);
+
+	/**
+	 * Called if a task is recovered as part of a <i>partial failover</i>, meaning a failover
+	 * handled by the scheduler's failover strategy (by default recovering a pipelined region).
 	 * The method is invoked for each subtask involved in that partial failover.
 	 *
 	 * <p>In contrast to this method, the {@link #resetToCheckpoint(long, byte[])} method is called in
 	 * the case of a global failover, which is the case when the coordinator (JobManager) is
 	 * recovered.
 	 */
-	void subtaskFailed(int subtask, @Nullable Throwable reason);
+	void subtaskReset(int subtask, long checkpointId);
 
 	// ------------------------------------------------------------------------
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -202,6 +202,12 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		mainThreadExecutor.assertRunningInMainThread();
+		coordinator.subtaskReset(subtask, checkpointId);
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
 		// unfortunately, this method does not run in the scheduler executor, but in the
 		// checkpoint coordinator time thread.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -229,7 +229,7 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 	}
 
 	@Override
-	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) throws Exception {
 		// ideally we would like to check this here, however this method is called early during
 		// execution graph construction, before the main thread executor is set
 
@@ -237,7 +237,7 @@ public class OperatorCoordinatorHolder implements OperatorCoordinator, OperatorC
 		if (context != null) {
 			context.resetFailed();
 		}
-		coordinator.resetToCheckpoint(checkpointData);
+		coordinator.resetToCheckpoint(checkpointId, checkpointData);
 	}
 
 	private void checkpointCoordinatorInternal(final long checkpointId, final CompletableFuture<byte[]> result) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -91,6 +91,13 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		coordinator.applyCall(
+			"subtaskReset",
+			c -> c.subtaskReset(subtask, checkpointId));
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> resultFuture) throws Exception {
 		coordinator.applyCall(
 				"checkpointCoordinator",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -105,7 +105,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void resetToCheckpoint(@Nullable byte[] checkpointData) {
+	public void resetToCheckpoint(final long checkpointId, @Nullable final byte[] checkpointData) {
 		// First bump up the coordinator epoch to fence out the active coordinator.
 		LOG.info("Resetting coordinator to checkpoint.");
 		// Replace the coordinator variable with a new DeferrableCoordinator instance.
@@ -123,7 +123,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 			if (!closed) {
 				// The previous coordinator has closed. Create a new one.
 				newCoordinator.createNewInternalCoordinator(context, provider);
-				newCoordinator.resetAndStart(checkpointData, started);
+				newCoordinator.resetAndStart(checkpointId, checkpointData, started);
 				newCoordinator.processPendingCalls();
 			}
 		});
@@ -248,7 +248,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	/**
-	 * A class that helps realize the fully async {@link #resetToCheckpoint(byte[])} behavior.
+	 * A class that helps realize the fully async {@link #resetToCheckpoint(long, byte[])} behavior.
 	 * The class wraps an {@link OperatorCoordinator} instance. It is going to be accessed
 	 * by two different thread: the scheduler thread and the closing thread created in
 	 * {@link #closeAsync(long)}. A DeferrableCoordinator could be in three states:
@@ -366,12 +366,15 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 			internalCoordinator.start();
 		}
 
-		void resetAndStart(@Nullable byte[] checkpointData, boolean started) {
+		void resetAndStart(
+				final long checkpointId,
+				@Nullable final byte[] checkpointData, boolean started) {
+
 			if (failed || closed || internalCoordinator == null) {
 				return;
 			}
 			try {
-				internalCoordinator.resetToCheckpoint(checkpointData);
+				internalCoordinator.resetToCheckpoint(checkpointId, checkpointData);
 				// Start the new coordinator if this coordinator has been started before reset to the checkpoint.
 				if (started) {
 					internalCoordinator.start();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -183,6 +183,11 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		// TODO - move the split reset logic here
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
 		runInEventLoop(
 			() -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -223,7 +223,10 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT> implements 
 	}
 
 	@Override
-	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(
+			final long checkpointId,
+			@Nullable final byte[] checkpointData) throws Exception {
+
 		checkState(!started, "The coordinator can only be reset if it was not yet started");
 		assert enumerator == null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -849,6 +849,9 @@ public class CheckpointCoordinatorTestingUtils {
 		public void resetToCheckpoint(long checkpointId, @$Nullable byte[] checkpointData) throws Exception {}
 
 		@Override
+		public void subtaskReset(int subtask, long checkpointId) {}
+
+		@Override
 		public OperatorID operatorId() {
 			return operatorID;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -60,7 +60,6 @@ import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
-import com.google.inject.internal.util.$Nullable;
 import org.junit.Assert;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -846,7 +845,7 @@ public class CheckpointCoordinatorTestingUtils {
 		}
 
 		@Override
-		public void resetToCheckpoint(long checkpointId, @$Nullable byte[] checkpointData) throws Exception {}
+		public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) throws Exception {}
 
 		@Override
 		public void subtaskReset(int subtask, long checkpointId) {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
+import com.google.inject.internal.util.$Nullable;
 import org.junit.Assert;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -845,9 +846,7 @@ public class CheckpointCoordinatorTestingUtils {
 		}
 
 		@Override
-		public void resetToCheckpoint(byte[] checkpointData) throws Exception {
-
-		}
+		public void resetToCheckpoint(long checkpointId, @$Nullable byte[] checkpointData) throws Exception {}
 
 		@Override
 		public OperatorID operatorId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -289,7 +289,9 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
 		}
 
 		@Override
-		public void resetToCheckpoint(byte[] checkpointData) throws Exception {
+		public void resetToCheckpoint(
+				final long checkpointId,
+				@Nullable final byte[] checkpointData) throws Exception {
 			executor.execute(() -> nextNumber = bytesToInt(checkpointData));
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -289,6 +289,9 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
 		}
 
 		@Override
+		public void subtaskReset(int subtask, long checkpointId) {}
+
+		@Override
 		public void resetToCheckpoint(
 				final long checkpointId,
 				@Nullable final byte[] checkpointData) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
@@ -49,6 +49,11 @@ public final class MockOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
 		throw new UnsupportedOperationException();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
@@ -59,7 +59,7 @@ public final class MockOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void resetToCheckpoint(byte[] checkpointData) {
+	public void resetToCheckpoint(long checkpointId, byte[] checkpointData) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -560,6 +560,9 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 		public void subtaskFailed(int subtask, @Nullable Throwable reason) {}
 
 		@Override
+		public void subtaskReset(int subtask, long checkpointId) {}
+
+		@Override
 		public abstract void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) throws Exception;
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -172,7 +172,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 		final OperatorCoordinatorHolder holder = createCoordinatorHolder(sender, TestingOperatorCoordinator::new);
 
 		triggerAndCompleteCheckpoint(holder, 1000L);
-		holder.resetToCheckpoint(new byte[0]);
+		holder.resetToCheckpoint(1L, new byte[0]);
 		getCoordinator(holder).getContext().sendEvent(new TestOperatorEvent(999), 1);
 
 		assertThat(sender.events, contains(
@@ -188,7 +188,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 		triggerAndCompleteCheckpoint(holder, 1000L);
 		getCoordinator(holder).getContext().sendEvent(new TestOperatorEvent(0), 0);
 		getCoordinator(holder).getContext().sendEvent(new TestOperatorEvent(1), 1);
-		holder.resetToCheckpoint(new byte[0]);
+		holder.resetToCheckpoint(2L, new byte[0]);
 
 		assertTrue(sender.events.isEmpty());
 	}
@@ -302,7 +302,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 						+ "should only take the first request from the coordinator to fail the job.",
 				firstGlobalFailure, globalFailure);
 
-		holder.resetToCheckpoint(new byte[0]);
+		holder.resetToCheckpoint(0L, new byte[0]);
 		holder.handleEventFromOperator(1, new TestOperatorEvent());
 		assertNotEquals("The new failures should be propagated after the coordinator "
 							+ "is reset.", firstGlobalFailure, globalFailure);
@@ -566,7 +566,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
 		public void notifyCheckpointComplete(long checkpointId) {}
 
 		@Override
-		public void resetToCheckpoint(byte[] checkpointData) throws Exception {}
+		public void resetToCheckpoint(long checkpointId, byte[] checkpointData) throws Exception {}
 
 		@Override
 		public void run() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -331,6 +331,7 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 
 		assertSame("coordinator should have null restored state",
 			TestingOperatorCoordinator.NULL_RESTORE_VALUE, coordinator.getLastRestoredCheckpointState());
+		assertEquals(OperatorCoordinator.NO_CHECKPOINT, coordinator.getLastRestoredCheckpointId());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -84,7 +84,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 		TestingOperatorCoordinator internalCoordinatorBeforeReset = getInternalCoordinator(coordinator);
 
 		byte[] stateToRestore = new byte[0];
-		coordinator.resetToCheckpoint(stateToRestore);
+		coordinator.resetToCheckpoint(1L, stateToRestore);
 
 		// Use the checkpoint to ensure all the previous method invocation has succeeded.
 		coordinator.waitForAllAsyncCallsFinish();
@@ -105,7 +105,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 		RecreateOnResetOperatorCoordinator coordinator =
 				(RecreateOnResetOperatorCoordinator) provider.create(context, closingTimeoutMs);
 
-		coordinator.resetToCheckpoint(new byte[0]);
+		coordinator.resetToCheckpoint(2L, new byte[0]);
 		CommonTestUtils.waitUtil(
 			context::isJobFailed,
 			Duration.ofSeconds(5),
@@ -130,7 +130,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 		// Reset the coordinator which closes the current internal coordinator
 		// and then create a new one. The closing of the current internal
 		// coordinator will block until the blockOnCloseLatch is pulled.
-		coordinator.resetToCheckpoint(restoredState);
+		coordinator.resetToCheckpoint(2L, restoredState);
 
 		// The following method calls should be applied to the new internal
 		// coordinator asynchronously because the current coordinator has not
@@ -189,7 +189,7 @@ public class RecreateOnResetOperatorCoordinatorTest {
 			future.thenRun(() -> coordinator.notifyCheckpointComplete(loop));
 			// The reset bytes has a length of i+1 here because this will be reset to the
 			// next internal coordinator.
-			coordinator.resetToCheckpoint(new byte[i + 1]);
+			coordinator.resetToCheckpoint(i, new byte[i + 1]);
 		}
 
 		coordinator.waitForAllAsyncCallsFinish();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -45,6 +45,7 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 
 	@Nullable
 	private byte[] lastRestoredCheckpointState;
+	private long lastRestoredCheckpointId;
 
 	private BlockingQueue<CompletableFuture<byte[]>> triggeredCheckpoints;
 
@@ -106,7 +107,8 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
-	public void resetToCheckpoint(@Nullable byte[] checkpointData) {
+	public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) {
+		lastRestoredCheckpointId = checkpointId;
 		lastRestoredCheckpointState = checkpointData == null
 				? NULL_RESTORE_VALUE
 				: checkpointData;
@@ -133,6 +135,10 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	@Nullable
 	public byte[] getLastRestoredCheckpointState() {
 		return lastRestoredCheckpointState;
+	}
+
+	public long getLastRestoredCheckpointId() {
+		return lastRestoredCheckpointId;
 	}
 
 	public CompletableFuture<byte[]> getLastTriggeredCheckpoint() throws InterruptedException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -40,6 +40,7 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	private final OperatorCoordinator.Context context;
 
 	private final ArrayList<Integer> failedTasks = new ArrayList<>();
+	private final ArrayList<SubtaskAndCheckpoint> restoredTasks = new ArrayList<>();
 
 	private final CountDownLatch blockOnCloseLatch;
 
@@ -96,6 +97,11 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		restoredTasks.add(new SubtaskAndCheckpoint(subtask, checkpointId));
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
 		boolean added = triggeredCheckpoints.offer(result);
 		assert added; // guard the test assumptions
@@ -132,6 +138,10 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 		return failedTasks;
 	}
 
+	public List<SubtaskAndCheckpoint> getRestoredTasks() {
+		return restoredTasks;
+	}
+
 	@Nullable
 	public byte[] getLastRestoredCheckpointState() {
 		return lastRestoredCheckpointState;
@@ -160,6 +170,19 @@ class TestingOperatorCoordinator implements OperatorCoordinator {
 
 	public boolean hasCompleteCheckpoint() throws InterruptedException {
 		return !lastCheckpointComplete.isEmpty();
+	}
+
+	// ------------------------------------------------------------------------
+
+	public static final class SubtaskAndCheckpoint {
+
+		public final int subtaskIndex;
+		public final long checkpointId;
+
+		public SubtaskAndCheckpoint(int subtaskIndex, long checkpointId) {
+			this.subtaskIndex = subtaskIndex;
+			this.checkpointId = checkpointId;
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
@@ -89,7 +89,7 @@ public class SourceCoordinatorProviderTest {
 		}
 
 		// reset the coordinator to the checkpoint which only contains reader 0.
-		coordinator.resetToCheckpoint(bytes);
+		coordinator.resetToCheckpoint(0L, bytes);
 		final SourceCoordinator<?, ?> restoredSourceCoordinator =
 				(SourceCoordinator<?, ?>) coordinator.getInternalCoordinator();
 		assertNotEquals("The restored source coordinator should be a different instance",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -89,7 +89,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 	public void testRestCheckpointAfterCoordinatorStarted() throws Exception {
 		// The following methods should only be invoked after the source coordinator has started.
 		sourceCoordinator.start();
-		verifyException(() -> sourceCoordinator.resetToCheckpoint(null),
+		verifyException(() -> sourceCoordinator.resetToCheckpoint(0L, null),
 				"Reset to checkpoint should fail after the coordinator has started",
 				"The coordinator can only be reset if it was not yet started");
 	}
@@ -146,7 +146,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
 		// restore from the checkpoints.
 		SourceCoordinator<?, ?> restoredCoordinator = getNewSourceCoordinator();
-		restoredCoordinator.resetToCheckpoint(bytes);
+		restoredCoordinator.resetToCheckpoint(100L, bytes);
 		MockSplitEnumerator restoredEnumerator = (MockSplitEnumerator) restoredCoordinator.getEnumerator();
 		SourceCoordinatorContext restoredContext = restoredCoordinator.getContext();
 		assertEquals("2 splits should have been assigned to reader 0",
@@ -328,7 +328,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 				"testOperator", context.getOperatorId(), source, 1);
 
 		final OperatorCoordinator coordinator = provider.getCoordinator(context);
-		coordinator.resetToCheckpoint(createEmptyCheckpoint(1L));
+		coordinator.resetToCheckpoint(1L, createEmptyCheckpoint(1L));
 		coordinator.start();
 
 		final ClassLoaderTestEnumerator enumerator = source.restoreEnumeratorFuture.get();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
@@ -197,7 +197,7 @@ public class CollectSinkOperatorCoordinator implements OperatorCoordinator, Coor
 	}
 
 	@Override
-	public void resetToCheckpoint(@Nullable byte[] checkpointData) throws Exception {
+	public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) throws Exception {
 		if (checkpointData == null) {
 			// restore before any checkpoint completed
 			closeConnection();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
@@ -184,6 +184,11 @@ public class CollectSinkOperatorCoordinator implements OperatorCoordinator, Coor
 	}
 
 	@Override
+	public void subtaskReset(int subtask, long checkpointId) {
+		// nothing to do here, connections are re-created lazily
+	}
+
+	@Override
 	public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) throws Exception {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(baos);


### PR DESCRIPTION
## This is based upon PR #14255, which represent the first of the three commits here.

# What is the purpose of the change

This extends the `OperatorCoordinator` with a `subtaskReset()` method.
  - The `subtaskReset()` method is the notification of a local failover (pipelined region) where the `OperatorCoordinator` is not reset as a whole, but only resets the subtask-dependent state.
  - That method complements the method `resetToCheckpoint()` which is called on a global-failover and resets the entire state of the `OperatorCoordinator`.

The behavior is transparent across batch and for streaming execution:
  - All notifications come on all global- and local failover, both in batch and streaming 
  - For streaming execution, the methods are invoked with the ID of the restored checkpoint.
  - For streaming execution, if there is not yet any completed checkpoint, then the methods are invoked with a checkpoint ID of _-1_. That represents a "virtual empty checkpoint" that marks the "beginning of the execution". _-1_ is before any other checkpoint ID, so it fits transparently into the contract of monotonous checkpoint IDs and "later-checkpoints-subsume-earlier-checkpoints".
  - Batch recovery behaves exactly like a streaming recovery before the first checkpoint: There is only ever the virtual empty checkpoint that represents the beginning of the execution, no additional checkpoint is taken. All recoveries refer to that empty checkpoint with no state. That way batch is strictly a special case of streaming.

This logic will allow us to make the consistency of the `SplitEnumerator` for sources easier (future PR).
Instead of reacting to failure notifications, we react to restore notifications.
  - Restore notifications are well ordered with checkpoints, we eliminate the races of [FLINK-20290](https://issues.apache.org/jira/browse/FLINK-20290)
  - Restore notifications generalize well across local and global failovers.
  - All restores are relative to checkpoints (including the virtual empty checkpoint at the beginning). That makes split assignment tracking transparent in the sources: When a task is restored, all splits that came after the restored checkpoint have to be re-assigned. In batch, the restored checkpoint is the initial empty checkpoint, so all splits every assigned to the task have to be re-assigned.

## Brief change log

  - Commit 9f760fa improves the `resetToCheckpoint()` method by passing in the ID of the restored checkpoint.
  - Commit cf30b0e adds the `subtaskReset()` method, the scheduler code to call that method, and the tests.

## Verifying this change

This PR adds a series of test scenarios. The class `OperatorCoordinatorSchedulerTest` covers the full contract of the `OperatorCoordinator` calls and notifications from the scheduler.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
