### PR TITLE
[FLINK-20514][python] Introduce StreamExecPythonGroupTableAggregateRule and StreamExecPythonGroupTableAggregate

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupTableAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonGroupTableAggregateRule.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.functions.python.PythonFunctionKind;
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableAggregate;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonGroupTableAggregate;
+import org.apache.flink.table.planner.plan.trait.FlinkRelDistribution;
+import org.apache.flink.table.planner.plan.utils.PythonUtil;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.AggregateCall;
+
+import java.util.List;
+
+import scala.collection.JavaConverters;
+
+/**
+ * Rule to convert a {@link FlinkLogicalTableAggregate} into a {@link StreamExecPythonGroupTableAggregate}.
+ */
+public class StreamExecPythonGroupTableAggregateRule extends ConverterRule {
+
+	public static final RelOptRule INSTANCE = new StreamExecPythonGroupTableAggregateRule();
+
+	public StreamExecPythonGroupTableAggregateRule() {
+		super(FlinkLogicalTableAggregate.class,
+			FlinkConventions.LOGICAL(),
+			FlinkConventions.STREAM_PHYSICAL(),
+			"StreamExecPythonGroupTableAggregateRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		FlinkLogicalTableAggregate agg = call.rel(0);
+
+		List<AggregateCall> aggCalls = agg.getAggCallList();
+		boolean existGeneralPythonFunction =
+			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.GENERAL));
+		boolean existPandasFunction =
+			aggCalls.stream().anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.PANDAS));
+		boolean existJavaUserDefinedFunction =
+			aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null) &&
+				!PythonUtil.isBuiltInAggregate(x));
+		if (existPandasFunction || existGeneralPythonFunction) {
+			if (existPandasFunction) {
+				throw new TableException("Pandas UDAFs are not supported in streaming mode currently.");
+			}
+			if (existJavaUserDefinedFunction) {
+				throw new TableException("Python UDAF and Java/Scala UDAF cannot be used together.");
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public RelNode convert(RelNode rel) {
+		FlinkLogicalTableAggregate agg = (FlinkLogicalTableAggregate) rel;
+		FlinkRelDistribution requiredDistribution;
+		if (agg.getGroupSet().cardinality() != 0) {
+			requiredDistribution = FlinkRelDistribution.hash(agg.getGroupSet().asList(), true);
+		} else {
+			requiredDistribution = FlinkRelDistribution.SINGLETON();
+		}
+
+		RelTraitSet requiredTraitSet = rel.getCluster().getPlanner().emptyTraitSet()
+			.replace(requiredDistribution)
+			.replace(FlinkConventions.STREAM_PHYSICAL());
+
+		RelTraitSet providedTraitSet = rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
+		RelNode newInput = RelOptRule.convert(agg.getInput(), requiredTraitSet);
+
+		return new StreamExecPythonGroupTableAggregate(
+			rel.getCluster(),
+			providedTraitSet,
+			newInput,
+			rel.getRowType(),
+			agg.getGroupSet().toArray(),
+			JavaConverters.asScalaIteratorConverter(agg.getAggCallList().iterator()).asScala().toSeq());
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregate.scala
@@ -25,7 +25,6 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator
 import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.plan.nodes.exec.LegacyStreamExecNode
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.runtime.operators.aggregate.GroupTableAggFunction
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
@@ -34,34 +33,29 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.RelNode
 
 import java.util
 
 import scala.collection.JavaConversions._
 
 /**
-  * Stream physical RelNode for unbounded group table aggregate.
+  * Stream physical RelNode for unbounded java/scala group table aggregate.
   */
 class StreamExecGroupTableAggregate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall])
-  extends SingleRel(cluster, traitSet, inputRel)
-  with StreamPhysicalRel
-  with LegacyStreamExecNode[RowData] {
-
-  val aggInfoList: AggregateInfoList = AggregateUtil.deriveAggregateInfoList(
-    this,
-    aggCalls,
-    grouping)
-
-  override def requireWatermark: Boolean = false
-
-  override def deriveRowType(): RelDataType = outputRowType
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall])
+  extends StreamExecGroupTableAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    outputRowType,
+    grouping,
+    aggCalls) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
     new StreamExecGroupTableAggregate(
@@ -72,20 +66,6 @@ class StreamExecGroupTableAggregate(
       grouping,
       aggCalls)
   }
