### PR TITLE
[FLINK-20430][doc] Fix broken links in some Chinese md files

### DIFF
--- a/docs/deployment/index.zh.md
+++ b/docs/deployment/index.zh.md
@@ -28,7 +28,7 @@ under the License.
 Flink is a versatile framework, supporting many different deployment scenarios in a mix and match fashion.
 
 Below, we briefly explain the building blocks of a Flink cluster, their purpose and available implementations.
-If you just want to start Flink locally, we recommend setting up a [Standalone Cluster]({% link deployment/resource-providers/standalone/index.md %}).
+If you just want to start Flink locally, we recommend setting up a [Standalone Cluster]({% link deployment/resource-providers/standalone/index.zh.md %}).
 
 * This will be replaced by the TOC
 {:toc}
@@ -63,11 +63,11 @@ When deploying Flink, there are often multiple options available for each buildi
             </td>
             <td>
                 <ul>
-                    <li><a href="{% link deployment/cli.md %}">Command Line Interface</a></li>
-                    <li><a href="{% link ops/rest_api.md %}">REST Endpoint</a></li>
-                    <li><a href="{% link dev/table/sqlClient.md %}">SQL Client</a></li>
-                    <li><a href="{% link deployment/repls/python_shell.md %}">Python REPL</a></li>
-                    <li><a href="{% link deployment/repls/scala_shell.md %}">Scala REPL</a></li>
+                    <li><a href="{% link deployment/cli.zh.md %}">Command Line Interface</a></li>
+                    <li><a href="{% link ops/rest_api.zh.md %}">REST Endpoint</a></li>
+                    <li><a href="{% link dev/table/sqlClient.zh.md %}">SQL Client</a></li>
+                    <li><a href="{% link deployment/repls/python_shell.zh.md %}">Python REPL</a></li>
+                    <li><a href="{% link deployment/repls/scala_shell.zh.md %}">Scala REPL</a></li>
                 </ul>
             </td>
         </tr>
@@ -84,11 +84,11 @@ When deploying Flink, there are often multiple options available for each buildi
             </td>
             <td>
                 <ul id="jmimpls">
-                    <li><a href="{% link deployment/resource-providers/standalone/index.md %}">Standalone</a> (this is the barebone mode that requires just JVMs to be launched. Deployment with <a href="{% link deployment/resource-providers/standalone/docker.md %}">Docker, Docker Swarm / Compose</a>, <a href="{% link deployment/resource-providers/standalone/kubernetes.md %}">non-native Kubernetes</a> and other models is possible through manual setup in this mode)
+                    <li><a href="{% link deployment/resource-providers/standalone/index.zh.md %}">Standalone</a> (this is the barebone mode that requires just JVMs to be launched. Deployment with <a href="{% link deployment/resource-providers/standalone/docker.zh.md %}">Docker, Docker Swarm / Compose</a>, <a href="{% link deployment/resource-providers/standalone/kubernetes.zh.md %}">non-native Kubernetes</a> and other models is possible through manual setup in this mode)
                     </li>
-                    <li><a href="{% link deployment/resource-providers/native_kubernetes.md %}">Kubernetes</a></li>
-                    <li><a href="{% link deployment/resource-providers/yarn.md %}">YARN</a></li>
-                    <li><a href="{% link deployment/resource-providers/mesos.md %}">Mesos</a></li>
+                    <li><a href="{% link deployment/resource-providers/native_kubernetes.zh.md %}">Kubernetes</a></li>
+                    <li><a href="{% link deployment/resource-providers/yarn.zh.md %}">YARN</a></li>
+                    <li><a href="{% link deployment/resource-providers/mesos.zh.md %}">Mesos</a></li>
                 </ul>
             </td>
         </tr>
@@ -112,8 +112,8 @@ When deploying Flink, there are often multiple options available for each buildi
             </td>
             <td>
                 <ul>
-                    <li><a href="{% link deployment/ha/zookeeper_ha.md %}">Zookeeper</a></li>
-                    <li><a href="{% link deployment/ha/kubernetes_ha.md %}">Kubernetes HA</a></li>
+                    <li><a href="{% link deployment/ha/zookeeper_ha.zh.md %}">Zookeeper</a></li>
+                    <li><a href="{% link deployment/ha/kubernetes_ha.zh.md %}">Kubernetes HA</a></li>
                 </ul>
             </td>
         </tr>
@@ -122,7 +122,7 @@ When deploying Flink, there are often multiple options available for each buildi
             <td>
                 For checkpointing (recovery mechanism for streaming jobs) Flink relies on external file storage systems
             </td>
