### PR TITLE
[FLINK-20431][connector/kafka] Fix the offsets commit in KafkaSourceReader when the SplitFetcher shuts down.

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -69,7 +69,7 @@ public class KafkaSourceFetcherManager<T>
 		if (offsetsToCommit.isEmpty()) {
 			return;
 		}
-		SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = fetchers.get(0);
+		SplitFetcher<Tuple3<T, Long, Long>, KafkaPartitionSplit> splitFetcher = getRunningFetcher();
 		if (splitFetcher != null) {
 			// The fetcher thread is still running. This should be the majority of the cases.
 			enqueueOffsetsCommitTask(splitFetcher, offsetsToCommit, callback);


### PR DESCRIPTION
## What is the purpose of the change
The patch fixes a bug that the `KafkaPartitionSplitFetcher` does not finish the pending offsets commit when the contained `KafkaConsumer` exits. This is actually a bug in KafkaConsumer but we need to handle it for now.

The previous test tries to play a trick so that the unit test passes. We should have handled this correctly in the `KafkaPartitionSplitFetcher` instead.

The patch also fixes the reported instability of the `KafkaSourceReaderTest.testCommitOffsetsWithoutAliveFetchers()`.

## Brief change log
The patch tracks all the pending async commit and commit them when the `KafkaPartitionSplitFetcher` exits.

## Verifying this change
The following unit tests have been added to verify the change.
`KafkaPartitionSplitReaderTest.testFinishPendingOffsetsCommitOnClose()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
