### PR TITLE
[FLINK-20492][runtime] Add implementations of cancelTask() and finish…

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -41,7 +41,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
 	private int currentSplitIndex = 0;
 	private boolean started;
-	private boolean closed;
+	private int timesClosed;
 	private boolean waitingForMoreSplits;
 
 	@GuardedBy("this")
@@ -53,7 +53,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
 	public MockSourceReader(boolean waitingForMoreSplits, boolean markIdleOnNoSplits) {
 		this.started = false;
-		this.closed = false;
+		this.timesClosed = 0;
 		this.availableFuture = CompletableFuture.completedFuture(null);
 		this.waitingForMoreSplits = waitingForMoreSplits;
 		this.markIdleOnNoSplits = markIdleOnNoSplits;
@@ -115,7 +115,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
 	@Override
 	public void close() throws Exception {
-		this.closed = true;
+		timesClosed++;
 	}
 
 	@Override
@@ -158,7 +158,11 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 	}
 
 	public boolean isClosed() {
-		return closed;
+		return timesClosed > 0;
+	}
+
+	public int getTimesClosed() {
+		return timesClosed;
 	}
 
 	public List<MockSourceSplit> getAssignedSplits() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -231,13 +231,24 @@ public class SourceOperator<OUT, SplitT extends SourceSplit>
 
 	@Override
 	public void close() throws Exception {
-		if (sourceReader != null) {
-			sourceReader.close();
-		}
 		if (eventTimeLogic != null) {
 			eventTimeLogic.stopPeriodicWatermarkEmits();
 		}
+		if (sourceReader != null) {
+			sourceReader.close();
+			// Set the field to null so the reader won't be closed again in dispose().
+			sourceReader = null;
+		}
 		super.close();
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		// We also need to close the source reader to make sure the resources
+		// are released if the task does not finish normally.
+		if (sourceReader != null) {
+			sourceReader.close();
+		}
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -59,6 +59,11 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 	}
 
 	@Override
+	protected CompletableFuture<Void> getCompletionFuture() {
+		return super.getCompletionFuture();
+	}
+
+	@Override
 	public void init() throws Exception {
 		final SourceOperator<T, ?> sourceOperator = this.mainOperator;
 		// reader initialization, which cannot happen in the constructor due to the

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -91,6 +91,7 @@ public class SourceOperatorTest {
 	@After
 	public void cleanUp() throws Exception {
 		operator.close();
+		operator.dispose();
 		assertTrue(mockSourceReader.isClosed());
 	}
 
@@ -175,6 +176,17 @@ public class SourceOperatorTest {
 		operator.snapshotState(new StateSnapshotContextSynchronousImpl(100L, 100L));
 		operator.notifyCheckpointAborted(100L);
 		assertEquals(100L, (long) mockSourceReader.getAbortedCheckpoints().get(0));
+	}
+
+	@Test
+	public void testDisposeAfterCloseOnlyClosesReaderOnce() throws Exception {
+		// Initialize the operator.
+		operator.initializeState(getStateContext());
+		// Open the operator.
+		operator.open();
+		operator.close();
+		operator.dispose();
+		assertEquals(1, mockSourceReader.getTimesClosed());
 	}
 
 	// ---------------- helper methods -------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -200,6 +200,9 @@ public class SourceOperatorStreamTaskTest {
 		// checkpoint is completed will block.
 		getSourceReaderFromTask(testHarness).markAvailable();
 		processUntil(testHarness, checkpointFuture::isDone);
+		Future<Void> checkpointNotified =
+			testHarness.getStreamTask().notifyCheckpointCompleteAsync(checkpointId);
+		processUntil(testHarness, checkpointNotified::isDone);
 		waitForAcknowledgeLatch.await();
 	}
 


### PR DESCRIPTION
…Task() to SourceOperatorStreamTask.

## What is the purpose of the change
The `SourceOperatorStreamTask` does not implement `cancelTask()` and `finishTask()` at this point. This causes resource leak on job cancellation or when job is stopped with savepoint.

## Brief change log
Add implementation of `cancelTask()` and `finishTask()` to the `SourceOperatorStreamTask`.

## Verifying this change
The following two unit tests has been added to the `SourceOperatorStreamTask`.
`testCancelTaskClosesTheSourceOperator()`
`testStopTaskWithSavepointClosesTheSourceOperator()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
