### PR TITLE
[FLINK-20546][kafka]fix method misuse in DynamicTableFactoryTest

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -574,7 +574,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 			.primaryKey(NAME)
 			.build();
 
-		Map<String, String> options1 = getModifiedOptions(
+		Map<String, String> sinkOptions = getModifiedOptions(
 			getBasicSinkOptions(),
 			options ->
 				options.put(
@@ -584,7 +584,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 						TestFormatFactory.CHANGELOG_MODE.key()),
 					"I;UA;UB;D"));
 		// pk can be defined on cdc table, should pass
-		createTableSink(pkSchema, options1);
+		createTableSink(pkSchema, sinkOptions);
 
 		try {
 			createTableSink(pkSchema, getBasicSinkOptions());
@@ -595,6 +595,18 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				" guarantee the semantic of primary key.";
 			assertEquals(error, t.getCause().getMessage());
 		}
+
+		Map<String, String> sourceOptions = getModifiedOptions(
+				getBasicSourceOptions(),
+				options ->
+						options.put(
+								String.format(
+										"%s.%s",
+										TestFormatFactory.IDENTIFIER,
+										TestFormatFactory.CHANGELOG_MODE.key()),
+								"I;UA;UB;D"));
+		// pk can be defined on cdc table, should pass
+		createTableSource(pkSchema, sourceOptions);
 
 		try {
 			createTableSource(pkSchema, getBasicSourceOptions());

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -528,7 +528,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 				+ "Supported values are ['at-least-once', 'exactly-once', 'none'].")));
 
 		final Map<String, String> modifiedOptions = getModifiedOptions(
-			getBasicSourceOptions(),
+			getBasicSinkOptions(),
 			options -> options.put("sink.semantic", "xyz"));
 
 		createTableSink(SCHEMA, modifiedOptions);
@@ -537,7 +537,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 	@Test
 	public void testSinkWithTopicListOrTopicPattern() {
 		Map<String, String> modifiedOptions = getModifiedOptions(
-			getBasicSourceOptions(),
+			getBasicSinkOptions(),
 			options -> {
 				options.put("topic", TOPICS);
 				options.put("scan.startup.mode", "earliest-offset");
@@ -553,7 +553,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		}
 
 		modifiedOptions = getModifiedOptions(
-			getBasicSourceOptions(),
+			getBasicSinkOptions(),
 			options -> options.put("topic-pattern", TOPIC_REGEX));
 
 		try {
@@ -575,7 +575,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 			.build();
 
 		Map<String, String> options1 = getModifiedOptions(
-			getBasicSourceOptions(),
+			getBasicSinkOptions(),
 			options ->
 				options.put(
 					String.format(
@@ -584,7 +584,6 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 						TestFormatFactory.CHANGELOG_MODE.key()),
 					"I;UA;UB;D"));
 		// pk can be defined on cdc table, should pass
-		createTableSink(pkSchema, options1);
 		createTableSink(pkSchema, options1);
 
 		try {
@@ -598,7 +597,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 		}
 
 		try {
-			createTableSource(pkSchema, getBasicSinkOptions());
+			createTableSource(pkSchema, getBasicSourceOptions());
 			fail();
 		} catch (Throwable t) {
 			String error = "The Kafka table 'default.default.scanTable' with 'test-format' format" +

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -225,7 +225,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 				.field("region", DataTypes.STRING())
 				.field("view_count", DataTypes.BIGINT())
 				.build();
-		createActualSource(illegalSchema, getFullSinkOptions());
+		createActualSource(illegalSchema, getFullSourceOptions());
 	}
 
 	@Test
@@ -273,7 +273,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 
 		createActualSource(SOURCE_SCHEMA,
 				getModifiedOptions(
-						getFullSinkOptions(),
+						getFullSourceOptions(),
 						options -> options.put(
 								String.format("value.%s.%s", TestFormatFactory.IDENTIFIER, TestFormatFactory.CHANGELOG_MODE.key()),
 								"I;UA;UB;D")));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
fix method misuse in `KafkaDynamicTableFactoryTest` and `UpsertKafkaDynamicTableFactoryTest`.

## Brief change log

*(for example:)*
  - use correct method to get options for creating table.


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
