### PR TITLE
[FLINK-20464] Some Table examples are not built correctly

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -280,12 +280,12 @@ under the License.
 
 							<archive>
 								<manifestEntries>
-									<program-class>org.apache.flink.table.examples.scala.StreamTableExample</program-class>
+									<program-class>org.apache.flink.table.examples.scala.basics.StreamTableExample</program-class>
 								</manifestEntries>
 							</archive>
 
 							<includes>
-								<include>org/apache/flink/table/examples/scala/StreamTableExample*</include>
+								<include>org/apache/flink/table/examples/scala/basics/StreamTableExample*</include>
 							</includes>
 						</configuration>
 					</execution>
@@ -302,12 +302,12 @@ under the License.
 
 							<archive>
 								<manifestEntries>
-									<program-class>org.apache.flink.table.examples.scala.TPCHQuery3Table</program-class>
+									<program-class>org.apache.flink.table.examples.scala.basics.TPCHQuery3Table</program-class>
 								</manifestEntries>
 							</archive>
 
 							<includes>
-								<include>org/apache/flink/table/examples/scala/TPCHQuery3Table*</include>
+								<include>org/apache/flink/table/examples/scala/basics/TPCHQuery3Table*</include>
 							</includes>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

Fixes the Table examples that were built incorrectly.


## Verifying this change

Run the examples.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
