### PR TITLE
[FLINK-20541][client] ClusterID is not used in the method!

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ApplicationDeployer.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ApplicationDeployer.java
@@ -37,7 +37,7 @@ public interface ApplicationDeployer {
 	 * @param applicationConfiguration an {@link ApplicationConfiguration} specific to
 	 *                                   the application to be executed.
 	 */
-	<ClusterID> void run(
+	 void run(
 			final Configuration configuration,
 			final ApplicationConfiguration applicationConfiguration) throws Exception;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ApplicationDeployer.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ApplicationDeployer.java
@@ -37,7 +37,7 @@ public interface ApplicationDeployer {
 	 * @param applicationConfiguration an {@link ApplicationConfiguration} specific to
 	 *                                   the application to be executed.
 	 */
-	 void run(
+	void run(
 			final Configuration configuration,
 			final ApplicationConfiguration applicationConfiguration) throws Exception;
 }


### PR DESCRIPTION
 the "ClusterID" before method "run(configuration,applicationConfiguration)" of class org.apache.flink.client.cli.ApplicationDeployer is not used!