### PR TITLE
[FLINK-20381][yarn] Restore yarn-session.sh -id argument

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/AbstractYarnCli.java
@@ -33,16 +33,17 @@ abstract class AbstractYarnCli extends AbstractCustomCommandLine {
 
 	public static final String ID = "yarn-cluster";
 
-	protected Option applicationId =
-		new Option("yid", "yarnapplicationId", true, "Attach to running YARN session");
+	protected Option applicationId;
+
 
 	protected Option addressOption =
 		new Option("m", "jobmanager", true, "Set to " + ID + " to use YARN execution mode.");
 
 	protected final Configuration configuration;
 
-	protected AbstractYarnCli(Configuration configuration) {
+	protected AbstractYarnCli(Configuration configuration, String shortPrefix, String longPrefix) {
 		this.configuration = configuration;
+		this.applicationId = new Option(shortPrefix + "id", longPrefix + "applicationId", true, "Attach to running YARN session");
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FallbackYarnSessionCli.java
@@ -32,7 +32,7 @@ import org.apache.commons.cli.CommandLine;
 public class FallbackYarnSessionCli extends AbstractYarnCli {
 
 	public FallbackYarnSessionCli(Configuration configuration) {
-		super(configuration);
+		super(configuration, "y", "yarn");
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -171,7 +171,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 			String shortPrefix,
 			String longPrefix,
 			boolean acceptInteractiveInput) throws FlinkException {
-		super(configuration);
+		super(configuration, shortPrefix, longPrefix);
 		this.clusterClientServiceLoader = checkNotNull(clusterClientServiceLoader);
 		this.configurationDirectory = checkNotNull(configurationDirectory);
 		this.acceptInteractiveInput = acceptInteractiveInput;


### PR DESCRIPTION


## What is the purpose of the change

https://github.com/apache/flink/pull/13358 accidentally removed the yarn-session.sh -id option, and replaced it with yarn-session.sh -yid, rendering the documentation and some log messages invalid.

This change fixes this problem.

