### PR TITLE
[FLINK-20470]MissingNode can't be casted to ObjectNode when deserializing JSON

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.MissingNode;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -90,7 +89,7 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
 		this.failOnMissingField = failOnMissingField;
 		this.ignoreParseErrors = ignoreParseErrors;
 		this.runtimeConverter = new JsonToRowDataConverters(failOnMissingField, ignoreParseErrors, timestampFormat)
-			.createRowConverter(checkNotNull(rowType));
+			.createConverter(checkNotNull(rowType));
 		this.timestampFormat = timestampFormat;
 		boolean hasDecimalType = LogicalTypeChecks.hasNested(rowType, t -> t instanceof DecimalType);
 		if (hasDecimalType) {
@@ -102,9 +101,6 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
 	public RowData deserialize(byte[] message) throws IOException {
 		try {
 			final JsonNode root = objectMapper.readTree(message);
-			if (root instanceof MissingNode) {
-				return null;
-			}
 			return (RowData) runtimeConverter.convert(root);
 		} catch (Throwable t) {
 			if (ignoreParseErrors) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.MissingNode;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -101,6 +102,9 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
 	public RowData deserialize(byte[] message) throws IOException {
 		try {
 			final JsonNode root = objectMapper.readTree(message);
+			if (root instanceof MissingNode) {
+				return null;
+			}
 			return (RowData) runtimeConverter.convert(root);
 		} catch (Throwable t) {
 			if (ignoreParseErrors) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.MissingNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.TextNode;
 
@@ -106,7 +107,7 @@ public class JsonToRowDataConverters implements Serializable {
 	/**
 	 * Creates a runtime converter which is null safe.
 	 */
-	private JsonToRowDataConverter createConverter(LogicalType type) {
+	public JsonToRowDataConverter createConverter(LogicalType type) {
 		return wrapIntoNullableConverter(createNotNullConverter(type));
 	}
 
@@ -368,7 +369,7 @@ public class JsonToRowDataConverters implements Serializable {
 	private JsonToRowDataConverter wrapIntoNullableConverter(
 		JsonToRowDataConverter converter) {
 		return jsonNode -> {
-			if (jsonNode == null || jsonNode.isNull()) {
+			if (jsonNode == null || jsonNode.isNull() || jsonNode instanceof MissingNode) {
 				return null;
 			}
 			try {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -40,7 +40,6 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.MissingNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.TextNode;
 
@@ -369,7 +368,7 @@ public class JsonToRowDataConverters implements Serializable {
 	private JsonToRowDataConverter wrapIntoNullableConverter(
 		JsonToRowDataConverter converter) {
 		return jsonNode -> {
-			if (jsonNode == null || jsonNode.isNull() || jsonNode instanceof MissingNode) {
+			if (jsonNode == null || jsonNode.isNull() || jsonNode.isMissingNode()) {
 				return null;
 			}
 			try {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -351,6 +351,17 @@ public class JsonRowDataSerDeSchemaTest {
 
 	@Test
 	public void testDeserializationMissingNode() throws Exception {
+		DataType dataType = ROW(FIELD("name", STRING()));
+		RowType schema = (RowType) dataType.getLogicalType();
+
+		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
+			schema, InternalTypeInfo.of(schema), false, false, TimestampFormat.ISO_8601);
+		RowData rowData = deserializationSchema.deserialize("".getBytes());
+		assertEquals(null, rowData);
+	}
+
+	@Test
+	public void testDeserializationMissingField() throws Exception {
 		ObjectMapper objectMapper = new ObjectMapper();
 
 		// Root

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -355,7 +355,7 @@ public class JsonRowDataSerDeSchemaTest {
 		RowType schema = (RowType) dataType.getLogicalType();
 
 		JsonRowDataDeserializationSchema deserializationSchema = new JsonRowDataDeserializationSchema(
-			schema, InternalTypeInfo.of(schema), false, false, TimestampFormat.ISO_8601);
+			schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
 		RowData rowData = deserializationSchema.deserialize("".getBytes());
 		assertEquals(null, rowData);
 	}


### PR DESCRIPTION

## What is the purpose of the change

*add check for MissingNode when deserializing JSON*


## Brief change log

  - *add check for MissingNode when deserializing JSON*



## Verifying this change


This change added tests and can be verified as follows:

*(example:)*
  - *testDeserializationMissingNode*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)no
