### PR TITLE
[FLINK-20621][python] Refactor the TypeInformation implementation in Python DataStream API.

### DIFF
--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -16,7 +16,8 @@
 # limitations under the License.
 ################################################################################
 from py4j.java_gateway import java_import, JavaObject
-from pyflink.common.typeinfo import TypeInformation, WrapperTypeInfo
+from pyflink.common import typeinfo
+from pyflink.common.typeinfo import TypeInformation
 
 from pyflink.util.utils import load_java_class
 
@@ -112,7 +113,7 @@ class JsonRowDeserializationSchema(DeserializationSchema):
                 raise TypeError("The json_schema must not be None.")
             j_type_info = get_gateway().jvm \
                 .org.apache.flink.formats.json.JsonRowSchemaConverter.convert(json_schema)
-            self._type_info = WrapperTypeInfo(j_type_info)
+            self._type_info = typeinfo._from_java_type(j_type_info)
             return self
 
         def fail_on_missing_field(self):
@@ -208,12 +209,9 @@ class CsvRowDeserializationSchema(DeserializationSchema):
         def __init__(self, type_info: TypeInformation):
             if type_info is None:
                 raise TypeError("Type information must not be None")
-            if isinstance(type_info, WrapperTypeInfo):
-                self._j_builder = get_gateway().jvm\
-                    .org.apache.flink.formats.csv.CsvRowDeserializationSchema.Builder(
-                    type_info.get_java_type_info())
-            else:
-                raise ValueError('type_info must be WrapperTypeInfo')
+            self._j_builder = get_gateway().jvm\
+                .org.apache.flink.formats.csv.CsvRowDeserializationSchema.Builder(
+                type_info.get_java_type_info())
 
         def set_field_delimiter(self, delimiter: str):
             self._j_builder = self._j_builder.setFieldDelimiter(delimiter)
@@ -266,12 +264,9 @@ class CsvRowSerializationSchema(SerializationSchema):
         def __init__(self, type_info: TypeInformation):
             if type_info is None:
                 raise TypeError("Type information must not be None")
-            if isinstance(type_info, WrapperTypeInfo):
-                self._j_builder = get_gateway().jvm\
-                    .org.apache.flink.formats.csv.CsvRowSerializationSchema.Builder(
-                    type_info.get_java_type_info())
-            else:
-                raise ValueError('type_info must be WrapperTypeInfo')
+            self._j_builder = get_gateway().jvm\
+                .org.apache.flink.formats.csv.CsvRowSerializationSchema.Builder(
+                type_info.get_java_type_info())
 
         def set_field_delimiter(self, c: str):
             self._j_builder = self._j_builder.setFieldDelimiter(c)

--- a/flink-python/pyflink/common/tests/test_typeinfo.py
+++ b/flink-python/pyflink/common/tests/test_typeinfo.py
@@ -131,3 +131,11 @@ class TypeInfoTests(PyFlinkTestCase):
         sql_date_type_info = Types.SQL_DATE()
         self.assertEqual(sql_date_type_info,
                          _from_java_type(sql_date_type_info.get_java_type_info()))
+
+        map_type_info = Types.MAP(Types.INT(), Types.STRING())
+        self.assertEqual(map_type_info,
+                         _from_java_type(map_type_info.get_java_type_info()))
+
+        list_type_info = Types.LIST(Types.INT())
+        self.assertEqual(list_type_info,
+                         _from_java_type(list_type_info.get_java_type_info()))

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -19,14 +19,14 @@ import calendar
 import datetime
 import time
 from abc import ABC
+from enum import Enum
 from typing import List, Union
 
 from py4j.java_gateway import JavaClass, JavaObject
-
 from pyflink.java_gateway import get_gateway
 
 
-class TypeInformation(ABC):
+class TypeInformation(object):
     """
     TypeInformation is the core class of Flink's type system. FLink requires a type information
     for all types that are used as input or return type of a user function. This type information
@@ -48,29 +48,11 @@ class TypeInformation(ABC):
     nested types).
     """
 
-
-class WrapperTypeInfo(TypeInformation):
-    """
-    A wrapper class for java TypeInformation Objects.
-    """
-
-    def __init__(self, j_typeinfo):
-        self._j_typeinfo = j_typeinfo
+    def __init__(self):
+        self._j_typeinfo = None
 
     def get_java_type_info(self) -> JavaObject:
         return self._j_typeinfo
-
-    def __eq__(self, o) -> bool:
-        if type(o) is type(self):
-            return self._j_typeinfo.equals(o._j_typeinfo)
-        else:
-            return False
-
-    def __hash__(self) -> int:
-        return hash(self._j_typeinfo)
-
-    def __str__(self):
-        return self._j_typeinfo.toString()
 
     def need_conversion(self):
         """
@@ -91,66 +73,117 @@ class WrapperTypeInfo(TypeInformation):
         return obj
 
 
-class BasicTypeInfo(TypeInformation, ABC):
+class BasicTypes(Enum):
+    STRING = "String"
+    BYTE = "Byte"
+    BOOLEAN = "Boolean"
+    SHORT = "Short"
+    INT = "Integer"
+    LONG = "Long"
+    FLOAT = "Float"
+    DOUBLE = "Double"
+    CHAR = "Char"
+    BIG_INT = "BigInteger"
+    BIG_DEC = "BigDecimal"
+
+
+class BasicTypeInformation(TypeInformation, ABC):
     """
     Type information for primitive types (int, long, double, byte, ...), String, BigInteger,
     and BigDecimal.
     """
 
+    def __init__(self, basic_type: BasicTypes):
+        self._basic_type = basic_type
+        super(BasicTypeInformation, self).__init__()
+
+    def get_java_type_info(self) -> JavaObject:
+        if self._basic_type == BasicTypes.STRING:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO
+        elif self._basic_type == BasicTypes.BYTE:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BYTE_TYPE_INFO
+        elif self._basic_type == BasicTypes.BOOLEAN:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BOOLEAN_TYPE_INFO
+        elif self._basic_type == BasicTypes.SHORT:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.SHORT_TYPE_INFO
+        elif self._basic_type == BasicTypes.INT:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
+        elif self._basic_type == BasicTypes.LONG:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO
+        elif self._basic_type == BasicTypes.FLOAT:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.FLOAT_TYPE_INFO
+        elif self._basic_type == BasicTypes.DOUBLE:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.DOUBLE_TYPE_INFO
+        elif self._basic_type == BasicTypes.CHAR:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.CHAR_TYPE_INFO
+        elif self._basic_type == BasicTypes.BIG_INT:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_INT_TYPE_INFO
+        elif self._basic_type == BasicTypes.BIG_DEC:
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_DEC_TYPE_INFO
+        return self._j_typeinfo
+
+    def __eq__(self, o) -> bool:
+        if isinstance(o, BasicTypeInformation):
+            return self._basic_type == o._basic_type
+        return False
+
+    def __repr__(self):
+        return self._basic_type.value
+
     @staticmethod
     def STRING_TYPE_INFO():
-        return WrapperTypeInfo(get_gateway().jvm
-                               .org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.STRING)
 
     @staticmethod
     def BOOLEAN_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.BOOLEAN_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.BOOLEAN)
 
     @staticmethod
     def BYTE_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.BYTE_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.BYTE)
 
     @staticmethod
     def SHORT_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.SHORT_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.SHORT)
 
     @staticmethod
     def INT_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.INT)
 
     @staticmethod
     def LONG_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.LONG)
 
     @staticmethod
     def FLOAT_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.FLOAT_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.FLOAT)
 
     @staticmethod
     def DOUBLE_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.DOUBLE_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.DOUBLE)
 
     @staticmethod
     def CHAR_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.CHAR_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.CHAR)
 
     @staticmethod
     def BIG_INT_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_INT_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.BIG_INT)
 
     @staticmethod
     def BIG_DEC_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_DEC_TYPE_INFO)
+        return BasicTypeInformation(BasicTypes.BIG_DEC)
 
 
 class SqlTimeTypeInfo(TypeInformation, ABC):
@@ -160,163 +193,110 @@ class SqlTimeTypeInfo(TypeInformation, ABC):
 
     @staticmethod
     def DATE():
-        return DateTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE)
+        return DateTypeInformation()
 
     @staticmethod
     def TIME():
-        return TimeTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME)
+        return TimeTypeInformation()
 
     @staticmethod
     def TIMESTAMP():
-        return TimestampTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP)
+        return TimestampTypeInformation()
 
 
-class PrimitiveArrayTypeInfo(WrapperTypeInfo, ABC):
+class PrimitiveArrayTypeInformation(TypeInformation, ABC):
     """
     A TypeInformation for arrays of primitive types (int, long, double, ...).
     Supports the creation of dedicated efficient serializers for these types.
     """
 
-    @staticmethod
-    def BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO)
+    def __init__(self, element_type: TypeInformation):
+        self._element_type = element_type
+        super(PrimitiveArrayTypeInformation, self).__init__()
 
-    @staticmethod
-    def BYTE_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO)
+    def get_java_type_info(self) -> JavaObject:
+        JPrimitiveArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
+            .PrimitiveArrayTypeInfo
+        if self._element_type == Types.BOOLEAN():
+            return JPrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.BYTE():
+            return JPrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.SHORT():
+            return JPrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.INT():
+            return JPrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.LONG():
+            return JPrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.FLOAT():
+            return JPrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.DOUBLE():
+            return JPrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.CHAR():
+            return JPrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO
+        else:
+            raise TypeError("Invalid element type for a primitive array.")
 
-    @staticmethod
-    def SHORT_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO)
+    def __eq__(self, o) -> bool:
+        if isinstance(o, PrimitiveArrayTypeInformation):
+            return self._element_type == o._element_type
+        return False
 
-    @staticmethod
-    def INT_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def LONG_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def FLOAT_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def CHAR_PRIMITIVE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO)
+    def __repr__(self) -> str:
+        return "PrimitiveArrayTypeInformation<%s>" % self._element_type
 
 
 def is_primitive_array_type_info(type_info: TypeInformation):
-    return type_info in {
-        PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO(),
-        PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO()
-    }
+    return isinstance(type_info, PrimitiveArrayTypeInformation)
 
 
-class BasicArrayTypeInfo(WrapperTypeInfo, ABC):
+class BasicArrayTypeInformation(TypeInformation, ABC):
     """
     A TypeInformation for arrays of boxed primitive types (Integer, Long, Double, ...).
     Supports the creation of dedicated efficient serializers for these types.
     """
-    @staticmethod
-    def BOOLEAN_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO)
 
-    @staticmethod
-    def BYTE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO)
+    def __init__(self, element_type: TypeInformation):
+        self._element_type = element_type
+        super(BasicArrayTypeInformation, self).__init__()
 
-    @staticmethod
-    def SHORT_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO)
+    def get_java_type_info(self) -> JavaObject:
+        JBasicArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
+            .BasicArrayTypeInfo
+        if self._element_type == Types.BOOLEAN():
+            return JBasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO
+        elif self._element_type == Types.BYTE():
+            return JBasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.SHORT():
+            return JBasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO
+        elif self._element_type == Types.INT():
+            return JBasicArrayTypeInfo.INT_ARRAY_TYPE_INFO
+        elif self._element_type == Types.LONG():
+            return JBasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
+        elif self._element_type == Types.FLOAT():
+            return JBasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO
+        elif self._element_type == Types.DOUBLE():
+            return JBasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO
+        elif self._element_type == Types.CHAR():
+            return JBasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO
+        elif self._element_type == Types.STRING():
+            return JBasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO
+        else:
+            raise TypeError("Invalid element type for a primitive array.")
 
-    @staticmethod
-    def INT_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO)
+    def __eq__(self, o) -> bool:
+        if isinstance(o, BasicArrayTypeInformation):
+            return self._element_type == o._element_type
+        return False
 
-    @staticmethod
-    def LONG_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def FLOAT_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def DOUBLE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def CHAR_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO)
-
-    @staticmethod
-    def STRING_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo
-            .BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO)
+    def __repr__(self):
+        return "BasicArrayTypeInformation<%s>" % self._element_type
 
 
 def is_basic_array_type_info(type_info: TypeInformation):
-    return type_info in {
-        BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO(),
-        BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO()
-    }
+    return isinstance(type_info, BasicArrayTypeInformation)
 
 
-class PickledBytesTypeInfo(WrapperTypeInfo, ABC):
+class PickledBytesTypeInfo(TypeInformation, ABC):
     """
     A PickledBytesTypeInfo indicates the data is a primitive byte array generated by pickle
     serializer.
@@ -324,11 +304,21 @@ class PickledBytesTypeInfo(WrapperTypeInfo, ABC):
 
     @staticmethod
     def PICKLED_BYTE_ARRAY_TYPE_INFO():
-        return WrapperTypeInfo(get_gateway().jvm.org.apache.flink.streaming.api.typeinfo.python
-                               .PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO)
+        return PickledBytesTypeInfo()
+
+    def get_java_type_info(self) -> JavaObject:
+        self._j_typeinfo = get_gateway().jvm.org.apache.flink.streaming.api.typeinfo.python\
+            .PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
+        return self._j_typeinfo
+
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, PickledBytesTypeInfo)
+
+    def __repr__(self):
+        return "PickledByteArrayTypeInformation"
 
 
-class RowTypeInfo(WrapperTypeInfo):
+class RowTypeInfo(TypeInformation):
     """
     TypeInformation for Row.
     """
@@ -336,51 +326,60 @@ class RowTypeInfo(WrapperTypeInfo):
     def __init__(self, types: List[TypeInformation], field_names: List[str] = None):
         self.types = types
         self.field_names = field_names
-        self.j_types_array = get_gateway().new_array(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation, len(types))
-        for i in range(len(types)):
-            wrapper_typeinfo = types[i]
-            if isinstance(wrapper_typeinfo, WrapperTypeInfo):
-                self.j_types_array[i] = wrapper_typeinfo.get_java_type_info()
-
-        if field_names is None:
-            self._j_typeinfo = get_gateway().jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(
-                self.j_types_array)
-        else:
-            j_names_array = get_gateway().new_array(get_gateway().jvm.java.lang.String,
-                                                    len(field_names))
-            for i in range(len(field_names)):
-                j_names_array[i] = field_names[i]
-            self._j_typeinfo = get_gateway().jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(
-                self.j_types_array, j_names_array)
-        self._need_conversion = [f.need_conversion() if isinstance(f, WrapperTypeInfo) else None
-                                 for f in types]
+        self._need_conversion = [f.need_conversion() if isinstance(f, TypeInformation) else None
+                                 for f in self.types]
         self._need_serialize_any_field = any(self._need_conversion)
