### PR TITLE
[FLINK-20432] Add timeouts to SQLClientSchemaRegistryITCase 

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -42,7 +42,6 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
@@ -89,9 +88,6 @@ public class SQLClientSchemaRegistryITCase {
 
 	private final KafkaContainerClient kafkaClient = new KafkaContainerClient(kafka);
 	private CachedSchemaRegistryClient registryClient;
-
-	public SQLClientSchemaRegistryITCase() throws IOException {
-	}
 
 	@Before
 	public void setUp() {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -35,9 +35,11 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -48,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -65,6 +68,9 @@ public class SQLClientSchemaRegistryITCase {
 	private final Path sqlConnectorKafkaJar = TestUtils.getResource(".*kafka.jar");
 
 	public final Network network = Network.newNetwork();
+
+	@ClassRule
+	public static final Timeout TIMEOUT = new Timeout(8, TimeUnit.MINUTES);
 
 	@Rule
 	public final KafkaContainer kafka = new KafkaContainer(
@@ -96,7 +102,7 @@ public class SQLClientSchemaRegistryITCase {
 			10);
 	}
 
-	@Test
+	@Test(timeout = 120_000)
 	public void testReading() throws Exception {
 		String testCategoryTopic = "test-category-" + UUID.randomUUID().toString();
 		String testResultsTopic = "test-results-" + UUID.randomUUID().toString();
@@ -163,7 +169,7 @@ public class SQLClientSchemaRegistryITCase {
 		));
 	}
 
-	@Test
+	@Test(timeout = 120_000)
 	public void testWriting() throws Exception {
 		String testUserBehaviorTopic = "test-user-behavior-" + UUID.randomUUID().toString();
 		// Create topic test-avro

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
@@ -266,7 +266,6 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 				// between tests runs.
 				String baseImage = buildBaseImage(flinkDist, flinkDistName);
 				ImageFromDockerfile configuredImage = buildConfiguredImage(
-					flinkDistName,
 					workersFile,
 					baseImage);
 
@@ -281,21 +280,19 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 					numTaskManagers,
 					logBackupDirectory.orElse(null));
 			} catch (Exception e) {
-				throw new RuntimeException("Could not build the flink-dist image", e);
-			} finally {
 				temporaryFolder.delete();
+				throw new RuntimeException("Could not build the flink-dist image", e);
 			}
 		}
 
 		private ImageFromDockerfile buildConfiguredImage(
-				String flinkDistName,
 				Path workersFile,
 				String baseImage) {
 			return new ImageFromDockerfile(
 				"flink-dist-configured")
 				.withDockerfileFromBuilder(
 					builder -> builder.from(baseImage)
-						.copy("workers", flinkDistName + "/conf/workers")
+						.copy("workers", "flink/conf/workers")
 						.cmd(FLINK_BIN + "/start-cluster.sh && tail -f /dev/null")
 						.build()
 				)

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
@@ -248,7 +248,6 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 		public FlinkContainer build() {
 			try {
 				Path flinkDist = FileUtils.findFlinkDist();
-				String flinkDistName = flinkDist.getFileName().toString();
 				temporaryFolder.create();
 				Path tmp = temporaryFolder.newFolder().toPath();
 				Path workersFile = tmp.resolve("workers");
@@ -264,7 +263,7 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 				//
 				// This lets us save some time for archiving and copying big, immutable files
 				// between tests runs.
-				String baseImage = buildBaseImage(flinkDist, flinkDistName);
+				String baseImage = buildBaseImage(flinkDist);
 				ImageFromDockerfile configuredImage = buildConfiguredImage(
 					workersFile,
 					baseImage);
@@ -300,9 +299,7 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 		}
 
 		@Nonnull
-		private String buildBaseImage(
-					Path flinkDist,
-					String flinkDistName)
+		private String buildBaseImage(Path flinkDist)
 				throws java.util.concurrent.TimeoutException {
 			String baseImage = "flink-dist-base";
 			if (!imageExists(baseImage)) {
@@ -310,10 +307,10 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 					.withDockerfileFromBuilder(
 						builder -> builder
 							.from("openjdk:" + getJavaVersionSuffix())
-							.copy(flinkDistName, "flink")
+							.copy("flink", "flink")
 							.build()
 					)
-					.withFileFromPath(flinkDistName, flinkDist)
+					.withFileFromPath("flink", flinkDist)
 					.get(1, TimeUnit.MINUTES);
 			}
 			return baseImage;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkContainer.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessin
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.NotFoundException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.junit.rules.TemporaryFolder;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -243,7 +245,7 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 			return this;
 		}
 
-		public FlinkContainer build() throws IOException {
+		public FlinkContainer build() {
 			try {
 				Path flinkDist = FileUtils.findFlinkDist();
 				String flinkDistName = flinkDist.getFileName().toString();
@@ -256,18 +258,17 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 						.mapToObj(i -> "localhost")
 						.collect(Collectors.toList()));
 
-				ImageFromDockerfile image = new ImageFromDockerfile("flink-dist", true)
-					.withDockerfileFromBuilder(
-						builder -> {
-							builder.from("openjdk:" + getJavaVersionSuffix())
-								.copy(flinkDistName, "flink")
-								.copy(flinkDistName + "/conf/workers", "workers")
-								.cmd(FLINK_BIN + "/start-cluster.sh && tail -f /dev/null")
-								.build();
-						}
-					)
-					.withFileFromPath("workers", workersFile)
-					.withFileFromPath(flinkDistName, flinkDist);
+				// Building the docker image is split into two stages:
+				// 1. build a base image with an immutable flink-dist
+				// 2. based on the base image add any mutable files such as e.g. workers files
+				//
+				// This lets us save some time for archiving and copying big, immutable files
+				// between tests runs.
+				String baseImage = buildBaseImage(flinkDist, flinkDistName);
+				ImageFromDockerfile configuredImage = buildConfiguredImage(
+					flinkDistName,
+					workersFile,
+					baseImage);
 
 				Optional<Path> logBackupDirectory = DISTRIBUTION_LOG_BACKUP_DIRECTORY.get();
 				if (!logBackupDirectory.isPresent()) {
@@ -275,9 +276,62 @@ public class FlinkContainer extends GenericContainer<FlinkContainer> implements 
 						"Property {} not set, logs will not be backed up in case of test failures.",
 						DISTRIBUTION_LOG_BACKUP_DIRECTORY.getPropertyName());
 				}
-				return new FlinkContainer(image, numTaskManagers, logBackupDirectory.orElse(null));
+				return new FlinkContainer(
+					configuredImage,
+					numTaskManagers,
+					logBackupDirectory.orElse(null));
+			} catch (Exception e) {
+				throw new RuntimeException("Could not build the flink-dist image", e);
 			} finally {
 				temporaryFolder.delete();
+			}
+		}
+
+		private ImageFromDockerfile buildConfiguredImage(
+				String flinkDistName,
+				Path workersFile,
+				String baseImage) {
+			return new ImageFromDockerfile(
+				"flink-dist-configured")
+				.withDockerfileFromBuilder(
+					builder -> builder.from(baseImage)
+						.copy("workers", flinkDistName + "/conf/workers")
+						.cmd(FLINK_BIN + "/start-cluster.sh && tail -f /dev/null")
+						.build()
+				)
+				.withFileFromPath("workers", workersFile);
+		}
+
+		@Nonnull
+		private String buildBaseImage(
+					Path flinkDist,
+					String flinkDistName)
+				throws java.util.concurrent.TimeoutException {
+			String baseImage = "flink-dist-base";
+			if (!imageExists(baseImage)) {
+				new ImageFromDockerfile(baseImage)
+					.withDockerfileFromBuilder(
+						builder -> builder
+							.from("openjdk:" + getJavaVersionSuffix())
+							.copy(flinkDistName, "flink")
+							.build()
+					)
+					.withFileFromPath(flinkDistName, flinkDist)
+					.get(1, TimeUnit.MINUTES);
+			}
+			return baseImage;
+		}
+
+		private boolean imageExists(String baseImage) {
+			try {
+				DockerClientFactory
+					.instance()
+					.client()
+					.inspectImageCmd(baseImage)
+					.exec();
+				return true;
+			} catch (NotFoundException e) {
+				return false;
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

The `SQLClientSchemaRegistryITCase` hanged on azure. I added timeouts to the test in order to fail more gracefully in case of taking excessive amount of time. I hope this will give us a bit more contextual info if it fails again, as the logs from the failure we had does not give us any hint.

## Brief change log

* I split creation of the Flink container image to two separate stages to speed it up a bit. Copying the flink-dist into the docker image takes some time, but at the same time it is immutable across runs.
* Added timeouts to test methods, as well as a global for the entire `SQLClientSchemaRegistryITCase` class.


## Verifying this change

This change improves a test.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
