### PR TITLE
[FLINK-19905][Connector][jdbc] The Jdbc-connector's 'lookup.max-retries' option initial value is 1 in JdbcLookupFunction

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcLookupFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcLookupFunction.java
@@ -147,7 +147,7 @@ public class JdbcLookupFunction extends TableFunction<Row> {
 			}
 		}
 
-		for (int retry = 1; retry <= maxRetryTimes; retry++) {
+		for (int retry = 0; retry <= maxRetryTimes; retry++) {
 			try {
 				statement.clearParameters();
 				for (int i = 0; i < keys.length; i++) {

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
@@ -115,7 +115,7 @@ public class JdbcValidator extends ConnectorDescriptorValidator {
 	private void validateLookupProperties(DescriptorProperties properties) {
 		properties.validateLong(CONNECTOR_LOOKUP_CACHE_MAX_ROWS, true);
 		properties.validateDuration(CONNECTOR_LOOKUP_CACHE_TTL, true, 1);
-		properties.validateInt(CONNECTOR_LOOKUP_MAX_RETRIES, true,0);
+		properties.validateInt(CONNECTOR_LOOKUP_MAX_RETRIES, true, 0);
 
 		checkAllOrNone(properties, new String[]{
 			CONNECTOR_LOOKUP_CACHE_MAX_ROWS,

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
@@ -115,7 +115,7 @@ public class JdbcValidator extends ConnectorDescriptorValidator {
 	private void validateLookupProperties(DescriptorProperties properties) {
 		properties.validateLong(CONNECTOR_LOOKUP_CACHE_MAX_ROWS, true);
 		properties.validateDuration(CONNECTOR_LOOKUP_CACHE_TTL, true, 1);
-		properties.validateInt(CONNECTOR_LOOKUP_MAX_RETRIES, true);
+		properties.validateInt(CONNECTOR_LOOKUP_MAX_RETRIES, true,0);
 
 		checkAllOrNone(properties, new String[]{
 			CONNECTOR_LOOKUP_CACHE_MAX_ROWS,

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcLookupTableITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcLookupTableITCase.java
@@ -118,10 +118,11 @@ public class JdbcLookupTableITCase extends JdbcLookupTestBase {
 				new String[]{"id1", "comment1", "comment2", "id2"},
 				new DataType[]{DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING()})
 				.build());
+		JdbcLookupOptions.Builder lookupOptionsBuilder = JdbcLookupOptions.builder().setMaxRetryTimes(0);
 		if (useCache) {
-			builder.setLookupOptions(JdbcLookupOptions.builder()
-				.setCacheMaxSize(1000).setCacheExpireMs(1000 * 1000).setMaxRetryTimes(0).build());
+			lookupOptionsBuilder.setCacheMaxSize(1000).setCacheExpireMs(1000 * 1000);
 		}
+		builder.setLookupOptions(lookupOptionsBuilder.build());
 		tEnv.registerFunction("jdbcLookup",
 			builder.build().getLookupFunction(t.getSchema().getFieldNames()));
 

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcLookupTableITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcLookupTableITCase.java
@@ -120,7 +120,7 @@ public class JdbcLookupTableITCase extends JdbcLookupTestBase {
 				.build());
 		if (useCache) {
 			builder.setLookupOptions(JdbcLookupOptions.builder()
-				.setCacheMaxSize(1000).setCacheExpireMs(1000 * 1000).build());
+				.setCacheMaxSize(1000).setCacheExpireMs(1000 * 1000).setMaxRetryTimes(0).build());
 		}
 		tEnv.registerFunction("jdbcLookup",
 			builder.build().getLookupFunction(t.getSchema().getFieldNames()));

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
@@ -255,6 +255,17 @@ public class JdbcTableSourceSinkFactoryTest {
 			fail("exception expected");
 		} catch (IllegalArgumentException ignored) {
 		}
+
+		// lookup max-retries properties not complete
+		try {
+			Map<String, String> properties = getBasicProperties();
+			properties.put("connector.lookup.max-retries", "-1");
+
+			TableFactoryService.find(StreamTableSourceFactory.class, properties)
+				.createStreamTableSource(properties);
+			fail("exception expected");
+		} catch (Throwable ignored) {
+		}
 	}
 
 	private Map<String, String> getBasicProperties() {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.connector.jdbc.internal.options.JdbcReadOptions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
 import org.apache.flink.table.factories.StreamTableSourceFactory;
@@ -256,15 +257,15 @@ public class JdbcTableSourceSinkFactoryTest {
 		} catch (IllegalArgumentException ignored) {
 		}
 
-		// lookup max-retries properties not complete
+		// lookup max-retries property less than zero
 		try {
 			Map<String, String> properties = getBasicProperties();
-			properties.put("connector.lookup.max-retries", "0");
+			properties.put("connector.lookup.max-retries", "-1");
 
 			TableFactoryService.find(StreamTableSourceFactory.class, properties)
 				.createStreamTableSource(properties);
 			fail("exception expected");
-		} catch (Throwable ignored) {
+		} catch (ValidationException ignored) {
 		}
 	}
 

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
@@ -259,7 +259,7 @@ public class JdbcTableSourceSinkFactoryTest {
 		// lookup max-retries properties not complete
 		try {
 			Map<String, String> properties = getBasicProperties();
-			properties.put("connector.lookup.max-retries", "-1");
+			properties.put("connector.lookup.max-retries", "0");
 
 			TableFactoryService.find(StreamTableSourceFactory.class, properties)
 				.createStreamTableSource(properties);


### PR DESCRIPTION
…es' option initial value is 1 in JdbcLookupFunction

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The Jdbc-connector's 'lookup.max-retries' option implementation is different from the meaning.


## Brief change log




## Verifying this change



This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