-        super(RowTypeInfo, self).__init__(self._j_typeinfo)
+        super(RowTypeInfo, self).__init__()
 
     def get_field_names(self) -> List[str]:
-        j_field_names = self._j_typeinfo.getFieldNames()
-        field_names = [name for name in j_field_names]
-        return field_names
+        if not self.field_names:
+            j_field_names = self.get_java_type_info().getFieldNames()
+            self.field_names = [name for name in j_field_names]
+        return self.field_names
 
     def get_field_index(self, field_name: str) -> int:
-        return self._j_typeinfo.getFieldIndex(field_name)
+        if self.field_names:
+            return self.field_names.index(field_name)
+        return -1
 
     def get_field_types(self) -> List[TypeInformation]:
         return self.types
 
-    def __eq__(self, other) -> bool:
-        return self._j_typeinfo.equals(other._j_typeinfo)
+    def get_java_type_info(self) -> JavaObject:
+        if not self._j_typeinfo:
+            j_types_array = get_gateway()\
+                .new_array(get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation,
+                           len(self.types))
+            for i in range(len(self.types)):
+                wrapper_typeinfo = self.types[i]
+                if isinstance(wrapper_typeinfo, TypeInformation):
+                    j_types_array[i] = wrapper_typeinfo.get_java_type_info()
 
-    def __hash__(self) -> int:
-        return self._j_typeinfo.hashCode()
+            if self.field_names is None:
+                self._j_typeinfo = get_gateway().jvm\
+                    .org.apache.flink.api.java.typeutils.RowTypeInfo(j_types_array)
+            else:
+                j_names_array = get_gateway().new_array(get_gateway().jvm.java.lang.String,
+                                                        len(self.field_names))
+                for i in range(len(self.field_names)):
+                    j_names_array[i] = self.field_names[i]
+                self._j_typeinfo = get_gateway().jvm\
+                    .org.apache.flink.api.java.typeutils.RowTypeInfo(j_types_array, j_names_array)
+        return self._j_typeinfo
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, RowTypeInfo):
+            return self.types == other.types
+        return False
 
     def __str__(self) -> str:
-
-        return "RowTypeInfo(%s)" % ', '.join([field_name + ': ' + field_type.__str__()
-                                              for field_name, field_type in
-                                              zip(self.get_field_names(),
-                                                  self.get_field_types())])
+        if self.field_names:
+            return "RowTypeInfo(%s)" % ', '.join([field_name + ': ' + str(field_type)
+                                                  for field_name, field_type in
+                                                  zip(self.get_field_names(),
+                                                      self.get_field_types())])
+        else:
+            return "RowTypeInfo(%s)" % ', '.join([str(field_type) for field_type in self.types])
 
     def need_conversion(self):
         return True
@@ -393,7 +392,7 @@ class RowTypeInfo(WrapperTypeInfo):
             # Only calling to_internal_type function for fields that need conversion
             if isinstance(obj, dict):
                 return tuple(f.to_internal_type(obj.get(n)) if c else obj.get(n)
-                             for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
+                             for n, f, c in zip(self.field_names, self.types,
                                                 self._need_conversion))
             elif isinstance(obj, (tuple, list)):
                 return tuple(f.to_internal_type(v) if c else v
@@ -407,12 +406,12 @@ class RowTypeInfo(WrapperTypeInfo):
                 raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
         else:
             if isinstance(obj, dict):
-                return tuple(obj.get(n) for n in self._j_typeinfo.getFieldNames())
+                return tuple(obj.get(n) for n in self.field_names)
             elif isinstance(obj, (list, tuple)):
                 return tuple(obj)
             elif hasattr(obj, "__dict__"):
                 d = obj.__dict__
-                return tuple(d.get(n) for n in self._j_typeinfo.getFieldNames())
+                return tuple(d.get(n) for n in self.field_names)
             else:
                 raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
 
@@ -431,45 +430,47 @@ class RowTypeInfo(WrapperTypeInfo):
         return tuple(values)
 
 
-class TupleTypeInfo(WrapperTypeInfo):
+class TupleTypeInfo(TypeInformation):
     """
     TypeInformation for Tuple.
     """
 
     def __init__(self, types: List[TypeInformation]):
         self.types = types
-        j_types_array = get_gateway().new_array(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation, len(types))
-
-        for i in range(len(types)):
-            field_type = types[i]
-            if isinstance(field_type, WrapperTypeInfo):
-                j_types_array[i] = field_type.get_java_type_info()
-
-        j_typeinfo = get_gateway().jvm \
-            .org.apache.flink.api.java.typeutils.TupleTypeInfo(j_types_array)
-        super(TupleTypeInfo, self).__init__(j_typeinfo=j_typeinfo)
+        super(TupleTypeInfo, self).__init__()
 
     def get_field_types(self) -> List[TypeInformation]:
         return self.types
 
-    def __eq__(self, other) -> bool:
-        return self._j_typeinfo.equals(other._j_typeinfo)
+    def get_java_type_info(self) -> JavaObject:
+        j_types_array = get_gateway().new_array(
+            get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation, len(self.types))
 
-    def __hash__(self) -> int:
-        return self._j_typeinfo.hashCode()
+        for i in range(len(self.types)):
+            field_type = self.types[i]
+            if isinstance(field_type, TypeInformation):
+                j_types_array[i] = field_type.get_java_type_info()
+
+        self._j_typeinfo = get_gateway().jvm \
+            .org.apache.flink.api.java.typeutils.TupleTypeInfo(j_types_array)
+        return self._j_typeinfo
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, TupleTypeInfo):
+            return self.types == other.types
+        return False
 
     def __str__(self) -> str:
-        return "TupleTypeInfo(%s)" % ', '.join([field_type.__str__() for field_type in self.types])
+        return "TupleTypeInfo(%s)" % ', '.join([str(field_type) for field_type in self.types])
 
 
-class DateTypeInfo(WrapperTypeInfo):
+class DateTypeInformation(TypeInformation):
     """
     TypeInformation for Date.
     """
 
-    def __init__(self, j_typeinfo):
-        super(DateTypeInfo, self).__init__(j_typeinfo)
+    def __init__(self):
+        super(DateTypeInformation, self).__init__()
 
     EPOCH_ORDINAL = datetime.datetime(1970, 1, 1).toordinal()
 
@@ -484,16 +485,24 @@ class DateTypeInfo(WrapperTypeInfo):
         if v is not None:
             return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
 
+    def get_java_type_info(self) -> JavaObject:
+        self._j_typeinfo = get_gateway().jvm\
+            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE
+        return self._j_typeinfo
 
-class TimeTypeInfo(WrapperTypeInfo):
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, DateTypeInformation)
+
+    def __repr__(self):
+        return "DateTypeInformation"
+
+
+class TimeTypeInformation(TypeInformation):
     """
     TypeInformation for Time.
     """
 
     EPOCH_ORDINAL = calendar.timegm(time.localtime(0)) * 10 ** 6
-
-    def __init__(self, j_typeinfo):
-        super(TimeTypeInfo, self).__init__(j_typeinfo)
 
     def need_conversion(self):
         return True
@@ -518,14 +527,22 @@ class TimeTypeInfo(WrapperTypeInfo):
             hours, minutes = divmod(minutes, 60)
             return datetime.time(hours, minutes, seconds, microseconds)
 
+    def get_java_type_info(self) -> JavaObject:
+        self._j_typeinfo = get_gateway().jvm\
+            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME
+        return self._j_typeinfo
 
-class TimestampTypeInfo(WrapperTypeInfo):
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, TimeTypeInformation)
+
+    def __repr__(self) -> str:
+        return "TimeTypeInformation"
+
+
+class TimestampTypeInformation(TypeInformation):
     """
     TypeInformation for Timestamp.
     """
-
-    def __init__(self, j_typeinfo):
-        super(TimestampTypeInfo, self).__init__(j_typeinfo)
 
     def need_conversion(self):
         return True
@@ -540,6 +557,17 @@ class TimestampTypeInfo(WrapperTypeInfo):
         if ts is not None:
             return datetime.datetime.fromtimestamp(ts // 10 ** 6).replace(microsecond=ts % 10 ** 6)
 
+    def get_java_type_info(self) -> JavaObject:
+        self._j_typeinfo = get_gateway().jvm\
+            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP
+        return self._j_typeinfo
+
+    def __eq__(self, o: object) -> bool:
+        return isinstance(o, TimestampTypeInformation)
+
+    def __repr__(self):
+        return "TimestampTypeInformation"
+
 
 class Types(object):
     """
@@ -547,17 +575,17 @@ class Types(object):
     built-in serializers and comparators.
     """
 
-    STRING = BasicTypeInfo.STRING_TYPE_INFO
-    BYTE = BasicTypeInfo.BYTE_TYPE_INFO
-    BOOLEAN = BasicTypeInfo.BOOLEAN_TYPE_INFO
-    SHORT = BasicTypeInfo.SHORT_TYPE_INFO
-    INT = BasicTypeInfo.INT_TYPE_INFO
-    LONG = BasicTypeInfo.LONG_TYPE_INFO
-    FLOAT = BasicTypeInfo.FLOAT_TYPE_INFO
-    DOUBLE = BasicTypeInfo.DOUBLE_TYPE_INFO
-    CHAR = BasicTypeInfo.CHAR_TYPE_INFO
-    BIG_INT = BasicTypeInfo.BIG_INT_TYPE_INFO
-    BIG_DEC = BasicTypeInfo.BIG_DEC_TYPE_INFO
+    STRING = BasicTypeInformation.STRING_TYPE_INFO
+    BYTE = BasicTypeInformation.BYTE_TYPE_INFO
+    BOOLEAN = BasicTypeInformation.BOOLEAN_TYPE_INFO
+    SHORT = BasicTypeInformation.SHORT_TYPE_INFO
+    INT = BasicTypeInformation.INT_TYPE_INFO
+    LONG = BasicTypeInformation.LONG_TYPE_INFO
+    FLOAT = BasicTypeInformation.FLOAT_TYPE_INFO
+    DOUBLE = BasicTypeInformation.DOUBLE_TYPE_INFO
+    CHAR = BasicTypeInformation.CHAR_TYPE_INFO
+    BIG_INT = BasicTypeInformation.BIG_INT_TYPE_INFO
+    BIG_DEC = BasicTypeInformation.BIG_DEC_TYPE_INFO
 
     SQL_DATE = SqlTimeTypeInfo.DATE
     SQL_TIME = SqlTimeTypeInfo.TIME
@@ -605,24 +633,7 @@ class Types(object):
         :param element_type element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
         Types.DOUBLE())
         """
-        if element_type == Types.BOOLEAN():
-            return PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.BYTE():
-            return PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.SHORT():
-            return PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.INT():
-            return PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.LONG():
-            return PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.FLOAT():
-            return PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.DOUBLE():
-            return PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO()
-        elif element_type == Types.CHAR():
-            return PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO()
-        else:
-            raise TypeError("Invalid element type for a primitive array.")
+        return PrimitiveArrayTypeInformation(element_type)
 
     @staticmethod
     def BASIC_ARRAY(element_type: TypeInformation) -> TypeInformation:
@@ -632,27 +643,8 @@ class Types(object):
         :param element_type element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
         Types.DOUBLE())
         """
-        if element_type == Types.BOOLEAN():
-            return BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO()
-        elif element_type == Types.BYTE():
-            return BasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO()
-        elif element_type == Types.SHORT():
-            return BasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO()
-        elif element_type == Types.INT():
-            return BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO()
-        elif element_type == Types.LONG():
-            return BasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO()
-        elif element_type == Types.FLOAT():
-            return BasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO()
-        elif element_type == Types.DOUBLE():
-            return BasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO()
-        elif element_type == Types.CHAR():
-            return BasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO()
-        elif element_type == Types.STRING():
-            return BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO()
-        else:
-            raise TypeError("Invalid element type for a boxed primitive array: %s" %
-                            str(element_type))
+
+        return BasicArrayTypeInformation(element_type)
 
 
 def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
@@ -710,8 +702,7 @@ def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
     elif _is_instance_of(j_type_info, JPrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO):
         return Types.PRIMITIVE_ARRAY(Types.CHAR())
 
-    JBasicArrayTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo \
-        .BasicArrayTypeInfo
+    JBasicArrayTypeInfo = gateway.jvm.org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo
 
     if _is_instance_of(j_type_info, JBasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO):
         return Types.BASIC_ARRAY(Types.BOOLEAN())

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -98,29 +98,32 @@ class BasicTypeInfo(TypeInformation):
         super(BasicTypeInfo, self).__init__()
 
     def get_java_type_info(self) -> JavaObject:
