### PR TITLE
[FLINK-20290][runtime] Fix split duplication issues in Sources

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
@@ -64,6 +64,16 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
 	}
 
 	// ------------------------------------------------------------------------
+
+	@Override
+	public String toString() {
+		return "PendingSplitsCheckpoint:\n" +
+				"\t\t Pending Splits: " + splits + '\n' +
+				"\t\t Processed Paths: " + alreadyProcessedPaths + '\n';
+	}
+
+
+	// ------------------------------------------------------------------------
 	//  factories
 	// ------------------------------------------------------------------------
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
@@ -125,7 +125,11 @@ public class ContinuousFileSplitEnumerator implements SplitEnumerator<FileSource
 
 	@Override
 	public PendingSplitsCheckpoint<FileSourceSplit> snapshotState() throws Exception {
-		return PendingSplitsCheckpoint.fromCollectionSnapshot(splitAssigner.remainingSplits(), pathsAlreadyProcessed);
+		final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
+				PendingSplitsCheckpoint.fromCollectionSnapshot(splitAssigner.remainingSplits(), pathsAlreadyProcessed);
+
+		LOG.debug("Source Checkpoint is {}", checkpoint);
+		return checkpoint;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceTextLinesITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/FileSourceTextLinesITCase.java
@@ -18,18 +18,33 @@
 
 package org.apache.flink.connector.file.src;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.reader.TextLineFormat;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.highavailability.nonha.embedded.TestingEmbeddedHaServices;
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.minicluster.TestingMiniCluster;
+import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionWithException;
 
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -42,9 +57,15 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -61,13 +82,57 @@ public class FileSourceTextLinesITCase extends TestLogger {
 	@ClassRule
 	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
-	@ClassRule
-	public static final MiniClusterWithClientResource MINI_CLUSTER = new MiniClusterWithClientResource(
-		new MiniClusterResourceConfiguration.Builder()
-			.setNumberTaskManagers(1)
-			.setNumberSlotsPerTaskManager(PARALLELISM)
-			.build());
+	private static TestingMiniCluster miniCluster;
 
+	private static TestingEmbeddedHaServices highAvailabilityServices;
+
+	private static CompletedCheckpointStore checkpointStore;
+
+	@BeforeClass
+	public static void setupMiniCluster() throws Exception  {
+		highAvailabilityServices = new HaServices(TestingUtils.defaultExecutor(),
+			() -> checkpointStore,
+			new StandaloneCheckpointIDCounter());
+
+		final Configuration configuration = createConfiguration();
+
+		miniCluster = new TestingMiniCluster(
+			new TestingMiniClusterConfiguration.Builder()
+				.setConfiguration(configuration)
+				.setNumTaskManagers(1)
+				.setNumSlotsPerTaskManager(PARALLELISM)
+				.setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+				.build(),
+			() -> highAvailabilityServices);
+
+		miniCluster.start();
+	}
+
+	private static Configuration createConfiguration() throws IOException {
+		final Configuration configuration = new Configuration();
+		final String checkPointDir = Path.fromLocalFile(TMP_FOLDER.newFolder()).toUri().toString();
+		configuration.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkPointDir);
+		return configuration;
+	}
+
+	@Before
+	public void setup() {
+		checkpointStore = new RecoverableCompletedCheckpointStore();
+	}
+
+	@AfterClass
+	public static void shutdownMiniCluster() throws Exception {
+		if (miniCluster != null) {
+			miniCluster.close();
+		}
+		if (highAvailabilityServices != null) {
+			highAvailabilityServices.closeAndCleanupAllData();
+			highAvailabilityServices = null;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  test cases
 	// ------------------------------------------------------------------------
 
 	/**
@@ -75,6 +140,28 @@ public class FileSourceTextLinesITCase extends TestLogger {
 	 */
 	@Test
 	public void testBoundedTextFileSource() throws Exception {
+		testBoundedTextFileSource(FailoverType.NONE);
+	}
+
+	/**
+	 * This test runs a job reading bounded input with a stream record format (text lines)
+	 * and restarts TaskManager.
+	 */
+	@Test
+	public void testBoundedTextFileSourceWithTaskManagerFailover() throws Exception {
+		testBoundedTextFileSource(FailoverType.TM);
+	}
+
+	/**
+	 * This test runs a job reading bounded input with a stream record format (text lines)
+	 * and triggers JobManager failover.
+	 */
+	@Test
+	public void testBoundedTextFileSourceWithJobManagerFailover() throws Exception {
+		testBoundedTextFileSource(FailoverType.JM);
+	}
+
+	private void testBoundedTextFileSource(FailoverType failoverType) throws Exception {
 		final File testDir = TMP_FOLDER.newFolder();
 
 		// our main test data
@@ -84,18 +171,32 @@ public class FileSourceTextLinesITCase extends TestLogger {
 		writeHiddenJunkFiles(testDir);
 
 		final FileSource<String> source = FileSource
-				.forRecordStreamFormat(new TextLineFormat(), Path.fromLocalFile(testDir))
-				.build();
+			.forRecordStreamFormat(new TextLineFormat(), Path.fromLocalFile(testDir))
+			.build();
 
-		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		final StreamExecutionEnvironment env = new TestStreamEnvironment(miniCluster, PARALLELISM);
 		env.setParallelism(PARALLELISM);
 
 		final DataStream<String> stream = env.fromSource(
-				source,
-				WatermarkStrategy.noWatermarks(),
-				"file-source");
+			source,
+			WatermarkStrategy.noWatermarks(),
+			"file-source");
 
-		final List<String> result = DataStreamUtils.collectBoundedStream(stream, "Bounded TextFiles Test");
+		final DataStream<String> streamFailingInTheMiddleOfReading =
+			RecordCounterToFail.wrapWithFailureAfter(stream, LINES.length / 2);
+
+		final ClientAndIterator<String> client = DataStreamUtils.collectWithClient(
+			streamFailingInTheMiddleOfReading,
+			"Bounded TextFiles Test");
+		final JobID jobId = client.client.getJobID();
+
+		RecordCounterToFail.waitToFail();
+		triggerFailover(failoverType, jobId, RecordCounterToFail::continueProcessing);
+
+		final List<String> result = new ArrayList<>();
+		while (client.iterator.hasNext()) {
+			result.add(client.iterator.next());
+		}
 
 		verifyResult(result);
 	}
@@ -106,23 +207,47 @@ public class FileSourceTextLinesITCase extends TestLogger {
 	 */
 	@Test
 	public void testContinuousTextFileSource() throws Exception {
+		testContinuousTextFileSource(FailoverType.NONE);
+	}
+
+	/**
+	 * This test runs a job reading continuous input (files appearing over time)
+	 * with a stream record format (text lines) and restarts TaskManager.
+	 */
+	@Test
+	public void testContinuousTextFileSourceWithTaskManagerFailover() throws Exception {
+		testContinuousTextFileSource(FailoverType.TM);
+	}
+
+	/**
+	 * This test runs a job reading continuous input (files appearing over time)
+	 * with a stream record format (text lines) and triggers JobManager failover.
+	 */
+	@Test
+	public void testContinuousTextFileSourceWithJobManagerFailover() throws Exception {
+		testContinuousTextFileSource(FailoverType.JM);
+	}
+
+	private void testContinuousTextFileSource(FailoverType type) throws Exception {
 		final File testDir = TMP_FOLDER.newFolder();
 
 		final FileSource<String> source = FileSource
-				.forRecordStreamFormat(new TextLineFormat(), Path.fromLocalFile(testDir))
-				.monitorContinuously(Duration.ofMillis(5))
-				.build();
+			.forRecordStreamFormat(new TextLineFormat(), Path.fromLocalFile(testDir))
+			.monitorContinuously(Duration.ofMillis(5))
+			.build();
 
-		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		final StreamExecutionEnvironment env = new TestStreamEnvironment(miniCluster, PARALLELISM);
 		env.setParallelism(PARALLELISM);
+		env.enableCheckpointing(10L);
 
 		final DataStream<String> stream = env.fromSource(
-				source,
-				WatermarkStrategy.noWatermarks(),
-				"file-source");
+			source,
+			WatermarkStrategy.noWatermarks(),
+			"file-source");
 
 		final ClientAndIterator<String> client =
 				DataStreamUtils.collectWithClient(stream, "Continuous TextFiles Monitoring Test");
+		final JobID jobId = client.client.getJobID();
 
 		// write one file, execute, and wait for its result
 		// that way we know that the application was running and the source has
@@ -138,15 +263,64 @@ public class FileSourceTextLinesITCase extends TestLogger {
 		for (int i = 1; i < LINES_PER_FILE.length; i++) {
 			Thread.sleep(10);
 			writeFile(testDir, i);
+			final boolean failAfterHalfOfInput = i == LINES_PER_FILE.length / 2;
+			if (failAfterHalfOfInput) {
+				triggerFailover(type, jobId, () -> {});
+			}
 		}
 
-		final List<String> result2 = DataStreamUtils.collectRecordsFromUnboundedStream(client, numLinesAfter);
+		final List<String> result2 = DataStreamUtils.collectRecordsFromUnboundedStream(
+			client,
+			numLinesAfter);
 
 		// shut down the job, now that we have all the results we expected.
 		client.client.cancel().get();
 
 		result1.addAll(result2);
 		verifyResult(result1);
+	}
+
+	// ------------------------------------------------------------------------
+	//  test utilities
+	// ------------------------------------------------------------------------
+
+	private enum FailoverType {
+		NONE,
+		TM,
+		JM
+	}
+
+	private static void triggerFailover(
+			FailoverType type,
+			JobID jobId,
+			Runnable afterFailAction) throws Exception {
+		switch (type) {
+			case NONE:
+				afterFailAction.run();
+				break;
+			case TM:
+				restartTaskManager(afterFailAction);
+				break;
+			case JM:
+				triggerJobManagerFailover(jobId, afterFailAction);
+				break;
+		}
+	}
+
+	private static void triggerJobManagerFailover(JobID jobId, Runnable afterFailAction) throws Exception {
+		highAvailabilityServices.revokeJobMasterLeadership(jobId).get();
+		Thread.sleep(50);
+		afterFailAction.run();
+		Thread.sleep(50);
+		highAvailabilityServices.grantJobMasterLeadership(jobId).get();
+	}
+
+	private static void restartTaskManager(Runnable afterFailAction) throws Exception {
+		miniCluster.terminateTaskExecutor(0).get();
+		Thread.sleep(50);
+		afterFailAction.run();
+		Thread.sleep(50);
+		miniCluster.startTaskExecutor();
 	}
 
 	// ------------------------------------------------------------------------
@@ -307,5 +481,88 @@ public class FileSourceTextLinesITCase extends TestLogger {
 		assertTrue(parent.mkdirs() || parent.exists());
 
 		assertTrue(stagingFile.renameTo(file));
+	}
+
+	// ------------------------------------------------------------------------
+	//  mini cluster failover utilities
+	// ------------------------------------------------------------------------
+
+	private static class HaServices extends TestingEmbeddedHaServices {
+		private final Supplier<CompletedCheckpointStore> completedCheckpointStoreFactory;
+		private final CheckpointIDCounter checkpointIDCounter;
+
+		private HaServices(
+				Executor executor,
+				Supplier<CompletedCheckpointStore> completedCheckpointStoreFactory,
+				CheckpointIDCounter checkpointIDCounter) {
+			super(executor);
+			this.completedCheckpointStoreFactory = completedCheckpointStoreFactory;
+			this.checkpointIDCounter = checkpointIDCounter;
+		}
+
+		@Override
+		public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
+			return new CheckpointRecoveryFactoryWithSettableStore(
+				completedCheckpointStoreFactory,
+				checkpointIDCounter);
+		}
+	}
+
+	private static class CheckpointRecoveryFactoryWithSettableStore implements CheckpointRecoveryFactory {
+		private final Supplier<CompletedCheckpointStore> completedCheckpointStoreFactory;
+		private final CheckpointIDCounter checkpointIDCounter;
+
+		private CheckpointRecoveryFactoryWithSettableStore(
+				Supplier<CompletedCheckpointStore> completedCheckpointStoreFactory,
+				CheckpointIDCounter checkpointIDCounter) {
+			this.completedCheckpointStoreFactory = completedCheckpointStoreFactory;
+			this.checkpointIDCounter = checkpointIDCounter;
+		}
+
+		@Override
+		public CompletedCheckpointStore createCheckpointStore(
+				JobID jobId,
+				int maxNumberOfCheckpointsToRetain,
+				ClassLoader userClassLoader) {
+			return completedCheckpointStoreFactory.get();
+		}
+
+		@Override
+		public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) {
+			return checkpointIDCounter;
+		}
+	}
+
+	private static class RecordCounterToFail {
+
+		private static AtomicInteger records;
+		private static CompletableFuture<Void> fail;
+		private static CompletableFuture<Void> continueProcessing;
+
+		private static <T> DataStream<T> wrapWithFailureAfter(
+				DataStream<T> stream,
+				int failAfter) {
+
+			records = new AtomicInteger();
+			fail = new CompletableFuture<>();
+			continueProcessing = new CompletableFuture<>();
+			return stream.map(record -> {
+				final boolean halfOfInputIsRead = records.incrementAndGet() > failAfter;
+				final boolean notFailedYet = !fail.isDone();
+				if (notFailedYet && halfOfInputIsRead) {
+					fail.complete(null);
+					continueProcessing.get();
+				}
+				return record;
+			});
+		}
+
+		private static void waitToFail() throws ExecutionException, InterruptedException {
+			fail.get();
+		}
+
+		private static void continueProcessing() {
+			continueProcessing.complete(null);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -298,11 +298,11 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 	/**
 	 * Get the split to put back. This only happens when a source reader subtask has failed.
 	 *
-	 * @param failedSubtaskId the failed subtask id.
+	 * @param subtaskId the failed subtask id.
 	 * @return A list of splits that needs to be added back to the {@link SplitEnumerator}.
 	 */
-	List<SplitT> getAndRemoveUncheckpointedAssignment(int failedSubtaskId) {
-		return assignmentTracker.getAndRemoveUncheckpointedAssignment(failedSubtaskId);
+	List<SplitT> getAndRemoveUncheckpointedAssignment(int subtaskId, long restoredCheckpointId) {
+		return assignmentTracker.getAndRemoveUncheckpointedAssignment(subtaskId, restoredCheckpointId);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -201,6 +201,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
 		// Fail reader 0.
 		sourceCoordinator.subtaskFailed(0, null);
+		sourceCoordinator.subtaskReset(0, 99L); // checkpoint ID before the triggered checkpoints
 
 		// check the state again.
 		check(() -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -144,8 +145,27 @@ public class SplitAssignmentTrackerTest {
 		takeSnapshot(tracker, checkpointId2);
 
 		// Now assume subtask 0 has failed.
-		List<MockSourceSplit> splitsToPutBack = tracker.getAndRemoveUncheckpointedAssignment(0);
+		List<MockSourceSplit> splitsToPutBack = tracker.getAndRemoveUncheckpointedAssignment(0, checkpointId1 - 1);
 		verifyAssignment(Arrays.asList("0", "3"), splitsToPutBack);
+	}
+
+	@Test
+	public void testGetAndRemoveSplitsAfterSomeCheckpoint() throws Exception {
+		final long checkpointId1 = 100L;
+		final long checkpointId2 = 101L;
+		SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
+
+		// Assign some splits and take snapshot 1.
+		tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
+		takeSnapshot(tracker, checkpointId1);
+
+		// Assign some more splits and take snapshot 2.
+		tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
+		takeSnapshot(tracker, checkpointId2);
+
+		// Now assume subtask 0 has failed.
+		List<MockSourceSplit> splitsToPutBack = tracker.getAndRemoveUncheckpointedAssignment(0, checkpointId1);
+		verifyAssignment(Collections.singletonList("3"), splitsToPutBack);
 	}
 
 	// ---------------------

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -68,8 +68,3 @@ logger.zkclient.level = INFO
 logger.zkclient.appenderRef.out.ref = ConsoleAppender
 logger.consumer.name = org.apache.flink.streaming.connectors.kafka.internals.SimpleConsumerThread
 logger.consumer.level = OFF
-
-# Enable TRACE logging for the sources to debug FLINK-19448
-logger.sources.name = org.apache.flink.connector.base.source.reader
-logger.sources.level = TRACE
-logger.sources.appenderRef.out.ref = ConsoleAppender


### PR DESCRIPTION
## What is the purpose of the change

This changes the split duplication problem in the new source framework, as initially observed on the File Source.
The issues are independent of the file source and affect all sources implemented against the new framework.

This PR combines the changes from
  - #14256 - Add `resetSubtask()` to `OperatorCoordinator`
  - #14199 - Add runtime failure tests based on the File Source

We need to squash some commits during merging.

## Verifying this change

This PR adds significant test coverage via the extension of the `FileTextLinesITCase` with TaskManager and JobManager failures.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**