### PR TITLE
[BP-1.12][FLINK-20419][table][hive] Avoid dynamic partition grouping if the input defines collation

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.connector.sink.abilities.SupportsWritingMetadata;
 import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -1094,7 +1095,8 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 	 */
 	private static class TestValuesTableSink implements
 			DynamicTableSink,
-			SupportsWritingMetadata {
+			SupportsWritingMetadata,
+			SupportsPartitioning {
 
 		private DataType consumedDataType;
 		private int[] primaryKeyIndices;
@@ -1253,6 +1255,15 @@ public final class TestValuesTableFactory implements DynamicTableSourceFactory, 
 		@Override
 		public void applyWritableMetadata(List<String> metadataKeys, DataType consumedDataType) {
 			this.consumedDataType = consumedDataType;
+		}
+
+		@Override
+		public void applyStaticPartition(Map<String, String> partition) {
+		}
+
+		@Override
+		public boolean requiresPartitionGrouping(boolean supportsGrouping) {
+			return supportsGrouping;
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
@@ -79,4 +79,23 @@ Sink(table=[default_catalog.default_database.sink2], fields=[total_min])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDynamicPartWithOrderBy">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b])
++- LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
+   +- LogicalProject(a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, b])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
@@ -78,4 +78,22 @@ class TableSinkTest extends TableTestBase {
 
     util.verifyPlan(stmtSet)
   }
+
+  @Test
+  def testDynamicPartWithOrderBy(): Unit = {
+    util.addTable(
+      s"""
+         |CREATE TABLE sink (
+         |  `a` INT,
+         |  `b` BIGINT
+         |) PARTITIONED BY (
+         |  `b`
+         |) WITH (
+         |  'connector' = 'values'
+         |)
+         |""".stripMargin)
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql("INSERT INTO sink SELECT a,b FROM MyTable ORDER BY a")
+    util.verifyPlan(stmtSet)
+  }
 }


### PR DESCRIPTION
This is a cherry pick back to release-1.12 branch.