-        JBasicTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
-        if self._basic_type == BasicType.STRING:
-            self._j_typeinfo = JBasicTypeInfo.STRING_TYPE_INFO
-        elif self._basic_type == BasicType.BYTE:
-            self._j_typeinfo = JBasicTypeInfo.BYTE_TYPE_INFO
-        elif self._basic_type == BasicType.BOOLEAN:
-            self._j_typeinfo = JBasicTypeInfo.BOOLEAN_TYPE_INFO
-        elif self._basic_type == BasicType.SHORT:
-            self._j_typeinfo = JBasicTypeInfo.SHORT_TYPE_INFO
-        elif self._basic_type == BasicType.INT:
-            self._j_typeinfo = JBasicTypeInfo.INT_TYPE_INFO
-        elif self._basic_type == BasicType.LONG:
-            self._j_typeinfo = JBasicTypeInfo.LONG_TYPE_INFO
-        elif self._basic_type == BasicType.FLOAT:
-            self._j_typeinfo = JBasicTypeInfo.FLOAT_TYPE_INFO
-        elif self._basic_type == BasicType.DOUBLE:
-            self._j_typeinfo = JBasicTypeInfo.DOUBLE_TYPE_INFO
-        elif self._basic_type == BasicType.CHAR:
-            self._j_typeinfo = JBasicTypeInfo.CHAR_TYPE_INFO
-        elif self._basic_type == BasicType.BIG_INT:
-            self._j_typeinfo = JBasicTypeInfo.BIG_INT_TYPE_INFO
-        elif self._basic_type == BasicType.BIG_DEC:
-            self._j_typeinfo = JBasicTypeInfo.BIG_DEC_TYPE_INFO
+        if not self._j_typeinfo:
+            JBasicTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
+            if self._basic_type == BasicType.STRING:
+                self._j_typeinfo = JBasicTypeInfo.STRING_TYPE_INFO
+            elif self._basic_type == BasicType.BYTE:
+                self._j_typeinfo = JBasicTypeInfo.BYTE_TYPE_INFO
+            elif self._basic_type == BasicType.BOOLEAN:
+                self._j_typeinfo = JBasicTypeInfo.BOOLEAN_TYPE_INFO
+            elif self._basic_type == BasicType.SHORT:
+                self._j_typeinfo = JBasicTypeInfo.SHORT_TYPE_INFO
+            elif self._basic_type == BasicType.INT:
+                self._j_typeinfo = JBasicTypeInfo.INT_TYPE_INFO
+            elif self._basic_type == BasicType.LONG:
+                self._j_typeinfo = JBasicTypeInfo.LONG_TYPE_INFO
+            elif self._basic_type == BasicType.FLOAT:
+                self._j_typeinfo = JBasicTypeInfo.FLOAT_TYPE_INFO
+            elif self._basic_type == BasicType.DOUBLE:
+                self._j_typeinfo = JBasicTypeInfo.DOUBLE_TYPE_INFO
+            elif self._basic_type == BasicType.CHAR:
+                self._j_typeinfo = JBasicTypeInfo.CHAR_TYPE_INFO
+            elif self._basic_type == BasicType.BIG_INT:
+                self._j_typeinfo = JBasicTypeInfo.BIG_INT_TYPE_INFO
+            elif self._basic_type == BasicType.BIG_DEC:
+                self._j_typeinfo = JBasicTypeInfo.BIG_DEC_TYPE_INFO
+            else:
+                raise TypeError("Invalid BasicType %s." % self._basic_type)
         return self._j_typeinfo
 
     def __eq__(self, o) -> bool:
@@ -234,7 +237,7 @@ class PrimitiveArrayTypeInfo(TypeInformation):
         return False
 
     def __repr__(self) -> str:
-        return "PrimitiveArrayTypeInformation<%s>" % self._element_type
+        return "PrimitiveArrayTypeInfo<%s>" % self._element_type
 
 
 class BasicArrayTypeInfo(TypeInformation):
@@ -280,7 +283,7 @@ class BasicArrayTypeInfo(TypeInformation):
         return False
 
     def __repr__(self):
-        return "BasicArrayTypeInformation<%s>" % self._element_type
+        return "BasicArrayTypeInfo<%s>" % self._element_type
 
 
 class PickledBytesTypeInfo(TypeInformation):
@@ -299,7 +302,7 @@ class PickledBytesTypeInfo(TypeInformation):
         return isinstance(o, PickledBytesTypeInfo)
 
     def __repr__(self):
-        return "PickledByteArrayTypeInformation"
+        return "PickledByteArrayTypeInfo"
 
 
 class RowTypeInfo(TypeInformation):
@@ -481,7 +484,7 @@ class DateTypeInfo(TypeInformation):
         return isinstance(o, DateTypeInfo)
 
     def __repr__(self):
-        return "DateTypeInformation"
+        return "DateTypeInfo"
 
 
 class TimeTypeInfo(TypeInformation):
@@ -524,7 +527,7 @@ class TimeTypeInfo(TypeInformation):
         return isinstance(o, TimeTypeInfo)
 
     def __repr__(self) -> str:
-        return "TimeTypeInformation"
+        return "TimeTypeInfo"
 
 
 class TimestampTypeInfo(TypeInformation):
@@ -555,7 +558,7 @@ class TimestampTypeInfo(TypeInformation):
         return isinstance(o, TimestampTypeInfo)
 
     def __repr__(self):
-        return "TimestampTypeInformation"
+        return "TimestampTypeInfo"
 
 
 class ListTypeInfo(TypeInformation):
@@ -613,23 +616,65 @@ class Types(object):
     built-in serializers and comparators.
     """
 
-    STRING = BasicTypeInfo.STRING_TYPE_INFO
-    BYTE = BasicTypeInfo.BYTE_TYPE_INFO
-    BOOLEAN = BasicTypeInfo.BOOLEAN_TYPE_INFO
-    SHORT = BasicTypeInfo.SHORT_TYPE_INFO
-    INT = BasicTypeInfo.INT_TYPE_INFO
-    LONG = BasicTypeInfo.LONG_TYPE_INFO
-    FLOAT = BasicTypeInfo.FLOAT_TYPE_INFO
-    DOUBLE = BasicTypeInfo.DOUBLE_TYPE_INFO
-    CHAR = BasicTypeInfo.CHAR_TYPE_INFO
-    BIG_INT = BasicTypeInfo.BIG_INT_TYPE_INFO
-    BIG_DEC = BasicTypeInfo.BIG_DEC_TYPE_INFO
+    @staticmethod
+    def STRING() -> TypeInformation:
+        return BasicTypeInfo.STRING_TYPE_INFO()
 
-    SQL_DATE = SqlTimeTypeInfo.DATE
-    SQL_TIME = SqlTimeTypeInfo.TIME
-    SQL_TIMESTAMP = SqlTimeTypeInfo.TIMESTAMP
+    @staticmethod
+    def BYTE() -> TypeInformation:
+        return BasicTypeInfo.BYTE_TYPE_INFO()
 
-    PICKLED_BYTE_ARRAY = PickledBytesTypeInfo
+    @staticmethod
+    def BOOLEAN() -> TypeInformation:
+        return BasicTypeInfo.BOOLEAN_TYPE_INFO()
+
+    @staticmethod
+    def SHORT() -> TypeInformation:
+        return BasicTypeInfo.SHORT_TYPE_INFO()
+
+    @staticmethod
+    def INT() -> TypeInformation:
+        return BasicTypeInfo.INT_TYPE_INFO()
+
+    @staticmethod
+    def LONG() -> TypeInformation:
+        return BasicTypeInfo.LONG_TYPE_INFO()
+
+    @staticmethod
+    def FLOAT() -> TypeInformation:
+        return BasicTypeInfo.FLOAT_TYPE_INFO()
+
+    @staticmethod
+    def DOUBLE() -> TypeInformation:
+        return BasicTypeInfo.DOUBLE_TYPE_INFO()
+
+    @staticmethod
+    def CHAR() -> TypeInformation:
+        return BasicTypeInfo.CHAR_TYPE_INFO()
+
+    @staticmethod
+    def BIG_INT() -> TypeInformation:
+        return BasicTypeInfo.BIG_INT_TYPE_INFO()
+
+    @staticmethod
+    def BIG_DEC() -> TypeInformation:
+        return BasicTypeInfo.BIG_DEC_TYPE_INFO()
+
+    @staticmethod
+    def SQL_DATE() -> TypeInformation:
+        return SqlTimeTypeInfo.DATE()
+
+    @staticmethod
+    def SQL_TIME() -> TypeInformation:
+        return SqlTimeTypeInfo.TIME()
+
+    @staticmethod
+    def SQL_TIMESTAMP() -> TypeInformation:
+        return SqlTimeTypeInfo.TIMESTAMP()
+
+    @staticmethod
+    def PICKLED_BYTE_ARRAY() -> TypeInformation:
+        return PickledBytesTypeInfo()
 
     @staticmethod
     def ROW(types: List[TypeInformation]):
@@ -702,7 +747,6 @@ class Types(object):
         A TypeInformation for the list type.
 
         :param element_type_info: The type of the elements in the list
-        :return:
         """
         return ListTypeInfo(element_type_info)
 

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -18,11 +18,11 @@
 import calendar
 import datetime
 import time
-from abc import ABC
 from enum import Enum
 from typing import List, Union
 
 from py4j.java_gateway import JavaClass, JavaObject
+
 from pyflink.java_gateway import get_gateway
 
 
@@ -52,7 +52,7 @@ class TypeInformation(object):
         self._j_typeinfo = None
 
     def get_java_type_info(self) -> JavaObject:
-        return self._j_typeinfo
+        pass
 
     def need_conversion(self):
         """
@@ -73,7 +73,7 @@ class TypeInformation(object):
         return obj
 
 
-class BasicTypes(Enum):
+class BasicType(Enum):
     STRING = "String"
     BYTE = "Byte"
     BOOLEAN = "Boolean"
@@ -87,54 +87,44 @@ class BasicTypes(Enum):
     BIG_DEC = "BigDecimal"
 
 
-class BasicTypeInformation(TypeInformation, ABC):
+class BasicTypeInfo(TypeInformation):
     """
     Type information for primitive types (int, long, double, byte, ...), String, BigInteger,
     and BigDecimal.
     """
 
-    def __init__(self, basic_type: BasicTypes):
+    def __init__(self, basic_type: BasicType):
         self._basic_type = basic_type
-        super(BasicTypeInformation, self).__init__()
+        super(BasicTypeInfo, self).__init__()
 
     def get_java_type_info(self) -> JavaObject:
-        if self._basic_type == BasicTypes.STRING:
-            self._j_typeinfo = get_gateway().jvm\
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO
-        elif self._basic_type == BasicTypes.BYTE:
-            self._j_typeinfo = get_gateway().jvm\
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BYTE_TYPE_INFO
-        elif self._basic_type == BasicTypes.BOOLEAN:
-            self._j_typeinfo = get_gateway().jvm\
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BOOLEAN_TYPE_INFO
-        elif self._basic_type == BasicTypes.SHORT:
-            self._j_typeinfo = get_gateway().jvm\
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.SHORT_TYPE_INFO
-        elif self._basic_type == BasicTypes.INT:
-            self._j_typeinfo = get_gateway().jvm\
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
-        elif self._basic_type == BasicTypes.LONG:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO
-        elif self._basic_type == BasicTypes.FLOAT:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.FLOAT_TYPE_INFO
-        elif self._basic_type == BasicTypes.DOUBLE:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.DOUBLE_TYPE_INFO
-        elif self._basic_type == BasicTypes.CHAR:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.CHAR_TYPE_INFO
-        elif self._basic_type == BasicTypes.BIG_INT:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_INT_TYPE_INFO
-        elif self._basic_type == BasicTypes.BIG_DEC:
-            self._j_typeinfo = get_gateway().jvm \
-                .org.apache.flink.api.common.typeinfo.BasicTypeInfo.BIG_DEC_TYPE_INFO
+        JBasicTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo.BasicTypeInfo
+        if self._basic_type == BasicType.STRING:
+            self._j_typeinfo = JBasicTypeInfo.STRING_TYPE_INFO
+        elif self._basic_type == BasicType.BYTE:
+            self._j_typeinfo = JBasicTypeInfo.BYTE_TYPE_INFO
+        elif self._basic_type == BasicType.BOOLEAN:
+            self._j_typeinfo = JBasicTypeInfo.BOOLEAN_TYPE_INFO
+        elif self._basic_type == BasicType.SHORT:
+            self._j_typeinfo = JBasicTypeInfo.SHORT_TYPE_INFO
+        elif self._basic_type == BasicType.INT:
+            self._j_typeinfo = JBasicTypeInfo.INT_TYPE_INFO
+        elif self._basic_type == BasicType.LONG:
+            self._j_typeinfo = JBasicTypeInfo.LONG_TYPE_INFO
+        elif self._basic_type == BasicType.FLOAT:
+            self._j_typeinfo = JBasicTypeInfo.FLOAT_TYPE_INFO
+        elif self._basic_type == BasicType.DOUBLE:
+            self._j_typeinfo = JBasicTypeInfo.DOUBLE_TYPE_INFO
+        elif self._basic_type == BasicType.CHAR:
+            self._j_typeinfo = JBasicTypeInfo.CHAR_TYPE_INFO
+        elif self._basic_type == BasicType.BIG_INT:
+            self._j_typeinfo = JBasicTypeInfo.BIG_INT_TYPE_INFO
+        elif self._basic_type == BasicType.BIG_DEC:
+            self._j_typeinfo = JBasicTypeInfo.BIG_DEC_TYPE_INFO
         return self._j_typeinfo
 
     def __eq__(self, o) -> bool:
-        if isinstance(o, BasicTypeInformation):
+        if isinstance(o, BasicTypeInfo):
             return self._basic_type == o._basic_type
         return False
 
@@ -143,68 +133,68 @@ class BasicTypeInformation(TypeInformation, ABC):
 
     @staticmethod
     def STRING_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.STRING)
+        return BasicTypeInfo(BasicType.STRING)
 
     @staticmethod
     def BOOLEAN_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.BOOLEAN)
+        return BasicTypeInfo(BasicType.BOOLEAN)
 
     @staticmethod
     def BYTE_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.BYTE)
+        return BasicTypeInfo(BasicType.BYTE)
 
     @staticmethod
     def SHORT_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.SHORT)
+        return BasicTypeInfo(BasicType.SHORT)
 
     @staticmethod
     def INT_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.INT)
+        return BasicTypeInfo(BasicType.INT)
 
     @staticmethod
     def LONG_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.LONG)
+        return BasicTypeInfo(BasicType.LONG)
 
     @staticmethod
     def FLOAT_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.FLOAT)
+        return BasicTypeInfo(BasicType.FLOAT)
 
     @staticmethod
     def DOUBLE_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.DOUBLE)
+        return BasicTypeInfo(BasicType.DOUBLE)
 
     @staticmethod
     def CHAR_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.CHAR)
+        return BasicTypeInfo(BasicType.CHAR)
 
     @staticmethod
     def BIG_INT_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.BIG_INT)
+        return BasicTypeInfo(BasicType.BIG_INT)
 
     @staticmethod
     def BIG_DEC_TYPE_INFO():
-        return BasicTypeInformation(BasicTypes.BIG_DEC)
+        return BasicTypeInfo(BasicType.BIG_DEC)
 
 
-class SqlTimeTypeInfo(TypeInformation, ABC):
+class SqlTimeTypeInfo(TypeInformation):
     """
     SqlTimeTypeInfo enables users to get Sql Time TypeInfo.
     """
 
     @staticmethod
     def DATE():
-        return DateTypeInformation()
+        return DateTypeInfo()
 
     @staticmethod
     def TIME():
-        return TimeTypeInformation()
+        return TimeTypeInfo()
 
     @staticmethod
     def TIMESTAMP():
-        return TimestampTypeInformation()
+        return TimestampTypeInfo()
 
 
-class PrimitiveArrayTypeInformation(TypeInformation, ABC):
+class PrimitiveArrayTypeInfo(TypeInformation):
     """
     A TypeInformation for arrays of primitive types (int, long, double, ...).
     Supports the creation of dedicated efficient serializers for these types.
