### PR TITLE
[FLINK-20507][python] Support Aggregate Operation in Python Table API

### DIFF
--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -34,12 +34,9 @@ _constant_num = 0
 
 def wrap_pandas_result(it):
     import pandas as pd
-    is_row_type = None
     arrays = []
     for result in it:
-        if is_row_type is None:
-            is_row_type = isinstance(result, (Row, Tuple))
-        if is_row_type:
+        if isinstance(result, (Row, Tuple)):
             arrays.append(pd.concat([pd.Series([item]) for item in result], axis=1))
         else:
             arrays.append(pd.Series([result]))

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -34,7 +34,16 @@ _constant_num = 0
 
 def wrap_pandas_result(it):
     import pandas as pd
-    return [pd.Series([result]) for result in it]
+    is_row_type = None
+    arrays = []
+    for result in it:
+        if is_row_type is None:
+            is_row_type = isinstance(result, (Row, Tuple))
+        if is_row_type:
+            arrays.append(pd.concat([pd.Series([item]) for item in result], axis=1))
+        else:
+            arrays.append(pd.Series([result]))
+    return arrays
 
 
 def extract_over_window_user_defined_function(user_defined_function_proto):

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -34,11 +34,6 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
 
         with self.assertRaises(
                 TypeError,
-                msg="Invalid returnType: Pandas UDAF doesn't support DataType type ROW currently"):
-            udaf(pandas_udaf, result_type=DataTypes.ROW(), func_type="pandas")
-
-        with self.assertRaises(
-                TypeError,
                 msg="Invalid returnType: Pandas UDAF doesn't support DataType type MAP currently"):
             udaf(pandas_udaf, result_type=DataTypes.MAP(DataTypes.INT(), DataTypes.INT()),
                  func_type="pandas")

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -48,19 +48,26 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
 
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b', 'c'],
-            [DataTypes.TINYINT(), DataTypes.FLOAT(), DataTypes.INT()])
+            [DataTypes.TINYINT(), DataTypes.FLOAT(),
+             DataTypes.ROW(
+                 [DataTypes.FIELD("a", DataTypes.INT()),
+                  DataTypes.FIELD("b", DataTypes.INT())])])
         self.t_env.register_table_sink("Results", table_sink)
         # general udf
         add = udf(lambda a: a + 1, result_type=DataTypes.INT())
         # pandas udf
         substract = udf(lambda a: a - 1, result_type=DataTypes.INT(), func_type="pandas")
-        max_udaf = udaf(lambda a: a.max(), result_type=DataTypes.INT(), func_type="pandas")
+        max_udaf = udaf(lambda a: (a.max(), a.min()),
+                        result_type=DataTypes.ROW(
+                            [DataTypes.FIELD("a", DataTypes.INT()),
+                             DataTypes.FIELD("b", DataTypes.INT())]),
+                        func_type="pandas")
         t.group_by("a") \
             .select(t.a, mean_udaf(add(t.b)), max_udaf(substract(t.c))) \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
-        self.assert_equals(actual, ["1,6.0,5", "2,3.0,3", "3,3.0,2"])
+        self.assert_equals(actual, ["1,6.0,5,2", "2,3.0,3,2", "3,3.0,2,2"])
 
     def test_group_aggregate_without_keys(self):
         t = self.t_env.from_elements(

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -15,10 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from pandas.util.testing import assert_frame_equal
 
 from pyflink.common import Row
+from pyflink.table import expressions as expr
 from pyflink.table.types import DataTypes
-from pyflink.table.udf import udf, udtf
+from pyflink.table.udf import udf, udtf, udaf, AggregateFunction
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
     PyFlinkBlinkStreamTableTestCase
@@ -106,11 +108,154 @@ class RowBasedOperationTests(object):
 
 
 class BatchRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkBatchTableTestCase):
