### PR TITLE
[hotfix][hbase] Fix NOTICE file of hbase 2.2

### DIFF
--- a/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
@@ -7,15 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
  - commons-codec:commons-codec:1.13
- - commons-lang:commons-lang:2.6
  - io.netty:netty-all:4.1.44.Final
  - io.dropwizard.metrics:metrics-core:3.2.6
  - org.apache.commons:commons-crypto:1.0.0
  - org.apache.commons:commons-lang3:3.3.2
  - org.apache.hbase:hbase-client:2.2.3
  - org.apache.hbase:hbase-common:2.2.3
- - org.apache.hbase:hbase-hadoop-compat:2.2.3
- - org.apache.hbase:hbase-hadoop2-compat:2.2.3
  - org.apache.hbase:hbase-protocol:2.2.3
  - org.apache.hbase:hbase-protocol-shaded:2.2.3
  - org.apache.hbase.thirdparty:hbase-shaded-protobuf:2.2.1


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the NOTICE file of hbase 2.2*


## Brief change log

  - *Remove three dependencies listed in NOTICE file*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
