### PR TITLE
[FLINK-20533][datadog] Add Histogram support 

### DIFF
--- a/docs/deployment/metric_reporters.md
+++ b/docs/deployment/metric_reporters.md
@@ -230,6 +230,10 @@ metrics.reporter.stsd.interval: 60 SECONDS
 Note any variables in Flink metrics, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>`, and `<operator_name>`,
 will be sent to Datadog as tags. Tags will look like `host:localhost` and `job_name:myjobname`.
 
+<span class="label label-info">Note</span> Histograms are exposed as a series of gauges following the naming convention of Datadog histograms (`<metric_name>.<aggregation>`).
+The `min` aggregation is reported by default, whereas `sum` is not available.
+In contrast to Datadog-provided Histograms the reported aggregations are not computed for a specific reporting interval.
+
 Parameters:
 
 - `apikey` - the Datadog API key

--- a/docs/deployment/metric_reporters.zh.md
+++ b/docs/deployment/metric_reporters.zh.md
@@ -230,6 +230,10 @@ metrics.reporter.stsd.interval: 60 SECONDS
 Note any variables in Flink metrics, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>`, and `<operator_name>`,
 will be sent to Datadog as tags. Tags will look like `host:localhost` and `job_name:myjobname`.
 
+<span class="label label-info">Note</span> Histograms are exposed as a series of gauges following the naming convention of Datadog histograms (`<metric_name>.<aggregation>`).
+The `min` aggregation is reported by default, whereas `sum` is not available.
+In contrast to Datadog-provided Histograms the reported aggregations are not computed for a specific reporting interval.
+
 Parameters:
 
 - `apikey` - the Datadog API key

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
@@ -32,7 +32,7 @@ public class DCounter extends DMetric {
 	private long currentReportCount = 0;
 
 	public DCounter(Counter c, String metricName, String host, List<String> tags, Clock clock) {
-		super(MetricType.count, metricName, host, tags, clock);
+		super(new MetricMetaData(MetricType.count, metricName, host, tags, clock));
 		counter = c;
 	}
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
@@ -37,10 +37,7 @@ public class DCounter extends DMetric {
 	}
 
 	/**
-	 * Visibility of this method must not be changed
-	 * since we deliberately not map it to json object in a Datadog-defined format.
-	 *
-	 * <p>Note: DataDog counters count the number of events during the reporting interval.
+	 * Returns the count of events since the last report.
 	 *
 	 * @return the number of events since the last retrieval
 	 */

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
@@ -29,7 +29,7 @@ public class DGauge extends DMetric {
 	private final Gauge<Number> gauge;
 
 	public DGauge(Gauge<Number> g, String metricName, String host, List<String> tags, Clock clock) {
-		super(MetricType.gauge, metricName, host, tags, clock);
+		super(new MetricMetaData(MetricType.gauge, metricName, host, tags, clock));
 		gauge = g;
 	}
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DGauge.java
@@ -33,10 +33,6 @@ public class DGauge extends DMetric {
 		gauge = g;
 	}
 
-	/**
-	 * Visibility of this method must not be changed
-	 * since we deliberately not map it to json object in a Datadog-defined format.
-	 */
 	@Override
 	public Number getMetricValue() {
 		return gauge.getValue();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DHistogram.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DHistogram.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+
+import java.util.List;
+
+/**
+ * Maps histograms to datadog gauges.
+ *
+ * <p>Note: We cannot map them to datadog histograms because the HTTP API does not support them.
+ */
+public class DHistogram {
+	@VisibleForTesting
+	static final String SUFFIX_AVG = ".avg";
+	@VisibleForTesting
+	static final String SUFFIX_COUNT = ".count";
+	@VisibleForTesting
+	static final String SUFFIX_MEDIAN = ".median";
+	@VisibleForTesting
+	static final String SUFFIX_95_PERCENTILE = ".95percentile";
+	@VisibleForTesting
+	static final String SUFFIX_MIN = ".min";
+	@VisibleForTesting
+	static final String SUFFIX_MAX = ".max";
+
+	private final Histogram histogram;
+
+	private final MetricMetaData metaDataAvg;
+	private final MetricMetaData metaDataCount;
+	private final MetricMetaData metaDataMedian;
+	private final MetricMetaData metaData95Percentile;
+	private final MetricMetaData metaDataMin;
+	private final MetricMetaData metaDataMax;
+
+	public DHistogram(Histogram histogram, String metricName, String host, List<String> tags, Clock clock) {
+		this.histogram = histogram;
+		this.metaDataAvg = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_AVG, host, tags, clock);
+		this.metaDataCount = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_COUNT, host, tags, clock);
+		this.metaDataMedian = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MEDIAN, host, tags, clock);
+		this.metaData95Percentile = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_95_PERCENTILE, host, tags, clock);
+		this.metaDataMin = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MIN, host, tags, clock);
+		this.metaDataMax = new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MAX, host, tags, clock);
+	}
+
+	public void addTo(DSeries series) {
+		final HistogramStatistics statistics = histogram.getStatistics();
+
+		// this selection is based on https://docs.datadoghq.com/developers/metrics/types/?tab=histogram
+		// we only exclude 'sum' (which is optional), because we cannot compute it
+		// the semantics for count are also slightly different, because we don't reset it after a report
+		series.add(new StaticDMetric(statistics.getMean(), metaDataAvg));
+		series.add(new StaticDMetric(histogram.getCount(), metaDataCount));
+		series.add(new StaticDMetric(statistics.getQuantile(.5), metaDataMedian));
+		series.add(new StaticDMetric(statistics.getQuantile(.95), metaData95Percentile));
+		series.add(new StaticDMetric(statistics.getMin(), metaDataMin));
+		series.add(new StaticDMetric(statistics.getMax(), metaDataMax));
+	}
+}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
@@ -44,45 +44,37 @@ public abstract class DMetric {
 	@VisibleForTesting
 	static final String FIELD_NAME_POINTS = "points";
 
-	private final String metricName;
-	private final MetricType type;
-	private final String host;
-	private final List<String> tags;
-	private final Clock clock;
+	private final MetricMetaData metaData;
 
-	public DMetric(MetricType metricType, String metricName, String host, List<String> tags, Clock clock) {
-		this.type = metricType;
-		this.metricName = metricName;
-		this.host = host;
-		this.tags = tags;
-		this.clock = clock;
+	public DMetric(MetricMetaData metaData) {
+		this.metaData = metaData;
 	}
 
 	@JsonGetter(FIELD_NAME_TYPE)
 	public MetricType getType() {
-		return type;
+		return metaData.getType();
 	}
 
 	@JsonGetter(FIELD_NAME_METRIC)
 	public String getMetricName() {
-		return metricName;
+		return metaData.getMetricName();
 	}
 
 	@JsonGetter(FIELD_NAME_HOST)
 	public String getHost() {
-		return host;
+		return metaData.getHost();
 	}
 
 	@JsonGetter(FIELD_NAME_TAGS)
 	public List<String> getTags() {
-		return tags;
+		return metaData.getTags();
 	}
 
 	@JsonGetter(FIELD_NAME_POINTS)
 	public List<List<Number>> getPoints() {
 		// One single data point
 		List<Number> point = new ArrayList<>();
-		point.add(clock.getUnixEpochTimestamp());
+		point.add(metaData.getClock().getUnixEpochTimestamp());
 		point.add(getMetricValue());
 
 		List<List<Number>> points = new ArrayList<>();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -30,40 +33,52 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class DMetric {
 
-	/**
-	 * Names of metric/type/tags field and their getters must not be changed
-	 * since they are mapped to json objects in a Datadog-defined format.
-	 */
-	private final String metric; // Metric name
+	@VisibleForTesting
+	static final String FIELD_NAME_TYPE = "type";
+	@VisibleForTesting
+	static final String FIELD_NAME_METRIC = "metric";
+	@VisibleForTesting
+	static final String FIELD_NAME_HOST = "host";
+	@VisibleForTesting
+	static final String FIELD_NAME_TAGS = "tags";
+	@VisibleForTesting
+	static final String FIELD_NAME_POINTS = "points";
+
+	private final String metricName;
 	private final MetricType type;
 	private final String host;
 	private final List<String> tags;
 	private final Clock clock;
 
-	public DMetric(MetricType metricType, String metric, String host, List<String> tags, Clock clock) {
+	public DMetric(MetricType metricType, String metricName, String host, List<String> tags, Clock clock) {
 		this.type = metricType;
-		this.metric = metric;
+		this.metricName = metricName;
 		this.host = host;
 		this.tags = tags;
 		this.clock = clock;
 	}
 
+	@JsonGetter(FIELD_NAME_TYPE)
 	public MetricType getType() {
 		return type;
 	}
 
-	public String getMetric() {
-		return metric;
+	@JsonGetter(FIELD_NAME_METRIC)
+	public String getMetricName() {
+		return metricName;
 	}
 
+	@JsonGetter(FIELD_NAME_HOST)
 	public String getHost() {
 		return host;
 	}
 
+	@JsonGetter(FIELD_NAME_TAGS)
 	public List<String> getTags() {
 		return tags;
 	}
 
+	@JsonGetter(FIELD_NAME_POINTS)
 	public List<List<Number>> getPoints() {
 		// One single data point
 		List<Number> point = new ArrayList<>();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
@@ -39,16 +39,8 @@ public class DSeries {
 		this.series = series;
 	}
 
-	public void addGauge(DGauge gauge) {
-		series.add(gauge);
-	}
-
-	public void addCounter(DCounter counter) {
-		series.add(counter);
-	}
-
-	public void addMeter(DMeter meter) {
-		series.add(meter);
+	public void add(DMetric metric) {
+		series.add(metric);
 	}
 
 	public List<DMetric> getSeries() {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,10 +29,9 @@ import java.util.List;
  * Json serialization between Flink and Datadog.
  */
 public class DSeries {
-	/**
-	 * Names of series field and its getters must not be changed
-	 * since they are mapped to json objects in a Datadog-defined format.
-	 */
+	@VisibleForTesting
+	static final String FIELD_NAME_SERIES = "series";
+
 	private final List<DMetric> series;
 
 	public DSeries() {
@@ -43,6 +46,7 @@ public class DSeries {
 		series.add(metric);
 	}
 
+	@JsonGetter(FIELD_NAME_SERIES)
 	public List<DMetric> getSeries() {
 		return series;
 	}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -137,8 +137,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 		DSeries request = new DSeries();
 
 		addGaugesAndUnregisterOnException(request);
-		counters.values().forEach(request::addCounter);
-		meters.values().forEach(request::addMeter);
+		counters.values().forEach(request::add);
+		meters.values().forEach(request::add);
 
 		int totalMetrics = request.getSeries().size();
 		int fromIndex = 0;
@@ -166,7 +166,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				// Will throw exception if the Gauge is not of Number type
 				// Flink uses Gauge to store many types other than Number
 				g.getMetricValue();
-				request.addGauge(g);
+				request.add(g);
 			} catch (ClassCastException e) {
 				LOGGER.info("The metric {} will not be reported because only number types are supported by this reporter.", g.getMetric());
 				gaugesToRemove.add(entry.getKey());

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -168,13 +168,13 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 				g.getMetricValue();
 				request.add(g);
 			} catch (ClassCastException e) {
-				LOGGER.info("The metric {} will not be reported because only number types are supported by this reporter.", g.getMetric());
+				LOGGER.info("The metric {} will not be reported because only number types are supported by this reporter.", g.getMetricName());
 				gaugesToRemove.add(entry.getKey());
 			} catch (Exception e) {
 				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("The metric {} will not be reported because it threw an exception.", g.getMetric(), e);
+					LOGGER.debug("The metric {} will not be reported because it threw an exception.", g.getMetricName(), e);
 				} else {
-					LOGGER.info("The metric {} will not be reported because it threw an exception.", g.getMetric());
+					LOGGER.info("The metric {} will not be reported because it threw an exception.", g.getMetricName());
 				}
 				gaugesToRemove.add(entry.getKey());
 			}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/MetricMetaData.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/MetricMetaData.java
@@ -18,25 +18,44 @@
 
 package org.apache.flink.metrics.datadog;
 
-import org.apache.flink.metrics.Meter;
-
 import java.util.List;
 
 /**
- * Mapping of meter between Flink and Datadog.
- *
- * <p>Only consider rate of the meter, due to Datadog HTTP API's limited support of meter
+ * All metadata associated with a given metric.
  */
-public class DMeter extends DMetric {
-	private final Meter meter;
+public final class MetricMetaData {
 
-	public DMeter(Meter m, String metricName, String host, List<String> tags, Clock clock) {
-		super(new MetricMetaData(MetricType.gauge, metricName, host, tags, clock));
-		meter = m;
+	private final String metricName;
+	private final MetricType type;
+	private final String host;
+	private final List<String> tags;
+	private final Clock clock;
+
+	public MetricMetaData(MetricType metricType, String metricName, String host, List<String> tags, Clock clock) {
+		this.type = metricType;
+		this.metricName = metricName;
+		this.host = host;
+		this.tags = tags;
+		this.clock = clock;
 	}
 
-	@Override
-	public Number getMetricValue() {
-		return meter.getRate();
+	public MetricType getType() {
+		return type;
+	}
+
+	public String getMetricName() {
+		return metricName;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public List<String> getTags() {
+		return tags;
+	}
+
+	public Clock getClock() {
+		return clock;
 	}
 }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/StaticDMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/StaticDMetric.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+/**
+ * A {@link DMetric} that returns a fixed value.
+ */
+public class StaticDMetric extends DMetric {
+	private final Number value;
+
+	public StaticDMetric(Number value, MetricMetaData metaData) {
+		super(metaData);
+		this.value = value;
+	}
+
+	public Number getMetricValue() {
+		return value;
+	}
+}

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -18,9 +18,8 @@
 
 package org.apache.flink.metrics.datadog;
 
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.util.TestCounter;
+import org.apache.flink.metrics.util.TestMeter;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -39,7 +38,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DatadogHttpClientTest {
 
-	private static List<String> tags = Arrays.asList("tag1", "tag2");
+	private static final List<String> tags = Arrays.asList("tag1", "tag2");
 
 	private static final long MOCKED_SYSTEM_MILLIS = 123L;
 
@@ -73,13 +72,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGauge() throws JsonProcessingException {
-
-		DGauge g = new DGauge(new Gauge<Number>() {
-			@Override
-			public Number getValue() {
-				return 1;
-			}
-		}, "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DGauge g = new DGauge(() -> 1, "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testCounter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
@@ -88,13 +81,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGaugeWithoutHost() throws JsonProcessingException {
-
-		DGauge g = new DGauge(new Gauge<Number>() {
-			@Override
-			public Number getValue() {
-				return 1;
-			}
-		}, "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DGauge g = new DGauge(() -> 1, "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testCounter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
@@ -103,24 +90,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeCounter() throws JsonProcessingException {
-		DCounter c = new DCounter(new Counter() {
-			@Override
-			public void inc() {}
-
-			@Override
-			public void inc(long n) {}
-
-			@Override
-			public void dec() {}
-
-			@Override
-			public void dec(long n) {}
-
-			@Override
-			public long getCount() {
-				return 1;
-			}
-		}, "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DCounter c = new DCounter(new TestCounter(1), "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testCounter\",\"type\":\"count\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
@@ -129,24 +99,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeCounterWithoutHost() throws JsonProcessingException {
-		DCounter c = new DCounter(new Counter() {
-			@Override
-			public void inc() {}
-
-			@Override
-			public void inc(long n) {}
-
-			@Override
-			public void dec() {}
-
-			@Override
-			public void dec(long n) {}
-
-			@Override
-			public long getCount() {
-				return 1;
-			}
-		}, "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DCounter c = new DCounter(new TestCounter(1), "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testCounter\",\"type\":\"count\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
@@ -155,24 +108,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeMeter() throws JsonProcessingException {
-
-		DMeter m = new DMeter(new Meter() {
-			@Override
-			public void markEvent() {}
-
-			@Override
-			public void markEvent(long n) {}
-
-			@Override
-			public double getRate() {
-				return 1;
-			}
-
-			@Override
-			public long getCount() {
-				return 0;
-			}
-		}, "testMeter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DMeter m = new DMeter(new TestMeter(0, 1), "testMeter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testMeter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",
@@ -181,24 +117,7 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeMeterWithoutHost() throws JsonProcessingException {
-
-		DMeter m = new DMeter(new Meter() {
-			@Override
-			public void markEvent() {}
-
-			@Override
-			public void markEvent(long n) {}
-
-			@Override
-			public double getRate() {
-				return 1;
-			}
-
-			@Override
-			public long getCount() {
-				return 0;
-			}
-		}, "testMeter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DMeter m = new DMeter(new TestMeter(0, 1), "testMeter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
 
 		assertEquals(
 			"{\"metric\":\"testMeter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -22,6 +22,9 @@ import org.apache.flink.metrics.util.TestCounter;
 import org.apache.flink.metrics.util.TestMeter;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.MapperFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
@@ -29,8 +32,12 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -39,6 +46,16 @@ import static org.junit.Assert.assertTrue;
 public class DatadogHttpClientTest {
 
 	private static final List<String> tags = Arrays.asList("tag1", "tag2");
+	private static final String TAGS_AS_JSON = tags.stream().collect(Collectors.joining("\",\"", "[\"", "\"]"));
+	private static final String HOST = "localhost";
+	private static final String METRIC = "testMetric";
+
+	private static final ObjectMapper MAPPER;
+
+	static {
+		MAPPER = new ObjectMapper();
+		MAPPER.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+	}
 
 	private static final long MOCKED_SYSTEM_MILLIS = 123L;
 
@@ -55,7 +72,7 @@ public class DatadogHttpClientTest {
 	@Test
 	public void testGetProxyWithNullProxyHost() {
 		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123, DataCenter.US, false);
-		assert(client.getProxy() == Proxy.NO_PROXY);
+		assert (client.getProxy() == Proxy.NO_PROXY);
 	}
 
 	@Test
@@ -72,55 +89,80 @@ public class DatadogHttpClientTest {
 
 	@Test
 	public void serializeGauge() throws JsonProcessingException {
-		DGauge g = new DGauge(() -> 1, "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DGauge(() -> 1, METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testCounter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-			DatadogHttpClient.serialize(g));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.gauge, true, "1"));
 	}
 
 	@Test
 	public void serializeGaugeWithoutHost() throws JsonProcessingException {
-		DGauge g = new DGauge(() -> 1, "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DGauge(() -> 1, METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testCounter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-			DatadogHttpClient.serialize(g));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.gauge, false, "1"));
 	}
 
 	@Test
 	public void serializeCounter() throws JsonProcessingException {
-		DCounter c = new DCounter(new TestCounter(1), "testCounter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DCounter(new TestCounter(1), METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testCounter\",\"type\":\"count\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-			DatadogHttpClient.serialize(c));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.count, true, "1"));
 	}
 
 	@Test
 	public void serializeCounterWithoutHost() throws JsonProcessingException {
-		DCounter c = new DCounter(new TestCounter(1), "testCounter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DCounter(new TestCounter(1), METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testCounter\",\"type\":\"count\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-			DatadogHttpClient.serialize(c));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.count, false, "1"));
 	}
 
 	@Test
 	public void serializeMeter() throws JsonProcessingException {
-		DMeter m = new DMeter(new TestMeter(0, 1), "testMeter", "localhost", tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DMeter(new TestMeter(0, 1), METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testMeter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",
-			DatadogHttpClient.serialize(m));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.gauge, true, "1.0"));
 	}
 
 	@Test
 	public void serializeMeterWithoutHost() throws JsonProcessingException {
-		DMeter m = new DMeter(new TestMeter(0, 1), "testMeter", null, tags, () -> MOCKED_SYSTEM_MILLIS);
+		DSeries series = new DSeries();
+		series.add(new DMeter(new TestMeter(0, 1), METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-		assertEquals(
-			"{\"metric\":\"testMeter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",
-			DatadogHttpClient.serialize(m));
+		assertSerialization(DatadogHttpClient.serialize(series), new MetricAssertion(MetricType.gauge, false, "1.0"));
+	}
+
+	private static void assertSerialization(String json, MetricAssertion... metricAssertions) throws JsonProcessingException {
+		final JsonNode series = MAPPER.readTree(json).get(DSeries.FIELD_NAME_SERIES);
+
+		for (int i = 0; i < metricAssertions.length; i++) {
+			final JsonNode parsedJson = series.get(i);
+			final MetricAssertion metricAssertion = metricAssertions[i];
+
+			if (metricAssertion.expectHost) {
+				assertThat(parsedJson.get(DMetric.FIELD_NAME_HOST).asText(), is(HOST));
+			} else {
+				assertThat(parsedJson.get(DMetric.FIELD_NAME_HOST), nullValue());
+			}
+			assertThat(parsedJson.get(DMetric.FIELD_NAME_METRIC).asText(), is(METRIC));
+			assertThat(parsedJson.get(DMetric.FIELD_NAME_TYPE).asText(), is(metricAssertion.expectedType.name()));
+			assertThat(parsedJson.get(DMetric.FIELD_NAME_POINTS).toString(), is(String.format("[[123,%s]]", metricAssertion.expectedValue)));
+			assertThat(parsedJson.get(DMetric.FIELD_NAME_TAGS).toString(), is(TAGS_AS_JSON));
+		}
+	}
+
+	private static final class MetricAssertion {
+		final MetricType expectedType;
+		final boolean expectHost;
+		final String expectedValue;
+
+		private MetricAssertion(MetricType expectedType, boolean expectHost, String expectedValue) {
+			this.expectedType = expectedType;
+			this.expectHost = expectHost;
+			this.expectedValue = expectedValue;
+		}
 	}
 }


### PR DESCRIPTION
Adds support for histograms to the datadog reporter, and does a bunch of cleanup work in the code.

Histograms are mapped to a series of gauges; while datadog does have a histogram metric type it is not supported via the HTTP API that we use.