@@ -212,32 +202,34 @@ class PrimitiveArrayTypeInformation(TypeInformation, ABC):
 
     def __init__(self, element_type: TypeInformation):
         self._element_type = element_type
-        super(PrimitiveArrayTypeInformation, self).__init__()
+        super(PrimitiveArrayTypeInfo, self).__init__()
 
     def get_java_type_info(self) -> JavaObject:
-        JPrimitiveArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
-            .PrimitiveArrayTypeInfo
-        if self._element_type == Types.BOOLEAN():
-            return JPrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.BYTE():
-            return JPrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.SHORT():
-            return JPrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.INT():
-            return JPrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.LONG():
-            return JPrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.FLOAT():
-            return JPrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.DOUBLE():
-            return JPrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.CHAR():
-            return JPrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO
-        else:
-            raise TypeError("Invalid element type for a primitive array.")
+        if not self._j_typeinfo:
+            JPrimitiveArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
+                .PrimitiveArrayTypeInfo
+            if self._element_type == Types.BOOLEAN():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.BYTE():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.SHORT():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.INT():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.LONG():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.FLOAT():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.DOUBLE():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.CHAR():
+                self._j_typeinfo = JPrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO
+            else:
+                raise TypeError("Invalid element type for a primitive array.")
+        return self._j_typeinfo
 
     def __eq__(self, o) -> bool:
-        if isinstance(o, PrimitiveArrayTypeInformation):
+        if isinstance(o, PrimitiveArrayTypeInfo):
             return self._element_type == o._element_type
         return False
 
@@ -245,11 +237,7 @@ class PrimitiveArrayTypeInformation(TypeInformation, ABC):
         return "PrimitiveArrayTypeInformation<%s>" % self._element_type
 
 
-def is_primitive_array_type_info(type_info: TypeInformation):
-    return isinstance(type_info, PrimitiveArrayTypeInformation)
-
-
-class BasicArrayTypeInformation(TypeInformation, ABC):
+class BasicArrayTypeInfo(TypeInformation):
     """
     A TypeInformation for arrays of boxed primitive types (Integer, Long, Double, ...).
     Supports the creation of dedicated efficient serializers for these types.
@@ -257,34 +245,37 @@ class BasicArrayTypeInformation(TypeInformation, ABC):
 
     def __init__(self, element_type: TypeInformation):
         self._element_type = element_type
-        super(BasicArrayTypeInformation, self).__init__()
+        super(BasicArrayTypeInfo, self).__init__()
 
     def get_java_type_info(self) -> JavaObject:
-        JBasicArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
-            .BasicArrayTypeInfo
-        if self._element_type == Types.BOOLEAN():
-            return JBasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO
-        elif self._element_type == Types.BYTE():
-            return JBasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.SHORT():
-            return JBasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO
-        elif self._element_type == Types.INT():
-            return JBasicArrayTypeInfo.INT_ARRAY_TYPE_INFO
-        elif self._element_type == Types.LONG():
-            return JBasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
-        elif self._element_type == Types.FLOAT():
-            return JBasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO
-        elif self._element_type == Types.DOUBLE():
-            return JBasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO
-        elif self._element_type == Types.CHAR():
-            return JBasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO
-        elif self._element_type == Types.STRING():
-            return JBasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO
-        else:
-            raise TypeError("Invalid element type for a primitive array.")
+        if not self._j_typeinfo:
+            JBasicArrayTypeInfo = get_gateway().jvm.org.apache.flink.api.common.typeinfo \
+                .BasicArrayTypeInfo
+            if self._element_type == Types.BOOLEAN():
+                self._j_typeinfo = JBasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO
+            elif self._element_type == Types.BYTE():
+                self._j_typeinfo = JBasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.SHORT():
+                self._j_typeinfo = JBasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO
+            elif self._element_type == Types.INT():
+                self._j_typeinfo = JBasicArrayTypeInfo.INT_ARRAY_TYPE_INFO
+            elif self._element_type == Types.LONG():
+                self._j_typeinfo = JBasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
+            elif self._element_type == Types.FLOAT():
+                self._j_typeinfo = JBasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO
+            elif self._element_type == Types.DOUBLE():
+                self._j_typeinfo = JBasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO
+            elif self._element_type == Types.CHAR():
+                self._j_typeinfo = JBasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO
+            elif self._element_type == Types.STRING():
+                self._j_typeinfo = JBasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO
+            else:
+                raise TypeError("Invalid element type for a primitive array.")
+
+        return self._j_typeinfo
 
     def __eq__(self, o) -> bool:
-        if isinstance(o, BasicArrayTypeInformation):
+        if isinstance(o, BasicArrayTypeInfo):
             return self._element_type == o._element_type
         return False
 
@@ -292,23 +283,16 @@ class BasicArrayTypeInformation(TypeInformation, ABC):
         return "BasicArrayTypeInformation<%s>" % self._element_type
 
 
-def is_basic_array_type_info(type_info: TypeInformation):
-    return isinstance(type_info, BasicArrayTypeInformation)
-
-
-class PickledBytesTypeInfo(TypeInformation, ABC):
+class PickledBytesTypeInfo(TypeInformation):
     """
     A PickledBytesTypeInfo indicates the data is a primitive byte array generated by pickle
     serializer.
     """
 
-    @staticmethod
-    def PICKLED_BYTE_ARRAY_TYPE_INFO():
-        return PickledBytesTypeInfo()
-
     def get_java_type_info(self) -> JavaObject:
-        self._j_typeinfo = get_gateway().jvm.org.apache.flink.streaming.api.typeinfo.python\
-            .PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm.org.apache.flink.streaming.api.typeinfo.python\
+                .PickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
         return self._j_typeinfo
 
     def __eq__(self, o: object) -> bool:
@@ -351,9 +335,9 @@ class RowTypeInfo(TypeInformation):
                 .new_array(get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation,
                            len(self.types))
             for i in range(len(self.types)):
-                wrapper_typeinfo = self.types[i]
-                if isinstance(wrapper_typeinfo, TypeInformation):
-                    j_types_array[i] = wrapper_typeinfo.get_java_type_info()
+                field_type = self.types[i]
+                if isinstance(field_type, TypeInformation):
+                    j_types_array[i] = field_type.get_java_type_info()
 
             if self.field_names is None:
                 self._j_typeinfo = get_gateway().jvm\
@@ -372,7 +356,7 @@ class RowTypeInfo(TypeInformation):
             return self.types == other.types
         return False
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         if self.field_names:
             return "RowTypeInfo(%s)" % ', '.join([field_name + ': ' + str(field_type)
                                                   for field_name, field_type in
@@ -392,7 +376,7 @@ class RowTypeInfo(TypeInformation):
             # Only calling to_internal_type function for fields that need conversion
             if isinstance(obj, dict):
                 return tuple(f.to_internal_type(obj.get(n)) if c else obj.get(n)
-                             for n, f, c in zip(self.field_names, self.types,
+                             for n, f, c in zip(self.get_field_names(), self.types,
                                                 self._need_conversion))
             elif isinstance(obj, (tuple, list)):
                 return tuple(f.to_internal_type(v) if c else v
@@ -400,18 +384,18 @@ class RowTypeInfo(TypeInformation):
             elif hasattr(obj, "__dict__"):
                 d = obj.__dict__
                 return tuple(f.to_internal_type(d.get(n)) if c else d.get(n)
-                             for n, f, c in zip(self._j_typeinfo.getFieldNames(), self.types,
+                             for n, f, c in zip(self.get_field_names(), self.types,
                                                 self._need_conversion))
             else:
                 raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
         else:
             if isinstance(obj, dict):
-                return tuple(obj.get(n) for n in self.field_names)
+                return tuple(obj.get(n) for n in self.get_field_names())
             elif isinstance(obj, (list, tuple)):
                 return tuple(obj)
             elif hasattr(obj, "__dict__"):
                 d = obj.__dict__
-                return tuple(d.get(n) for n in self.field_names)
+                return tuple(d.get(n) for n in self.get_field_names())
             else:
                 raise ValueError("Unexpected tuple %r with RowTypeInfo" % obj)
 
@@ -443,16 +427,18 @@ class TupleTypeInfo(TypeInformation):
         return self.types
 
     def get_java_type_info(self) -> JavaObject:
-        j_types_array = get_gateway().new_array(
-            get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation, len(self.types))
+        if not self._j_typeinfo:
+            j_types_array = get_gateway().new_array(
+                get_gateway().jvm.org.apache.flink.api.common.typeinfo.TypeInformation,
+                len(self.types))
 
-        for i in range(len(self.types)):
-            field_type = self.types[i]
-            if isinstance(field_type, TypeInformation):
-                j_types_array[i] = field_type.get_java_type_info()
+            for i in range(len(self.types)):
+                field_type = self.types[i]
+                if isinstance(field_type, TypeInformation):
+                    j_types_array[i] = field_type.get_java_type_info()
 
-        self._j_typeinfo = get_gateway().jvm \
-            .org.apache.flink.api.java.typeutils.TupleTypeInfo(j_types_array)
+            self._j_typeinfo = get_gateway().jvm \
+                .org.apache.flink.api.java.typeutils.TupleTypeInfo(j_types_array)
         return self._j_typeinfo
 
     def __eq__(self, other) -> bool:
@@ -460,17 +446,17 @@ class TupleTypeInfo(TypeInformation):
             return self.types == other.types
         return False
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return "TupleTypeInfo(%s)" % ', '.join([str(field_type) for field_type in self.types])
 
 
-class DateTypeInformation(TypeInformation):
+class DateTypeInfo(TypeInformation):
     """
     TypeInformation for Date.
     """
 
     def __init__(self):
-        super(DateTypeInformation, self).__init__()
+        super(DateTypeInfo, self).__init__()
 
     EPOCH_ORDINAL = datetime.datetime(1970, 1, 1).toordinal()
 
@@ -486,18 +472,19 @@ class DateTypeInformation(TypeInformation):
             return datetime.date.fromordinal(v + self.EPOCH_ORDINAL)
 
     def get_java_type_info(self) -> JavaObject:
-        self._j_typeinfo = get_gateway().jvm\
-            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.DATE
         return self._j_typeinfo
 
     def __eq__(self, o: object) -> bool:
-        return isinstance(o, DateTypeInformation)
+        return isinstance(o, DateTypeInfo)
 
     def __repr__(self):
         return "DateTypeInformation"
 
 
-class TimeTypeInformation(TypeInformation):
+class TimeTypeInfo(TypeInformation):
     """
     TypeInformation for Time.
     """
@@ -528,18 +515,19 @@ class TimeTypeInformation(TypeInformation):
             return datetime.time(hours, minutes, seconds, microseconds)
 
     def get_java_type_info(self) -> JavaObject:
-        self._j_typeinfo = get_gateway().jvm\
-            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIME
         return self._j_typeinfo
 
     def __eq__(self, o: object) -> bool:
-        return isinstance(o, TimeTypeInformation)
+        return isinstance(o, TimeTypeInfo)
 
     def __repr__(self) -> str:
         return "TimeTypeInformation"
 
 
-class TimestampTypeInformation(TypeInformation):
+class TimestampTypeInfo(TypeInformation):
     """
     TypeInformation for Timestamp.
     """
@@ -558,15 +546,65 @@ class TimestampTypeInformation(TypeInformation):
             return datetime.datetime.fromtimestamp(ts // 10 ** 6).replace(microsecond=ts % 10 ** 6)
 
     def get_java_type_info(self) -> JavaObject:
-        self._j_typeinfo = get_gateway().jvm\
-            .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo.TIMESTAMP
         return self._j_typeinfo
 
     def __eq__(self, o: object) -> bool:
-        return isinstance(o, TimestampTypeInformation)
+        return isinstance(o, TimestampTypeInfo)
 
     def __repr__(self):
         return "TimestampTypeInformation"
+
+
+class ListTypeInfo(TypeInformation):
+    """
+    A TypeInformation for the list types.
+    """
+
+    def __init__(self, element_type: TypeInformation):
+        self.elem_type = element_type
+        super(ListTypeInfo, self).__init__()
+
+    def get_java_type_info(self) -> JavaObject:
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.Types.LIST(
+                self.elem_type.get_java_type_info())
+        return self._j_typeinfo
+
+    def __eq__(self, other):
+        if isinstance(other, ListTypeInfo):
+            return self.elem_type == other.elem_type
+        else:
+            return False
+
+    def __repr__(self):
+        return "ListTypeInfo<%s>" % self.elem_type
+
+
+class MapTypeInfo(TypeInformation):
+
+    def __init__(self, key_type_info: TypeInformation, value_type_info: TypeInformation):
+        self.key_type_info = key_type_info
+        self.value_type_info = value_type_info
+        super(MapTypeInfo, self).__init__()
+
+    def get_java_type_info(self) -> JavaObject:
+        if not self._j_typeinfo:
+            self._j_typeinfo = get_gateway().jvm\
+                .org.apache.flink.api.common.typeinfo.Types.MAP(
+                self.key_type_info.get_java_type_info(), self.value_type_info.get_java_type_info())
+        return self._j_typeinfo
+
+    def __eq__(self, other):
+        if isinstance(other, MapTypeInfo):
+            return self.key_type_info == other.key_type_info and \
+                self.value_type_info == other.value_type_info
+
+    def __repr__(self) -> str:
+        return 'MapTypeInfo<{}, {}>'.format(self.key_type_info, self.value_type_info)
 
 
 class Types(object):
@@ -575,23 +613,23 @@ class Types(object):
     built-in serializers and comparators.
     """
 
