### PR TITLE
[FLINK-20436][table-planner-blink] Simplify type parameter of ExecNode

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -450,8 +450,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 		Table table = tEnv.sqlQuery("select * from hive.source_db.test_parallelism_limit_pushdown limit 1");
 		PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
 		RelNode relNode = planner.optimize(TableTestUtil.toRelNode(table));
-		@SuppressWarnings("unchecked")
-		ExecNode<PlannerBase, ?> execNode = (ExecNode<PlannerBase, ?>) planner.translateToExecNodePlan(
+		ExecNode<?> execNode = planner.translateToExecNodePlan(
 				toScala(Collections.singletonList(relNode))).get(0);
 		Transformation<?> transformation = (execNode.translateToPlan(planner).getInputs().get(0)).getInputs().get(0);
 		Assert.assertEquals(1, transformation.getParallelism());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/AbstractExecNodeExactlyOnceVisitor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/AbstractExecNodeExactlyOnceVisitor.java
@@ -27,13 +27,13 @@ import java.util.Set;
  */
 public abstract class AbstractExecNodeExactlyOnceVisitor implements ExecNodeVisitor {
 
-	private final Set<ExecNode<?, ?>> visited;
+	private final Set<ExecNode<?>> visited;
 
 	public AbstractExecNodeExactlyOnceVisitor() {
 		this.visited = new HashSet<>();
 	}
 
-	public void visit(ExecNode<?, ?> node) {
+	public void visit(ExecNode<?> node) {
 		if (visited.contains(node)) {
 			return;
 		}
@@ -41,9 +41,9 @@ public abstract class AbstractExecNodeExactlyOnceVisitor implements ExecNodeVisi
 		visitNode(node);
 	}
 
-	protected abstract void visitNode(ExecNode<?, ?> node);
+	protected abstract void visitNode(ExecNode<?> node);
 
-	protected void visitInputs(ExecNode<?, ?> node) {
+	protected void visitInputs(ExecNode<?> node) {
 		node.getInputNodes().forEach(n -> n.accept(this));
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeVisitor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeVisitor.java
@@ -28,6 +28,6 @@ public interface ExecNodeVisitor {
 	 *
 	 * @param node ExecNode to visit
 	 */
-	void visit(ExecNode<?, ?> node);
+	void visit(ExecNode<?> node);
 
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeVisitorImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeVisitorImpl.java
@@ -24,11 +24,11 @@ package org.apache.flink.table.planner.plan.nodes.exec;
  */
 public class ExecNodeVisitorImpl implements ExecNodeVisitor {
 
-	public void visit(ExecNode<?, ?> node) {
+	public void visit(ExecNode<?> node) {
 		visitInputs(node);
 	}
 
-	protected void visitInputs(ExecNode<?, ?> node) {
+	protected void visitInputs(ExecNode<?> node) {
 		node.getInputNodes().forEach(n -> n.accept(this));
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/process/DAGProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/process/DAGProcessor.java
@@ -30,5 +30,5 @@ public interface DAGProcessor {
 	/**
 	 * Given a dag, process it and return the result dag.
 	 */
-	List<ExecNode<?, ?>> process(List<ExecNode<?, ?>> sinkNodes, DAGProcessContext context);
+	List<ExecNode<?>> process(List<ExecNode<?>> sinkNodes, DAGProcessContext context);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/DeadlockBreakupProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/DeadlockBreakupProcessor.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class DeadlockBreakupProcessor implements DAGProcessor {
 
 	@Override
-	public List<ExecNode<?, ?>> process(List<ExecNode<?, ?>> rootNodes, DAGProcessContext context) {
+	public List<ExecNode<?>> process(List<ExecNode<?>> rootNodes, DAGProcessContext context) {
 		if (!rootNodes.stream().allMatch(r -> r instanceof BatchExecNode)) {
 			throw new TableException("Only BatchExecNode DAG is supported now");
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculator.java
@@ -42,7 +42,7 @@ import java.util.Set;
 @Internal
 public class InputOrderCalculator extends InputPriorityGraphGenerator {
 
-	private final Set<ExecNode<?, ?>> boundaries;
+	private final Set<ExecNode<?>> boundaries;
 
 	/**
 	 * Create a {@link InputOrderCalculator} for the given {@link ExecNode} sub-graph.
@@ -53,45 +53,45 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 	 *                        {@link ExecEdge.DamBehavior} stricter or equal than this
 	 */
 	public InputOrderCalculator(
-			ExecNode<?, ?> root,
-			Set<ExecNode<?, ?>> boundaries,
+			ExecNode<?> root,
+			Set<ExecNode<?>> boundaries,
 			ExecEdge.DamBehavior safeDamBehavior) {
 		super(Collections.singletonList(root), boundaries, safeDamBehavior);
 		this.boundaries = boundaries;
 	}
 
-	public Map<ExecNode<?, ?>, Integer> calculate() {
+	public Map<ExecNode<?>, Integer> calculate() {
 		createTopologyGraph();
 
 		// some boundaries node may be connected from the outside of the sub-graph,
 		// which we cannot deduce by the above process,
 		// so we need to check each pair of boundaries and see if they're related
 		dealWithPossiblyRelatedBoundaries();
-		Map<ExecNode<?, ?>, Integer> distances = graph.calculateMaximumDistance();
+		Map<ExecNode<?>, Integer> distances = graph.calculateMaximumDistance();
 
 		// extract only the distances of the boundaries and renumbering the distances
 		// so that the smallest value starts from 0
 		// the smaller the distance, the higher the priority
 		Set<Integer> boundaryDistanceSet = new HashSet<>();
-		for (ExecNode<?, ?> boundary : boundaries) {
+		for (ExecNode<?> boundary : boundaries) {
 			boundaryDistanceSet.add(distances.getOrDefault(boundary, 0));
 		}
 		List<Integer> boundaryDistanceList = new ArrayList<>(boundaryDistanceSet);
 		Collections.sort(boundaryDistanceList);
 
-		Map<ExecNode<?, ?>, Integer> results = new HashMap<>();
-		for (ExecNode<?, ?> boundary : boundaries) {
+		Map<ExecNode<?>, Integer> results = new HashMap<>();
+		for (ExecNode<?> boundary : boundaries) {
 			results.put(boundary, boundaryDistanceList.indexOf(distances.get(boundary)));
 		}
 		return results;
 	}
 
 	private void dealWithPossiblyRelatedBoundaries() {
-		List<ExecNode<?, ?>> boundaries = new ArrayList<>(this.boundaries);
+		List<ExecNode<?>> boundaries = new ArrayList<>(this.boundaries);
 		for (int i = 0; i < boundaries.size(); i++) {
-			ExecNode<?, ?> boundaryA = boundaries.get(i);
+			ExecNode<?> boundaryA = boundaries.get(i);
 			for (int j = i + 1; j < boundaries.size(); j++) {
-				ExecNode<?, ?> boundaryB = boundaries.get(j);
+				ExecNode<?> boundaryB = boundaries.get(j);
 				// if boundaries are already comparable in the topology graph
 				// we do not need to check them
 				if (graph.canReach(boundaryA, boundaryB) || graph.canReach(boundaryB, boundaryA)) {
@@ -102,9 +102,9 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 		}
 	}
 
-	private void dealWithPossiblyRelatedBoundaries(ExecNode<?, ?> boundaryA, ExecNode<?, ?> boundaryB) {
-		Set<ExecNode<?, ?>> ancestorsA = calculateAllAncestors(boundaryA);
-		Set<ExecNode<?, ?>> ancestorsB = calculateAllAncestors(boundaryB);
+	private void dealWithPossiblyRelatedBoundaries(ExecNode<?> boundaryA, ExecNode<?> boundaryB) {
+		Set<ExecNode<?>> ancestorsA = calculateAllAncestors(boundaryA);
+		Set<ExecNode<?>> ancestorsB = calculateAllAncestors(boundaryB);
 		if (checkPipelinedPath(boundaryA, ancestorsB)) {
 			// boundary A and B are related, and there exists a path
 			// which only goes through PIPELINED edges from their public ancestor to boundary A.
@@ -117,11 +117,11 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 		}
 	}
 
-	private static Set<ExecNode<?, ?>> calculateAllAncestors(ExecNode<?, ?> node) {
-		Set<ExecNode<?, ?>> ret = new HashSet<>();
+	private static Set<ExecNode<?>> calculateAllAncestors(ExecNode<?> node) {
+		Set<ExecNode<?>> ret = new HashSet<>();
 		AbstractExecNodeExactlyOnceVisitor visitor = new AbstractExecNodeExactlyOnceVisitor() {
 			@Override
-			protected void visitNode(ExecNode<?, ?> node) {
+			protected void visitNode(ExecNode<?> node) {
 				ret.add(node);
 				visitInputs(node);
 			}
@@ -131,23 +131,23 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 	}
 
 	@VisibleForTesting
-	static boolean checkPipelinedPath(ExecNode<?, ?> node, Set<ExecNode<?, ?>> goals) {
+	static boolean checkPipelinedPath(ExecNode<?> node, Set<ExecNode<?>> goals) {
 		PipelinedPathChecker checker = new PipelinedPathChecker(goals);
 		node.accept(checker);
 		return checker.res;
 	}
 
 	private static class PipelinedPathChecker extends AbstractExecNodeExactlyOnceVisitor {
-		private final Set<ExecNode<?, ?>> goals;
+		private final Set<ExecNode<?>> goals;
 		private boolean res;
 
-		private PipelinedPathChecker(Set<ExecNode<?, ?>> goals) {
+		private PipelinedPathChecker(Set<ExecNode<?>> goals) {
 			this.goals = goals;
 			this.res = false;
 		}
 
 		@Override
-		protected void visitNode(ExecNode<?, ?> node) {
+		protected void visitNode(ExecNode<?> node) {
 			if (goals.contains(node)) {
 				res = true;
 				return;
@@ -167,7 +167,7 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
 	}
 
 	@Override
-	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
+	protected void resolveInputPriorityConflict(ExecNode<?> node, int higherInput, int lowerInput) {
 		throw new IllegalStateException(
 			"A conflict is detected. This is a bug. Please file an issue.\n" +
 				"To work around this bug, please set " +

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolver.java
@@ -51,7 +51,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 	 * 	                  with this shuffleMode to resolve conflict
 	 */
 	public InputPriorityConflictResolver(
-			List<ExecNode<?, ?>> roots,
+			List<ExecNode<?>> roots,
 			ExecEdge.DamBehavior safeDamBehavior,
 			ShuffleMode shuffleMode) {
 		super(roots, Collections.emptySet(), safeDamBehavior);
@@ -63,9 +63,9 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 	}
 
 	@Override
-	protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
-		ExecNode<?, ?> higherNode = node.getInputNodes().get(higherInput);
-		ExecNode<?, ?> lowerNode = node.getInputNodes().get(lowerInput);
+	protected void resolveInputPriorityConflict(ExecNode<?> node, int higherInput, int lowerInput) {
+		ExecNode<?> higherNode = node.getInputNodes().get(higherInput);
+		ExecNode<?> lowerNode = node.getInputNodes().get(lowerInput);
 		if (lowerNode instanceof BatchExecExchange) {
 			BatchExecExchange exchange = (BatchExecExchange) lowerNode;
 			if (isConflictCausedByExchange(higherNode, exchange)) {
@@ -76,16 +76,16 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 					exchange.getInput(),
 					exchange.getDistribution());
 				newExchange.setRequiredShuffleMode(shuffleMode);
-				node.replaceInputNode(lowerInput, (ExecNode) newExchange);
+				node.replaceInputNode(lowerInput, newExchange);
 			} else {
 				exchange.setRequiredShuffleMode(shuffleMode);
 			}
 		} else {
-			node.replaceInputNode(lowerInput, (ExecNode) createExchange(node, lowerInput));
+			node.replaceInputNode(lowerInput, createExchange(node, lowerInput));
 		}
 	}
 
-	private boolean isConflictCausedByExchange(ExecNode<?, ?> higherNode, BatchExecExchange lowerNode) {
+	private boolean isConflictCausedByExchange(ExecNode<?> higherNode, BatchExecExchange lowerNode) {
 		// check if `lowerNode` is the ancestor of `higherNode`,
 		// if yes then conflict is caused by `lowerNode`
 		ConflictCausedByExchangeChecker checker = new ConflictCausedByExchangeChecker(lowerNode);
@@ -93,7 +93,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 		return checker.found;
 	}
 
-	private BatchExecExchange createExchange(ExecNode<?, ?> node, int idx) {
+	private BatchExecExchange createExchange(ExecNode<?> node, int idx) {
 		RelNode inputRel = (RelNode) node.getInputNodes().get(idx);
 
 		FlinkRelDistribution distribution;
@@ -129,11 +129,11 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 		}
 
 		@Override
-		protected void visitNode(ExecNode<?, ?> node) {
+		protected void visitNode(ExecNode<?> node) {
 			if (node == exchange) {
 				found = true;
 			}
-			for (ExecNode<?, ?> inputNode : node.getInputNodes()) {
+			for (ExecNode<?> inputNode : node.getInputNodes()) {
 				visit(inputNode);
 				if (found) {
 					return;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraph.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraph.java
@@ -41,23 +41,23 @@ import java.util.Set;
 @Internal
 class TopologyGraph {
 
-	private final Map<ExecNode<?, ?>, TopologyNode> nodes;
+	private final Map<ExecNode<?>, TopologyNode> nodes;
 
-	TopologyGraph(List<ExecNode<?, ?>> roots) {
+	TopologyGraph(List<ExecNode<?>> roots) {
 		this(roots, Collections.emptySet());
 	}
 
-	TopologyGraph(List<ExecNode<?, ?>> roots, Set<ExecNode<?, ?>> boundaries) {
+	TopologyGraph(List<ExecNode<?>> roots, Set<ExecNode<?>> boundaries) {
 		this.nodes = new HashMap<>();
 
 		// we first link all edges in the original exec node graph
 		AbstractExecNodeExactlyOnceVisitor visitor = new AbstractExecNodeExactlyOnceVisitor() {
 			@Override
-			protected void visitNode(ExecNode<?, ?> node) {
+			protected void visitNode(ExecNode<?> node) {
 				if (boundaries.contains(node)) {
 					return;
 				}
-				for (ExecNode<?, ?> input : node.getInputNodes()) {
+				for (ExecNode<?> input : node.getInputNodes()) {
 					link(input, node);
 				}
 				visitInputs(node);
@@ -70,7 +70,7 @@ class TopologyGraph {
 	 * Link an edge from `from` node to `to` node if no loop will occur after adding this edge.
 	 * Returns if this edge is successfully added.
 	 */
-	boolean link(ExecNode<?, ?> from, ExecNode<?, ?> to) {
+	boolean link(ExecNode<?> from, ExecNode<?> to) {
 		TopologyNode fromNode = getOrCreateTopologyNode(from);
 		TopologyNode toNode = getOrCreateTopologyNode(to);
 
@@ -88,7 +88,7 @@ class TopologyGraph {
 	/**
 	 * Remove the edge from `from` node to `to` node. If there is no edge between them then do nothing.
 	 */
-	void unlink(ExecNode<?, ?> from, ExecNode<?, ?> to) {
+	void unlink(ExecNode<?> from, ExecNode<?> to) {
 		TopologyNode fromNode = getOrCreateTopologyNode(from);
 		TopologyNode toNode = getOrCreateTopologyNode(to);
 
@@ -104,8 +104,8 @@ class TopologyGraph {
 	 * <p>Distance of a node is defined as the number of edges one needs to go through from the
 	 * nodes without inputs to this node.
 	 */
-	Map<ExecNode<?, ?>, Integer> calculateMaximumDistance() {
-		Map<ExecNode<?, ?>, Integer> result = new HashMap<>();
+	Map<ExecNode<?>, Integer> calculateMaximumDistance() {
+		Map<ExecNode<?>, Integer> result = new HashMap<>();
 		Map<TopologyNode, Integer> inputsVisitedMap = new HashMap<>();
 
 		Queue<TopologyNode> queue = new LinkedList<>();
@@ -143,7 +143,7 @@ class TopologyGraph {
 	 * Make the distance of node A at least as far as node B by adding edges
 	 * from all inputs of node B to node A.
 	 */
-	void makeAsFarAs(ExecNode<?, ?> a, ExecNode<?, ?> b) {
+	void makeAsFarAs(ExecNode<?> a, ExecNode<?> b) {
 		TopologyNode nodeA = getOrCreateTopologyNode(a);
 		TopologyNode nodeB = getOrCreateTopologyNode(b);
 
@@ -153,7 +153,7 @@ class TopologyGraph {
 	}
 
 	@VisibleForTesting
-	boolean canReach(ExecNode<?, ?> from, ExecNode<?, ?> to) {
+	boolean canReach(ExecNode<?> from, ExecNode<?> to) {
 		TopologyNode fromNode = getOrCreateTopologyNode(from);
 		TopologyNode toNode = getOrCreateTopologyNode(to);
 		return canReach(fromNode, toNode);
@@ -183,12 +183,12 @@ class TopologyGraph {
 		return false;
 	}
 
-	private TopologyNode getOrCreateTopologyNode(ExecNode<?, ?> execNode) {
+	private TopologyNode getOrCreateTopologyNode(ExecNode<?> execNode) {
 		// NOTE: We treat different `BatchExecBoundedStreamScan`s with same `DataStream` object as the same
 		if (execNode instanceof BatchExecBoundedStreamScan) {
 			DataStream<?> currentStream = ((BatchExecBoundedStreamScan) execNode).boundedStreamTable().dataStream();
-			for (Map.Entry<ExecNode<?, ?>, TopologyNode> entry : nodes.entrySet()) {
-				ExecNode<?, ?> key = entry.getKey();
+			for (Map.Entry<ExecNode<?>, TopologyNode> entry : nodes.entrySet()) {
+				ExecNode<?> key = entry.getKey();
 				if (key instanceof BatchExecBoundedStreamScan) {
 					DataStream<?> existingStream = ((BatchExecBoundedStreamScan) key).boundedStreamTable().dataStream();
 					if (existingStream.equals(currentStream)) {
@@ -209,11 +209,11 @@ class TopologyGraph {
 	 * A node in the {@link TopologyGraph}.
 	 */
 	private static class TopologyNode {
-		private final ExecNode<?, ?> execNode;
+		private final ExecNode<?> execNode;
 		private final Set<TopologyNode> inputs;
 		private final Set<TopologyNode> outputs;
 
-		private TopologyNode(ExecNode<?, ?> execNode) {
+		private TopologyNode(ExecNode<?> execNode) {
 			this.execNode = execNode;
 			this.inputs = new HashSet<>();
 			this.outputs = new HashSet<>();

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -60,7 +60,7 @@ class BatchPlanner(
   override protected def getOptimizer: Optimizer = new BatchCommonSubGraphBasedOptimizer(this)
 
   override private[flink] def translateToExecNodePlan(
-      optimizedRelNodes: Seq[RelNode]): util.List[ExecNode[_, _]] = {
+      optimizedRelNodes: Seq[RelNode]): util.List[ExecNode[_]] = {
     val execNodePlan = super.translateToExecNodePlan(optimizedRelNodes)
     val context = new DAGProcessContext(this)
 
@@ -78,7 +78,7 @@ class BatchPlanner(
   }
 
   override protected def translateToPlan(
-      execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]] = {
+      execNodes: util.List[ExecNode[_]]): util.List[Transformation[_]] = {
     val planner = createDummyPlanner()
     planner.overrideEnvParallelism()
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -300,7 +300,7 @@ abstract class PlannerBase(
     */
   @VisibleForTesting
   private[flink] def translateToExecNodePlan(
-      optimizedRelNodes: Seq[RelNode]): util.List[ExecNode[_, _]] = {
+      optimizedRelNodes: Seq[RelNode]): util.List[ExecNode[_]] = {
     require(optimizedRelNodes.forall(_.isInstanceOf[FlinkPhysicalRel]))
     // Rewrite same rel object to different rel objects
     // in order to get the correct dag (dag reuse is based on object not digest)
@@ -309,7 +309,7 @@ abstract class PlannerBase(
     // reuse subplan
     val reusedPlan = SubplanReuser.reuseDuplicatedSubplan(relsWithoutSameObj, config)
     // convert FlinkPhysicalRel DAG to ExecNode DAG
-    reusedPlan.map(_.asInstanceOf[ExecNode[_, _]])
+    reusedPlan.map(_.asInstanceOf[ExecNode[_]])
   }
 
   /**
@@ -318,7 +318,7 @@ abstract class PlannerBase(
     * @param execNodes The node DAG to translate.
     * @return The [[Transformation]] DAG that corresponds to the node DAG.
     */
-  protected def translateToPlan(execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]]
+  protected def translateToPlan(execNodes: util.List[ExecNode[_]]): util.List[Transformation[_]]
 
   /**
    * Creates a [[SelectTableSinkBase]] for a select query.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -58,7 +58,7 @@ class StreamPlanner(
   override protected def getOptimizer: Optimizer = new StreamCommonSubGraphBasedOptimizer(this)
 
   override protected def translateToPlan(
-      execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]] = {
+      execNodes: util.List[ExecNode[_]]): util.List[Transformation[_]] = {
     val planner = createDummyPlanner()
     planner.overrideEnvParallelism()
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/BatchExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/BatchExecNode.scala
@@ -24,4 +24,4 @@ import org.apache.flink.table.planner.utils.Logging
 /**
   * Base class for batch ExecNode.
   */
-trait BatchExecNode[T] extends ExecNode[BatchPlanner, T] with Logging
+trait BatchExecNode[T] extends ExecNodeBase[BatchPlanner, T] with Logging

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.table.delegation.Planner
+
+import org.apache.calcite.rel.RelDistribution
+import org.apache.calcite.rel.core.Exchange
+
+import scala.collection.JavaConversions._
+
+/**
+ * Base class of [[ExecNode]]s.
+ *
+ * @tparam P The Planner
+ * @tparam T The type of the elements that result from this [[Transformation]]
+ */
+trait ExecNodeBase[P <: Planner, T] extends ExecNode[T] {
+
+  /**
+   * The [[Transformation]] translated from this node.
+   */
+  private var transformation: Transformation[T] = _
+
+  /**
+   * Translates this node into a Flink operator.
+   *
+   * <p>NOTE: returns same translate result if called multiple times.
+   *
+   * @param planner The [[Planner]] of the translated Table.
+   */
+  def translateToPlan(planner: Planner): Transformation[T] = {
+    if (transformation == null) {
+      transformation = translateToPlanInternal(planner.asInstanceOf[P])
+    }
+    transformation
+  }
+
+  /**
+   * Internal method, translates this node into a Flink operator.
+   *
+   * @param planner The [[Planner]] of the translated Table.
+   */
+  protected def translateToPlanInternal(planner: P): Transformation[T]
+
+  /**
+   * Accepts a visit from a [[ExecNodeVisitor]].
+   *
+   * @param visitor ExecNodeVisitor
+   */
+  def accept(visitor: ExecNodeVisitor): Unit = {
+    visitor.visit(this)
+  }
+
+  /**
+   *  Whether there is singleton exchange node as input.
+   */
+  protected def inputsContainSingleton(): Boolean = {
+    getInputNodes.exists { node =>
+      node.isInstanceOf[Exchange] &&
+        node.asInstanceOf[Exchange].getDistribution.getType == RelDistribution.Type.SINGLETON
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/StreamExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/StreamExecNode.scala
@@ -28,7 +28,7 @@ import scala.collection.JavaConversions._
 /**
   * Base class for stream ExecNode.
   */
-trait StreamExecNode[T] extends ExecNode[StreamPlanner, T] with Logging {
+trait StreamExecNode[T] extends ExecNodeBase[StreamPlanner, T] with Logging {
 
   def getInputEdges: util.List[ExecEdge] = {
     // TODO fill out the required shuffle for each stream exec node

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecBoundedStreamScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecBoundedStreamScan.scala
@@ -72,13 +72,13 @@ class BatchExecBoundedStreamScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = List()
+  override def getInputNodes: util.List[ExecNode[_]] = List()
 
   override def getInputEdges: util.List[ExecEdge] = List()
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCalcBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCalcBase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, TraitUtil}
 import org.apache.flink.table.planner.plan.nodes.common.CommonCalc
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecEdge, ExecNode}
@@ -111,14 +110,14 @@ abstract class BatchExecCalcBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelate.scala
@@ -24,9 +24,9 @@ import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Correlate, JoinRelType}
-import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, TraitUtil}
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecEdge, ExecNode}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
@@ -157,14 +156,14 @@ abstract class BatchExecCorrelateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExchange.scala
@@ -100,8 +100,8 @@ class BatchExecExchange(
     }
   }
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = {
     val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
@@ -129,7 +129,7 @@ class BatchExecExchange(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExpand.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExpand.scala
@@ -69,15 +69,15 @@ class BatchExecExpand(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashAggregate.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashAggregateBase.scala
@@ -107,12 +107,12 @@ abstract class BatchExecHashAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashJoin.scala
@@ -173,8 +173,8 @@ class BatchExecHashJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = {
     val (buildRequiredShuffle, probeRequiredShuffle) = if (isBroadcast) {
@@ -207,7 +207,7 @@ class BatchExecHashJoin(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecHashWindowAggregateBase.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
+import org.apache.flink.configuration.MemorySize
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.functions.UserDefinedFunction
@@ -42,7 +43,6 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.tools.RelBuilder
-import org.apache.flink.configuration.MemorySize
 
 import java.util
 
@@ -106,12 +106,12 @@ abstract class BatchExecHashWindowAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLegacySink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLegacySink.scala
@@ -61,8 +61,8 @@ class BatchExecLegacySink[T](
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   // the input records will not trigger any output of a sink because it has no output,
   // so it's dam behavior is BLOCKING
@@ -73,7 +73,7 @@ class BatchExecLegacySink[T](
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLegacyTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLegacyTableSourceScan.scala
@@ -77,13 +77,13 @@ class BatchExecLegacyTableSourceScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = List()
+  override def getInputNodes: util.List[ExecNode[_]] = List()
 
   override def getInputEdges: util.List[ExecEdge] = List()
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLimit.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLimit.scala
@@ -89,14 +89,14 @@ class BatchExecLimit(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLocalHashAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLocalHashAggregate.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLocalSortAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLocalSortAggregate.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
 
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecLookupJoin.scala
@@ -68,15 +68,15 @@ class BatchExecLookupJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInput.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecMultipleInput.scala
@@ -56,15 +56,15 @@ class BatchExecMultipleInput(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def getInputEdges: util.List[ExecEdge] = inputEdges.toList
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     throw new UnsupportedOperationException()
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecNestedLoopJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecNestedLoopJoin.scala
@@ -121,8 +121,8 @@ class BatchExecNestedLoopJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = {
     // this is in sync with BatchExecNestedLoopJoinRuleBase#createNestedLoopJoin
@@ -151,7 +151,7 @@ class BatchExecNestedLoopJoin(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregate.scala
@@ -34,8 +34,8 @@ import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.utils.AggregateUtil.transformToBatchAggregateInfoList
-import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.getLongBoundary
 import org.apache.flink.table.planner.plan.utils.OverAggregateUtil
+import org.apache.flink.table.planner.plan.utils.OverAggregateUtil.getLongBoundary
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator
 import org.apache.flink.table.runtime.operators.over.frame.OffsetOverFrame.CalcOffsetFunc
 import org.apache.flink.table.runtime.operators.over.frame._

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecOverAggregateBase.scala
@@ -22,7 +22,6 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecEdge, ExecNode}
@@ -313,14 +312,14 @@ abstract class BatchExecOverAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -23,10 +23,11 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Correlate, JoinRelType}
-import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
@@ -77,8 +77,8 @@ class BatchExecPythonGroupAggregate(
   with BatchExecNode[RowData]
   with CommonPythonAggregate {
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(
     ExecEdge.builder()
@@ -87,7 +87,7 @@ class BatchExecPythonGroupAggregate(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
@@ -121,14 +121,14 @@ class BatchExecPythonGroupWindowAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecRank.scala
@@ -236,14 +236,14 @@ class BatchExecRank(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
@@ -56,8 +56,8 @@ class BatchExecSink(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   // the input records will not trigger any output of a sink because it has no output,
   // so it's dam behavior is BLOCKING
@@ -68,7 +68,7 @@ class BatchExecSink(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSort.scala
@@ -91,8 +91,8 @@ class BatchExecSort(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(
     ExecEdge.builder()
@@ -101,7 +101,7 @@ class BatchExecSort(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortAggregate.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.functions.UserDefinedFunction
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortAggregateBase.scala
@@ -89,12 +89,12 @@ abstract class BatchExecSortAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortLimit.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortLimit.scala
@@ -112,8 +112,8 @@ class BatchExecSortLimit(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] = List(
     ExecEdge.builder()
@@ -122,7 +122,7 @@ class BatchExecSortLimit(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
@@ -183,8 +183,8 @@ class BatchExecSortMergeJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   // this method must be in sync with the behavior of SortMergeJoinOperator.
   override def getInputEdges: util.List[ExecEdge] = List(
@@ -197,7 +197,7 @@ class BatchExecSortMergeJoin(
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregate.scala
@@ -20,8 +20,8 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 import org.apache.flink.table.planner.plan.logical.LogicalWindow
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortWindowAggregateBase.scala
@@ -95,12 +95,12 @@ abstract class BatchExecSortWindowAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecTableSourceScan.scala
@@ -66,13 +66,13 @@ class BatchExecTableSourceScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = List()
+  override def getInputNodes: util.List[ExecNode[_]] = List()
 
   override def getInputEdges: util.List[ExecEdge] = List()
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecUnion.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecUnion.scala
@@ -98,15 +98,15 @@ class BatchExecUnion(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def getInputEdges: util.List[ExecEdge] =
     inputRels.map(_ => ExecEdge.DEFAULT)
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecValues.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecValues.scala
@@ -60,13 +60,13 @@ class BatchExecValues(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = List()
+  override def getInputNodes: util.List[ExecNode[_]] = List()
 
   override def getInputEdges: util.List[ExecEdge] = List()
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCalcBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCalcBase.scala
@@ -18,17 +18,17 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import java.util
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.plan.nodes.common.CommonCalc
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rex.RexProgram
-import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.plan.nodes.common.CommonCalc
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+
+import java.util
 
 import scala.collection.JavaConversions._
 
@@ -51,12 +51,12 @@ abstract class StreamExecCalcBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] =
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    List(getInput.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecChangelogNormalize.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecChangelogNormalize.scala
@@ -18,9 +18,6 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
@@ -32,6 +29,10 @@ import org.apache.flink.table.planner.plan.utils.{AggregateUtil, ChangelogPlanUt
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator
 import org.apache.flink.table.runtime.operators.deduplicate.{ProcTimeDeduplicateKeepLastRowFunction, ProcTimeMiniBatchDeduplicateKeepLastRowFunction}
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 
 import java.util
 
@@ -72,13 +73,13 @@ class StreamExecChangelogNormalize(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
     ordinalInParent: Int,
-    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
@@ -25,9 +25,9 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFuncti
 import org.apache.flink.table.runtime.operators.AbstractProcessStreamOperator
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
@@ -82,12 +81,12 @@ abstract class StreamExecCorrelateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] =
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDataStreamScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDataStreamScan.scala
@@ -84,11 +84,11 @@ class StreamExecDataStreamScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = List()
+  override def getInputNodes: util.List[ExecNode[_]] = List()
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDeduplicate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDeduplicate.scala
@@ -94,13 +94,13 @@ class StreamExecDeduplicate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDropUpdateBefore.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecDropUpdateBefore.scala
@@ -61,13 +61,13 @@ class StreamExecDropUpdateBefore(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
     ordinalInParent: Int,
-    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecExchange.scala
@@ -61,13 +61,13 @@ class StreamExecExchange(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecExpand.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecExpand.scala
@@ -58,13 +58,13 @@ class StreamExecExpand(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGlobalGroupAggregate.scala
@@ -95,13 +95,13 @@ class StreamExecGlobalGroupAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupAggregate.scala
@@ -33,6 +33,7 @@ import org.apache.flink.table.runtime.operators.aggregate.{GroupAggFunction, Min
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
@@ -95,13 +96,13 @@ class StreamExecGroupAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregate.scala
@@ -87,13 +87,13 @@ class StreamExecGroupTableAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregate.scala
@@ -23,9 +23,9 @@ import org.apache.flink.table.planner.plan.logical._
 import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rel.RelNode
 
 /**
   * Streaming group window aggregate physical node which will be translate to window operator.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
@@ -100,13 +100,13 @@ abstract class StreamExecGroupWindowAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowTableAggregate.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rel.RelNode
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.plan.logical._
 import org.apache.flink.table.planner.plan.utils.WindowEmitStrategy
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
 
 /**
   * Streaming group window table aggregate physical node which will be translate to window operator.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecIncrementalGroupAggregate.scala
@@ -117,13 +117,13 @@ class StreamExecIncrementalGroupAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecIntervalJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecIntervalJoin.scala
@@ -113,12 +113,12 @@ class StreamExecIntervalJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
   
   override def replaceInputNode(
-      ordinalInParent: Int, newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      ordinalInParent: Int, newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecJoin.scala
@@ -118,13 +118,13 @@ class StreamExecJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLegacySink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLegacySink.scala
@@ -63,13 +63,13 @@ class StreamExecLegacySink[T](
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLegacyTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLegacyTableSourceScan.scala
@@ -82,13 +82,13 @@ class StreamExecLegacyTableSourceScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLimit.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLimit.scala
@@ -84,13 +84,13 @@ class StreamExecLimit(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLocalGroupAggregate.scala
@@ -90,13 +90,13 @@ class StreamExecLocalGroupAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecLookupJoin.scala
@@ -69,13 +69,13 @@ class StreamExecLookupJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
@@ -146,13 +146,13 @@ class StreamExecMatch(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
     ordinalInParent: Int,
-    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMiniBatchAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMiniBatchAssigner.scala
@@ -71,13 +71,13 @@ class StreamExecMiniBatchAssigner(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMultipleInput.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMultipleInput.scala
@@ -53,13 +53,13 @@ class StreamExecMultipleInput(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     throw new UnsupportedOperationException()
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecOverAggregate.scala
@@ -35,10 +35,10 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelFieldCollation.Direction.ASCENDING
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Window.Group
 import org.apache.calcite.rel.core.{AggregateCall, Window}
-import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexLiteral
 import org.apache.calcite.tools.RelBuilder
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecOverAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecOverAggregateBase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.CalcitePair
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
 
@@ -102,13 +101,13 @@ abstract class StreamExecOverAggregateBase(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.asScala.map(_.asInstanceOf[ExecNode[StreamPlanner, _]]).asJava
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.asScala.map(_.asInstanceOf[ExecNode[_]]).asJava
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCalc
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
@@ -18,17 +18,13 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.{RelNode, RelWriter}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.AggregateCall
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.functions.python.{PythonAggregateFunctionInfo, PythonFunctionInfo}
+import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
@@ -38,8 +34,14 @@ import org.apache.flink.table.planner.typeutils.DataViewUtils.DataViewSpec
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
 
-import scala.collection.JavaConversions._
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter}
+
 import java.util
+
+import scala.collection.JavaConversions._
 
 /**
   * Stream physical RelNode for Python unbounded group aggregate.
@@ -90,13 +92,13 @@ class StreamExecPythonGroupAggregate(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecRank.scala
@@ -116,13 +116,13 @@ class StreamExecRank(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSink.scala
@@ -59,13 +59,13 @@ class StreamExecSink(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSort.scala
@@ -89,13 +89,13 @@ class StreamExecSort(
     *
     * @return Array of this node's inputs
     */
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSortLimit.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecSortLimit.scala
@@ -101,13 +101,13 @@ class StreamExecSortLimit(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTableSourceScan.scala
@@ -27,7 +27,6 @@ import org.apache.flink.table.planner.plan.nodes.common.CommonPhysicalTableSourc
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.schema.TableSourceTable
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
-import org.apache.flink.table.sources.StreamTableSource
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
@@ -63,13 +62,13 @@ class StreamExecTableSourceScan(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTemporalJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTemporalJoin.scala
@@ -37,10 +37,12 @@ import org.apache.flink.table.runtime.operators.join.temporal.{TemporalProcessTi
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.util.Preconditions.checkState
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Join, JoinInfo, JoinRelType}
 import org.apache.calcite.rex._
+
 import java.util
 
 import scala.collection.JavaConversions._
@@ -86,13 +88,13 @@ class StreamExecTemporalJoin(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
     ordinalInParent: Int,
-    newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTemporalSort.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecTemporalSort.scala
@@ -80,13 +80,13 @@ class StreamExecTemporalSort(
     *
     * @return Array of this node's inputs
     */
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    List(getInput.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    List(getInput.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecUnion.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecUnion.scala
@@ -62,13 +62,13 @@ class StreamExecUnion(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecValues.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecValues.scala
@@ -55,13 +55,13 @@ class StreamExecValues(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    new util.ArrayList[ExecNode[StreamPlanner, _]]()
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    new util.ArrayList[ExecNode[_]]()
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecWatermarkAssigner.scala
@@ -79,13 +79,13 @@ class StreamExecWatermarkAssigner(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] = {
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+  override def getInputNodes: util.List[ExecNode[_]] = {
+    getInputs.map(_.asInstanceOf[ExecNode[_]])
   }
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+      newInputNode: ExecNode[_]): Unit = {
     replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ExecNodePlanDumper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ExecNodePlanDumper.scala
@@ -53,7 +53,7 @@ object ExecNodePlanDumper {
     * @return                   explain plan of ExecNode
     */
   def treeToString(
-      node: ExecNode[_, _],
+      node: ExecNode[_],
       detailLevel: SqlExplainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
       withExecNodeId: Boolean = false,
       withChangelogTraits: Boolean = false,
@@ -80,7 +80,7 @@ object ExecNodePlanDumper {
     * @return                   explain plan of ExecNode
     */
   def dagToString(
-      nodes: Seq[ExecNode[_, _]],
+      nodes: Seq[ExecNode[_]],
       detailLevel: SqlExplainLevel = SqlExplainLevel.DIGEST_ATTRIBUTES,
       withExecNodeId: Boolean = false,
       withChangelogTraits: Boolean = false,
@@ -99,16 +99,16 @@ object ExecNodePlanDumper {
     val reuseInfoBuilder = new ReuseInfoBuilder()
     nodes.foreach(reuseInfoBuilder.visit)
     // node sets that stop explain when meet them
-    val stopExplainNodes = Sets.newIdentityHashSet[ExecNode[_, _]]()
+    val stopExplainNodes = Sets.newIdentityHashSet[ExecNode[_]]()
     // mapping node to reuse info, the map value is a tuple2,
     // the first value of the tuple is reuse id,
     // the second value is true if the node is first visited else false.
-    val reuseInfoMap = Maps.newIdentityHashMap[ExecNode[_, _], (Integer, Boolean)]()
+    val reuseInfoMap = Maps.newIdentityHashMap[ExecNode[_], (Integer, Boolean)]()
     // mapping node object to visited times
-    val mapNodeToVisitedTimes = Maps.newIdentityHashMap[ExecNode[_, _], Int]()
+    val mapNodeToVisitedTimes = Maps.newIdentityHashMap[ExecNode[_], Int]()
     val sb = new StringBuilder()
     val visitor = new ExecNodeVisitorImpl {
-      override def visit(node: ExecNode[_, _]): Unit = {
+      override def visit(node: ExecNode[_]): Unit = {
         val visitedTimes = mapNodeToVisitedTimes.getOrDefault(node, 0) + 1
         mapNodeToVisitedTimes.put(node, visitedTimes)
         if (visitedTimes == 1) {
@@ -150,13 +150,13 @@ object ExecNodePlanDumper {
   }
 
   private def doConvertTreeToString(
-      node: ExecNode[_, _],
+      node: ExecNode[_],
       detailLevel: SqlExplainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
       withExecNodeId: Boolean = false,
       withChangelogTraits: Boolean = false,
       withOutputType: Boolean = false,
-      stopExplainNodes: Option[util.Set[ExecNode[_, _]]] = None,
-      reuseInfoMap: Option[util.IdentityHashMap[ExecNode[_, _], (Integer, Boolean)]] = None,
+      stopExplainNodes: Option[util.Set[ExecNode[_]]] = None,
+      reuseInfoMap: Option[util.IdentityHashMap[ExecNode[_], (Integer, Boolean)]] = None,
       withResource: Boolean = false
   ): String = {
     // TODO refactor this part of code
@@ -182,12 +182,12 @@ object ExecNodePlanDumper {
   */
 class ReuseInfoBuilder extends ExecNodeVisitorImpl {
   // visited node set
-  private val visitedNodes = Sets.newIdentityHashSet[ExecNode[_, _]]()
+  private val visitedNodes = Sets.newIdentityHashSet[ExecNode[_]]()
   // mapping reuse node to its reuse id
-  private val mapReuseNodeToReuseId = Maps.newIdentityHashMap[ExecNode[_, _], Integer]()
+  private val mapReuseNodeToReuseId = Maps.newIdentityHashMap[ExecNode[_], Integer]()
   private val reuseIdGenerator = new AtomicInteger(0)
 
-  override def visit(node: ExecNode[_, _]): Unit = {
+  override def visit(node: ExecNode[_]): Unit = {
     // if a node is visited more than once, this node is a reusable node
     if (visitedNodes.contains(node)) {
       if (!mapReuseNodeToReuseId.containsKey(node)) {
@@ -204,7 +204,7 @@ class ReuseInfoBuilder extends ExecNodeVisitorImpl {
     * Returns reuse id if the given node is a reuse node (that means it has multiple outputs),
     * else None.
     */
-  def getReuseId(node: ExecNode[_, _]): Option[Integer] = {
+  def getReuseId(node: ExecNode[_]): Option[Integer] = {
     if (mapReuseNodeToReuseId.containsKey(node)) {
       Some(mapReuseNodeToReuseId.get(node))
     } else {
@@ -217,14 +217,14 @@ class ReuseInfoBuilder extends ExecNodeVisitorImpl {
   * Convert node tree to string as a tree style.
   */
 class NodeTreeWriterImpl(
-    node: ExecNode[_, _],
+    node: ExecNode[_],
     pw: PrintWriter,
     explainLevel: SqlExplainLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES,
     withExecNodeId: Boolean = false,
     withChangelogTraits: Boolean = false,
     withOutputType: Boolean = false,
-    stopExplainNodes: Option[util.Set[ExecNode[_, _]]] = None,
-    reuseInfoMap: Option[util.IdentityHashMap[ExecNode[_, _], (Integer, Boolean)]] = None,
+    stopExplainNodes: Option[util.Set[ExecNode[_]]] = None,
+    reuseInfoMap: Option[util.IdentityHashMap[ExecNode[_], (Integer, Boolean)]] = None,
     withResource: Boolean = false)
   extends RelWriterImpl(pw, explainLevel, false) {
 
@@ -235,19 +235,19 @@ class NodeTreeWriterImpl(
   // else rebuild it using `ReuseInfoBuilder`
   class ReuseInfo {
     // mapping node object to visited times
-    var mapNodeToVisitedTimes: util.Map[ExecNode[_, _], Int] = _
+    var mapNodeToVisitedTimes: util.Map[ExecNode[_], Int] = _
     var reuseInfoBuilder: ReuseInfoBuilder = _
 
     if (reuseInfoMap.isEmpty) {
       reuseInfoBuilder = new ReuseInfoBuilder()
       reuseInfoBuilder.visit(node)
-      mapNodeToVisitedTimes = Maps.newIdentityHashMap[ExecNode[_, _], Int]()
+      mapNodeToVisitedTimes = Maps.newIdentityHashMap[ExecNode[_], Int]()
     }
 
     /**
       * Returns reuse id if the given node is a reuse node, else None.
       */
-    def getReuseId(node: ExecNode[_, _]): Option[Integer] = {
+    def getReuseId(node: ExecNode[_]): Option[Integer] = {
       reuseInfoMap match {
         case Some(map) => if (map.containsKey(node)) Some(map.get(node)._1) else None
         case _ => reuseInfoBuilder.getReuseId(node)
@@ -257,7 +257,7 @@ class NodeTreeWriterImpl(
     /**
       * Returns true if the given node is first visited, else false.
       */
-    def isFirstVisited(node: ExecNode[_, _]): Boolean = {
+    def isFirstVisited(node: ExecNode[_]): Boolean = {
       reuseInfoMap match {
         case Some(map) => if (map.containsKey(node)) map.get(node)._2 else true
         case _ => mapNodeToVisitedTimes.get(node) == 1
@@ -267,7 +267,7 @@ class NodeTreeWriterImpl(
     /**
       * Updates visited times for given node if `reuseInfoMap` is None.
       */
-    def addVisitedTimes(node: ExecNode[_, _]): Unit = {
+    def addVisitedTimes(node: ExecNode[_]): Unit = {
       reuseInfoMap match {
         case Some(_) => // do nothing
         case _ =>
@@ -284,7 +284,7 @@ class NodeTreeWriterImpl(
   var depth = 0
 
   override def explain_(rel: RelNode, values: JList[Pair[String, AnyRef]]): Unit = {
-    val node = rel.asInstanceOf[ExecNode[_, _]]
+    val node = rel.asInstanceOf[ExecNode[_]]
     reuseInfo.addVisitedTimes(node)
     val inputs = rel.getInputs
     // whether explain input nodes of current node
@@ -394,7 +394,7 @@ class NodeTreeWriterImpl(
   /**
     * Returns true if `stopExplainNodes` is not None and contains the given node, else false.
     */
-  private def needExplainInputs(node: ExecNode[_, _]): Boolean = {
+  private def needExplainInputs(node: ExecNode[_]): Boolean = {
     stopExplainNodes match {
       case Some(nodes) => !nodes.contains(node)
       case _ => true

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/MultipleInputNodeCreationProcessorTest.java
@@ -102,7 +102,7 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
 		Table table = util.tableEnv().sqlQuery(sql);
 		RelNode relNode = TableTestUtil.toRelNode(table);
 		RelNode optimizedRel = util.getPlanner().optimize(relNode);
-		ExecNode<?, ?> execNode = (ExecNode<?, ?>) optimizedRel;
+		ExecNode<?> execNode = (ExecNode<?>) optimizedRel;
 		while (!execNode.getInputNodes().isEmpty()) {
 			execNode = execNode.getInputNodes().get(0);
 		}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculatorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputOrderCalculatorTest.java
@@ -93,7 +93,7 @@ public class InputOrderCalculatorTest {
 			nodes[8],
 			new HashSet<>(Arrays.asList(nodes[1], nodes[3], nodes[5])),
 			ExecEdge.DamBehavior.BLOCKING);
-		Map<ExecNode<?, ?>, Integer> result = calculator.calculate();
+		Map<ExecNode<?>, Integer> result = calculator.calculate();
 		Assert.assertEquals(3, result.size());
 		Assert.assertEquals(0, result.get(nodes[3]).intValue());
 		Assert.assertEquals(1, result.get(nodes[1]).intValue());
@@ -124,7 +124,7 @@ public class InputOrderCalculatorTest {
 			nodes[5],
 			new HashSet<>(Arrays.asList(nodes[0], nodes[1], nodes[3], nodes[6])),
 			ExecEdge.DamBehavior.BLOCKING);
-		Map<ExecNode<?, ?>, Integer> result = calculator.calculate();
+		Map<ExecNode<?>, Integer> result = calculator.calculate();
 		Assert.assertEquals(4, result.size());
 		Assert.assertEquals(1, result.get(nodes[0]).intValue());
 		Assert.assertEquals(1, result.get(nodes[1]).intValue());
@@ -159,7 +159,7 @@ public class InputOrderCalculatorTest {
 			nodes[4],
 			new HashSet<>(Arrays.asList(nodes[1], nodes[3], nodes[5], nodes[7])),
 			ExecEdge.DamBehavior.BLOCKING);
-		Map<ExecNode<?, ?>, Integer> result = calculator.calculate();
+		Map<ExecNode<?>, Integer> result = calculator.calculate();
 		Assert.assertEquals(4, result.size());
 		Assert.assertEquals(0, result.get(nodes[1]).intValue());
 		Assert.assertEquals(1, result.get(nodes[3]).intValue());

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityConflictResolverTest.java
@@ -114,11 +114,11 @@ public class InputPriorityConflictResolverTest {
 			ShuffleMode.BATCH);
 		resolver.detectAndResolve();
 
-		ExecNode<?, ?> input0 = nodes[1].getInputNodes().get(0);
-		ExecNode<?, ?> input1 = nodes[1].getInputNodes().get(1);
+		ExecNode<?> input0 = nodes[1].getInputNodes().get(0);
+		ExecNode<?> input1 = nodes[1].getInputNodes().get(1);
 		Assert.assertNotSame(input0, input1);
 
-		Consumer<ExecNode<?, ?>> checkExchange = execNode -> {
+		Consumer<ExecNode<?>> checkExchange = execNode -> {
 			Assert.assertTrue(execNode instanceof BatchExecExchange);
 			BatchExecExchange e = (BatchExecExchange) execNode;
 			Assert.assertEquals(ShuffleMode.BATCH, e.getShuffleMode(new Configuration()));

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/InputPriorityGraphGeneratorTest.java
@@ -59,7 +59,7 @@ public class InputPriorityGraphGeneratorTest {
 			Collections.singletonList(nodes[2]),
 			Collections.emptySet(),
 			ExecEdge.DamBehavior.END_INPUT);
-		List<ExecNode<?, ?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
+		List<ExecNode<?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
 		Assert.assertEquals(2, ancestors.size());
 		Assert.assertTrue(ancestors.contains(nodes[0]));
 		Assert.assertTrue(ancestors.contains(nodes[5]));
@@ -84,7 +84,7 @@ public class InputPriorityGraphGeneratorTest {
 			Collections.singletonList(nodes[2]),
 			new HashSet<>(Collections.singleton(nodes[1])),
 			ExecEdge.DamBehavior.END_INPUT);
-		List<ExecNode<?, ?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
+		List<ExecNode<?>> ancestors = resolver.calculatePipelinedAncestors(nodes[2]);
 		Assert.assertEquals(1, ancestors.size());
 		Assert.assertTrue(ancestors.contains(nodes[1]));
 	}
@@ -92,14 +92,14 @@ public class InputPriorityGraphGeneratorTest {
 	private static class TestingInputPriorityConflictResolver extends InputPriorityGraphGenerator {
 
 		private TestingInputPriorityConflictResolver(
-				List<ExecNode<?, ?>> roots,
-				Set<ExecNode<?, ?>> boundaries,
+				List<ExecNode<?>> roots,
+				Set<ExecNode<?>> boundaries,
 				ExecEdge.DamBehavior safeDamBehavior) {
 			super(roots, boundaries, safeDamBehavior);
 		}
 
 		@Override
-		protected void resolveInputPriorityConflict(ExecNode<?, ?> node, int higherInput, int lowerInput) {
+		protected void resolveInputPriorityConflict(ExecNode<?> node, int higherInput, int lowerInput) {
 			// do nothing
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraphTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/processors/utils/TopologyGraphTest.java
@@ -130,7 +130,7 @@ public class TopologyGraphTest {
 		TopologyGraph graph = tuple2.f0;
 		TestingBatchExecNode[] nodes = tuple2.f1;
 
-		Map<ExecNode<?, ?>, Integer> result = graph.calculateMaximumDistance();
+		Map<ExecNode<?>, Integer> result = graph.calculateMaximumDistance();
 		Assert.assertEquals(8, result.size());
 		Assert.assertEquals(0, result.get(nodes[0]).intValue());
 		Assert.assertEquals(1, result.get(nodes[1]).intValue());
@@ -148,7 +148,7 @@ public class TopologyGraphTest {
 		TopologyGraph graph = tuple2.f0;
 		TestingBatchExecNode[] nodes = tuple2.f1;
 
-		Map<ExecNode<?, ?>, Integer> result = graph.calculateMaximumDistance();
+		Map<ExecNode<?>, Integer> result = graph.calculateMaximumDistance();
 		Assert.assertEquals(6, result.size());
 		Assert.assertEquals(0, result.get(nodes[2]).intValue());
 		Assert.assertEquals(0, result.get(nodes[3]).intValue());
@@ -165,7 +165,7 @@ public class TopologyGraphTest {
 		TestingBatchExecNode[] nodes = tuple2.f1;
 
 		graph.makeAsFarAs(nodes[4], nodes[7]);
-		Map<ExecNode<?, ?>, Integer> distances = graph.calculateMaximumDistance();
+		Map<ExecNode<?>, Integer> distances = graph.calculateMaximumDistance();
 		Assert.assertEquals(4, distances.get(nodes[7]).intValue());
 		Assert.assertEquals(4, distances.get(nodes[4]).intValue());
 	}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/nodes/exec/TestingBatchExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/nodes/exec/TestingBatchExecNode.scala
@@ -39,25 +39,25 @@ class TestingBatchExecNode
     with BatchPhysicalRel
     with BatchExecNode[BatchPlanner]  {
 
-  val inputNodes: util.List[ExecNode[BatchPlanner, _]] =
-    new util.ArrayList[ExecNode[BatchPlanner, _]]()
+  val inputNodes: util.List[ExecNode[_]] =
+    new util.ArrayList[ExecNode[_]]()
   val inputEdges: util.List[ExecEdge] = new util.ArrayList[ExecEdge]()
 
-  def addInput(node: ExecNode[BatchPlanner, _]): Unit =
+  def addInput(node: ExecNode[_]): Unit =
     addInput(node, ExecEdge.builder().build())
 
-  def addInput(node: ExecNode[BatchPlanner, _], edge: ExecEdge): Unit = {
+  def addInput(node: ExecNode[_], edge: ExecEdge): Unit = {
     inputNodes.add(node)
     inputEdges.add(edge)
   }
 
-  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] = inputNodes
+  override def getInputNodes: util.List[ExecNode[_]] = inputNodes
 
   override def getInputEdges: util.List[ExecEdge] = inputEdges
 
   override def replaceInputNode(
       ordinalInParent: Int,
-      newInputNode: ExecNode[BatchPlanner, _]): Unit =
+      newInputNode: ExecNode[_]): Unit =
     inputNodes.set(ordinalInParent, newInputNode)
 
   override def getTraitSet: RelTraitSet = TestingBatchExecNode.traitSet

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -437,7 +437,7 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
     val withChangelogTraits = extraDetails.contains(ExplainDetail.CHANGELOG_MODE)
 
     optimizedRels.head match {
-      case _: ExecNode[_, _] =>
+      case _: ExecNode[_] =>
         val optimizedNodes = planner.translateToExecNodePlan(optimizedRels)
         require(optimizedNodes.length == optimizedRels.length)
         ExecNodePlanDumper.dagToString(


### PR DESCRIPTION

## What is the purpose of the change

*Just as the description in [FLINK-20436](https://issues.apache.org/jira/browse/FLINK-20436), this pr aims to simplify type parameter of ExecNode, and move all the implementation to ExecNodeBase.*


## Brief change log

*(for example:)*
  - *Remove type parameter `P <: Planner` from ExecNode, and move all the implementation to ExecNodeBase.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
