### PR TITLE
[FLINK-20473][web]when get metrics option, its hard to see the full name unless u choosed

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
@@ -21,7 +21,9 @@
   <ng-template #elseTemplate>
     Add Metric:
     <nz-select nzSize="small" [ngModel]="null" nzShowSearch [nzPlaceHolder]="'Select Metric Name'" (ngModelChange)="updateMetric($event)">
-      <nz-option *ngFor="let name of listOfUnselectedMetric" [nzLabel]="name" [nzValue]="name"></nz-option>
+		<nz-option nzCustomContent *ngFor="let name of listOfUnselectedMetric" [nzLabel]="name" [nzValue]="name">
+			<span nz-tooltip nzTitle="{{name}}">{{name}}</span>
+		</nz-option>
     </nz-select>
   </ng-template>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes user can see the metrics full name when they choose the metrics option, this situation happens when the metrics full is too long and the select widget cannot shows it.


## Brief change log
*modify the web ui metrics tab, when cursor hover on the  select widget option and display the full metrics name.


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)