### PR TITLE
[FLINK-20425][runtime] Change exit code in FatalExitExceptionHandler to be different from JvmShutdownSafeguard

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -33,6 +33,8 @@ import org.apache.commons.cli.PosixParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.flink.runtime.util.ExitCode.RUNNER_INIT;
+
 /**
  * The entry point for running a TaskManager in a Mesos container.
  */
@@ -40,7 +42,7 @@ public class MesosTaskExecutorRunner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MesosTaskExecutorRunner.class);
 
-	private static final int INIT_ERROR_EXIT_CODE = 31;
+	private static final int INIT_ERROR_EXIT_CODE = RUNNER_INIT.getExitCode();
 
 	private static final Options ALL_OPTIONS;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ExitCode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ExitCode.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+/**
+ * Enumeration to indicate the associated process exit code.
+ */
+public enum ExitCode {
+
+	/** The exit code of the succeeded application process. */
+	SUCCESS(0),
+	/** The exit code for running a TaskExecutor in the container. */
+	RUNNER_INIT(31),
+	/** The exit code of the JVM process killed by the safeguard. */
+	JVM_SHUTDOWN(-17),
+	/** The exit code of the fatal handler for uncaught exceptions. */
+	FATAL_UNCAUGHT(-99);
+
+	// --------------------------------------------------------------------------------------------
+
+	private final int exitCode;
+
+	ExitCode(int exitCode) {
+		this.exitCode = exitCode;
+	}
+
+	public int getExitCode() {
+		return exitCode;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.flink.runtime.util.ExitCode.FATAL_UNCAUGHT;
+
 /**
  * Handler for uncaught exceptions that will log the exception and kill the process afterwards.
  *
@@ -32,7 +34,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 	private static final Logger LOG = LoggerFactory.getLogger(FatalExitExceptionHandler.class);
 
 	public static final FatalExitExceptionHandler INSTANCE = new FatalExitExceptionHandler();
-	public static final int EXIT_CODE = -17;
+	public static final int EXIT_CODE = FATAL_UNCAUGHT.getExitCode();
 
 	@Override
 	@SuppressWarnings("finally")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmShutdownSafeguard.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmShutdownSafeguard.java
@@ -22,6 +22,7 @@ import org.apache.flink.util.ShutdownHookUtil;
 
 import org.slf4j.Logger;
 
+import static org.apache.flink.runtime.util.ExitCode.JVM_SHUTDOWN;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -41,7 +42,7 @@ public class JvmShutdownSafeguard extends Thread {
 	private static final long DEFAULT_DELAY = 5000L;
 
 	/** The exit code returned by the JVM process if it is killed by the safeguard */
-	private static final int EXIT_CODE = -17;
+	private static final int EXIT_CODE = JVM_SHUTDOWN.getExitCode();
 
 	/** The thread that actually does the termination */
 	private final Thread terminator;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ApplicationStatusTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ApplicationStatusTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static org.apache.flink.runtime.util.ExitCode.SUCCESS;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertThat;
  */
 public class ApplicationStatusTest extends TestLogger {
 
-	private static final int SUCCESS_EXIT_CODE = 0;
+	private static final int SUCCESS_EXIT_CODE = SUCCESS.getExitCode();
 
 	@Test
 	public void succeededStatusMapsToSuccessExitCode() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Map;
 
+import static org.apache.flink.runtime.util.ExitCode.RUNNER_INIT;
+
 /**
  * This class is the executable entry point for running a TaskExecutor in a YARN container.
  */
@@ -51,7 +53,7 @@ public class YarnTaskExecutorRunner {
 	private static final Map<String, String> ENV = System.getenv();
 
 	/** The exit code returned if the initialization of the yarn task executor runner failed. */
-	private static final int INIT_ERROR_EXIT_CODE = 31;
+	private static final int INIT_ERROR_EXIT_CODE = RUNNER_INIT.getExitCode();
 
 	// ------------------------------------------------------------------------
 	//  Program entry point


### PR DESCRIPTION
## What is the purpose of the change

*`FatalExitExceptionHandler` and `JvmShutdownSafeguard` use the same exit code (-17), making it impossible to distinguish the cause of an unexpected Flink JVM exit based on the exit code alone.  Enum `ExitCode` should be introduced that defines all possible exit codes in Flink. The exit codes are different for `FatalExitExceptionHandler` and `JvmShutdownSafeguard`.*

## Brief change log

  - *Add `ExitCode` enum to indicate the associated process exit code.*
  - *Change the exit code in `FatalExitExceptionHandler` to be different from `JvmShutdownSafeguard`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)