-    STRING = BasicTypeInformation.STRING_TYPE_INFO
-    BYTE = BasicTypeInformation.BYTE_TYPE_INFO
-    BOOLEAN = BasicTypeInformation.BOOLEAN_TYPE_INFO
-    SHORT = BasicTypeInformation.SHORT_TYPE_INFO
-    INT = BasicTypeInformation.INT_TYPE_INFO
-    LONG = BasicTypeInformation.LONG_TYPE_INFO
-    FLOAT = BasicTypeInformation.FLOAT_TYPE_INFO
-    DOUBLE = BasicTypeInformation.DOUBLE_TYPE_INFO
-    CHAR = BasicTypeInformation.CHAR_TYPE_INFO
-    BIG_INT = BasicTypeInformation.BIG_INT_TYPE_INFO
-    BIG_DEC = BasicTypeInformation.BIG_DEC_TYPE_INFO
+    STRING = BasicTypeInfo.STRING_TYPE_INFO
+    BYTE = BasicTypeInfo.BYTE_TYPE_INFO
+    BOOLEAN = BasicTypeInfo.BOOLEAN_TYPE_INFO
+    SHORT = BasicTypeInfo.SHORT_TYPE_INFO
+    INT = BasicTypeInfo.INT_TYPE_INFO
+    LONG = BasicTypeInfo.LONG_TYPE_INFO
+    FLOAT = BasicTypeInfo.FLOAT_TYPE_INFO
+    DOUBLE = BasicTypeInfo.DOUBLE_TYPE_INFO
+    CHAR = BasicTypeInfo.CHAR_TYPE_INFO
+    BIG_INT = BasicTypeInfo.BIG_INT_TYPE_INFO
+    BIG_DEC = BasicTypeInfo.BIG_DEC_TYPE_INFO
 
     SQL_DATE = SqlTimeTypeInfo.DATE
     SQL_TIME = SqlTimeTypeInfo.TIME
     SQL_TIMESTAMP = SqlTimeTypeInfo.TIMESTAMP
 
-    PICKLED_BYTE_ARRAY = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
+    PICKLED_BYTE_ARRAY = PickledBytesTypeInfo
 
     @staticmethod
     def ROW(types: List[TypeInformation]):
@@ -630,21 +668,43 @@ class Types(object):
         Returns type information for arrays of primitive type (such as byte[]). The array must not
         be null.
 
-        :param element_type element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
+        :param element_type: element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
         Types.DOUBLE())
         """
-        return PrimitiveArrayTypeInformation(element_type)
+        return PrimitiveArrayTypeInfo(element_type)
 
     @staticmethod
     def BASIC_ARRAY(element_type: TypeInformation) -> TypeInformation:
         """
         Returns type information for arrays of boxed primitive type (such as Integer[]).
 
-        :param element_type element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
+        :param element_type: element type of the array (e.g. Types.BOOLEAN(), Types.INT(),
         Types.DOUBLE())
         """
 
-        return BasicArrayTypeInformation(element_type)
+        return BasicArrayTypeInfo(element_type)
+
+    @staticmethod
+    def MAP(key_type_info: TypeInformation, value_type_info: TypeInformation) -> TypeInformation:
+        """
+        Special TypeInformation used by MapStateDescriptor
+
+        :param key_type_info: Element type of key (e.g. Types.BOOLEAN(), Types.INT(),
+                              Types.DOUBLE())
+        :param value_type_info: Element type of value (e.g. Types.BOOLEAN(), Types.INT(),
+                                Types.DOUBLE())
+        """
+        return MapTypeInfo(key_type_info, value_type_info)
+
+    @staticmethod
+    def LIST(element_type_info: TypeInformation) -> TypeInformation:
+        """
+        A TypeInformation for the list type.
+
+        :param element_type_info: The type of the elements in the list
+        :return:
+        """
+        return ListTypeInfo(element_type_info)
 
 
 def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
@@ -744,6 +804,17 @@ def _from_java_type(j_type_info: JavaObject) -> TypeInformation:
             j_field_types.append(j_type_info.getTypeAt(i))
         field_types = [_from_java_type(j_field_type) for j_field_type in j_field_types]
         return TupleTypeInfo(field_types)
+
+    JMapTypeInfo = get_gateway().jvm.org.apache.flink.api.java.typeutils.MapTypeInfo
+    if _is_instance_of(j_type_info, JMapTypeInfo):
+        j_key_type_info = j_type_info.getKeyTypeInfo()
+        j_value_type_info = j_type_info.getValueTypeInfo()
+        return MapTypeInfo(_from_java_type(j_key_type_info), _from_java_type(j_value_type_info))
+
+    JListTypeInfo = get_gateway().jvm.org.apache.flink.api.java.typeutils.ListTypeInfo
+    if _is_instance_of(j_type_info, JListTypeInfo):
+        j_element_type_info = j_type_info.getElementTypeInfo()
+        return ListTypeInfo(_from_java_type(j_element_type_info))
 
     raise TypeError("The java type info: %s is not supported in PyFlink currently." % j_type_info)
 

--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Union
 
 from pyflink.common import typeinfo
 from pyflink.common.serialization import DeserializationSchema, Encoder, SerializationSchema
-from pyflink.common.typeinfo import RowTypeInfo, WrapperTypeInfo, TypeInformation
+from pyflink.common.typeinfo import RowTypeInfo, TypeInformation
 from pyflink.datastream.functions import SourceFunction, SinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import load_java_class, to_jarray
@@ -354,11 +354,8 @@ class JdbcSink(SinkFunction):
         gateway = get_gateway()
         JJdbcTypeUtil = gateway.jvm.org.apache.flink.connector.jdbc.utils.JdbcTypeUtil
         for field_type in type_info.get_field_types():
-            if isinstance(field_type, WrapperTypeInfo):
-                sql_types.append(JJdbcTypeUtil
-                                 .typeInformationToSqlType(field_type.get_java_type_info()))
-            else:
-                raise ValueError('field_type must be WrapperTypeInfo')
+            sql_types.append(JJdbcTypeUtil
+                             .typeInformationToSqlType(field_type.get_java_type_info()))
         j_sql_type = to_jarray(gateway.jvm.int, sql_types)
         output_format_clz = gateway.jvm.Class\
             .forName('org.apache.flink.connector.jdbc.internal.JdbcBatchingOutputFormat', False,

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -18,8 +18,7 @@
 from typing import Callable, Union
 
 from pyflink.common import typeinfo, ExecutionConfig, Row
-from pyflink.common.typeinfo import RowTypeInfo, PickledBytesTypeInfo, Types, WrapperTypeInfo
-from pyflink.common.typeinfo import TypeInformation
+from pyflink.common.typeinfo import RowTypeInfo, PickledBytesTypeInfo, Types, TypeInformation
 from pyflink.common.watermark_strategy import WatermarkStrategy
 from pyflink.datastream.functions import _get_python_env, FlatMapFunctionWrapper, FlatMapFunction, \
     MapFunction, MapFunctionWrapper, Function, FunctionWrapper, SinkFunction, FilterFunction, \
@@ -294,9 +293,6 @@ class DataStream(object):
         if key_type_info is None:
             key_type_info = Types.PICKLED_BYTE_ARRAY()
             is_key_pickled_byte_array = True
-
-        if not isinstance(key_type_info, WrapperTypeInfo):
-            raise ValueError('key_type_info must be WrapperTypeInfo')
 
         intermediate_map_stream = self.map(
             lambda x: Row(key_selector.get_key(x), x),  # type: ignore

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -15,10 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from typing import Callable, Union
+from typing import Callable, Union, List
 
 from pyflink.common import typeinfo, ExecutionConfig, Row
-from pyflink.common.typeinfo import RowTypeInfo, PickledBytesTypeInfo, Types, TypeInformation
+from pyflink.common.typeinfo import RowTypeInfo, Types, TypeInformation
 from pyflink.common.watermark_strategy import WatermarkStrategy
 from pyflink.datastream.functions import _get_python_env, FlatMapFunctionWrapper, FlatMapFunction, \
     MapFunction, MapFunctionWrapper, Function, FunctionWrapper, SinkFunction, FilterFunction, \
@@ -644,7 +644,7 @@ class DataStream(object):
         """
         output_type_info_class = self._j_data_stream.getTransformation().getOutputType().getClass()
         if output_type_info_class.isAssignableFrom(
-                PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO().get_java_type_info()
+                Types.PICKLED_BYTE_ARRAY().get_java_type_info()
                 .getClass()):
             def python_obj_to_str_map_func(value):
                 if not isinstance(value, (str, bytes)):
@@ -1034,7 +1034,7 @@ class ConnectedStreams(object):
 def _get_one_input_stream_operator(data_stream: DataStream,
                                    func: Union[Function, FunctionWrapper],
                                    func_type: int,
-                                   type_info: TypeInformation = None):
+                                   type_info: Union[TypeInformation, List] = None):
     """
     Create a Java one input stream operator.
 
@@ -1049,7 +1049,7 @@ def _get_one_input_stream_operator(data_stream: DataStream,
     serialized_func = cloudpickle.dumps(func)
     j_input_types = data_stream._j_data_stream.getTransformation().getOutputType()
     if type_info is None:
-        output_type_info = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO()
+        output_type_info = Types.PICKLED_BYTE_ARRAY()  # type: TypeInformation
     elif isinstance(type_info, list):
         output_type_info = RowTypeInfo(type_info)
     else:
@@ -1116,7 +1116,7 @@ def _get_two_input_stream_operator(connected_streams: ConnectedStreams,
     j_input_types2 = connected_streams.stream2._j_data_stream.getTransformation().getOutputType()
 
     if type_info is None:
-        output_type_info = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO()
+        output_type_info = Types.PICKLED_BYTE_ARRAY()  # type: TypeInformation
     elif isinstance(type_info, list):
         output_type_info = RowTypeInfo(type_info)
     else:

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -26,8 +26,7 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.job_client import JobClient
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
-from pyflink.common.typeinfo import PickledBytesTypeInfo, TypeInformation, _from_java_type, \
-    WrapperTypeInfo
+from pyflink.common.typeinfo import PickledBytesTypeInfo, TypeInformation
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream
@@ -678,7 +677,7 @@ class StreamExecutionEnvironment(object):
         :param type_info: type of the returned stream. Optional.
         :return: the data stream constructed.
         """
-        if type_info and isinstance(type_info, WrapperTypeInfo):
+        if type_info:
             j_type_info = type_info.get_java_type_info()
         else:
             j_type_info = None
