### PR TITLE
[FLINK-12130][clients] Apply command line options to configuration be…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -256,7 +256,7 @@ public class CliFrontend {
 
 		@Override
 		public void printHelp() {
-      CliFrontendParser.printHelpForRunApplication(customCommandLines);
+			CliFrontendParser.printHelpForRunApplication(customCommandLines);
 		}
 	}
 
@@ -1193,8 +1193,8 @@ public class CliFrontend {
 				throw ute.getCause();
 			}
 
-		} catch (CliArgsException e) {
-			return handleArgException(e);
+		} catch (CliArgsException ce) {
+			return handleArgException(ce);
 		} catch (ProgramParametrizationException ppe) {
 			return handleParametrizationException(ppe);
 		} catch (ProgramMissingJobException pmje) {
@@ -1215,7 +1215,7 @@ public class CliFrontend {
 	 * Parses the command line arguments.
 	 *
 	 * @param args command line arguments of the client.
-	 * @return parsed CommandAction, or null if no executable action found.
+	 * @return parsed CommandAction.
 	 */
 	public CommandAction parseAction(String[] args) {
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1202,11 +1202,8 @@ public class CliFrontend {
 		} catch (Exception e) {
 			return handleError(e);
 		} catch (Throwable t) {
-			final Throwable strippedThrowable = ExceptionUtils.stripException(
-				t,
-				UndeclaredThrowableException.class);
-			LOG.error("Fatal error while running command line interface.", strippedThrowable);
-			strippedThrowable.printStackTrace();
+			LOG.error("Fatal error while running command line interface.", t);
+			t.printStackTrace();
 			return 31;
 		}
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
@@ -26,15 +26,19 @@ import static org.apache.flink.client.cli.CliFrontendParser.HELP_OPTION;
  * Base class for all options parsed from the command line.
  * Contains options for printing help and the JobManager address.
  */
-public abstract class CommandLineOptions {
+public class CommandLineOptions {
 
-	private final boolean printHelp;
+	private final CommandLine commandLine;
 
 	protected CommandLineOptions(CommandLine line) {
-		this.printHelp = line.hasOption(HELP_OPTION.getOpt());
+		this.commandLine = line;
+	}
+
+	public CommandLine getCommandLine() {
+		return commandLine;
 	}
 
 	public boolean isPrintHelp() {
-		return printHelp;
+		return commandLine.hasOption(HELP_OPTION.getOpt());
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -67,7 +67,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		});
 
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 		cancelLatch.await();
 	}
 
@@ -78,7 +78,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -88,7 +88,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 	}
 
 	/**
@@ -110,7 +110,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 				return CompletableFuture.completedFuture(savepointDirectory);
 			});
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.cancel(parameters);
+			testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 			cancelWithSavepointLatch.await();
 		}
 
@@ -128,7 +128,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 				return CompletableFuture.completedFuture(savepointDirectory);
 			});
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.cancel(parameters);
+			testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 			cancelWithSavepointLatch.await();
 		}
 	}
@@ -141,7 +141,7 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -152,6 +152,6 @@ public class CliFrontendCancelTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionCancel(), parameters);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendDynamicPropertiesTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendDynamicPropertiesTest.java
@@ -121,7 +121,7 @@ public class CliFrontendDynamicPropertiesTest extends CliFrontendTestBase {
 			String userCodeClassLoaderClassName) throws Exception {
 		TestingCliFrontend testFrontend =
 			new TestingCliFrontend(configuration, cliUnderTest, expectedResolveOrderOption, userCodeClassLoaderClassName);
-		testFrontend.run(parameters); // verifies the expected values (see below)
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters); // verifies the expected values (see below)
 	}
 
 	private static final class TestingCliFrontend extends CliFrontend {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -45,7 +45,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionInfo(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -55,7 +55,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.cancel(parameters);
+		testAction(testFrontend, testFrontend.new ActionInfo(), parameters);
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli()));
-			testFrontend.info(parameters);
+			testAction(testFrontend, testFrontend.new ActionInfo(), parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\" : 4"));
 		}
 		finally {
@@ -85,7 +85,7 @@ public class CliFrontendInfoTest extends CliFrontendTestBase {
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli()));
-			testFrontend.info(parameters);
+			testAction(testFrontend, testFrontend.new ActionInfo(), parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\" : 17"));
 		}
 		catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -95,7 +95,7 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.list(parameters);
+		testAction(testFrontend, testFrontend.new ActionList(), parameters);
 	}
 
 	@Test
@@ -105,7 +105,7 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 			String[] parameters = {"-r", "-s", "-a"};
 			ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-			testFrontend.list(parameters);
+			testAction(testFrontend, testFrontend.new ActionList(), parameters);
 			Mockito.verify(clusterClient, times(1))
 				.listJobs();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.cli.CommandLine;
 import org.junit.AfterClass;
@@ -56,7 +55,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the RUN command with {@link PackagedProgram PackagedPrograms}.
  */
-public class CliFrontendPackageProgramTest extends TestLogger {
+public class CliFrontendPackageProgramTest extends CliFrontendTestBase {
 
 	private CliFrontend frontend;
 
@@ -178,7 +177,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 	@Test(expected = CliArgsException.class)
 	public void testNoJarNoArgumentsAtAll() throws Exception {
-		frontend.run(new String[0]);
+		testAction(frontend, frontend.new ActionRun(), new String[0]);
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -130,7 +130,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.run(parameters);
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -141,7 +141,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.run(parameters);
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -152,7 +152,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.run(parameters);
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -170,7 +170,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 						cli,
 						expectedParallelism,
 						isDetached);
-		testFrontend.run(parameters); // verifies the expected values (see below)
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters); // verifies the expected values (see below)
 	}
 
 	public static void verifyCliFrontend(
@@ -187,7 +187,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 						cli,
 						expectedParallelism,
 						isDetached);
-		testFrontend.run(parameters); // verifies the expected values (see below)
+		testAction(testFrontend, testFrontend.new ActionRun(), parameters); // verifies the expected values (see below)
 	}
 
 	private static final class RunTestingCliFrontend extends CliFrontend {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -86,7 +86,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString() };
-			frontend.savepoint(parameters);
+			testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), isNull(String.class));
@@ -116,7 +116,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			String[] parameters = { jobId.toString() };
 
 			try {
-				frontend.savepoint(parameters);
+				testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 				fail("Savepoint should have failed.");
 			} catch (FlinkException e) {
@@ -138,7 +138,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 
 			String[] parameters = { "invalid job id" };
 			try {
-				frontend.savepoint(parameters);
+				testAction(frontend, frontend.new ActionSavepoint(), parameters);
 				fail("Should have failed.");
 			} catch (CliArgsException e) {
 				assertThat(e.getMessage(), Matchers.containsString("Cannot parse JobID"));
@@ -167,7 +167,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString(), savepointDirectory };
-			frontend.savepoint(parameters);
+			testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), eq(savepointDirectory));
@@ -199,7 +199,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { "-d", savepointPath };
-			frontend.savepoint(parameters);
+			testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 			String outMsg = buffer.toString();
 			assertTrue(outMsg.contains(savepointPath));
