### PR TITLE
[FLINK-20475][doc] Fix the broken links in gettingStarted.zh.md

### DIFF
--- a/docs/dev/table/sql/gettingStarted.zh.md
+++ b/docs/dev/table/sql/gettingStarted.zh.md
@@ -34,7 +34,7 @@ You only need to have basic knowledge of SQL to follow along. No other programmi
 
 ### Installation
 
-There are multiple ways to install Flink. For experimentation, the most common option is to download the binaries and run them locally. You can follow the steps in [local nstallation]({%link try-flink/local_installation.md %}) to set up an environment for the rest of the tutorial. 
+There are multiple ways to install Flink. For experimentation, the most common option is to download the binaries and run them locally. You can follow the steps in [local nstallation]({%link try-flink/local_installation.zh.md %}) to set up an environment for the rest of the tutorial. 
 
 Once you're all set, use the following command to start a local cluster from the installation folder:
 
@@ -46,7 +46,7 @@ Once started, the Flink WebUI on [localhost:8081](localhost:8081) is available l
 
 ### SQL Client
 
-The [SQL Client]({% link dev/table/sqlClient.md %}) is an interactive client to submit SQL queries to Flink and visualize the results. 
+The [SQL Client]({% link dev/table/sqlClient.zh.md %}) is an interactive client to submit SQL queries to Flink and visualize the results. 
 To start the SQL client, run the `sql-client` script from the installation folder.
 
  {% highlight bash %}
@@ -62,7 +62,7 @@ Let's start with printing 'Hello World', using the following simple query:
 SELECT 'Hello World';
 {% endhighlight %}
 
-Running the `HELP` command lists the full set of supported SQL statements. Let's run one such command, `SHOW`, to see a full list of Flink [built-in functions]({% link dev/table/functions/systemFunctions.md %}).
+Running the `HELP` command lists the full set of supported SQL statements. Let's run one such command, `SHOW`, to see a full list of Flink [built-in functions]({% link dev/table/functions/systemFunctions.zh.md %}).
 
 {% highlight sql %}
 SHOW FUNCTIONS;
@@ -88,7 +88,7 @@ Flink data processing pipelines begin with source tables. Source tables produce 
 
 Tables can be defined through the SQL client or using environment config file. The SQL client support [SQL DDL commands]({{ site.baseurl }}/dev/table/sql) similar to traditional SQL. Standard SQL DDL is used to [create]({{ site.baseurl }}/dev/table/sql/create.html), [alter]({{ site.baseurl }}/dev/table/sql/alter.html), [drop]({{ site.baseurl }}/dev/table/sql/drop.html) tables. 
 
-Flink has a support for different [connectors]({% link dev/table/connect.md %}) and [formats]({%link dev/table/connectors/formats/index.md %}) that can be used with tables. Following is an example to define a source table backed by a [CSV file]({%link dev/table/connectors/formats/csv.md %}) with `emp_id`, `name`, `dept_id` as columns in a `CREATE` table statement.
+Flink has a support for different [connectors]({% link dev/table/connect.zh.md %}) and [formats]({%link dev/table/connectors/formats/index.zh.md %}) that can be used with tables. Following is an example to define a source table backed by a [CSV file]({%link dev/table/connectors/formats/csv.zh.md %}) with `emp_id`, `name`, `dept_id` as columns in a `CREATE` table statement.
 
 {% highlight sql %}
 CREATE TABLE employee_information (


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the broken links in gettingStarted.zh.md*


## Brief change log

  - *Fix the broken links in gettingStarted.zh.md*

## Verifying this change

 - *Executing the script `build_docs.sh`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
