### PR TITLE
[FLINK-20525][python] Fix StreamArrowPythonGroupWindowAggregateFunctionOperator incorrect handling of rowtime and proctime fields

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -380,8 +380,10 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
 					windowProperty.setField(i, TimestampData.fromEpochMillis(((TimeWindow) currentWindow).getEnd()));
 					break;
 				case 2:
-					windowProperty.setField(i, TimestampData.fromEpochMillis(currentWindow.maxTimestamp()));
+					windowProperty.setField(i, TimestampData.fromEpochMillis(((TimeWindow) currentWindow).getEnd() - 1));
 					break;
+				case 3:
+					windowProperty.setField(i, TimestampData.fromEpochMillis(-1));
 			}
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.expressions.{PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart}
+import org.apache.flink.table.planner.expressions.{PlannerProctimeAttribute, PlannerRowtimeAttribute, PlannerWindowEnd, PlannerWindowStart}
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonGroupWindowAggregate.ARROW_STREAM_PYTHON_GROUP_WINDOW_AGGREGATE_FUNCTION_OPERATOR_NAME
@@ -219,6 +219,7 @@ class StreamExecPythonGroupWindowAggregate(
           case PlannerWindowStart(_) => 0
           case PlannerWindowEnd(_) => 1
           case PlannerRowtimeAttribute(_) => 2
+          case PlannerProctimeAttribute(_) => 3
         }
       }.toArray
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix StreamArrowPythonGroupWindowAggregateFunctionOperator incorrect handling of rowtime and proctime fields*



## Verifying this change

This change added tests and can be verified as follows:

  - *it case `test_tumbling_group_window_over_time`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
