### PR TITLE
[FLINK-20584]fix the ORC format code in scala example.

### DIFF
--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -409,8 +409,9 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]
-    nameColVector.setVal(batch.size + 1, element.getName.getBytes(StandardCharsets.UTF_8))
-    ageColVector.vector(batch.size + 1) = element.getAge
+    nameColVector.setVal(batch.size, element.getName.getBytes(StandardCharsets.UTF_8))
+    ageColVector.vector(batch.size) = element.getAge
+    batch.size+=1
   }
 
 }

--- a/docs/dev/connectors/streamfile_sink.zh.md
+++ b/docs/dev/connectors/streamfile_sink.zh.md
@@ -393,8 +393,9 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]
-    nameColVector.setVal(batch.size + 1, element.getName.getBytes(StandardCharsets.UTF_8))
-    ageColVector.vector(batch.size + 1) = element.getAge
+    nameColVector.setVal(batch.size, element.getName.getBytes(StandardCharsets.UTF_8))
+    ageColVector.vector(batch.size) = element.getAge
+    batch.size+=1
   }
 
 }


### PR DESCRIPTION
## What is the purpose of the change
This pull request fix the document: Streaming File Sink - ORC Format, example of Scala, file is empty after being written


## Brief change log
fix example error in document of Streaming File Sink .


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know)  no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