-    pass
+    def test_aggregate_with_pandas_udaf(self):
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c'],
+            [DataTypes.TINYINT(), DataTypes.FLOAT(), DataTypes.INT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        pandas_udaf = udaf(lambda a: (a.mean(), a.max()),
+                           result_type=DataTypes.ROW(
+                               [DataTypes.FIELD("a", DataTypes.FLOAT()),
+                                DataTypes.FIELD("b", DataTypes.INT())]),
+                           func_type="pandas")
+        t.group_by(t.a) \
+            .aggregate(pandas_udaf(t.b).alias("c", "d")) \
+            .select("a, c, d").execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,5.0,8", "2,2.0,3"])
+
+    def test_aggregate_with_pandas_udaf_without_keys(self):
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b'],
+            [DataTypes.FLOAT(), DataTypes.INT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        pandas_udaf = udaf(lambda a: Row(a.mean(), a.max()),
+                           result_type=DataTypes.ROW(
+                               [DataTypes.FIELD("a", DataTypes.FLOAT()),
+                                DataTypes.FIELD("b", DataTypes.INT())]),
+                           func_type="pandas")
+        t.aggregate(pandas_udaf(t.b).alias("c", "d")) \
+            .select("c, d").execute_insert("Results") \
+            .wait()
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["3.8,8"])
+
+    def test_window_aggregate_with_pandas_udaf(self):
+        import datetime
+        from pyflink.table.window import Tumble
+        t = self.t_env.from_elements(
+            [
+                (1, 2, 3, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (3, 2, 4, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (2, 1, 2, datetime.datetime(2018, 3, 11, 3, 10, 0, 0)),
+                (1, 3, 1, datetime.datetime(2018, 3, 11, 3, 40, 0, 0)),
+                (1, 8, 5, datetime.datetime(2018, 3, 11, 4, 20, 0, 0)),
+                (2, 3, 6, datetime.datetime(2018, 3, 11, 3, 30, 0, 0))
+            ],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT()),
+                 DataTypes.FIELD("rowtime", DataTypes.TIMESTAMP(3))]))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c'],
+            [
+                DataTypes.TIMESTAMP(3),
+                DataTypes.FLOAT(),
+                DataTypes.INT()
+            ])
+        self.t_env.register_table_sink("Results", table_sink)
+        pandas_udaf = udaf(lambda a: (a.mean(), a.max()),
+                           result_type=DataTypes.ROW(
+                               [DataTypes.FIELD("a", DataTypes.FLOAT()),
+                                DataTypes.FIELD("b", DataTypes.INT())]),
+                           func_type="pandas")
+        tumble_window = Tumble.over(expr.lit(1).hours) \
+            .on(expr.col("rowtime")) \
+            .alias("w")
+        t.window(tumble_window) \
+            .group_by("w") \
+            .aggregate(pandas_udaf(t.b).alias("d", "e")) \
+            .select("w.rowtime, d, e") \
+            .execute_insert("Results") \
+            .wait()
+
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["2018-03-11 03:59:59.999,2.2,3",
+                            "2018-03-11 04:59:59.999,8.0,8"])
 
 
 class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkStreamTableTestCase):
-    pass
+    def test_aggregate(self):
+        import pandas as pd
+        t = self.t_env.from_elements(
+            [(1, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
+            DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.BIGINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())]))
+
+        function = CountAndSumAggregateFunction()
+        agg = udaf(function,
+                   result_type=function.get_result_type(),
+                   accumulator_type=function.get_accumulator_type(),
+                   name=str(function.__class__.__name__))
+        result = t.group_by(t.a) \
+            .aggregate(agg(t.b).alias("c", "d")) \
+            .select("a, c, d") \
+            .to_pandas()
+        assert_frame_equal(result, pd.DataFrame([[1, 3, 15], [2, 2, 4]], columns=['a', 'c', 'd']))
+
+
+class CountAndSumAggregateFunction(AggregateFunction):
+
+    def get_value(self, accumulator):
+        from pyflink.common import Row
+        return Row(accumulator[0], accumulator[1])
+
+    def create_accumulator(self):
+        from pyflink.common import Row
+        return Row(0, 0)
+
+    def accumulate(self, accumulator, *args):
+        accumulator[0] += 1
+        accumulator[1] += args[0]
+
+    def retract(self, accumulator, *args):
+        accumulator[0] -= 1
+        accumulator[1] -= args[0]
+
+    def merge(self, accumulator, accumulators):
+        for other_acc in accumulators:
+            accumulator[0] += other_acc[0]
+            accumulator[1] += other_acc[1]
+
+    def get_accumulator_type(self):
+        return DataTypes.ROW(
+            [DataTypes.FIELD("a", DataTypes.BIGINT()),
+             DataTypes.FIELD("b", DataTypes.BIGINT())])
+
+    def get_result_type(self):
+        return DataTypes.ROW(
+            [DataTypes.FIELD("a", DataTypes.BIGINT()),
+             DataTypes.FIELD("b", DataTypes.BIGINT())])
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -448,8 +448,8 @@ class UserDefinedAggregateFunctionWrapper(UserDefinedFunctionWrapper):
         if not isinstance(result_type, DataType):
             raise TypeError(
                 "Invalid returnType: returnType should be DataType but is {}".format(result_type))
-        from pyflink.table.types import RowType, MapType
-        if func_type == 'pandas' and isinstance(result_type, (RowType, MapType)):
+        from pyflink.table.types import MapType
+        if func_type == 'pandas' and isinstance(result_type, MapType):
             raise TypeError(
                 "Invalid returnType: Pandas UDAF doesn't support DataType type {} currently"
                 .format(result_type))


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Support Aggregate Operation in Python Table API*


## Brief change log

  - *Add `aggregate` API in `Table`, `GroupedTable` and `WindowGroupedTable`*
  - *Add `AggregatedTable`*
  - *Add the support of `RowType` as `result_type` in Pandas UDAF*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added sequence it cases in `test_row_based_operation.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