@@ -237,7 +237,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			final String disposePath = "any-path";
 			String[] parameters = { "-d", disposePath, "-j", f.getAbsolutePath() };
 
-			frontend.savepoint(parameters);
+			testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 			final String actualSavepointPath = disposeSavepointFuture.get();
 
@@ -264,7 +264,7 @@ public class CliFrontendSavepointTest extends CliFrontendTestBase {
 			String[] parameters = { "-d", savepointPath };
 
 			try {
-				frontend.savepoint(parameters);
+				testAction(frontend, frontend.new ActionSavepoint(), parameters);
 
 				fail("Savepoint should have failed.");
 			} catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopWithSavepointTest.java
@@ -73,7 +73,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 
 		stopWithSavepointLatch.await();
 	}
@@ -93,7 +93,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 			return CompletableFuture.completedFuture(savepointDirectory);
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 
 		stopWithSavepointLatch.await();
 	}
@@ -113,7 +113,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 			return CompletableFuture.completedFuture(savepointDirectory);
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 		stopWithSavepointLatch.await();
 	}
 
@@ -132,7 +132,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 			return CompletableFuture.completedFuture(savepointDirectory);
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 
 		stopWithSavepointLatch.await();
 	}
@@ -152,7 +152,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 			return CompletableFuture.completedFuture(savepointDirectory);
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 
 		stopWithSavepointLatch.await();
 	}
@@ -172,7 +172,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 			return CompletableFuture.completedFuture(savepointDirectory);
 		});
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 
 		stopWithSavepointLatch.await();
 	}
@@ -185,7 +185,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -196,7 +196,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli()));
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -204,7 +204,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		JobID jid = new JobID();
 		String[] parameters = { "-s", "-d", "test-target-dir", jid.toString() };
 		MockedCliFrontend testFrontend = new MockedCliFrontend(new TestingClusterClient());
-		testFrontend.stop(parameters);
+		testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 	}
 
 	@Test
@@ -220,7 +220,7 @@ public class CliFrontendStopWithSavepointTest extends CliFrontendTestBase {
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
 		try {
-			testFrontend.stop(parameters);
+			testAction(testFrontend, testFrontend.new ActionStop(), parameters);
 			fail("Should have failed.");
 		} catch (FlinkException e) {
 			assertTrue(ExceptionUtils.findThrowableWithMessage(e, expectedMessage).isPresent());

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -34,4 +34,20 @@ public abstract class CliFrontendTestBase extends TestLogger {
 	static AbstractCustomCommandLine getCli() {
 		return new DefaultCLI();
 	}
+
+	static void testAction(
+		CliFrontend cliFrontend,
+		CliFrontend.CommandAction commandAction,
+		String[] parameters) throws Exception {
+		final CommandLineOptions commandLineOptions = commandAction.parse(parameters);
+
+		final CustomCommandLine activeCommandLine = cliFrontend.validateAndGetActiveCommandLine(
+			commandLineOptions.getCommandLine());
+
+		final Configuration effectiveConfiguration = commandAction.getConfiguration(
+			commandLineOptions,
+			activeCommandLine);
+
+		commandAction.runAction(commandLineOptions, effectiveConfiguration);
+	}
 }


### PR DESCRIPTION
…fore installing security modules

## What is the purpose of the change

This pull request makes dynamic properties in command line taking effect before installing security modules, so the users can configure Kerberos credentials through command line, like this:

```
link run -m yarn-cluster -yD security.kerberos.login.keytab=/path/to/keytab -yD security.kerberos.login.principal=xxx /path/to/my.jar
```

## Brief change log

  - *Add a new type `CommandAction`, which represents the action specified in command line, like run/info/stop.*
  - *Parse command line args to `CommandAction` first, and get effective configuration before installing security modules.*
  - *Install effective configuration and run action.*


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.client.cli.CliFrontendRunTest/org.apache.flink.client.cli.CliFrontendCancelTest/etc.*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes, it affects deployment**)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
