### PR TITLE
[FLINK-20605][coordination] Only process acknowledgements from registered TaskExecutors

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -516,6 +516,10 @@ public class DeclarativeSlotManager implements SlotManager {
 
 		CompletableFuture<Void> slotAllocationResponseProcessingFuture = completableFuture.handleAsync(
 			(Acknowledge acknowledge, Throwable throwable) -> {
+				if (!taskExecutorManager.isTaskManagerRegistered(instanceId)) {
+					LOG.debug("Ignoring slot allocation response from task executor (instanceID={}) for job {} and slot {} because the task executor is no longer registered.", instanceId,  jobId, slotId);
+					return null;
+				}
 				if (acknowledge != null) {
 					LOG.trace("Completed allocation of slot {} for job {}.", slotId, jobId);
 					slotTracker.notifyAllocationComplete(slotId, jobId);


### PR DESCRIPTION
It is possible that a notification from a task executor about a slot being allocated can be processed after that very task executor has unregistered itself from the resource manager.
As a result we run into an exception when trying to mark this slot as allocated, because it no longer exists and a precondition catches this case.

We could solve this by checking in `DeclarativeResourceManager#allocateSlot` whether the task executor from which we received the acknowledgement from is still registered.
