### PR TITLE
[FLINK-20483][python] Support Pandas UDF for Map Operation in Python Table API

### DIFF
--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -195,9 +195,19 @@ class PandasUDFITTests(object):
 
         @udf(result_type=row_type, func_type="pandas")
         def row_func(row_param):
-            assert isinstance(row_param, pd.Series)
-            assert isinstance(row_param[0], dict), \
-                'row_param of wrong type %s !' % type(row_param[0])
+            assert isinstance(row_param, pd.DataFrame)
+            assert isinstance(row_param.f1, pd.Series)
+            assert isinstance(row_param.f1[0], np.int32), \
+                'row_param.f1 of wrong type %s !' % type(row_param.f1[0])
+            assert isinstance(row_param.f2, pd.Series)
+            assert isinstance(row_param.f2[0], str), \
+                'row_param.f2 of wrong type %s !' % type(row_param.f2[0])
+            assert isinstance(row_param.f3, pd.Series)
+            assert isinstance(row_param.f3[0], datetime.datetime), \
+                'row_param.f3 of wrong type %s !' % type(row_param.f3[0])
+            assert isinstance(row_param.f4, pd.Series)
+            assert isinstance(row_param.f4[0], np.ndarray), \
+                'row_param.f4 of wrong type %s !' % type(row_param.f4[0])
             return row_param
 
         table_sink = source_sink_utils.TestAppendSink(

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -49,7 +49,7 @@ class RowBasedOperationTests(object):
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["4,9", "3,4", "7,36", "10,81", "5,16"])
 
-    def test_map_pandas(self):
+    def test_map_with_pandas_udf(self):
         t = self.t_env.from_elements(
             [(1, Row(2, 3)), (2, Row(1, 3)), (1, Row(5, 4)), (1, Row(8, 6)), (2, Row(3, 4))],
             DataTypes.ROW(

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -49,6 +49,35 @@ class RowBasedOperationTests(object):
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["4,9", "3,4", "7,36", "10,81", "5,16"])
 
+    def test_map_pandas(self):
+        t = self.t_env.from_elements(
+            [(1, Row(2, 3)), (2, Row(1, 3)), (1, Row(5, 4)), (1, Row(8, 6)), (2, Row(3, 4))],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b",
+                                 DataTypes.ROW([DataTypes.FIELD("a", DataTypes.INT()),
+                                                DataTypes.FIELD("b", DataTypes.INT())]))]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'],
+            [DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        def func(x, y):
+            import pandas as pd
+            a = (x * 2).rename('b')
+            res = pd.concat([a, x], axis=1) + y
+            return res
+
+        pandas_udf = udf(func,
+                         result_type=DataTypes.ROW(
+                             [DataTypes.FIELD("c", DataTypes.BIGINT()),
+                              DataTypes.FIELD("d", DataTypes.BIGINT())]),
+                         func_type='pandas')
+        t.map(pandas_udf(t.a, t.b)).execute_insert("Results").wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["3,5", "3,7", "6,6", "9,8", "5,8"])
+
 
 class BatchRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkBatchTableTestCase):
     pass


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Support Pandas UDF for Map Operation in Python Table API*


## Brief change log

  - *Merge multiple `Pandas.Series` into a `Pandas.DataFrame` when input DataType of the column is `RowType`*
  - *Flatten a `Pandas.DataFrame` into multiple `Pandas.Series` when result DataType of the column is `RowType`*

## Verifying this change

This change added tests and can be verified as follows:

  - *IT in `test_map_pandas` in `test_row_based_operation.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
