### PR TITLE
[FLINK-19013][state-backends] Add start/end logs for state restoration

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
@@ -24,6 +24,9 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
@@ -33,6 +36,8 @@ import java.util.Collection;
  */
 public abstract class AbstractKeyedStateBackendBuilder<K>
 	implements StateBackendBuilder<AbstractKeyedStateBackend, BackendBuildingException> {
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
+
 	protected final TaskKvStateRegistry kvStateRegistry;
 	protected final StateSerializerProvider<K> keySerializerProvider;
 	protected final ClassLoader userCodeClassLoader;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
@@ -112,6 +112,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
 			keyContext);
 		try {
 			restoreOperation.restore();
+			logger.info("Finished to build heap keyed state-backend.");
 		} catch (Exception e) {
 			throw new BackendBuildingException("Failed when trying to restore heap backend", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -46,6 +46,8 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -65,6 +67,8 @@ import static org.apache.flink.runtime.state.StateUtil.unexpectedStateHandleExce
  * @param <K> The data type that the serializer serializes.
  */
 public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
+	private static final Logger LOG = LoggerFactory.getLogger(HeapRestoreOperation.class);
+
 	private final Collection<KeyedStateHandle> restoreStateHandles;
 	private final StateSerializerProvider<K> keySerializerProvider;
 	private final ClassLoader userCodeClassLoader;
@@ -122,6 +126,7 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 				throw unexpectedStateHandleException(KeyGroupsStateHandle.class, keyedStateHandle.getClass());
 			}
 
+			LOG.info("Starting to restore from state handle: {}.", keyedStateHandle);
 			KeyGroupsStateHandle keyGroupsStateHandle = (KeyGroupsStateHandle) keyedStateHandle;
 			FSDataInputStream fsDataInputStream = keyGroupsStateHandle.openInputStream();
 			cancelStreamRegistry.registerCloseable(fsDataInputStream);
@@ -164,6 +169,7 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 					kvStatesById, restoredMetaInfos.size(),
 					serializationProxy.getReadVersion(),
 					serializationProxy.isUsingKeyGroupCompression());
+				LOG.info("Finished restoring from state handle: {}.", keyedStateHandle);
 			} finally {
 				if (cancelStreamRegistry.unregisterCloseable(fsDataInputStream)) {
 					IOUtils.closeQuietly(fsDataInputStream);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -55,8 +55,6 @@ import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -82,7 +80,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBuilder<K> {
 
-	private static final Logger LOG = LoggerFactory.getLogger(RocksDBKeyedStateBackendBuilder.class);
 	static final String DB_INSTANCE_DIR_STRING = "db";
 
 	/** String that identifies the operator that owns this backend. */
@@ -317,14 +314,14 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 			try {
 				FileUtils.deleteDirectory(instanceBasePath);
 			} catch (Exception ex) {
-				LOG.warn("Failed to instance base path for RocksDB: " + instanceBasePath, ex);
+				logger.warn("Failed to delete base path for RocksDB: " + instanceBasePath, ex);
 			}
 			// Log and rethrow
 			if (e instanceof BackendBuildingException) {
 				throw (BackendBuildingException) e;
 			} else {
 				String errMsg = "Caught unexpected exception.";
-				LOG.error(errMsg, e);
+				logger.error(errMsg, e);
 				throw new BackendBuildingException(errMsg, e);
 			}
 		}
@@ -332,6 +329,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 			keyGroupRange,
 			numberOfKeyGroups
 		);
+		logger.info("Finished building RocksDB keyed state-backend at {}.", instanceBasePath);
 		return new RocksDBKeyedStateBackend<>(
 			this.userCodeClassLoader,
 			this.instanceBasePath,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/AbstractRocksDBRestoreOperation.java
@@ -42,6 +42,8 @@ import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -60,6 +62,8 @@ import java.util.function.Function;
  * @param <K> The data type that the serializer serializes.
  */
 public abstract class AbstractRocksDBRestoreOperation<K> implements RocksDBRestoreOperation, AutoCloseable {
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
+
 	protected final KeyGroupRange keyGroupRange;
 	protected final int keyGroupPrefixBytes;
 	protected final int numberOfTransferringThreads;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -162,11 +162,13 @@ public class RocksDBFullRestoreOperation<K> extends AbstractRocksDBRestoreOperat
 	private void restoreKeyGroupsInStateHandle()
 		throws IOException, StateMigrationException, RocksDBException {
 		try {
+			logger.info("Starting to restore from state handle: {}.", currentKeyGroupsStateHandle);
 			currentStateHandleInStream = currentKeyGroupsStateHandle.openInputStream();
 			cancelStreamRegistry.registerCloseable(currentStateHandleInStream);
 			currentStateHandleInView = new DataInputViewStreamWrapper(currentStateHandleInStream);
 			restoreKVStateMetaData();
 			restoreKVStateData();
+			logger.info("Finished restoring from state handle: {}.", currentKeyGroupsStateHandle);
 		} finally {
 			if (cancelStreamRegistry.unregisterCloseable(currentStateHandleInStream)) {
 				IOUtils.closeQuietly(currentStateHandleInStream);


### PR DESCRIPTION
## What is the purpose of the change

Add start/end logs for state restoration so that users could know when the state restoration is finished.


## Brief change log

  -  Add logs for RocksDB full/incremental restoration.
  -  Add logs for heap full/incremental restoration.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
