### PR TITLE
[FLINK-20258][web] format configured memory sizes on the JM

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/metrics/job-manager-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/metrics/job-manager-metrics.component.html
@@ -31,7 +31,7 @@
           <img src="assets/images/process_mem_model.svg">
         </td>
         <td class="table-header">JVM Heap</td>
-        <td>{{ config['jobmanager.memory.heap.size'] || '-' }}</td>
+        <td>{{ config['jobmanager.memory.heap.size'] | parseInt | humanizeBytes }}</td>
         <td>
           <nz-progress nzSize="small" nzStrokeLinecap="square"
                        [nzPercent]="+(metrics['Status.JVM.Memory.Heap.Used'] / metrics['Status.JVM.Memory.Heap.Max']  * 100 | number:'1.0-2')"
@@ -44,13 +44,13 @@
       </tr>
       <tr>
         <td class="table-header">Off-Heap Memory</td>
-        <td>{{ config['jobmanager.memory.off-heap.size'] || '-' }}</td>
+        <td>{{ config['jobmanager.memory.off-heap.size'] | parseInt | humanizeBytes }}</td>
         <td><i nz-icon nz-tooltip nzTitle="Metrics related to this configuration parameter cannot be monitored. Flink does not have full control over these memory pools"
                nzType="info-circle"></i></td>
       </tr>
       <tr>
         <td class="table-header">JVM Metaspace</td>
-        <td>{{ config['jobmanager.memory.jvm-metaspace.size'] || '-' }}</td>
+        <td>{{ config['jobmanager.memory.jvm-metaspace.size'] | parseInt | humanizeBytes }}</td>
         <td>
           <nz-progress nzSize="small" nzStrokeLinecap="square"
                        [nzPercent]="+(metrics['Status.JVM.Memory.Metaspace.Used'] / metrics['Status.JVM.Memory.Metaspace.Max']  * 100 | number:'1.0-2')"
@@ -63,7 +63,7 @@
         <td class="table-header">JVM Overhead</td>
         <td>
           <ng-container *ngIf="config['jobmanager.memory.jvm-overhead.min'] === config['jobmanager.memory.jvm-overhead.max']; else minMaxTemplate">
-            {{ config['jobmanager.memory.jvm-overhead.min'] || '-' }}
+            {{ config['jobmanager.memory.jvm-overhead.min'] | parseInt | humanizeBytes }}
           </ng-container>
           <ng-template #minMaxTemplate>
             Min: {{ config['jobmanager.memory.jvm-overhead.min'] || '-'}}

--- a/flink-runtime-web/web-dashboard/src/app/share/pipes/parse-int.pipe.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/pipes/parse-int.pipe.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'parseInt'
+})
+export class ParseIntPipe implements PipeTransform {
+  transform(value: string): number | null {
+    const parsed = parseInt(value, 10);
+    if (isNaN(parsed)) {
+      return null;
+    } else {
+      return parsed;
+    }
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/share/pipes/pipe.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/pipes/pipe.module.ts
@@ -23,6 +23,7 @@ import { HumanizeWatermarkPipe } from 'share/pipes/humanize-watermark.pipe';
 import { HumanizeDurationPipe } from './humanize-duration.pipe';
 import { HumanizeDatePipe } from './humanize-date.pipe';
 import { HumanizeChartNumericPipe } from './humanize-chart-numeric.pipe';
+import { ParseIntPipe } from './parse-int.pipe';
 
 @NgModule({
   imports: [CommonModule],
@@ -31,8 +32,16 @@ import { HumanizeChartNumericPipe } from './humanize-chart-numeric.pipe';
     HumanizeDatePipe,
     HumanizeBytesPipe,
     HumanizeWatermarkPipe,
+    ParseIntPipe,
     HumanizeChartNumericPipe
   ],
-  exports: [HumanizeDurationPipe, HumanizeDatePipe, HumanizeBytesPipe, HumanizeWatermarkPipe, HumanizeChartNumericPipe]
+  exports: [
+    HumanizeDurationPipe,
+    HumanizeDatePipe,
+    HumanizeBytesPipe,
+    HumanizeWatermarkPipe,
+    HumanizeChartNumericPipe,
+    ParseIntPipe
+  ]
 })
 export class PipeModule {}


### PR DESCRIPTION
## What is the purpose of the change

ref https://issues.apache.org/jira/browse/FLINK-20258

## Brief change log

Configured memory sizes on the JM metrics page should be displayed with proper units.



## Verifying this change

- visit JM metric page
- check the configured value column

before:

![image](https://user-images.githubusercontent.com/1506722/101738562-4b580d80-3b01-11eb-9cf7-1eb80f56b5a4.png)




after:

![image](https://user-images.githubusercontent.com/1506722/101738578-51e68500-3b01-11eb-9f6d-d2b4af6d1906.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
