### PR TITLE
[FLINK-20485][table] Improve performance of data views

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
@@ -25,7 +25,9 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.dataview.DataView;
 import org.apache.flink.table.api.dataview.ListView;
 import org.apache.flink.table.api.dataview.MapView;
+import org.apache.flink.table.data.binary.LazyBinaryFormat;
 import org.apache.flink.table.dataview.NullSerializer;
+import org.apache.flink.table.runtime.typeutils.ExternalSerializer;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
@@ -43,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldNames;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasNested;
@@ -99,10 +102,21 @@ public final class DataViewUtils {
 	}
 
 	/**
-	 * Adapts the data type of an accumulator regarding data views.
+	 * Modifies the data type of an accumulator regarding data views.
+	 *
+	 * <p>For performance reasons, each data view is wrapped into a RAW type which gives it {@link LazyBinaryFormat}
+	 * semantics and avoids multiple deserialization steps during access. Furthermore, a data view will
+	 * not be serialized if a state backend is used (the serializer of the RAW type will be a {@link NullSerializer}
+	 * in this case).
 	 */
-	public static DataType replaceDataViewsWithNull(DataType accumulatorDataType) {
-		return DataTypeUtils.transform(accumulatorDataType, DataViewsTransformation.INSTANCE);
+	public static DataType adjustDataViews(DataType accumulatorDataType, boolean hasStateBackedDataViews) {
+		final Function<DataType, TypeSerializer<?>> serializer;
+		if (hasStateBackedDataViews) {
+			serializer = dataType -> NullSerializer.INSTANCE;
+		} else {
+			serializer = ExternalSerializer::of;
+		}
+		return DataTypeUtils.transform(accumulatorDataType, new DataViewsTransformation(serializer));
 	}
 
 	/**
@@ -143,13 +157,19 @@ public final class DataViewUtils {
 
 	private static class DataViewsTransformation implements TypeTransformation {
 
-		static final DataViewsTransformation INSTANCE = new DataViewsTransformation();
+		private Function<DataType, TypeSerializer<?>> serializer;
+
+		private DataViewsTransformation(Function<DataType, TypeSerializer<?>> serializer) {
+			this.serializer = serializer;
+		}
 
 		@Override
 		@SuppressWarnings({"unchecked", "rawtypes"})
 		public DataType transform(DataType dataType) {
 			if (isDataView(dataType.getLogicalType(), DataView.class)) {
-				return DataTypes.RAW(dataType.getConversionClass(), (TypeSerializer)  NullSerializer.INSTANCE);
+				return DataTypes.RAW(
+					dataType.getConversionClass(),
+					(TypeSerializer) serializer.apply(dataType));
 			}
 			return dataType;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
@@ -301,16 +301,8 @@ public final class DataViewUtils {
 	 */
 	public static class DistinctViewSpec extends MapViewSpec {
 
-		// stores the entire view data type for off-heap operations
-		private final DataType distinctViewDataType;
-
 		public DistinctViewSpec(String stateId, DataType distinctViewDataType) {
 			super(stateId, -1, distinctViewDataType.getChildren().get(0), true); // handles null keys
-			this.distinctViewDataType = distinctViewDataType;
-		}
-
-		public DataType getDistinctViewDataType() {
-			return distinctViewDataType;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/DataViewUtils.java
@@ -157,7 +157,7 @@ public final class DataViewUtils {
 
 	private static class DataViewsTransformation implements TypeTransformation {
 
-		private Function<DataType, TypeSerializer<?>> serializer;
+		private final Function<DataType, TypeSerializer<?>> serializer;
 
 		private DataViewsTransformation(Function<DataType, TypeSerializer<?>> serializer) {
 			this.serializer = serializer;

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -474,11 +474,8 @@ object AggregateUtil extends Enumeration {
     } else {
       Array()
     }
-    val adjustedAccumulatorDataType = if (hasStateBackedDataViews) {
-      DataViewUtils.replaceDataViewsWithNull(accumulatorDataType)
-    } else {
-      accumulatorDataType
-    }
+    val adjustedAccumulatorDataType =
+      DataViewUtils.adjustDataViews(accumulatorDataType, hasStateBackedDataViews)
 
     AggregateInfo(
         call,
@@ -677,11 +674,8 @@ object AggregateUtil extends Enumeration {
       } else {
         None
       }
-      val adjustedAccumulatorDataType = if (hasStateBackedDataViews) {
-        DataViewUtils.replaceDataViewsWithNull(distinctViewDataType)
-      } else {
-        distinctViewDataType
-      }
+      val adjustedAccumulatorDataType =
+        DataViewUtils.adjustDataViews(distinctViewDataType, hasStateBackedDataViews)
 
       DistinctInfo(
         d.argIndexes,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
@@ -212,7 +212,9 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
 
 	@Override
 	public ArrayData deserialize(ArrayData reuse, DataInputView source) throws IOException {
-		return deserializeReuse(reuse instanceof GenericArrayData ? new BinaryArrayData() : (BinaryArrayData) reuse, source);
+		return deserializeReuse(
+			reuse instanceof BinaryArrayData ? (BinaryArrayData) reuse : new BinaryArrayData(),
+			source);
 	}
 
 	private BinaryArrayData deserializeReuse(BinaryArrayData reuse, DataInputView source) throws IOException {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
@@ -180,7 +180,9 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
 
 	@Override
 	public MapData deserialize(MapData reuse, DataInputView source) throws IOException {
-		return deserializeReuse(reuse instanceof GenericMapData ? new BinaryMapData() : (BinaryMapData) reuse, source);
+		return deserializeReuse(
+			reuse instanceof BinaryMapData ? (BinaryMapData) reuse : new BinaryMapData(),
+			source);
 	}
 
 	private BinaryMapData deserializeReuse(BinaryMapData reuse, DataInputView source) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

This improves the performance when using map views in aggregate functions with retraction and distinct aggregates.

## Brief change log

- It reduces the deserialization overhead by using a lazy binary format.
- It reuses internal data structures during deserialization from bytes to external data structure (e.g. required for deduplicating map views using regular Java `Map`).

## Verifying this change

Manually benchmarked using the following test in `AggregateITCase` with LocalGlobal=ON, MiniBatch=ON, HEAP:

```
  @Test
  def testPerf(): Unit = {
    tEnv.executeSql(
      s"""
         |CREATE TABLE datagen (a INT, b BIGINT, c STRING) WITH (
         | 'connector'='datagen',
         | 'rows-per-second'='500000',
         | 'number-of-rows'='1000000',
         | 'fields.a.kind' = 'random',
         | 'fields.a.min' = '1',
         | 'fields.a.max' = '10000',
         | 'fields.b.min' = '1',
         | 'fields.b.max' = '100000',
         | 'fields.c.length' = '1000'
         |)
         |""".stripMargin)

    val sqlQuery =
      "SELECT b, " +
        "  SUM(DISTINCT (a * 3)), " +
        "  COUNT(DISTINCT SUBSTRING(c FROM 1 FOR 2))," +
        "  MAX(DISTINCT a), " +
        "  MIN(DISTINCT b), " +
        "  MAX(a), " +
        "  MIN(b), " +
        "  COUNT(DISTINCT c) " +
        "FROM datagen " +
        "GROUP BY b"

    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
    result.addSink(new DiscardingSink[(Boolean, Row)])
    env.execute()
  }
```

The performance shows similar number that 1.11 or slightly better.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