-
-  override def explainTerms(pw: RelWriter): RelWriter = {
-    val inputRowType = getInput.getRowType
-    super.explainTerms(pw)
-      .itemIf("groupBy",
-        RelExplainUtil.fieldToString(grouping, inputRowType), grouping.nonEmpty)
-      .item("select", RelExplainUtil.streamGroupAggregationToString(
-        inputRowType,
-        getRowType,
-        aggInfoList,
-        grouping))
-  }
-
-  //~ ExecNode methods -----------------------------------------------------------
 
   override protected def translateToPlanInternal(
       planner: StreamPlanner): Transformation[RowData] = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupTableAggregateBase.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.plan.nodes.exec.LegacyStreamExecNode
+import org.apache.flink.table.planner.plan.utils._
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+
+/**
+  * Base Stream physical RelNode for unbounded group table aggregate.
+  */
+abstract class StreamExecGroupTableAggregateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    val grouping: Array[Int],
+    val aggCalls: Seq[AggregateCall])
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel
+  with LegacyStreamExecNode[RowData] {
+
+  val aggInfoList: AggregateInfoList = AggregateUtil.deriveAggregateInfoList(
+    this,
+    aggCalls,
+    grouping)
+
+  override def requireWatermark: Boolean = false
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val inputRowType = getInput.getRowType
+    super.explainTerms(pw)
+      .itemIf("groupBy",
+              RelExplainUtil.fieldToString(grouping, inputRowType), grouping.nonEmpty)
+      .item("select", RelExplainUtil.streamGroupAggregationToString(
+        inputRowType,
+        getRowType,
+        aggInfoList,
+        grouping))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupTableAggregate.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.delegation.StreamPlanner
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.AggregateCall
+
+import java.util
+
+/**
+  * Stream physical RelNode for unbounded python group table aggregate.
+  */
+class StreamExecPythonGroupTableAggregate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    outputRowType: RelDataType,
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall])
+  extends StreamExecGroupTableAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    outputRowType,
+    grouping,
+    aggCalls) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new StreamExecPythonGroupTableAggregate(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      outputRowType,
+      grouping,
+      aggCalls)
+  }
+
+  override protected def translateToPlanInternal(
+      planner: StreamPlanner): Transformation[RowData] = {
+    throw new TableException("The implementation will be in FLINK-20528.")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -178,7 +178,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         val providedTrait = new ModifyKindSetTrait(builder.build())
         createNewNode(agg, children, providedTrait, requiredTrait, requester)
 
-      case tagg: StreamExecGroupTableAggregate =>
+      case tagg: StreamExecGroupTableAggregateBase =>
         // table agg support all changes in input
         val children = visitChildren(tagg, ModifyKindSetTrait.ALL_CHANGES)
         // table aggregate will produce all changes, including deletions
@@ -462,7 +462,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         visitSink(sink, sinkRequiredTraits)
 
       case _: StreamExecGroupAggregate | _: StreamExecGroupTableAggregate |
-           _: StreamExecLimit | _: StreamExecPythonGroupAggregate =>
+           _: StreamExecLimit | _: StreamExecPythonGroupAggregate |
+           _: StreamExecPythonGroupTableAggregate =>
         // Aggregate, TableAggregate and Limit requires update_before if there are updates
         val requiredChildTrait = beforeAfterOrNone(getModifyKindSet(rel.getInput(0)))
         val children = visitChildren(rel, requiredChildTrait)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -420,6 +420,7 @@ object FlinkStreamRuleSets {
     StreamExecGroupAggregateRule.INSTANCE,
     StreamExecGroupTableAggregateRule.INSTANCE,
     StreamExecPythonGroupAggregateRule.INSTANCE,
+    StreamExecPythonGroupTableAggregateRule.INSTANCE,
     // over agg
     StreamExecOverAggregateRule.INSTANCE,
     StreamExecPythonOverAggregateRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupTableAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecGroupTableAggregateRule.scala
@@ -18,13 +18,14 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
-import org.apache.calcite.plan.RelOptRule
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableAggregate
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecGroupTableAggregate
+import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 
 import scala.collection.JavaConversions._
 
@@ -33,6 +34,11 @@ class StreamExecGroupTableAggregateRule extends ConverterRule(
     FlinkConventions.LOGICAL,
     FlinkConventions.STREAM_PHYSICAL,
     "StreamExecGroupTableAggregateRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val agg: FlinkLogicalTableAggregate = call.rel(0)
+    !agg.getAggCallList.exists(isPythonAggregate(_))
+  }
 
   def convert(rel: RelNode): RelNode = {
     val agg: FlinkLogicalTableAggregate = rel.asInstanceOf[FlinkLogicalTableAggregate]

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testTableAggregate">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[AS($1, _UTF-16LE'd')], e=[AS($2, _UTF-16LE'e')])
++- LogicalTableAggregate(group=[{1}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0 AS d, f1 AS e])
++- PythonGroupTableAggregate(groupBy=[b], select=[b, PythonEmptyTableAggFunc(a, c) AS (f0, f1)])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableAggregateWithoutKeys">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[AS($0, _UTF-16LE'd')], e=[AS($1, _UTF-16LE'e')])
++- LogicalTableAggregate(group=[{}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0 AS d, f1 AS e])
++- PythonGroupTableAggregate(select=[PythonEmptyTableAggFunc(a, c) AS (f0, f1)])
+   +- Exchange(distribution=[single])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testTableAggregateMixedWithJavaCalls">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(d=[AS($1, _UTF-16LE'd')], e=[AS($2, _UTF-16LE'e')])
++- LogicalTableAggregate(group=[{1}], tableAggregate=[[PythonEmptyTableAggFunc($0, $2)]])
+   +- LogicalProject(a=[$0], b=[$1], $f3=[+($2, 1)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[f0 AS d, f1 AS e])
++- PythonGroupTableAggregate(groupBy=[b], select=[b, PythonEmptyTableAggFunc(a, $f3) AS (f0, f1)])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b, +(c, 1) AS $f3])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonTableAggregateTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.planner.utils.{PythonEmptyTableAggFunc, TableTestBase}
+
+import org.junit.Test
+
+class PythonTableAggregateTest extends TableTestBase {
+
+  @Test
+  def testTableAggregate(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonEmptyTableAggFunc
+
+    val resultTable = sourceTable.groupBy('b)
+      .flatAggregate(func('a, 'c) as ('d, 'e))
+      .select('d, 'e)
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testTableAggregateWithoutKeys(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonEmptyTableAggFunc
+
+    val resultTable = sourceTable.flatAggregate(func('a, 'c) as ('d, 'e)).select('d, 'e)
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testTableAggregateMixedWithJavaCalls(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonEmptyTableAggFunc
+
+    val resultTable = sourceTable.groupBy('b)
+      .flatAggregate(func('a, 'c + 1) as ('d, 'e))
+      .select('d, 'e)
+
+    util.verifyPlan(resultTable)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
@@ -18,17 +18,14 @@
 
 package org.apache.flink.table.planner.utils
 
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.table.annotation.{DataTypeHint, FunctionHint}
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.dataview.MapView
 import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.functions.TableAggregateFunction
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.planner.JLong
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
-import org.apache.flink.table.types.logical.IntType
-import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 
 import java.lang.{Integer => JInt, Iterable => JIterable}
@@ -297,4 +294,19 @@ class EmptyTableAggFuncWithIntResultType extends TableAggregateFunction[JInt, To
   def accumulate(acc: Top3Accum, value: JInt): Unit = {}
 
   def emitValue(acc: Top3Accum, out: Collector[JInt]): Unit = {}
+}
+
+class PythonEmptyTableAggFunc
+  extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Accum]
+  with PythonFunction {
+
+  override def getSerializedPythonFunction: Array[Byte] = Array(0)
+
+  override def getPythonEnv: PythonEnv = null
+
+  override def createAccumulator(): Top3Accum = new Top3Accum
+
+  def accumulate(acc: Top3Accum, value1: JInt, value2: JInt): Unit = {}
+
+  def emitValue(acc: Top3Accum, out: Collector[JTuple2[JInt, JInt]]): Unit = {}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Introduce StreamExecPythonGroupTableAggregateRule and StreamExecPythonGroupTableAggregate*


## Brief change log

  - *Introduce physical rule `StreamExecPythonGroupTableAggregateRule`*
  - *Introduce base table aggregate physical node `StreamExecGroupTableAggregateBase`*
  - *Introduce python table aggregate physical node `StreamExecPythonGroupTableAggregate`*
  - *Make `StreamExecGroupTableAggregate` extend `StreamExecGroupTableAggregateBase`*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add UT in `PythonTableAggregateTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
