### PR TITLE
[FLINK-20404][zookeeper] Disable JMX log4j integration

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/zookeeper.sh
+++ b/flink-dist/src/main/flink-bin/bin/zookeeper.sh
@@ -58,6 +58,9 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     args=("--zkConfigFile" "${ZK_CONF}" "--peerId" "${PEER_ID}")
 fi
 
+# the JMX log4j integration in ZK 3.4 does not work log4j 2
+export JVM_ARGS="$JVM_ARGS -Dzookeeper.jmx.log4j.disable=true"
+
 if [[ $STARTSTOP == "start-foreground" ]]; then
     "${FLINK_BIN_DIR}"/flink-console.sh zookeeper "${args[@]}"
 else


### PR DESCRIPTION
This PR disables the Zookeeper JMX log4j integration, which allows users to change the log4j settings via JMX.
The ZK 3.4 implementation has a hard requirement on log4j 1, which we no longer use by default.
This results in zookeeper not starting up successfully if multiple quorum peers are configured.