### PR TITLE
[FLINK-20512][table-planner-blink] Introduce getDesc(), getOutputType(), replaceInputEdge(int, ExecEdge) methods for ExecNode

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.List;
 
@@ -30,6 +31,18 @@ import java.util.List;
  * @param <T> The type of the elements that result from this node.
  */
 public interface ExecNode<T> {
+
+	/**
+	 * Returns a string which describes this node.
+	 * TODO rename to `getDescription` once all ExecNodes do not extend from FlinkPhysicalRel,
+	 *  because RelNode already has `getDescription` method.
+	 */
+	String getDesc();
+
+	/**
+	 * Returns the output {@link RowType} of this node.
+	 */
+	RowType getOutputType();
 
 	/**
 	 * Returns a list of this node's input nodes.
@@ -49,12 +62,21 @@ public interface ExecNode<T> {
 
 	/**
 	 * Replaces the <code>ordinalInParent</code><sup>th</sup> input.
-	 * You must override this method if you override {@link #getInputNodes}.
+	 * Once we introduce source node and target node for {@link ExecEdge},
+	 * we will remove this method.
 	 *
 	 * @param ordinalInParent Position of the child input, 0 is the first
 	 * @param newInputNode New node that should be put at position ordinalInParent
 	 */
 	void replaceInputNode(int ordinalInParent, ExecNode<?> newInputNode);
+
+	/**
+	 * Replaces the <code>ordinalInParent</code><sup>th</sup> edge.
+	 *
+	 * @param ordinalInParent Position of the child input, 0 is the first
+	 * @param newInputEdge New edge that should be put at position ordinalInParent
+	 */
+	void replaceInputEdge(int ordinalInParent, ExecEdge newInputEdge);
 
 	/**
 	 * Translates this node into a Flink operator.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/LegacyExecNodeBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/LegacyExecNodeBase.scala
@@ -20,6 +20,9 @@ package org.apache.flink.table.planner.plan.nodes.exec
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.delegation.Planner
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
+import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.util.Preconditions.{checkArgument, checkNotNull}
 
 import org.apache.calcite.rel.RelDistribution
@@ -50,6 +53,14 @@ trait LegacyExecNodeBase[P <: Planner, T] extends ExecNode[T] {
    */
   private var inputNodes: util.List[ExecNode[_]] = _
 
+  override def getDesc: String = {
+    this.asInstanceOf[FlinkPhysicalRel].getRelDetailedDescription
+  }
+
+  override def getOutputType: RowType = {
+    FlinkTypeFactory.toLogicalRowType(this.asInstanceOf[FlinkPhysicalRel].getRowType)
+  }
+
   override def getInputNodes: util.List[ExecNode[_]] = {
     checkNotNull(inputNodes)
   }
@@ -62,6 +73,10 @@ trait LegacyExecNodeBase[P <: Planner, T] extends ExecNode[T] {
   // TODO this is a temporary solution to set input nodes
   def setInputNodes(inputNodes: util.List[ExecNode[_]]): Unit = {
     this.inputNodes = new util.ArrayList[ExecNode[_]](inputNodes)
+  }
+
+  override def replaceInputEdge(ordinalInParent: Int, newInputEdge: ExecEdge): Unit = {
+    throw new UnsupportedOperationException("This method is unsupported on LegacyExecNodeBase")
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

*introduce getDesc() method which returns the description information of the ExecNode,
introduce getOutputType() method which returns the output RowType of the ExecNode,
introduce replaceInputEdge(int ordinalInParent, ExecEdge newInputEdge) method which can update the input edge  at the given index*


## Brief change log

  - *Introduce getDesc(), getOutputType(), replaceInputEdge(int, ExecEdge) methods for ExecNode*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
