### PR TITLE
[FLINK-19863][test] Fix SQLClientHBaseITCase.testHBase failed with process timeout

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -170,12 +170,14 @@ public class SQLClientKafkaITCase extends TestLogger {
 
 	private void executeSqlStatements(ClusterController clusterController, List<String> sqlLines) throws IOException {
 		LOG.info("Executing Kafka {} end-to-end SQL statements.", kafkaSQLVersion);
-		clusterController.submitSQLJob(new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
-			.addJar(sqlAvroJar)
-			.addJars(apacheAvroJars)
-			.addJar(sqlConnectorKafkaJar)
-			.addJar(sqlToolBoxJar)
-			.build());
+		clusterController.submitSQLJob(
+			new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+				.addJar(sqlAvroJar)
+				.addJars(apacheAvroJars)
+				.addJar(sqlConnectorKafkaJar)
+				.addJar(sqlToolBoxJar)
+				.build(),
+			Duration.ofMinutes(2L));
 	}
 
 	private List<String> initializeSqlLines(Map<String, String> vars) throws IOException {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/StreamingKafkaITCase.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -97,17 +98,19 @@ public class StreamingKafkaITCase extends TestLogger {
 			kafka.createTopic(1, 1, outputTopic);
 
 			// run the Flink job (detached mode)
-			clusterController.submitJob(new JobSubmission.JobSubmissionBuilder(kafkaExampleJar)
-				.setDetached(true)
-				.addArgument("--input-topic", inputTopic)
-				.addArgument("--output-topic", outputTopic)
-				.addArgument("--prefix", "PREFIX")
-				.addArgument("--bootstrap.servers", kafka.getBootstrapServerAddresses().stream().map(address -> address.getHostString() + ':' + address.getPort()).collect(Collectors.joining(",")))
-				.addArgument("--group.id", "myconsumer")
-				.addArgument("--auto.offset.reset", "earliest")
-				.addArgument("--transaction.timeout.ms", "900000")
-				.addArgument("--flink.partition-discovery.interval-millis", "1000")
-				.build());
+			clusterController.submitJob(
+				new JobSubmission.JobSubmissionBuilder(kafkaExampleJar)
+					.setDetached(true)
+					.addArgument("--input-topic", inputTopic)
+					.addArgument("--output-topic", outputTopic)
+					.addArgument("--prefix", "PREFIX")
+					.addArgument("--bootstrap.servers", kafka.getBootstrapServerAddresses().stream().map(address -> address.getHostString() + ':' + address.getPort()).collect(Collectors.joining(",")))
+					.addArgument("--group.id", "myconsumer")
+					.addArgument("--auto.offset.reset", "earliest")
+					.addArgument("--transaction.timeout.ms", "900000")
+					.addArgument("--flink.partition-discovery.interval-millis", "1000")
+					.build(),
+				Duration.ofMinutes(2L));
 
 			LOG.info("Sending messages to Kafka topic [{}] ...", inputTopic);
 			// send some data to Kafka

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/ClusterController.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/ClusterController.java
@@ -21,6 +21,7 @@ package org.apache.flink.tests.util.flink;
 import org.apache.flink.util.AutoCloseableAsync;
 
 import java.io.IOException;
+import java.time.Duration;
 
 /**
  * Controller for interacting with a cluster.
@@ -31,16 +32,18 @@ public interface ClusterController extends AutoCloseableAsync {
 	 * Submits the given job to the cluster.
 	 *
 	 * @param job job to submit
+	 * @param timeout the maximum time to wait.
 	 * @return JobController for the submitted job
 	 * @throws IOException
 	 */
-	JobController submitJob(JobSubmission job) throws IOException;
+	JobController submitJob(JobSubmission job, Duration timeout) throws IOException;
 
 	/**
 	 * Submits the given SQL job to the cluster.
 	 *
 	 * @param job job to submit.
+	 * @param timeout the maximum time to wait.
 	 * @throws IOException if any IO error happen.
 	 */
-	void submitSQLJob(SQLJobSubmission job) throws IOException;
+	void submitSQLJob(SQLJobSubmission job, Duration timeout) throws IOException;
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
@@ -22,6 +22,7 @@ import org.apache.flink.tests.util.util.FactoryUtils;
 import org.apache.flink.util.ExternalResource;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,7 +39,7 @@ public interface FlinkResource extends ExternalResource {
 	 * <p>The exact constellation of the cluster is undefined.
 	 *
 	 * <p>In the case of per-job clusters this method may not start any Flink processes, deferring this to
-	 * {@link ClusterController#submitJob(JobSubmission)}.
+	 * {@link ClusterController#submitJob(JobSubmission, Duration)}.
 	 *
 	 * @return controller for interacting with the cluster
 	 * @throws IOException

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -185,15 +186,15 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 		}
 
 		@Override
-		public JobController submitJob(JobSubmission job) throws IOException {
-			final JobID run = distribution.submitJob(job);
+		public JobController submitJob(JobSubmission job, Duration timeout) throws IOException {
+			final JobID run = distribution.submitJob(job, timeout);
 
 			return new StandaloneJobController(run);
 		}
 
 		@Override
-		public void submitSQLJob(SQLJobSubmission job) throws IOException {
-			distribution.submitSQLJob(job);
+		public void submitSQLJob(SQLJobSubmission job, Duration timeout) throws IOException {
+			distribution.submitSQLJob(job, timeout);
 		}
 
 		@Override

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
@@ -212,10 +212,12 @@ public class SQLClientHBaseITCase extends TestLogger {
 
 	private void executeSqlStatements(ClusterController clusterController, List<String> sqlLines) throws IOException {
 		LOG.info("Executing SQL: HBase source table -> HBase sink table");
-		clusterController.submitSQLJob(new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
-			.addJar(sqlToolBoxJar)
-			.addJar(sqlConnectorHBaseJar)
-			.addJars(hadoopClasspathJars)
-			.build());
+		clusterController.submitSQLJob(
+			new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+				.addJar(sqlToolBoxJar)
+				.addJar(sqlConnectorHBaseJar)
+				.addJars(hadoopClasspathJars)
+				.build(),
+			Duration.ofMinutes(2L));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* This pull request aims to fix the unstable test `SQLClientHBaseITCase.testHBase`, the test failed in submission phase, the default timeout for streaming job submission is `1 minute`, but the timeout for sql job submission is `30 seconds`, and `testHBase` need submit three jobs in `30 seconds`. It may lead the process timeout when the machine resource is busy. 


## Brief change log

  - Add `timeout` parameter for `submitJob` and `submitSqlJob` function
  -Set the default timeout to 2 minutes which is same as common e2e test timeout time

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
