### PR TITLE
[FLINK-20500][upsert-kafka] Fix unstable UpsertKafkaTableITCase.testT…

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -106,7 +106,15 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 		String topic = USERS_TOPIC + "_" + format;
 		createTestTopic(topic, 2, 1);
 		// -------------   test   ---------------
+		// Kafka DefaultPartitioner's hash strategy is slightly different from Flink KeyGroupStreamPartitioner,
+		// which causes the records in the different Flink partitions are written into the same Kafka partition.
+		// When reading from the out-of-order Kafka partition, we need to set suitable watermark interval to
+		// tolerate the disorderliness.
+		// For convenience, we just set the parallelism 1 to make all records are in the same Flink partition and
+		// use the Kafka DefaultPartition to repartition the records.
+		env.setParallelism(1);
 		writeChangelogToUpsertKafkaWithMetadata(topic);
+		env.setParallelism(2);
 		temporalJoinUpsertKafka(topic);
 		// ------------- clean up ---------------
 		deleteTestTopic(topic);
@@ -384,7 +392,6 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 	}
 
 	private void writeChangelogToUpsertKafkaWithMetadata(String userTable) throws Exception {
-		env.setParallelism(1);
 		String bootstraps = standardProps.getProperty("bootstrap.servers");
 
 		// ------------- test data ---------------
@@ -480,7 +487,6 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 	}
 
 	private void temporalJoinUpsertKafka(String userTable) throws Exception {
-		env.setParallelism(2);
 		// ------------- test data ---------------
 		List<Row> input = Arrays.asList(
 			Row.of(10001L, 100L, LocalDateTime.parse("2020-08-15T00:00:02")),

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -104,7 +104,6 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 	@Test
 	public void testTemporalJoin() throws Exception {
 		String topic = USERS_TOPIC + "_" + format;
-		env.setParallelism(2);
 		createTestTopic(topic, 2, 1);
 		// -------------   test   ---------------
 		writeChangelogToUpsertKafkaWithMetadata(topic);
@@ -385,6 +384,7 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 	}
 
 	private void writeChangelogToUpsertKafkaWithMetadata(String userTable) throws Exception {
+		env.setParallelism(1);
 		String bootstraps = standardProps.getProperty("bootstrap.servers");
 
 		// ------------- test data ---------------
@@ -480,7 +480,7 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
 	}
 
 	private void temporalJoinUpsertKafka(String userTable) throws Exception {
-
+		env.setParallelism(2);
 		// ------------- test data ---------------
 		List<Row> input = Arrays.asList(
 			Row.of(10001L, 100L, LocalDateTime.parse("2020-08-15T00:00:02")),


### PR DESCRIPTION
…emporalJoin

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the origin test, it has 2 parallelisms and source will emit records to two producer threads. However, Kafka `DefaultPartitioner` hash strategy is slightly different from Flink `KeyGroupStreamPartitioner`, which causes the records in the different Flink partitions may be written into the same Kafka partition.  In the case above,  the Kafka partition is out-of-order and some records are late. This is the reason why we have the unstable test. 

Here we just reset the parallelism to 1 to fix the test.  If users has the same problem, he/she can adjust the watermark strategy to tolerate the disorderness

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
