### PR TITLE
[FLINK-20315][doc] Optimize the compaction document to warn users about backpressure

### DIFF
--- a/docs/dev/table/connectors/filesystem.md
+++ b/docs/dev/table/connectors/filesystem.md
@@ -186,6 +186,7 @@ If enabled, file compaction will merge multiple small files into larger files ba
 When running file compaction in production, please be aware that:
 - Only files in a single checkpoint are compacted, that is, at least the same number of files as the number of checkpoints is generated.
 - The file before merging is invisible, so the visibility of the file may be: checkpoint interval + compaction time.
+- If the compaction takes too long, it will backpressure the job and extend the time period of checkpoint.
 
 ### Partition Commit
 

--- a/docs/dev/table/connectors/filesystem.zh.md
+++ b/docs/dev/table/connectors/filesystem.zh.md
@@ -186,6 +186,7 @@ If enabled, file compaction will merge multiple small files into larger files ba
 When running file compaction in production, please be aware that:
 - Only files in a single checkpoint are compacted, that is, at least the same number of files as the number of checkpoints is generated.
 - The file before merging is invisible, so the visibility of the file may be: checkpoint interval + compaction time.
+- If the compaction takes too long, it will backpressure the job and extend the time period of checkpoint.
 
 ### Partition Commit
 


### PR DESCRIPTION
Since if the files are big and the compaction use too much time, it will backpressure the job and also extend the time period of checkpoint, we might explicitly warns users about the possibility of this case to avoid perplexity.