### PR TITLE
[FLINK-20273][table/kafka] Fix the Kafka round-robin behaviour when keys are specified

### DIFF
--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -527,9 +527,9 @@ See more about how to use the CDC formats in [debezium-json]({% link dev/table/c
 ### Sink Partitioning
 
 The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions.
-By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records.
-It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
-In order to control the routing of rows into partitions, a custom sink partitioner can be provided. The 'fixed' partitioner will write the records in the same Flink partition into the same partition, which could reduce the cost of the network connections.
+By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records. It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
+
+In order to control the routing of rows into partitions, a custom sink partitioner can be provided. The 'fixed' partitioner will write the records in the same Flink partition into the same Kafka partition, which could reduce the cost of the network connections.
 
 ### Consistency guarantees
 

--- a/docs/dev/table/connectors/kafka.md
+++ b/docs/dev/table/connectors/kafka.md
@@ -333,14 +333,16 @@ Connector Options
     <tr>
       <td><h5>sink.partitioner</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">'default'</td>
       <td>String</td>
       <td>Output partitioning from Flink's partitions into Kafka's partitions. Valid values are
       <ul>
+        <li><code>default</code>: use the kafka default partitioner to partition records.</li>
         <li><code>fixed</code>: each Flink partition ends up in at most one Kafka partition.</li>
-        <li><code>round-robin</code>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+        <li><code>round-robin</code>: a Flink partition is distributed to Kafka partitions sticky round-robin. It only works when record's keys are not specified.</li>
         <li>Custom <code>FlinkKafkaPartitioner</code> subclass: e.g. <code>'org.mycompany.MyPartitioner'</code>.</li>
       </ul>
+      See the following <a href="#sink-partitioning">Sink Partitioning</a> for more details.
       </td>
     </tr>
     <tr>
@@ -525,9 +527,9 @@ See more about how to use the CDC formats in [debezium-json]({% link dev/table/c
 ### Sink Partitioning
 
 The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions.
-By default, a Kafka sink writes to at most as many partitions as its own parallelism (each parallel instance of the sink writes to exactly one partition).
-In order to distribute the writes to more partitions or control the routing of rows into partitions, a custom sink partitioner can be provided. The `round-robin` partitioner is useful to avoid an unbalanced partitioning.
-However, it will cause a lot of network connections between all the Flink instances and all the Kafka brokers.
+By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records.
+It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
+In order to control the routing of rows into partitions, a custom sink partitioner can be provided. The 'fixed' partitioner will write the records in the same Flink partition into the same partition, which could reduce the cost of the network connections.
 
 ### Consistency guarantees
 

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -333,14 +333,16 @@ Connector Options
     <tr>
       <td><h5>sink.partitioner</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">'default'</td>
       <td>String</td>
       <td>Output partitioning from Flink's partitions into Kafka's partitions. Valid values are
       <ul>
+        <li><code>default</code>: use the kafka default partitioner to partition records.</li>
         <li><code>fixed</code>: each Flink partition ends up in at most one Kafka partition.</li>
-        <li><code>round-robin</code>: a Flink partition is distributed to Kafka partitions round-robin.</li>
+        <li><code>round-robin</code>: a Flink partition is distributed to Kafka partitions sticky round-robin. It only works when record's keys are not specified.</li>
         <li>Custom <code>FlinkKafkaPartitioner</code> subclass: e.g. <code>'org.mycompany.MyPartitioner'</code>.</li>
       </ul>
+      See the following <a href="#sink-partitioning">Sink Partitioning</a> for more details.
       </td>
     </tr>
     <tr>
@@ -526,9 +528,9 @@ See more about how to use the CDC formats in [debezium-json]({% link dev/table/c
 ### Sink Partitioning
 
 The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions.
-By default, a Kafka sink writes to at most as many partitions as its own parallelism (each parallel instance of the sink writes to exactly one partition).
-In order to distribute the writes to more partitions or control the routing of rows into partitions, a custom sink partitioner can be provided. The `round-robin` partitioner is useful to avoid an unbalanced partitioning.
-However, it will cause a lot of network connections between all the Flink instances and all the Kafka brokers.
+By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records.
+It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
+In order to control the routing of rows into partitions, a custom sink partitioner can be provided. The 'fixed' partitioner will write the records in the same Flink partition into the same partition, which could reduce the cost of the network connections.
 
 ### Consistency guarantees
 

--- a/docs/dev/table/connectors/kafka.zh.md
+++ b/docs/dev/table/connectors/kafka.zh.md
@@ -528,8 +528,8 @@ See more about how to use the CDC formats in [debezium-json]({% link dev/table/c
 ### Sink Partitioning
 
 The config option `sink.partitioner` specifies output partitioning from Flink's partitions into Kafka's partitions.
-By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records.
-It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
+By default, Flink uses the [Kafka default partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java) to parititon records. It uses the [sticky partition strategy](https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/) for records with null keys and uses a murmur2 hash to compute the partition for a record with the key defined.
+
 In order to control the routing of rows into partitions, a custom sink partitioner can be provided. The 'fixed' partitioner will write the records in the same Flink partition into the same partition, which could reduce the cost of the network connections.
 
 ### Consistency guarantees

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -176,11 +176,12 @@ public class KafkaOptions {
 	public static final ConfigOption<String> SINK_PARTITIONER = ConfigOptions
 			.key("sink.partitioner")
 			.stringType()
-			.noDefaultValue()
+			.defaultValue("default")
 			.withDescription("Optional output partitioning from Flink's partitions\n"
 					+ "into Kafka's partitions valid enumerations are\n"
+					+ "\"default\": (use kafka default partitioner to partition records),\n"
 					+ "\"fixed\": (each Flink partition ends up in at most one Kafka partition),\n"
-					+ "\"round-robin\": (a Flink partition is distributed to Kafka partitions round-robin)\n"
+					+ "\"round-robin\": (a Flink partition is distributed to Kafka partitions round-robin when 'key.fields' is not specified.)\n"
 					+ "\"custom class name\": (use a custom FlinkKafkaPartitioner subclass)");
 
 	public static final ConfigOption<String> SINK_SEMANTIC = ConfigOptions.key("sink.semantic")
@@ -207,12 +208,14 @@ public class KafkaOptions {
 			SCAN_STARTUP_MODE_VALUE_TIMESTAMP));
 
 	// Sink partitioner.
+	public static final String SINK_PARTITIONER_VALUE_DEFAULT = "default";
 	public static final String SINK_PARTITIONER_VALUE_FIXED = "fixed";
 	public static final String SINK_PARTITIONER_VALUE_ROUND_ROBIN = "round-robin";
 
 	private static final Set<String> SINK_PARTITIONER_ENUMS = new HashSet<>(Arrays.asList(
 			SINK_PARTITIONER_VALUE_FIXED,
-			SINK_PARTITIONER_VALUE_ROUND_ROBIN));
+			SINK_PARTITIONER_VALUE_ROUND_ROBIN,
+			SINK_PARTITIONER_VALUE_DEFAULT));
 
 	// Sink semantic
 	public static final String SINK_SEMANTIC_VALUE_EXACTLY_ONCE = "exactly-once";
@@ -314,12 +317,12 @@ public class KafkaOptions {
 	private static void validateSinkPartitioner(ReadableConfig tableOptions) {
 		tableOptions.getOptional(SINK_PARTITIONER)
 				.ifPresent(partitioner -> {
-					if (!SINK_PARTITIONER_ENUMS.contains(partitioner.toLowerCase())) {
-						if (partitioner.isEmpty()) {
-							throw new ValidationException(
-									String.format("Option '%s' should be a non-empty string.",
-											SINK_PARTITIONER.key()));
-						}
+					if (partitioner.equals(SINK_PARTITIONER_VALUE_ROUND_ROBIN) && tableOptions.getOptional(KEY_FIELDS).isPresent()) {
+						throw new ValidationException("Currently 'round-robin' partitioner only works when option 'key.fields' is not specified.");
+					} else if (partitioner.isEmpty()) {
+						throw new ValidationException(
+								String.format("Option '%s' should be a non-empty string.",
+										SINK_PARTITIONER.key()));
 					}
 				});
 	}
@@ -440,6 +443,7 @@ public class KafkaOptions {
 					switch (partitioner) {
 					case SINK_PARTITIONER_VALUE_FIXED:
 						return Optional.of(new FlinkFixedPartitioner<>());
+					case SINK_PARTITIONER_VALUE_DEFAULT:
 					case SINK_PARTITIONER_VALUE_ROUND_ROBIN:
 						return Optional.empty();
 					// Default fallback to full class name of the partitioner.

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaOptions.java
@@ -212,11 +212,6 @@ public class KafkaOptions {
 	public static final String SINK_PARTITIONER_VALUE_FIXED = "fixed";
 	public static final String SINK_PARTITIONER_VALUE_ROUND_ROBIN = "round-robin";
 
-	private static final Set<String> SINK_PARTITIONER_ENUMS = new HashSet<>(Arrays.asList(
-			SINK_PARTITIONER_VALUE_FIXED,
-			SINK_PARTITIONER_VALUE_ROUND_ROBIN,
-			SINK_PARTITIONER_VALUE_DEFAULT));
-
 	// Sink semantic
 	public static final String SINK_SEMANTIC_VALUE_EXACTLY_ONCE = "exactly-once";
 	public static final String SINK_SEMANTIC_VALUE_AT_LEAST_ONCE = "at-least-once";

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -502,8 +502,21 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				+ "class 'abc'")));
 
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-				getBasicSourceOptions(),
+				getBasicSinkOptions(),
 				options -> options.put("sink.partitioner", "abc"));
+
+		createTableSink(SCHEMA, modifiedOptions);
+	}
+
+	@Test
+	public void testInvalidRoundRobinPartitionerWithKeyFields() {
+		thrown.expect(ValidationException.class);
+		thrown.expect(containsCause(new ValidationException("Currently 'round-robin' partitioner only works " +
+				"when option 'key.fields' is not specified.")));
+
+		final Map<String, String> modifiedOptions = getModifiedOptions(
+				getKeyValueOptions(),
+				options -> options.put("sink.partitioner", "round-robin"));
 
 		createTableSink(SCHEMA, modifiedOptions);
 	}


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix the kafka round-robin partition behaviour.*


## Brief change log

  - *Add value `'default'` for option `'sink.partitioner'`. It uses the kafka default partitioner.*
  - *Forbid use of the `round-robin` partitioner when record's key is specified.*
  - *Modify the wrong description of the partitioner.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add an invalid test when using `round-robin` partitioner and `key.fields` together*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