-            <td>See <a href="{% link deployment/filesystems/index.md %}">FileSystems</a> page.</td>
+            <td>See <a href="{% link deployment/filesystems/index.zh.md %}">FileSystems</a> page.</td>
         </tr>
         <tr>
             <td>Resource Provider</td>
@@ -136,7 +136,7 @@ When deploying Flink, there are often multiple options available for each buildi
             <td>
                 Flink components report internal metrics and Flink jobs can report additional, job specific metrics as well.
             </td>
-            <td>See <a href="{% link deployment/metric_reporters.md %}">Metrics Reporter</a> page.</td>
+            <td>See <a href="{% link deployment/metric_reporters.zh.md %}">Metrics Reporter</a> page.</td>
         </tr>
         <tr>
             <td>Application-level data sources and sinks</td>
@@ -151,7 +151,7 @@ When deploying Flink, there are often multiple options available for each buildi
                     <li>ElasticSearch</li>
                     <li>Apache Cassandra</li>
                 </ul>
-                See <a href="{% link dev/connectors/index.md %}">Connectors</a> page.
+                See <a href="{% link dev/connectors/index.zh.md %}">Connectors</a> page.
             </td>
         </tr>
     </tbody>

--- a/docs/deployment/resource-providers/yarn.zh.md
+++ b/docs/deployment/resource-providers/yarn.zh.md
@@ -78,7 +78,7 @@ Congratulations! You have successfully run a Flink application by deploying Flin
 
 ## Deployment Modes Supported by Flink on YARN
 
