### PR TITLE
[FLINK-20506][python] Support FlatMap Operation in Python Table API

### DIFF
--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -780,6 +780,29 @@ class Table(object):
         else:
             return Table(self._j_table.map(func._j_expr), self._t_env)
 
+    def flat_map(self, func: Union[str, Expression]) -> 'Table':
+        """
+        Performs a flatMap operation with an user-defined table function.
+
+        Example:
+        ::
+
+            >>> @udtf(result_types=[DataTypes.INT(), DataTypes.STRING()])
+            ... def split(x, string):
+            ...     for s in string.split(","):
+            ...         yield x, s
+            >>> tab.flat_map(split(tab.a, table.b))
+
+        :param func: user-defined table function.
+        :return: The result table.
+
+        .. versionadded:: 1.13.0
+        """
+        if isinstance(func, str):
+            return Table(self._j_table.flatMap(func), self._t_env)
+        else:
+            return Table(self._j_table.flatMap(func._j_expr), self._t_env)
+
     def insert_into(self, table_path: str):
         """
         Writes the :class:`~pyflink.table.Table` to a :class:`~pyflink.table.TableSink` that was


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support FlatMap Operation in Python Table API*


## Brief change log

  - *Add `flat_map` api in Python `Table`*

## Verifying this change

This change added tests and can be verified as follows:

  - *IT `test_flat_map` in `test_row_based_operation.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
