### PR TITLE
[FLINK-20441] Deprecate CheckpointConfig.setPreferCheckpointForRecovery and .isPreferCheckpointForRecovery

### DIFF
--- a/docs/dev/stream/state/checkpointing.md
+++ b/docs/dev/stream/state/checkpointing.md
@@ -105,9 +105,6 @@ env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 // enable externalized checkpoints which are retained after job cancellation
 env.getCheckpointConfig().enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 
-// allow job recovery fallback to checkpoint when there is a more recent savepoint
-env.getCheckpointConfig().setPreferCheckpointForRecovery(true);
-
 // enables the experimental unaligned checkpoints
 env.getCheckpointConfig.enableUnalignedCheckpoints();
 {% endhighlight %}

--- a/docs/dev/stream/state/checkpointing.zh.md
+++ b/docs/dev/stream/state/checkpointing.zh.md
@@ -95,8 +95,6 @@ env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
 // 开启在 job 中止后仍然保留的 externalized checkpoints
 env.getCheckpointConfig().enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
 
-// 允许在有更近 savepoint 时回退到 checkpoint
-env.getCheckpointConfig().setPreferCheckpointForRecovery(true);
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -430,16 +430,26 @@ public class CheckpointConfig implements java.io.Serializable {
 	 * Returns whether a job recovery should fallback to checkpoint when there is a more recent savepoint.
 	 *
 	 * @return <code>true</code> if a job recovery should fallback to checkpoint.
+	 *
+	 * @deprecated Don't activate prefer checkpoints for recovery because it can lead to data loss
+	 * and duplicate output. This option will soon be removed. See <a href="https://issues.apache.org/jira/browse/FLINK-20427">FLINK-20427</a>
+	 * for more information.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public boolean isPreferCheckpointForRecovery() {
 		return preferCheckpointForRecovery;
 	}
 
 	/**
 	 * Sets whether a job recovery should fallback to checkpoint when there is a more recent savepoint.
+	 *
+	 * @deprecated Don't activate prefer checkpoints for recovery because it can lead to data loss
+	 * and duplicate output. This option will soon be removed. See <a href="https://issues.apache.org/jira/browse/FLINK-20427">FLINK-20427</a>
+	 * for more information.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public void setPreferCheckpointForRecovery(boolean preferCheckpointForRecovery) {
 		this.preferCheckpointForRecovery = preferCheckpointForRecovery;
 	}


### PR DESCRIPTION
CheckpointConfig.setPreferCheckpointForRecovery(true) can lead to data loss and duplicate outputs. Hence,
it is no longer recommended to use.