### PR TITLE
[FLINK-20510][conf][log4j] Enable monitorInterval by default

### DIFF
--- a/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
@@ -16,6 +16,9 @@
 # limitations under the License.
 ################################################################################
 
+# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
+monitorInterval=30
+
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = FileAppender
 

--- a/flink-dist/src/main/flink-bin/conf/log4j-console.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-console.properties
@@ -16,6 +16,9 @@
 # limitations under the License.
 ################################################################################
 
+# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
+monitorInterval=30
+
 # This affects logging for both user code and Flink
 rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = ConsoleAppender

--- a/flink-dist/src/main/flink-bin/conf/log4j-session.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-session.properties
@@ -16,6 +16,9 @@
 # limitations under the License.
 ################################################################################
 
+# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
+monitorInterval=30
+
 rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = ConsoleAppender
 

--- a/flink-dist/src/main/flink-bin/conf/log4j.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j.properties
@@ -16,6 +16,9 @@
 # limitations under the License.
 ################################################################################
 
+# Allows this configuration to be modified at runtime. The file will be checked every 30 seconds.
+monitorInterval=30
+
 # This affects logging for both user code and Flink
 rootLogger.level = INFO
 rootLogger.appenderRef.file.ref = MainAppender


### PR DESCRIPTION
This PR sets the log4j monitorInterval to 30 seconds by default, allowing the configuration to be changed at runtime.

Note: I tried to do the same for logback, but it just kinda broke down and wiped the existing log file.