-For production use, we recommend deploying Flink Applications in the [Per-job or Application Mode]({% link deployment/index.md %}#deployment-modes), as these modes provide a better isolation for the Applications.
+For production use, we recommend deploying Flink Applications in the [Per-job or Application Mode]({% link deployment/index.zh.md %}#deployment-modes), as these modes provide a better isolation for the Applications.
 
 ### Application Mode
 
@@ -159,7 +159,7 @@ You can **re-attach to a YARN session** using the following command:
 ./bin/yarn-session.sh -id application_XXXX_YY
 ```
 
-Besides passing [configuration]({% link deployment/config.md %}) via the `conf/flink-conf.yaml` file, you can also pass any configuration at submission time to the `./bin/yarn-session.sh` client using `-Dkey=value` arguments.
+Besides passing [configuration]({% link deployment/config.zh.md %}) via the `conf/flink-conf.yaml` file, you can also pass any configuration at submission time to the `./bin/yarn-session.sh` client using `-Dkey=value` arguments.
 
 The YARN session client also has a few "shortcut arguments" for commonly used settings. They can be listed with `./bin/yarn-session.sh -h`.
 
@@ -169,7 +169,7 @@ The YARN session client also has a few "shortcut arguments" for commonly used se
 
 ### Configuring Flink on YARN
 
-The YARN-specific configurations are listed on the [configuration page]({% link deployment/config.md %}#yarn).
+The YARN-specific configurations are listed on the [configuration page]({% link deployment/config.zh.md %}#yarn).
 
 The following configuration parameters are managed by Flink on YARN, as they might get overwritten by the framework at runtime:
 - `jobmanager.rpc.address` (dynamically set to the address of the JobManager container by Flink on YARN)
@@ -182,17 +182,17 @@ If you need to pass additional Hadoop configuration files to Flink, you can do s
 
 A JobManager running on YARN will request additional TaskManagers, if it can not run all submitted jobs with the existing resources. In particular when running in Session Mode, the JobManager will, if needed, allocate additional TaskManagers as additional jobs are submitted. Unused TaskManagers are freed up again after a timeout.
 
-The memory configurations for JobManager and TaskManager processes will be respected by the YARN implementation. The number of reported VCores is by default equal to the number of configured slots per TaskManager. The [yarn.containers.vcores]({% link deployment/config.md %}#yarn-containers-vcores) allows overwriting the number of vcores with a custom value. In order for this parameter to work you should enable CPU scheduling in your YARN cluster.
+The memory configurations for JobManager and TaskManager processes will be respected by the YARN implementation. The number of reported VCores is by default equal to the number of configured slots per TaskManager. The [yarn.containers.vcores]({% link deployment/config.zh.md %}#yarn-containers-vcores) allows overwriting the number of vcores with a custom value. In order for this parameter to work you should enable CPU scheduling in your YARN cluster.
 
-Failed containers (including the JobManager) are replaced by YARN. The maximum number of JobManager container restarts is configured via [yarn.application-attempts]({% link deployment/config.md %}#yarn-application-attempts) (default 1). The YARN Application will fail once all attempts are exhausted.
+Failed containers (including the JobManager) are replaced by YARN. The maximum number of JobManager container restarts is configured via [yarn.application-attempts]({% link deployment/config.zh.md %}#yarn-application-attempts) (default 1). The YARN Application will fail once all attempts are exhausted.
 
 ### High-Availability on YARN
 
-High-Availability on YARN is achieved through a combination of YARN and a [high availability service]({% link deployment/ha/index.md %}).
+High-Availability on YARN is achieved through a combination of YARN and a [high availability service]({% link deployment/ha/index.zh.md %}).
 
 Once a HA service is configured, it will persist JobManager metadata and perform leader elections.
 
-YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
+YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.zh.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
 
 Note that Flink is managing the `high-availability.cluster-id` configuration parameter when running on YARN. **You should not overwrite this parameter when running an HA cluster on YARN**. The cluster ID is used to distinguish multiple HA clusters in the HA backend (for example Zookeeper). Overwriting this configuration parameter can lead to multiple YARN clusters affecting each other.
 
@@ -221,11 +221,11 @@ Some YARN clusters use firewalls for controlling the network traffic between the
 In those setups, Flink jobs can only be submitted to a YARN session from within the cluster's network (behind the firewall).
 If this is not feasible for production use, Flink allows to configure a port range for its REST endpoint, used for the client-cluster communication. With this range configured, users can also submit jobs to Flink crossing the firewall.
 
-The configuration parameter for specifying the REST endpoint port is [rest.bind-port]({% link deployment/config.md %}#rest-bind-port). This configuration option accepts single ports (for example: "50010"), ranges ("50000-50025"), or a combination of both.
+The configuration parameter for specifying the REST endpoint port is [rest.bind-port]({% link deployment/config.zh.md %}#rest-bind-port). This configuration option accepts single ports (for example: "50010"), ranges ("50000-50025"), or a combination of both.
 
 ### User jars & Classpath
 
-By default Flink will include the user jars into the system classpath when running a single job. This behavior can be controlled with the [yarn.per-job-cluster.include-user-jar]({% link deployment/config.md %}#yarn-per-job-cluster-include-user-jar) parameter.
+By default Flink will include the user jars into the system classpath when running a single job. This behavior can be controlled with the [yarn.per-job-cluster.include-user-jar]({% link deployment/config.zh.md %}#yarn-per-job-cluster-include-user-jar) parameter.
 
 When setting this to `DISABLED` Flink will include the jar in the user classpath instead.
 

--- a/docs/dev/table/streaming/joins.zh.md
+++ b/docs/dev/table/streaming/joins.zh.md
@@ -71,7 +71,7 @@ WHERE o.id = s.orderId AND
 时态表 Join
 --------------------------
 <span class="label label-danger">注意</span> 只在 Blink planner 中支持。
-<span class="label label-danger">注意</span> 时态表有两种方式去定义，即 [时态表函数]({% link dev/table/streaming/temporal_tables.zh.md %)#时态表函数) 和 [时态表 DDL]({% link dev/table/streaming/temporal_tables.zh.md %}#时态表)，使用时态表函数的时态表 join 只支持在 Table API 中使用，使用时态表 DDL 的时态表 join 只支持在 SQL 中使用。
+<span class="label label-danger">注意</span> 时态表有两种方式去定义，即 [时态表函数]({% link dev/table/streaming/temporal_tables.zh.md %}#时态表函数) 和 [时态表 DDL]({% link dev/table/streaming/temporal_tables.zh.md %}#时态表)，使用时态表函数的时态表 join 只支持在 Table API 中使用，使用时态表 DDL 的时态表 join 只支持在 SQL 中使用。
 请参考[时态表]({% link dev/table/streaming/temporal_tables.zh.md %})页面获取更多关于时态表和时态表函数的区别。
 
 时态表 Join 意味着对任意表（左输入/探针侧）去关联一个时态表（右输入/构建侧）的版本，时态表可以是一张跟踪所有变更记录的表（例如数据库表的 changelog，包含多个表快照），也可以是物化所有变更之后的表（例如数据库表，只有最新表快照）。


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix broken links in some Chinese md files*


## Brief change log

  - *Fix broken links in `docs/deployment/index.zh.md`*
  - *Fix broken links in `docs/deployment/resource-providers/yarn.zh.md`*
  - *Fix broken links in `docs/dev/table/streaming/joins.zh.md`*


## Verifying this change

 - *Executinig the script `build_docs.sh`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