@@ -717,11 +716,7 @@ class StreamExecutionEnvironment(object):
         :return: the data stream representing the given collection.
         """
         if type_info is not None:
-            if isinstance(type_info, WrapperTypeInfo):
-                wrapper_type = _from_java_type(type_info.get_java_type_info())
-                collection = [wrapper_type.to_internal_type(element)
-                              if isinstance(wrapper_type, WrapperTypeInfo) else None
-                              for element in collection]
+            collection = [type_info.to_internal_type(element) for element in collection]
         return self._from_collection(collection, type_info)
 
     def _from_collection(self, elements: List[Any],

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -26,7 +26,7 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.job_client import JobClient
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
-from pyflink.common.typeinfo import PickledBytesTypeInfo, TypeInformation
+from pyflink.common.typeinfo import TypeInformation, Types
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream
@@ -732,7 +732,7 @@ class StreamExecutionEnvironment(object):
             # list.
             if type_info is None:
                 j_objs = gateway.jvm.PythonBridgeUtils.readPickledBytes(temp_file.name)
-                out_put_type_info = PickledBytesTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO()
+                out_put_type_info = Types.PICKLED_BYTE_ARRAY()  # type: TypeInformation
             else:
                 j_objs = gateway.jvm.PythonBridgeUtils.readPythonObjects(temp_file.name)
                 out_put_type_info = type_info

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -19,9 +19,9 @@ import ast
 import datetime
 import pickle
 
-from pyflink.common import typeinfo
 from pyflink.common.typeinfo import RowTypeInfo, TupleTypeInfo, Types, \
-    is_primitive_array_type_info, is_basic_array_type_info
+    BasicArrayTypeInfo, \
+    PrimitiveArrayTypeInfo, MapTypeInfo, ListTypeInfo
 from pyflink.java_gateway import get_gateway
 
 
@@ -65,9 +65,22 @@ def pickled_bytes_to_python_converter(data, field_type):
             return field_type.from_internal_type(int(data.timestamp() * 10 ** 6))
         elif field_type == Types.FLOAT():
             return field_type.from_internal_type(ast.literal_eval(data))
-        elif is_basic_array_type_info(field_type) or is_primitive_array_type_info(field_type):
-            element_type = typeinfo._from_java_type(
-                field_type.get_java_type_info().getComponentInfo())
+        elif isinstance(field_type, BasicArrayTypeInfo) or \
+                isinstance(field_type, PrimitiveArrayTypeInfo):
+            element_type = field_type._element_type
+            elements = []
+            for element_bytes in data:
+                elements.append(pickled_bytes_to_python_converter(element_bytes, element_type))
+            return elements
+        elif isinstance(field_type, MapTypeInfo):
+            key_type = field_type.key_type_info
+            value_type = field_type.value_type_info
+            zip_kv = zip(data[0], data[1])
+            return dict((pickled_bytes_to_python_converter(k, key_type),
+                         pickled_bytes_to_python_converter(v, value_type))
+                        for k, v in zip_kv)
+        elif isinstance(field_type, ListTypeInfo):
+            element_type = field_type.elem_type
             elements = []
             for element_bytes in data:
                 elements.append(pickled_bytes_to_python_converter(element_bytes, element_type))

--- a/flink-python/pyflink/fn_execution/beam/beam_operations.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations.py
@@ -150,8 +150,7 @@ def _create_user_defined_function_operation(factory, transform_proto, consumers,
             internal_operation_cls,
             keyed_state_backend)
     elif internal_operation_cls == operations.KeyedProcessFunctionOperation:
-        key_type_info = spec.serialized_fn.key_type_info
-        key_row_coder = from_type_info_proto(key_type_info.field[0].type)
+        key_row_coder = from_type_info_proto(spec.serialized_fn.key_type_info)
         keyed_state_backend = RemoteKeyedStateBackend(
             factory.state_handler,
             key_row_coder,

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -612,4 +612,12 @@ def from_type_info_proto(field_type):
         if field_type_name == type_info_name.TUPLE:
             return TupleCoder([from_type_info_proto(f.type)
                                for f in field_type.tuple_type_info.field])
+
+        if field_type_name == type_info_name.MAP:
+            return MapCoder(from_type_info_proto(field_type.map_type_info.key_type),
+                            from_type_info_proto(field_type.map_type_info.value_type))
+
+        if field_type_name == type_info_name.LIST:
+            return BasicArrayCoder(from_type_info_proto(field_type.collection_element_type))
+
         raise ValueError("field_type %s is not supported." % field_type)

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -161,7 +161,7 @@ class DataStreamMapCoder(BaseCoder):
 
     @staticmethod
     def from_type_info_proto(type_info_proto):
-        return DataStreamMapCoder(from_type_info_proto(type_info_proto.field[0].type))
+        return DataStreamMapCoder(from_type_info_proto(type_info_proto))
 
     def __repr__(self):
         return 'DataStreamMapCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
@@ -193,7 +193,7 @@ class DataStreamFlatMapCoder(BaseCoder):
 
     @staticmethod
     def from_type_info_proto(type_info_proto):
-        return DataStreamFlatMapCoder(from_type_info_proto(type_info_proto.field[0].type))
+        return DataStreamFlatMapCoder(from_type_info_proto(type_info_proto))
 
     def __repr__(self):
         return 'DataStreamFlatMapCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
@@ -225,7 +225,7 @@ class DataStreamCoFlatMapCoder(BaseCoder):
 
     @staticmethod
     def from_type_info_proto(type_info_proto):
-        return DataStreamCoFlatMapCoder(from_type_info_proto(type_info_proto.field[0].type))
+        return DataStreamCoFlatMapCoder(from_type_info_proto(type_info_proto))
 
     def __repr__(self):
         return 'DataStreamCoFlatMapCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
@@ -594,30 +594,31 @@ _type_info_name_mappings = {
 }
 
 
-def from_type_info_proto(field_type):
-    field_type_name = field_type.type_name
+def from_type_info_proto(type_info):
+    field_type_name = type_info.type_name
     try:
         return _type_info_name_mappings[field_type_name]
     except KeyError:
         if field_type_name == type_info_name.ROW:
-            return RowCoder([from_type_info_proto(f.type) for f in field_type.row_type_info.field],
-                            [f.name for f in field_type.row_type_info.field])
+            return RowCoder([from_type_info_proto(f.field_type)
+                             for f in type_info.row_type_info.fields],
+                            [f.field_name for f in type_info.row_type_info.fields])
 
         if field_type_name == type_info_name.PRIMITIVE_ARRAY:
-            return PrimitiveArrayCoder(from_type_info_proto(field_type.collection_element_type))
+            return PrimitiveArrayCoder(from_type_info_proto(type_info.collection_element_type))
 
         if field_type_name == type_info_name.BASIC_ARRAY:
-            return BasicArrayCoder(from_type_info_proto(field_type.collection_element_type))
+            return BasicArrayCoder(from_type_info_proto(type_info.collection_element_type))
 
         if field_type_name == type_info_name.TUPLE:
-            return TupleCoder([from_type_info_proto(f.type)
-                               for f in field_type.tuple_type_info.field])
+            return TupleCoder([from_type_info_proto(f.field_type)
+                               for f in type_info.tuple_type_info.fields])
 
         if field_type_name == type_info_name.MAP:
-            return MapCoder(from_type_info_proto(field_type.map_type_info.key_type),
-                            from_type_info_proto(field_type.map_type_info.value_type))
+            return MapCoder(from_type_info_proto(type_info.map_type_info.key_type),
+                            from_type_info_proto(type_info.map_type_info.value_type))
 
         if field_type_name == type_info_name.LIST:
-            return BasicArrayCoder(from_type_info_proto(field_type.collection_element_type))
+            return BasicArrayCoder(from_type_info_proto(type_info.collection_element_type))
 
-        raise ValueError("field_type %s is not supported." % field_type)
+        raise ValueError("field_type %s is not supported." % type_info)

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc0\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"\x86\x01\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\x12\x0b\n\x07PROCESS\x10\x05\x12\x11\n\rKEYED_PROCESS\x10\x06\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x07\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xb8\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x8e\x08\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\x9f\x01\n\x0bMapTypeInfo\x12\x46\n\x08key_type\x18\x01 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\x12H\n\nvalue_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\x1a\x96\x03\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x95\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x08\n\x04LIST\x10\x14\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc0\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"\x86\x01\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\x12\x0b\n\x07PROCESS\x10\x05\x12\x11\n\rKEYED_PROCESS\x10\x06\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x07\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xb8\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xb1\t\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xa8\x01\n\rTupleTypeInfo\x12N\n\x06\x66ields\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo.Field\x1aG\n\x05\x46ield\x12>\n\nfield_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\x95\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x42\x0b\n\ttype_infoB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -302,7 +302,7 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='PICKLED_BYTES', index=16, number=16,
+      name='PRIMITIVE_ARRAY', index=16, number=16,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
@@ -310,7 +310,7 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='PRIMITIVE_ARRAY', index=18, number=18,
+      name='LIST', index=18, number=18,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
@@ -318,14 +318,14 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='LIST', index=20, number=20,
+      name='PICKLED_BYTES', index=20, number=20,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=5676,
-  serialized_end=5953,
+  serialized_start=5826,
+  serialized_end=6103,
 )
 _sym_db.RegisterEnumDescriptor(_TYPEINFO_TYPENAME)
 
@@ -1511,95 +1511,27 @@ _TYPEINFO_MAPTYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4993,
-  serialized_end=5152,
+  serialized_start=5326,
+  serialized_end=5465,
 )
 
-_TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
-  name='FieldType',
-  full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='type_name', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.type_name', index=0,
-      number=1, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='collection_element_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.collection_element_type', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='row_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.row_type_info', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='tuple_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.tuple_type_info', index=3,
-      number=4, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='map_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.map_type_info', index=4,
-      number=5, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-    _descriptor.OneofDescriptor(
-      name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.type_info',
-      index=0, containing_type=None, fields=[]),
-  ],
-  serialized_start=5155,
-  serialized_end=5561,
-)
-
-_TYPEINFO_FIELD = _descriptor.Descriptor(
+_TYPEINFO_ROWTYPEINFO_FIELD = _descriptor.Descriptor(
   name='Field',
-  full_name='org.apache.flink.fn_execution.v1.TypeInfo.Field',
+  full_name='org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='org.apache.flink.fn_execution.v1.TypeInfo.Field.name', index=0,
+      name='field_name', full_name='org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field.field_name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='description', full_name='org.apache.flink.fn_execution.v1.TypeInfo.Field.description', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.Field.type', index=2,
-      number=3, type=11, cpp_type=10, label=1,
+      name='field_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field.field_type', index=1,
+      number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1616,8 +1548,98 @@ _TYPEINFO_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5563,
-  serialized_end=5673,
+  serialized_start=5561,
+  serialized_end=5652,
+)
+
+_TYPEINFO_ROWTYPEINFO = _descriptor.Descriptor(
+  name='RowTypeInfo',
+  full_name='org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='fields', full_name='org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.fields', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_TYPEINFO_ROWTYPEINFO_FIELD, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5468,
+  serialized_end=5652,
+)
+
+_TYPEINFO_TUPLETYPEINFO_FIELD = _descriptor.Descriptor(
+  name='Field',
+  full_name='org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo.Field',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='field_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo.Field.field_type', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5752,
+  serialized_end=5823,
+)
+
+_TYPEINFO_TUPLETYPEINFO = _descriptor.Descriptor(
+  name='TupleTypeInfo',
+  full_name='org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='fields', full_name='org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo.fields', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_TYPEINFO_TUPLETYPEINFO_FIELD, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5655,
+  serialized_end=5823,
 )
 
 _TYPEINFO = _descriptor.Descriptor(
@@ -1628,16 +1650,44 @@ _TYPEINFO = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='field', full_name='org.apache.flink.fn_execution.v1.TypeInfo.field', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
+      name='type_name', full_name='org.apache.flink.fn_execution.v1.TypeInfo.type_name', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='collection_element_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.collection_element_type', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='row_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.row_type_info', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='tuple_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.tuple_type_info', index=3,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='map_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.map_type_info', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
-  nested_types=[_TYPEINFO_MAPTYPEINFO, _TYPEINFO_FIELDTYPE, _TYPEINFO_FIELD, ],
+  nested_types=[_TYPEINFO_MAPTYPEINFO, _TYPEINFO_ROWTYPEINFO, _TYPEINFO_TUPLETYPEINFO, ],
   enum_types=[
     _TYPEINFO_TYPENAME,
   ],
@@ -1646,9 +1696,12 @@ _TYPEINFO = _descriptor.Descriptor(
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
+    _descriptor.OneofDescriptor(
+      name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.type_info',
+      index=0, containing_type=None, fields=[]),
   ],
   serialized_start=4915,
-  serialized_end=5953,
+  serialized_end=6116,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -1757,31 +1810,35 @@ _SCHEMA_FIELD.fields_by_name['type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_FIELD.containing_type = _SCHEMA
 _SCHEMA.fields_by_name['fields'].message_type = _SCHEMA_FIELD
 _SCHEMA_TYPENAME.containing_type = _SCHEMA
-_TYPEINFO_MAPTYPEINFO.fields_by_name['key_type'].message_type = _TYPEINFO_FIELDTYPE
-_TYPEINFO_MAPTYPEINFO.fields_by_name['value_type'].message_type = _TYPEINFO_FIELDTYPE
+_TYPEINFO_MAPTYPEINFO.fields_by_name['key_type'].message_type = _TYPEINFO
+_TYPEINFO_MAPTYPEINFO.fields_by_name['value_type'].message_type = _TYPEINFO
 _TYPEINFO_MAPTYPEINFO.containing_type = _TYPEINFO
-_TYPEINFO_FIELDTYPE.fields_by_name['type_name'].enum_type = _TYPEINFO_TYPENAME
-_TYPEINFO_FIELDTYPE.fields_by_name['collection_element_type'].message_type = _TYPEINFO_FIELDTYPE
-_TYPEINFO_FIELDTYPE.fields_by_name['row_type_info'].message_type = _TYPEINFO
-_TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'].message_type = _TYPEINFO
-_TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'].message_type = _TYPEINFO_MAPTYPEINFO
-_TYPEINFO_FIELDTYPE.containing_type = _TYPEINFO
-_TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _TYPEINFO_FIELDTYPE.fields_by_name['collection_element_type'])
-_TYPEINFO_FIELDTYPE.fields_by_name['collection_element_type'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
-_TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _TYPEINFO_FIELDTYPE.fields_by_name['row_type_info'])
-_TYPEINFO_FIELDTYPE.fields_by_name['row_type_info'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
-_TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'])
-_TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
-_TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'])
-_TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
-_TYPEINFO_FIELD.fields_by_name['type'].message_type = _TYPEINFO_FIELDTYPE
-_TYPEINFO_FIELD.containing_type = _TYPEINFO
-_TYPEINFO.fields_by_name['field'].message_type = _TYPEINFO_FIELD
+_TYPEINFO_ROWTYPEINFO_FIELD.fields_by_name['field_type'].message_type = _TYPEINFO
+_TYPEINFO_ROWTYPEINFO_FIELD.containing_type = _TYPEINFO_ROWTYPEINFO
+_TYPEINFO_ROWTYPEINFO.fields_by_name['fields'].message_type = _TYPEINFO_ROWTYPEINFO_FIELD
+_TYPEINFO_ROWTYPEINFO.containing_type = _TYPEINFO
+_TYPEINFO_TUPLETYPEINFO_FIELD.fields_by_name['field_type'].message_type = _TYPEINFO
+_TYPEINFO_TUPLETYPEINFO_FIELD.containing_type = _TYPEINFO_TUPLETYPEINFO
+_TYPEINFO_TUPLETYPEINFO.fields_by_name['fields'].message_type = _TYPEINFO_TUPLETYPEINFO_FIELD
+_TYPEINFO_TUPLETYPEINFO.containing_type = _TYPEINFO
+_TYPEINFO.fields_by_name['type_name'].enum_type = _TYPEINFO_TYPENAME
+_TYPEINFO.fields_by_name['collection_element_type'].message_type = _TYPEINFO
+_TYPEINFO.fields_by_name['row_type_info'].message_type = _TYPEINFO_ROWTYPEINFO
+_TYPEINFO.fields_by_name['tuple_type_info'].message_type = _TYPEINFO_TUPLETYPEINFO
+_TYPEINFO.fields_by_name['map_type_info'].message_type = _TYPEINFO_MAPTYPEINFO
 _TYPEINFO_TYPENAME.containing_type = _TYPEINFO
+_TYPEINFO.oneofs_by_name['type_info'].fields.append(
+  _TYPEINFO.fields_by_name['collection_element_type'])
+_TYPEINFO.fields_by_name['collection_element_type'].containing_oneof = _TYPEINFO.oneofs_by_name['type_info']
+_TYPEINFO.oneofs_by_name['type_info'].fields.append(
+  _TYPEINFO.fields_by_name['row_type_info'])
+_TYPEINFO.fields_by_name['row_type_info'].containing_oneof = _TYPEINFO.oneofs_by_name['type_info']
+_TYPEINFO.oneofs_by_name['type_info'].fields.append(
+  _TYPEINFO.fields_by_name['tuple_type_info'])
+_TYPEINFO.fields_by_name['tuple_type_info'].containing_oneof = _TYPEINFO.oneofs_by_name['type_info']
+_TYPEINFO.oneofs_by_name['type_info'].fields.append(
+  _TYPEINFO.fields_by_name['map_type_info'])
+_TYPEINFO.fields_by_name['map_type_info'].containing_oneof = _TYPEINFO.oneofs_by_name['type_info']
 DESCRIPTOR.message_types_by_name['Input'] = _INPUT
 DESCRIPTOR.message_types_by_name['UserDefinedFunction'] = _USERDEFINEDFUNCTION
 DESCRIPTOR.message_types_by_name['UserDefinedFunctions'] = _USERDEFINEDFUNCTIONS
@@ -1994,17 +2051,31 @@ TypeInfo = _reflection.GeneratedProtocolMessageType('TypeInfo', (_message.Messag
     ))
   ,
 
-  FieldType = _reflection.GeneratedProtocolMessageType('FieldType', (_message.Message,), dict(
-    DESCRIPTOR = _TYPEINFO_FIELDTYPE,
+  RowTypeInfo = _reflection.GeneratedProtocolMessageType('RowTypeInfo', (_message.Message,), dict(
+
+    Field = _reflection.GeneratedProtocolMessageType('Field', (_message.Message,), dict(
+      DESCRIPTOR = _TYPEINFO_ROWTYPEINFO_FIELD,
+      __module__ = 'flink_fn_execution_pb2'
+      # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field)
+      ))
+    ,
+    DESCRIPTOR = _TYPEINFO_ROWTYPEINFO,
     __module__ = 'flink_fn_execution_pb2'
-    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.FieldType)
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo)
     ))
   ,
 
-  Field = _reflection.GeneratedProtocolMessageType('Field', (_message.Message,), dict(
-    DESCRIPTOR = _TYPEINFO_FIELD,
+  TupleTypeInfo = _reflection.GeneratedProtocolMessageType('TupleTypeInfo', (_message.Message,), dict(
+
+    Field = _reflection.GeneratedProtocolMessageType('Field', (_message.Message,), dict(
+      DESCRIPTOR = _TYPEINFO_TUPLETYPEINFO_FIELD,
+      __module__ = 'flink_fn_execution_pb2'
+      # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo.Field)
+      ))
+    ,
+    DESCRIPTOR = _TYPEINFO_TUPLETYPEINFO,
     __module__ = 'flink_fn_execution_pb2'
-    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.Field)
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfo)
     ))
   ,
   DESCRIPTOR = _TYPEINFO,
@@ -2013,8 +2084,10 @@ TypeInfo = _reflection.GeneratedProtocolMessageType('TypeInfo', (_message.Messag
   ))
 _sym_db.RegisterMessage(TypeInfo)
 _sym_db.RegisterMessage(TypeInfo.MapTypeInfo)
-_sym_db.RegisterMessage(TypeInfo.FieldType)
-_sym_db.RegisterMessage(TypeInfo.Field)
+_sym_db.RegisterMessage(TypeInfo.RowTypeInfo)
+_sym_db.RegisterMessage(TypeInfo.RowTypeInfo.Field)
+_sym_db.RegisterMessage(TypeInfo.TupleTypeInfo)
+_sym_db.RegisterMessage(TypeInfo.TupleTypeInfo.Field)
 
 
 DESCRIPTOR.has_options = True

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc0\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"\x86\x01\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\x12\x0b\n\x07PROCESS\x10\x05\x12\x11\n\rKEYED_PROCESS\x10\x06\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x07\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xb8\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x88\x06\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\xc5\x02\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x82\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"u\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xc0\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"\x86\x01\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06REDUCE\x10\x02\x12\n\n\x06\x43O_MAP\x10\x03\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x04\x12\x0b\n\x07PROCESS\x10\x05\x12\x11\n\rKEYED_PROCESS\x10\x06\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x07\"\xef\x05\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\xb8\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\x8e\x08\n\x08TypeInfo\x12?\n\x05\x66ield\x18\x01 \x03(\x0b\x32\x30.org.apache.flink.fn_execution.v1.TypeInfo.Field\x1a\x9f\x01\n\x0bMapTypeInfo\x12\x46\n\x08key_type\x18\x01 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\x12H\n\nvalue_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\x1a\x96\x03\n\tFieldType\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12W\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldTypeH\x00\x12\x43\n\rrow_type_info\x18\x03 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12\x45\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x42\x0b\n\ttype_info\x1an\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x42\n\x04type\x18\x03 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.TypeInfo.FieldType\"\x95\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x11\n\rPICKLED_BYTES\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x08\n\x04LIST\x10\x14\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -313,11 +313,19 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
       name='PRIMITIVE_ARRAY', index=18, number=18,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MAP', index=19, number=19,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='LIST', index=20, number=20,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=5433,
-  serialized_end=5691,
+  serialized_start=5676,
+  serialized_end=5953,
 )
 _sym_db.RegisterEnumDescriptor(_TYPEINFO_TYPENAME)
 
@@ -1470,6 +1478,43 @@ _SCHEMA = _descriptor.Descriptor(
 )
 
 
+_TYPEINFO_MAPTYPEINFO = _descriptor.Descriptor(
+  name='MapTypeInfo',
+  full_name='org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfo.key_type', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value_type', full_name='org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfo.value_type', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4993,
+  serialized_end=5152,
+)
+
 _TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
   name='FieldType',
   full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType',
@@ -1505,6 +1550,13 @@ _TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='map_type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.map_type_info', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -1520,8 +1572,8 @@ _TYPEINFO_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=4993,
-  serialized_end=5318,
+  serialized_start=5155,
+  serialized_end=5561,
 )
 
 _TYPEINFO_FIELD = _descriptor.Descriptor(
@@ -1564,8 +1616,8 @@ _TYPEINFO_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5320,
-  serialized_end=5430,
+  serialized_start=5563,
+  serialized_end=5673,
 )
 
 _TYPEINFO = _descriptor.Descriptor(
@@ -1585,7 +1637,7 @@ _TYPEINFO = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_TYPEINFO_FIELDTYPE, _TYPEINFO_FIELD, ],
+  nested_types=[_TYPEINFO_MAPTYPEINFO, _TYPEINFO_FIELDTYPE, _TYPEINFO_FIELD, ],
   enum_types=[
     _TYPEINFO_TYPENAME,
   ],
@@ -1596,7 +1648,7 @@ _TYPEINFO = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=4915,
-  serialized_end=5691,
+  serialized_end=5953,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -1705,10 +1757,14 @@ _SCHEMA_FIELD.fields_by_name['type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_FIELD.containing_type = _SCHEMA
 _SCHEMA.fields_by_name['fields'].message_type = _SCHEMA_FIELD
 _SCHEMA_TYPENAME.containing_type = _SCHEMA
+_TYPEINFO_MAPTYPEINFO.fields_by_name['key_type'].message_type = _TYPEINFO_FIELDTYPE
+_TYPEINFO_MAPTYPEINFO.fields_by_name['value_type'].message_type = _TYPEINFO_FIELDTYPE
+_TYPEINFO_MAPTYPEINFO.containing_type = _TYPEINFO
 _TYPEINFO_FIELDTYPE.fields_by_name['type_name'].enum_type = _TYPEINFO_TYPENAME
 _TYPEINFO_FIELDTYPE.fields_by_name['collection_element_type'].message_type = _TYPEINFO_FIELDTYPE
 _TYPEINFO_FIELDTYPE.fields_by_name['row_type_info'].message_type = _TYPEINFO
 _TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'].message_type = _TYPEINFO
+_TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'].message_type = _TYPEINFO_MAPTYPEINFO
 _TYPEINFO_FIELDTYPE.containing_type = _TYPEINFO
 _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _TYPEINFO_FIELDTYPE.fields_by_name['collection_element_type'])
@@ -1719,6 +1775,9 @@ _TYPEINFO_FIELDTYPE.fields_by_name['row_type_info'].containing_oneof = _TYPEINFO
 _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'])
 _TYPEINFO_FIELDTYPE.fields_by_name['tuple_type_info'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
+_TYPEINFO_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'])
+_TYPEINFO_FIELDTYPE.fields_by_name['map_type_info'].containing_oneof = _TYPEINFO_FIELDTYPE.oneofs_by_name['type_info']
 _TYPEINFO_FIELD.fields_by_name['type'].message_type = _TYPEINFO_FIELDTYPE
 _TYPEINFO_FIELD.containing_type = _TYPEINFO
 _TYPEINFO.fields_by_name['field'].message_type = _TYPEINFO_FIELD
@@ -1928,6 +1987,13 @@ _sym_db.RegisterMessage(Schema.Field)
 
 TypeInfo = _reflection.GeneratedProtocolMessageType('TypeInfo', (_message.Message,), dict(
 
+  MapTypeInfo = _reflection.GeneratedProtocolMessageType('MapTypeInfo', (_message.Message,), dict(
+    DESCRIPTOR = _TYPEINFO_MAPTYPEINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfo)
+    ))
+  ,
+
   FieldType = _reflection.GeneratedProtocolMessageType('FieldType', (_message.Message,), dict(
     DESCRIPTOR = _TYPEINFO_FIELDTYPE,
     __module__ = 'flink_fn_execution_pb2'
@@ -1946,6 +2012,7 @@ TypeInfo = _reflection.GeneratedProtocolMessageType('TypeInfo', (_message.Messag
   # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.TypeInfo)
   ))
 _sym_db.RegisterMessage(TypeInfo)
+_sym_db.RegisterMessage(TypeInfo.MapTypeInfo)
 _sym_db.RegisterMessage(TypeInfo.FieldType)
 _sym_db.RegisterMessage(TypeInfo.Field)
 

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -283,8 +283,14 @@ message TypeInfo {
     PICKLED_BYTES = 16;
     TUPLE = 17;
     PRIMITIVE_ARRAY = 18;
+    MAP = 19;
+    LIST = 20;
   }
 
+  message MapTypeInfo {
+    FieldType key_type = 1;
+    FieldType value_type = 2;
+  }
 
   message FieldType {
     TypeName type_name = 1;
@@ -292,6 +298,7 @@ message TypeInfo {
       FieldType collection_element_type = 2;
       TypeInfo row_type_info = 3;
       TypeInfo tuple_type_info = 4;
+      MapTypeInfo map_type_info = 5;
     }
   }
 

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -280,33 +280,38 @@ message TypeInfo {
     SQL_TIME = 13;
     SQL_TIMESTAMP = 14;
     BASIC_ARRAY = 15;
-    PICKLED_BYTES = 16;
+    PRIMITIVE_ARRAY = 16;
     TUPLE = 17;
-    PRIMITIVE_ARRAY = 18;
+    LIST = 18;
     MAP = 19;
-    LIST = 20;
+    PICKLED_BYTES = 20;
   }
 
   message MapTypeInfo {
-    FieldType key_type = 1;
-    FieldType value_type = 2;
+    TypeInfo key_type = 1;
+    TypeInfo value_type = 2;
   }
 
-  message FieldType {
-    TypeName type_name = 1;
-    oneof type_info {
-      FieldType collection_element_type = 2;
-      TypeInfo row_type_info = 3;
-      TypeInfo tuple_type_info = 4;
-      MapTypeInfo map_type_info = 5;
+  message RowTypeInfo {
+    message Field {
+      string field_name = 1;
+      TypeInfo field_type = 2;
     }
+    repeated Field fields = 1;
   }
 
-  message Field {
-    string name = 1;
-    //description is used in Table schema, no need in DataStream.
-    string description = 2;
-    FieldType type = 3;
+  message TupleTypeInfo {
+    message Field {
+      TypeInfo field_type = 1;
+    }
+    repeated Field fields = 1;
   }
-  repeated Field field = 1;
+
+  TypeName type_name = 1;
+  oneof type_info {
+    TypeInfo collection_element_type = 2;
+    RowTypeInfo row_type_info = 3;
+    TupleTypeInfo tuple_type_info = 4;
+    MapTypeInfo map_type_info = 5;
+  }
 }

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -27,7 +27,7 @@ from py4j.java_gateway import get_java_class, get_method
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table.sources import TableSource
 
-from pyflink.common.typeinfo import TypeInformation, WrapperTypeInfo
+from pyflink.common.typeinfo import TypeInformation
 from pyflink.datastream.data_stream import DataStream
 
 from pyflink.common import JobExecutionResult
@@ -1763,11 +1763,7 @@ class StreamTableEnvironment(TableEnvironment):
 
         .. versionadded:: 1.12.0
         """
