### PR TITLE
[FLINK-20418][core] Fixing checkpointing of IteratorSourceReader.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
@@ -129,8 +130,12 @@ public class IteratorSourceReader<E, IterT extends Iterator<E>, SplitT extends I
 
 	@Override
 	public List<SplitT> snapshotState(long checkpointId) {
+		if (remainingSplits == null) {
+			// no assignment yet
+			return Collections.emptyList();
+		}
 		final ArrayList<SplitT> allSplits = new ArrayList<>(1 + remainingSplits.size());
-		if (iterator != null) {
+		if (iterator != null && iterator.hasNext()) {
 			@SuppressWarnings("unchecked")
 			final SplitT inProgressSplit = (SplitT) currentSplit.getUpdatedSplitForIterator(iterator);
 			allSplits.add(inProgressSplit);

--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source.lib;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.StreamCollector;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Tests {@link NumberSequenceSource}.
+ */
+public class NumberSequenceSourceITCase {
+	@Rule
+	public StreamCollector collector = new StreamCollector();
+
+	@Test
+	public void testCheckpointingWithDelayedAssignment() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.setRestartStrategy(new RestartStrategies.NoRestartStrategyConfiguration());
+		env.enableCheckpointing(10, CheckpointingMode.EXACTLY_ONCE);
+		final SingleOutputStreamOperator<Long> stream = env
+			.fromSequence(0, 100)
+			.map(x -> {
+				Thread.sleep(10);
+				return x;
+			});
+		final CompletableFuture<Collection<Long>> result = collector.collect(stream);
+		env.execute();
+
+		assertArrayEquals(LongStream.rangeClosed(0, 100).boxed().toArray(), result.get().toArray());
+	}
+}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

IteratorSourceReader fails checkpointing when assignment has not yet happened with NPE.
Furthermore, if the last element of a split has been pulled just before checkpointing, then a split would be created with (to+1, to) leading to an IllegalArgumentException: 'from' must be <= 'to'.

## Brief change log

- Fixed checkpointing of IteratorSourceReader.

## Verifying this change

Added ITCase in flink-tests (since we cannot really test checkpointing integration in flink-core).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
