### PR TITLE
[FLINK-19659][table-planner] Array type supports equals and not_equal…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -78,6 +78,8 @@ object CodeGenUtils {
 
   val BINARY_ARRAY: String = className[BinaryArrayData]
 
+  val GENERIC_ARRAY: String = className[GenericArrayData]
+
   val BINARY_RAW_VALUE: String = className[BinaryRawValueData[_]]
 
   val BINARY_STRING: String = className[BinaryStringData]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -2026,7 +2026,8 @@ object ScalarOperatorGens {
                |}
              """.stripMargin
           val sourceElementExpr =
-            GeneratedExpression(sourceElement, sourceElementNullTerm, sourceElementCode, sourceElementType)
+            GeneratedExpression(
+              sourceElement, sourceElementNullTerm, sourceElementCode, sourceElementType)
           val elementCastExpr = generateCast(ctx, sourceElementExpr, targetElementType)
 
           val stmt =

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -181,7 +181,7 @@ public abstract class BuiltInFunctionTestBase {
 			expectedDataType.getLogicalType(),
 			result.getTableSchema().getFieldDataTypes()[0].getLogicalType());
 
-		assertEquals("Result doesn't match.", testItem.result, row.getField(0));
+		assertEquals("Result doesn't match.", Row.of(testItem.result), row);
 	}
 
 	/**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.DataTypes.ARRAY;
+
+/**
+ * Tests for comparison functions in {@link BuiltInFunctionDefinitions}.
+ */
+public class ComparisonFunctionITCase extends BuiltInFunctionTestBase {
+
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static List<TestSpec> testData() {
+		return Arrays.asList(
+			// equal comparison between arrays
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.EQUALS, "compare between arrays")
+				.onFieldsWithData(Arrays.asList(1L, 2L, 3L))
+				.andDataTypes(ARRAY(DataTypes.BIGINT()))
+				.testSqlResult(
+					"f0 = Array[1, 2, 3]",
+					true,
+					DataTypes.BOOLEAN()),
+
+			TestSpec
+				.forFunction(BuiltInFunctionDefinitions.EQUALS, "compare between nested arrays")
+				.onFieldsWithData(Arrays.asList(new Integer[]{1, 2, 3}, new Integer[]{4, 5, 6}))
+				.andDataTypes(ARRAY(ARRAY(DataTypes.INT())))
+				.testSqlResult(
+					"f0 = Array[Array[1.0, 2.0, 3.0], Array[4.0, 5.0, 6.0]]",
+					true,
+					DataTypes.BOOLEAN())
+		);
+	}
+}


### PR DESCRIPTION
…s operator when element types are different but castable

## What is the purpose of the change

Array type supports equals and not_equals operator when element types are different but castable

## Brief change log

Add the cast code between array and array


## Verifying this change

This change added tests and can be verified as follows:
1.  Add test to ScalarOperatorsTest#testCompareOperator to verify the comparison between array and array
2. Add test to ScalarOperatorsTest#testCast to verify that it is castable between array and array

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no / don't know)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no / don't know)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