-        if isinstance(type_info, WrapperTypeInfo):
-            j_data_stream = self._j_tenv.toAppendStream(table._j_table,
-                                                        type_info.get_java_type_info())
-        else:
-            raise TypeError('type_info must be WrapperTypeInfo')
+        j_data_stream = self._j_tenv.toAppendStream(table._j_table, type_info.get_java_type_info())
         return DataStream(j_data_stream=j_data_stream)
 
     def to_retract_stream(self, table: Table, type_info: TypeInformation) -> DataStream:
@@ -1787,11 +1783,7 @@ class StreamTableEnvironment(TableEnvironment):
 
         .. versionadded:: 1.12.0
         """
-        if isinstance(type_info, WrapperTypeInfo):
-            j_data_stream = self._j_tenv.toRetractStream(table._j_table,
-                                                         type_info.get_java_type_info())
-        else:
-            raise TypeError('type_info must be WrapperTypeInfo')
+        j_data_stream = self._j_tenv.toRetractStream(table._j_table, type_info.get_java_type_info())
         return DataStream(j_data_stream=j_data_stream)
 
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamDataStreamPythonFunctionRunner.java
@@ -83,13 +83,11 @@ public class BeamDataStreamPythonFunctionRunner extends BeamPythonFunctionRunner
 	}
 
 	private RunnerApi.Coder getInputOutputCoderProto(TypeInformation typeInformation) {
-		FlinkFnApi.TypeInfo.FieldType builtFieldType = PythonTypeUtils.TypeInfoToProtoConverter
-			.getFieldType(typeInformation);
 		return RunnerApi.Coder.newBuilder()
 			.setSpec(RunnerApi.FunctionSpec.newBuilder()
 						.setUrn(this.coderUrn)
 						.setPayload(org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString.copyFrom(
-							PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(builtFieldType).toByteArray()
+							PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(typeInformation).toByteArray()
 						)).build()
 			).build();
 	}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
@@ -208,11 +208,10 @@ public enum PythonOperatorUtils {
 		FlinkFnApi.UserDefinedDataStreamFunction userDefinedDataStreamFunction =
 			getUserDefinedDataStreamFunctionProto(dataStreamPythonFunctionInfo, runtimeContext,
 				internalParameters);
-		FlinkFnApi.TypeInfo.FieldType builtKeyFieldType = PythonTypeUtils.TypeInfoToProtoConverter
-			.getFieldType(keyTypeInfo);
+		FlinkFnApi.TypeInfo builtKeyTypeInfo = PythonTypeUtils.TypeInfoToProtoConverter
+			.toTypeInfoProto(keyTypeInfo);
 		return userDefinedDataStreamFunction.toBuilder()
-			.setKeyTypeInfo(PythonTypeUtils.TypeInfoToProtoConverter
-				.toTypeInfoProto(builtKeyFieldType)).build();
+			.setKeyTypeInfo(builtKeyTypeInfo).build();
 	}
 
 	public static boolean endOfLastFlatMap(int length, byte[] rawData) {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -71,7 +71,7 @@ public class PythonTypeUtils {
 	 */
 	public static class TypeInfoToProtoConverter {
 
-		public static FlinkFnApi.TypeInfo.FieldType getFieldType(TypeInformation typeInformation) {
+		public static FlinkFnApi.TypeInfo toTypeInfoProto(TypeInformation typeInformation) {
 
 			if (typeInformation instanceof BasicTypeInfo) {
 				return buildBasicTypeProto((BasicTypeInfo) typeInformation);
@@ -86,7 +86,7 @@ public class PythonTypeUtils {
 			}
 
 			if (typeInformation instanceof PickledByteArrayTypeInfo) {
-				return buildPickledBytesTypeProto((PickledByteArrayTypeInfo) typeInformation);
+				return buildPickledBytesTypeProto();
 			}
 
 			if (typeInformation instanceof TupleTypeInfo) {
@@ -110,11 +110,11 @@ public class PythonTypeUtils {
 					typeInformation.toString()));
 		}
 
-		public static FlinkFnApi.TypeInfo toTypeInfoProto(FlinkFnApi.TypeInfo.FieldType fieldType) {
-			return FlinkFnApi.TypeInfo.newBuilder().addField(FlinkFnApi.TypeInfo.Field.newBuilder().setType(fieldType).build()).build();
-		}
+//		public static FlinkFnApi.TypeInfo toTypeInfoProto(FlinkFnApi.TypeInfo.FieldType fieldType) {
+//			return FlinkFnApi.TypeInfo.newBuilder().addField(FlinkFnApi.TypeInfo.Field.newBuilder().setType(fieldType).build()).build();
+//		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildBasicTypeProto(BasicTypeInfo basicTypeInfo) {
+		private static FlinkFnApi.TypeInfo buildBasicTypeProto(BasicTypeInfo basicTypeInfo) {
 
 			FlinkFnApi.TypeInfo.TypeName typeName = null;
 
@@ -168,13 +168,13 @@ public class PythonTypeUtils {
 						basicTypeInfo.toString()));
 			}
 
-			return FlinkFnApi.TypeInfo.FieldType.newBuilder()
+			return FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(typeName).build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildPrimitiveArrayTypeProto(
+		private static FlinkFnApi.TypeInfo buildPrimitiveArrayTypeProto(
 			PrimitiveArrayTypeInfo primitiveArrayTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType elementFieldType = null;
+			FlinkFnApi.TypeInfo elementFieldType = null;
 			if (primitiveArrayTypeInfo.equals(PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO)) {
 				elementFieldType = buildBasicTypeProto(BasicTypeInfo.BOOLEAN_TYPE_INFO);
 			}
@@ -213,15 +213,15 @@ public class PythonTypeUtils {
 						, primitiveArrayTypeInfo.toString()));
 			}
 
-			FlinkFnApi.TypeInfo.FieldType.Builder builder = FlinkFnApi.TypeInfo.FieldType.newBuilder()
+			FlinkFnApi.TypeInfo.Builder builder = FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(FlinkFnApi.TypeInfo.TypeName.PRIMITIVE_ARRAY);
 			builder.setCollectionElementType(elementFieldType);
 			return builder.build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildBasicArrayTypeProto(
+		private static FlinkFnApi.TypeInfo buildBasicArrayTypeProto(
 			BasicArrayTypeInfo basicArrayTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType elementFieldType = null;
+			FlinkFnApi.TypeInfo elementFieldType = null;
 			if (basicArrayTypeInfo.equals(BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO)) {
 				elementFieldType = buildBasicTypeProto(BasicTypeInfo.BOOLEAN_TYPE_INFO);
 			}
@@ -264,74 +264,72 @@ public class PythonTypeUtils {
 						, basicArrayTypeInfo.toString()));
 			}
 
-			FlinkFnApi.TypeInfo.FieldType.Builder builder = FlinkFnApi.TypeInfo.FieldType.newBuilder()
+			FlinkFnApi.TypeInfo.Builder builder = FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(FlinkFnApi.TypeInfo.TypeName.BASIC_ARRAY);
 			builder.setCollectionElementType(elementFieldType);
 			return builder.build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildRowTypeProto(RowTypeInfo rowTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType.Builder builder =
-				FlinkFnApi.TypeInfo.FieldType.newBuilder()
+		private static FlinkFnApi.TypeInfo buildRowTypeProto(RowTypeInfo rowTypeInfo) {
+			FlinkFnApi.TypeInfo.Builder builder =
+				FlinkFnApi.TypeInfo.newBuilder()
 					.setTypeName(FlinkFnApi.TypeInfo.TypeName.ROW);
 
-			FlinkFnApi.TypeInfo.Builder rowTypeInfoBuilder = FlinkFnApi.TypeInfo.newBuilder();
+			FlinkFnApi.TypeInfo.RowTypeInfo.Builder rowTypeInfoBuilder = FlinkFnApi.TypeInfo.RowTypeInfo.newBuilder();
 
 			int arity = rowTypeInfo.getArity();
 			for (int index = 0; index < arity; index++) {
-				rowTypeInfoBuilder.addField(
-					FlinkFnApi.TypeInfo.Field.newBuilder()
-						.setName(rowTypeInfo.getFieldNames()[index])
-						.setType(TypeInfoToProtoConverter.getFieldType(rowTypeInfo.getTypeAt(index)))
+				rowTypeInfoBuilder.addFields(
+					FlinkFnApi.TypeInfo.RowTypeInfo.Field.newBuilder()
+						.setFieldName(rowTypeInfo.getFieldNames()[index])
+						.setFieldType(TypeInfoToProtoConverter.toTypeInfoProto(rowTypeInfo.getTypeAt(index)))
 						.build());
 			}
 			builder.setRowTypeInfo(rowTypeInfoBuilder.build());
 			return builder.build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildPickledBytesTypeProto(PickledByteArrayTypeInfo pickledByteArrayTypeInfo) {
-			return FlinkFnApi.TypeInfo.FieldType.newBuilder()
+		private static FlinkFnApi.TypeInfo buildPickledBytesTypeProto() {
+			return FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(FlinkFnApi.TypeInfo.TypeName.PICKLED_BYTES).build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildTupleTypeProto(TupleTypeInfo tupleTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType.Builder builder =
-				FlinkFnApi.TypeInfo.FieldType.newBuilder()
-					.setTypeName(FlinkFnApi.TypeInfo.TypeName.TUPLE);
+		private static FlinkFnApi.TypeInfo buildTupleTypeProto(TupleTypeInfo tupleTypeInfo) {
+			FlinkFnApi.TypeInfo.Builder builder =
+				FlinkFnApi.TypeInfo.newBuilder().setTypeName(FlinkFnApi.TypeInfo.TypeName.TUPLE);
 
-			FlinkFnApi.TypeInfo.Builder tupleTypeInfoBuilder = FlinkFnApi.TypeInfo.newBuilder();
+			FlinkFnApi.TypeInfo.TupleTypeInfo.Builder tupleTypeInfoBuilder = FlinkFnApi.TypeInfo.TupleTypeInfo.newBuilder();
 
 			int arity = tupleTypeInfo.getArity();
 			for (int index = 0; index < arity; index++) {
-				tupleTypeInfoBuilder.addField(
-					FlinkFnApi.TypeInfo.Field.newBuilder()
-						.setName(tupleTypeInfo.getFieldNames()[index])
-						.setType(TypeInfoToProtoConverter.getFieldType(tupleTypeInfo.getTypeAt(index)))
+				tupleTypeInfoBuilder.addFields(
+					FlinkFnApi.TypeInfo.TupleTypeInfo.Field.newBuilder()
+						.setFieldType(TypeInfoToProtoConverter.toTypeInfoProto(tupleTypeInfo.getTypeAt(index)))
 						.build());
 			}
 			builder.setTupleTypeInfo(tupleTypeInfoBuilder.build());
 			return builder.build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildMapTypeProto(MapTypeInfo mapTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType.Builder builder =
-				FlinkFnApi.TypeInfo.FieldType.newBuilder()
+		private static FlinkFnApi.TypeInfo buildMapTypeProto(MapTypeInfo mapTypeInfo) {
+			FlinkFnApi.TypeInfo.Builder builder =
+				FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(FlinkFnApi.TypeInfo.TypeName.MAP);
 			FlinkFnApi.TypeInfo.MapTypeInfo.Builder mapTypeInfoBuilder = FlinkFnApi.TypeInfo.MapTypeInfo.newBuilder();
 
 			mapTypeInfoBuilder
-				.setKeyType(TypeInfoToProtoConverter.getFieldType(mapTypeInfo.getKeyTypeInfo()))
-				.setValueType(TypeInfoToProtoConverter.getFieldType(mapTypeInfo.getValueTypeInfo()));
+				.setKeyType(TypeInfoToProtoConverter.toTypeInfoProto(mapTypeInfo.getKeyTypeInfo()))
+				.setValueType(TypeInfoToProtoConverter.toTypeInfoProto(mapTypeInfo.getValueTypeInfo()));
 
 			builder.setMapTypeInfo(mapTypeInfoBuilder.build());
 			return builder.build();
 		}
 
-		private static FlinkFnApi.TypeInfo.FieldType buildListTypeProto(ListTypeInfo listTypeInfo) {
-			FlinkFnApi.TypeInfo.FieldType.Builder builder =
-				FlinkFnApi.TypeInfo.FieldType.newBuilder()
+		private static FlinkFnApi.TypeInfo buildListTypeProto(ListTypeInfo listTypeInfo) {
+			FlinkFnApi.TypeInfo.Builder builder =
+				FlinkFnApi.TypeInfo.newBuilder()
 				.setTypeName(FlinkFnApi.TypeInfo.TypeName.LIST);
-			builder.setCollectionElementType(TypeInfoToProtoConverter.getFieldType(listTypeInfo.getElementTypeInfo()));
+			builder.setCollectionElementType(TypeInfoToProtoConverter.toTypeInfoProto(listTypeInfo.getElementTypeInfo()));
 			return builder.build();
 		}
 	}

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -74,31 +74,31 @@ public class PythonTypeUtilsTest {
 
 		for (Map.Entry<TypeInformation, FlinkFnApi.TypeInfo.TypeName> entry : typeInformationTypeNameMap.entrySet()) {
 			assertEquals(entry.getValue(),
-				PythonTypeUtils.TypeInfoToProtoConverter.getFieldType(entry.getKey()).getTypeName());
+				PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(entry.getKey()).getTypeName());
 		}
 
 		TypeInformation primitiveIntegerArrayTypeInfo = PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO;
-		FlinkFnApi.TypeInfo.FieldType convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter
-			.getFieldType(primitiveIntegerArrayTypeInfo);
+		FlinkFnApi.TypeInfo convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter
+			.toTypeInfoProto(primitiveIntegerArrayTypeInfo);
 		assertEquals(convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.PRIMITIVE_ARRAY);
 		assertEquals(convertedFieldType.getCollectionElementType().getTypeName(), FlinkFnApi.TypeInfo.TypeName.INT);
 
 		TypeInformation basicIntegerArrayTypeInfo = BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO;
-		FlinkFnApi.TypeInfo.FieldType convertedBasicFieldType = PythonTypeUtils.TypeInfoToProtoConverter
-			.getFieldType(basicIntegerArrayTypeInfo);
+		FlinkFnApi.TypeInfo convertedBasicFieldType = PythonTypeUtils.TypeInfoToProtoConverter
+			.toTypeInfoProto(basicIntegerArrayTypeInfo);
 		assertEquals(convertedBasicFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.BASIC_ARRAY);
 		assertEquals(convertedBasicFieldType.getCollectionElementType().getTypeName(), FlinkFnApi.TypeInfo.TypeName.INT);
 
 		TypeInformation rowTypeInfo = Types.ROW(Types.INT);
-		convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.getFieldType(rowTypeInfo);
+		convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(rowTypeInfo);
 		assertEquals(convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.ROW);
-		assertEquals(convertedFieldType.getRowTypeInfo().getField(0).getType().getTypeName(),
+		assertEquals(convertedFieldType.getRowTypeInfo().getFields(0).getFieldType().getTypeName(),
 			FlinkFnApi.TypeInfo.TypeName.INT);
 
 		TypeInformation tupleTypeInfo = Types.TUPLE(Types.INT);
-		convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.getFieldType(tupleTypeInfo);
+		convertedFieldType = PythonTypeUtils.TypeInfoToProtoConverter.toTypeInfoProto(tupleTypeInfo);
 		assertEquals(convertedFieldType.getTypeName(), FlinkFnApi.TypeInfo.TypeName.TUPLE);
-		assertEquals(convertedFieldType.getTupleTypeInfo().getField(0).getType().getTypeName(),
+		assertEquals(convertedFieldType.getTupleTypeInfo().getFields(0).getFieldType().getTypeName(),
 			FlinkFnApi.TypeInfo.TypeName.INT);
 	}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when users declare a TypeInfo in Python DataStream job it will create a Java TypeInfo instance when instantiating. We should make it in a lazy style that creates the Java TypeInfo instance only when calling TypeInformation.get_java_type_info().

## Brief change log

- *Removed WrapperTypeInfo*
- *No need to create Java TypeInfo in Python TypeInfo constructor*

## Verifying this change

This change has test case covered by all existing IT cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
