### PR TITLE
[FLINK-20605][coordination] Rework cancellation of slot allocation futures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
@@ -173,8 +173,8 @@ public class DefaultSlotTracker implements SlotTracker {
 
 	private void transitionSlotToAllocated(DeclarativeTaskManagerSlot slot, JobID jobId) {
 		Preconditions.checkNotNull(slot);
-		Preconditions.checkState(slot.getState() == SlotState.PENDING);
-		Preconditions.checkState(jobId.equals(slot.getJobId()));
+		Preconditions.checkState(jobId.equals(slot.getJobId()), "Job ID from slot status updated (%s) does not match currently assigned job ID (%s) for slot %s.", jobId, slot.getJobId(), slot.getSlotId());
+		Preconditions.checkState(slot.getState() == SlotState.PENDING, "State of slot %s must be %s, but was %s.", slot.getSlotId(), SlotState.PENDING, slot.getState());
 
 		slot.completeAllocation();
 		slotStatusUpdateListeners.notifySlotStatusChange(slot, SlotState.PENDING, SlotState.ALLOCATED, jobId);
@@ -267,6 +267,7 @@ public class DefaultSlotTracker implements SlotTracker {
 
 		@Override
 		public void notifySlotStatusChange(TaskManagerSlotInformation slot, SlotState previous, SlotState current, JobID jobId) {
+			LOG.trace("Slot {} transitioned from {} to {} for job {}.", slot.getSlotId(), previous, current, jobId);
 			listeners.forEach(listeners -> listeners.notifySlotStatusChange(slot, previous, current, jobId));
 		}
 	}


### PR DESCRIPTION
Properly skip the processing of slot allocation that have already concluded by no longer relying on the cancellation of futures, as it is unreliable when using async operations since other operations may occur in-between, and instead using a set for tracking pending allocations and checking at the start of processing.

Basically, in the current code the future to be cancelled can be completed without the async portion having run but being scheduled. If now some operation occurs that would lead to the future being cancelled, then the async portion still runs because a completed future cannot be cancelled.

This wasn't a problem in the old slot manager because it was a lot more lenient when it comes to changing slot states.
