### PR TITLE
[FLINK-20521][rpc] Add support for sending null responses 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
@@ -20,6 +20,8 @@ package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -41,6 +43,7 @@ public class SerializedValue<T> implements java.io.Serializable {
 	private static final long serialVersionUID = -3564011643393683761L;
 
 	/** The serialized data. */
+	@Nullable
 	private final byte[] serializedData;
 
 	private SerializedValue(byte[] serializedData) {
@@ -63,6 +66,7 @@ public class SerializedValue<T> implements java.io.Serializable {
 	 *
 	 * @return Serialized data.
 	 */
+	@Nullable
 	public byte[] getByteArray() {
 		return serializedData;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for remote AkkaRpcActors.
+ */
+public class RemoteAkkaRpcActorTest extends TestLogger {
+
+	private static AkkaRpcService rpcService;
+	private static AkkaRpcService otherRpcService;
+
+	@BeforeClass
+	public static void setupClass() throws Exception {
+		final Configuration configuration = new Configuration();
+		rpcService = AkkaRpcServiceUtils.createRemoteRpcService(
+			configuration,
+			"localhost",
+			"0",
+			null,
+			Optional.empty());
+
+		otherRpcService = AkkaRpcServiceUtils.createRemoteRpcService(
+			configuration,
+			"localhost",
+			"0",
+			null,
+			Optional.empty());
+	}
+
+	@AfterClass
+	public static void teardownClass() throws InterruptedException, ExecutionException, TimeoutException {
+		RpcUtils.terminateRpcServices(Time.seconds(10), rpcService, otherRpcService);
+	}
+
+	@Test
+	public void canRespondWithNullValueRemotely() throws Exception {
+		try (final AkkaRpcActorTest.NullRespondingEndpoint nullRespondingEndpoint = new AkkaRpcActorTest.NullRespondingEndpoint(rpcService)) {
+			nullRespondingEndpoint.start();
+
+			final AkkaRpcActorTest.NullRespondingGateway rpcGateway = otherRpcService.connect(
+				nullRespondingEndpoint.getAddress(),
+				AkkaRpcActorTest.NullRespondingGateway.class).join();
+
+			final CompletableFuture<Integer> nullValuedResponseFuture = rpcGateway.foobar();
+
+			assertThat(nullValuedResponseFuture.join(), is(nullValue()));
+		}
+	}
+
+	@Test
+	public void canRespondWithSynchronousNullValueRemotely() throws Exception {
+		try (final AkkaRpcActorTest.NullRespondingEndpoint nullRespondingEndpoint = new AkkaRpcActorTest.NullRespondingEndpoint(rpcService)) {
+			nullRespondingEndpoint.start();
+
+			final AkkaRpcActorTest.NullRespondingGateway rpcGateway = otherRpcService.connect(
+				nullRespondingEndpoint.getAddress(),
+				AkkaRpcActorTest.NullRespondingGateway.class).join();
+
+			final Integer value = rpcGateway.synchronousFoobar();
+
+			assertThat(value, is(nullValue()));
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The AkkaRpcActor failed at sending asynchronous null responses because
it did not wrap the null value in a Status.Success message for local messages.
For remote messages it ran into a NPE because it did not check the
SerializedValue.getByteArray(). This commit fixes both problems so that Flink's
RPC service now supports to respond with null values.

## Verifying this change

Added `RemoteAkkaRpcActorTest` and `AkkaRpcActorTest.canRespondWithNullValueLocally` and `AkkaRpcActorTest.canRespondWithSynchronousNullValueLocally`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
