### PR TITLE
[FLINK-20624][table-planner]Refactor StreamExecJoinRule, StreamExecIntervalJoinRule and StreamExecTemporalJoinRule

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecIntervalJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecIntervalJoinRule.scala
@@ -62,15 +62,17 @@ class StreamExecIntervalJoinRule
 
   override protected def transform(
       join: FlinkLogicalJoin,
-      convertedLeft: RelNode,
-      convertedRight: RelNode,
+      leftInput: FlinkRelNode,
+      leftConversion: RelNode => RelNode,
+      rightInput: FlinkRelNode,
+      rightConversion: RelNode => RelNode,
       providedTraitSet: RelTraitSet): FlinkRelNode = {
     val (windowBounds, remainCondition) = extractWindowBounds(join)
     new StreamExecIntervalJoin(
       join.getCluster,
       providedTraitSet,
-      convertedLeft,
-      convertedRight,
+      leftConversion(leftInput),
+      rightConversion(rightInput),
       join.getCondition,
       join.getJoinType,
       join.getRowType,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecIntervalJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecIntervalJoinRule.scala
@@ -18,18 +18,12 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
-import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
-import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecIntervalJoin
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, IntervalJoinUtil}
-
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.convert.ConverterRule
-
-import java.util
 
 import scala.collection.JavaConversions._
 
@@ -38,11 +32,7 @@ import scala.collection.JavaConversions._
   * to [[StreamExecIntervalJoin]].
   */
 class StreamExecIntervalJoinRule
-  extends ConverterRule(
-    classOf[FlinkLogicalJoin],
-    FlinkConventions.LOGICAL,
-    FlinkConventions.STREAM_PHYSICAL,
-    "StreamExecIntervalJoinRule") {
+  extends StreamExecJoinRuleBase("StreamExecIntervalJoinRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: FlinkLogicalJoin = call.rel(0)
@@ -53,13 +43,7 @@ class StreamExecIntervalJoinRule
       return false
     }
 
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
-    val (windowBounds, _) = IntervalJoinUtil.extractWindowBoundsFromPredicate(
-      join.getCondition,
-      join.getLeft.getRowType.getFieldCount,
-      joinRowType,
-      join.getCluster.getRexBuilder,
-      tableConfig)
+    val (windowBounds, _) = extractWindowBounds(join)
 
     if (windowBounds.isDefined) {
       if (windowBounds.get.isEventTime) {
@@ -76,55 +60,20 @@ class StreamExecIntervalJoinRule
     }
   }
 
-  override def convert(rel: RelNode): RelNode = {
-    val join: FlinkLogicalJoin = rel.asInstanceOf[FlinkLogicalJoin]
-    val joinRowType = join.getRowType
-    val left = join.getLeft
-    val right = join.getRight
-
-    def toHashTraitByColumns(
-        columns: util.Collection[_ <: Number],
-        inputTraitSet: RelTraitSet): RelTraitSet = {
-      val distribution = if (columns.size() == 0) {
-        FlinkRelDistribution.SINGLETON
-      } else {
-        FlinkRelDistribution.hash(columns)
-      }
-      inputTraitSet
-        .replace(FlinkConventions.STREAM_PHYSICAL)
-        .replace(distribution)
-    }
-
-    val joinInfo = join.analyzeCondition
-    val (leftRequiredTrait, rightRequiredTrait) = (
-      toHashTraitByColumns(joinInfo.leftKeys, left.getTraitSet),
-      toHashTraitByColumns(joinInfo.rightKeys, right.getTraitSet))
-
-    val newLeft = RelOptRule.convert(left, leftRequiredTrait)
-    val newRight = RelOptRule.convert(right, rightRequiredTrait)
-    val providedTraitSet = join.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-
-    val tableConfig = rel
-      .getCluster
-      .getPlanner
-      .getContext
-      .unwrap(classOf[FlinkContext])
-      .getTableConfig
-    val (windowBounds, remainCondition) = IntervalJoinUtil.extractWindowBoundsFromPredicate(
-      join.getCondition,
-      left.getRowType.getFieldCount,
-      joinRowType,
-      join.getCluster.getRexBuilder,
-      tableConfig)
-
+  override protected def transform(
+      join: FlinkLogicalJoin,
+      convertedLeft: RelNode,
+      convertedRight: RelNode,
+      providedTraitSet: RelTraitSet): FlinkRelNode = {
+    val (windowBounds, remainCondition) = extractWindowBounds(join)
     new StreamExecIntervalJoin(
-      rel.getCluster,
+      join.getCluster,
       providedTraitSet,
-      newLeft,
-      newRight,
+      convertedLeft,
+      convertedRight,
       join.getCondition,
       join.getJoinType,
-      joinRowType,
+      join.getRowType,
       windowBounds.get.isEventTime,
       windowBounds.get.leftLowerBound,
       windowBounds.get.leftUpperBound,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRule.scala
@@ -19,16 +19,13 @@
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkTypeFactory}
-import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
-import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalJoin, FlinkLogicalRel, FlinkLogicalSnapshot}
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecJoin
 import org.apache.flink.table.planner.plan.utils.{IntervalJoinUtil, TemporalJoinUtil}
-import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
-import java.util
 
 import scala.collection.JavaConversions._
 
@@ -37,11 +34,7 @@ import scala.collection.JavaConversions._
   * to [[StreamExecJoin]].
   */
 class StreamExecJoinRule
-  extends RelOptRule(
-    operand(classOf[FlinkLogicalJoin],
-      operand(classOf[FlinkLogicalRel], any()),
-      operand(classOf[FlinkLogicalRel], any())),
-    "StreamExecJoinRule") {
+  extends StreamExecJoinRuleBase("StreamExecJoinRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join: FlinkLogicalJoin = call.rel(0)
@@ -51,7 +44,6 @@ class StreamExecJoinRule
     }
     val left: FlinkLogicalRel = call.rel(1).asInstanceOf[FlinkLogicalRel]
     val right: FlinkLogicalRel = call.rel(2).asInstanceOf[FlinkLogicalRel]
-    val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
     val joinRowType = join.getRowType
 
     if (left.isInstanceOf[FlinkLogicalSnapshot]) {
@@ -65,13 +57,7 @@ class StreamExecJoinRule
       return false
     }
 
-    val (windowBounds, remainingPreds) = IntervalJoinUtil.extractWindowBoundsFromPredicate(
-      join.getCondition,
-      join.getLeft.getRowType.getFieldCount,
-      joinRowType,
-      join.getCluster.getRexBuilder,
-      tableConfig)
-
+    val (windowBounds, remainingPreds) = extractWindowBounds(join)
     if (windowBounds.isDefined) {
       return false
     }
@@ -95,42 +81,18 @@ class StreamExecJoinRule
     !remainingPredsAccessTime
   }
 
-  override def onMatch(call: RelOptRuleCall): Unit = {
-    val join: FlinkLogicalJoin = call.rel(0)
-    val left = join.getLeft
-    val right = join.getRight
-
-    def toHashTraitByColumns(
-        columns: util.Collection[_ <: Number],
-        inputTraitSets: RelTraitSet): RelTraitSet = {
-      val distribution = if (columns.isEmpty) {
-        FlinkRelDistribution.SINGLETON
-      } else {
-        FlinkRelDistribution.hash(columns)
-      }
-      inputTraitSets
-        .replace(FlinkConventions.STREAM_PHYSICAL)
-        .replace(distribution)
-    }
-
-    val joinInfo = join.analyzeCondition()
-    val (leftRequiredTrait, rightRequiredTrait) = (
-      toHashTraitByColumns(joinInfo.leftKeys, left.getTraitSet),
-      toHashTraitByColumns(joinInfo.rightKeys, right.getTraitSet))
-
-    val providedTraitSet = join.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-
-    val newLeft: RelNode = RelOptRule.convert(left, leftRequiredTrait)
-    val newRight: RelNode = RelOptRule.convert(right, rightRequiredTrait)
-
-    val newJoin = new StreamExecJoin(
+  override protected def transform(
+      join: FlinkLogicalJoin,
+      convertedLeft: RelNode,
+      convertedRight: RelNode,
+      providedTraitSet: RelTraitSet): FlinkRelNode = {
+    new StreamExecJoin(
       join.getCluster,
       providedTraitSet,
-      newLeft,
-      newRight,
+      convertedLeft,
+      convertedRight,
       join.getCondition,
       join.getJoinType)
-    call.transformTo(newJoin)
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRule.scala
@@ -83,14 +83,16 @@ class StreamExecJoinRule
 
   override protected def transform(
       join: FlinkLogicalJoin,
-      convertedLeft: RelNode,
-      convertedRight: RelNode,
+      leftInput: FlinkRelNode,
+      leftConversion: RelNode => RelNode,
+      rightInput: FlinkRelNode,
+      rightConversion: RelNode => RelNode,
       providedTraitSet: RelTraitSet): FlinkRelNode = {
     new StreamExecJoin(
       join.getCluster,
       providedTraitSet,
-      convertedLeft,
-      convertedRight,
+      leftConversion(leftInput),
+      rightConversion(rightInput),
       join.getCondition,
       join.getJoinType)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecJoinRuleBase.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream
+
+import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
+import org.apache.flink.table.planner.plan.nodes.{FlinkConventions, FlinkRelNode}
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalJoin, FlinkLogicalRel, FlinkLogicalSnapshot}
+import org.apache.flink.table.planner.plan.utils.IntervalJoinUtil.WindowBounds
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, IntervalJoinUtil}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rex.RexNode
+
+import java.util
+
+/**
+ * Base implementation for rules match stream-stream join, including
+ * regular stream join, interval join and temporal join.
+ */
+abstract class StreamExecJoinRuleBase(description: String)
+  extends RelOptRule(
+    operand(classOf[FlinkLogicalJoin],
+      operand(classOf[FlinkLogicalRel], any()),
+      operand(classOf[FlinkLogicalRel], any())),
+    description) {
+
+  protected def extractWindowBounds(join: FlinkLogicalJoin):
+    (Option[WindowBounds], Option[RexNode]) = {
+    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
+    IntervalJoinUtil.extractWindowBoundsFromPredicate(
+      join.getCondition,
+      join.getLeft.getRowType.getFieldCount,
+      join.getRowType,
+      join.getCluster.getRexBuilder,
+      tableConfig)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val join = call.rel[FlinkLogicalJoin](0)
+    val left = call.rel[FlinkLogicalRel](1)
+    val right = call.rel[FlinkLogicalRel](2)
+
+    def toHashTraitByColumns(
+        columns: util.Collection[_ <: Number],
+        inputTraitSet: RelTraitSet): RelTraitSet = {
+      val distribution = if (columns.size() == 0) {
+        FlinkRelDistribution.SINGLETON
+      } else {
+        FlinkRelDistribution.hash(columns)
+      }
+      inputTraitSet
+          .replace(FlinkConventions.STREAM_PHYSICAL)
+          .replace(distribution)
+    }
+
+    val newRight = right match {
+      case snapshot: FlinkLogicalSnapshot =>
+        snapshot.getInput
+      case rel: FlinkLogicalRel => rel
+    }
+
+    val joinInfo = join.analyzeCondition
+    val (leftRequiredTrait, rightRequiredTrait) = (
+        toHashTraitByColumns(joinInfo.leftKeys, left.getTraitSet),
+        toHashTraitByColumns(joinInfo.rightKeys, newRight.getTraitSet))
+
+    val convertedLeft: RelNode = RelOptRule.convert(left, leftRequiredTrait)
+    val convertedRight: RelNode = RelOptRule.convert(newRight, rightRequiredTrait)
+    val providedTraitSet: RelTraitSet = join.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
+
+    val newJoin = transform(join, convertedLeft, convertedRight, providedTraitSet)
+    call.transformTo(newJoin)
+  }
+
+  protected def transform(
+      join: FlinkLogicalJoin,
+      convertedLeft: RelNode,
+      convertedRight: RelNode,
+      providedTraitSet: RelTraitSet): FlinkRelNode
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTemporalJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTemporalJoinRule.scala
@@ -58,14 +58,21 @@ class StreamExecTemporalJoinRule
 
   override protected def transform(
       join: FlinkLogicalJoin,
-      convertedLeft: RelNode,
-      convertedRight: RelNode,
+      leftInput: FlinkRelNode,
+      leftConversion: RelNode => RelNode,
+      rightInput: FlinkRelNode,
+      rightConversion: RelNode => RelNode,
       providedTraitSet: RelTraitSet): FlinkRelNode = {
+    val newRight = rightInput match {
+      case snapshot: FlinkLogicalSnapshot =>
+        snapshot.getInput
+      case rel: FlinkLogicalRel => rel
+    }
     new StreamExecTemporalJoin(
       join.getCluster,
       providedTraitSet,
-      convertedLeft,
-      convertedRight,
+      leftConversion(leftInput),
+      rightConversion(newRight),
       join.getCondition,
       join.getJoinType)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTemporalJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecTemporalJoinRule.scala
@@ -18,14 +18,10 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream
 
-import java.util
-
-import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
-import org.apache.flink.table.planner.plan.nodes.FlinkConventions
+import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
 import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecTemporalJoin
-import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, IntervalJoinUtil, TemporalJoinUtil}
-import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.JoinRelType
@@ -36,11 +32,7 @@ import org.apache.flink.util.Preconditions.checkState
  * the temporal join node is a [[FlinkLogicalJoin]] which contains [[TemporalJoinCondition]].
  */
 class StreamExecTemporalJoinRule
-  extends RelOptRule(
-    operand(classOf[FlinkLogicalJoin],
-      operand(classOf[FlinkLogicalRel], any()),
-      operand(classOf[FlinkLogicalRel], any())),
-    "StreamExecTemporalJoinRule") {
+  extends StreamExecJoinRuleBase("StreamExecJoinRuleBase") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join = call.rel[FlinkLogicalJoin](0)
@@ -60,59 +52,22 @@ class StreamExecTemporalJoinRule
   }
 
   private def matchesTemporalTableFunctionJoin(join: FlinkLogicalJoin): Boolean = {
-    val joinInfo = join.analyzeCondition
-    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(join)
-    val (windowBounds, _) = IntervalJoinUtil.extractWindowBoundsFromPredicate(
-      joinInfo.getRemaining(join.getCluster.getRexBuilder),
-      join.getLeft.getRowType.getFieldCount,
-      join.getRowType,
-      join.getCluster.getRexBuilder,
-      tableConfig)
+    val (windowBounds, _) = extractWindowBounds(join)
     windowBounds.isEmpty && join.getJoinType == JoinRelType.INNER
   }
 
-  override def onMatch(call: RelOptRuleCall): Unit = {
-    val join = call.rel[FlinkLogicalJoin](0)
-    val left = call.rel[FlinkLogicalRel](1)
-    val right = call.rel[FlinkLogicalRel](2)
-
-    val newRight = right match {
-      case snapshot: FlinkLogicalSnapshot =>
-        snapshot.getInput
-      case rel: FlinkLogicalRel => rel
-    }
-
-    def toHashTraitByColumns(
-        columns: util.Collection[_ <: Number],
-        inputTraitSets: RelTraitSet) = {
-      val distribution = if (columns.size() == 0) {
-        FlinkRelDistribution.SINGLETON
-      } else {
-        FlinkRelDistribution.hash(columns)
-      }
-      inputTraitSets.
-        replace(FlinkConventions.STREAM_PHYSICAL).
-        replace(distribution)
-    }
-
-    val joinInfo = join.analyzeCondition
-    val (leftRequiredTrait, rightRequiredTrait) = (
-      toHashTraitByColumns(joinInfo.leftKeys, left.getTraitSet),
-      toHashTraitByColumns(joinInfo.rightKeys, newRight.getTraitSet))
-
-    val convLeft: RelNode = RelOptRule.convert(left, leftRequiredTrait)
-    val convRight: RelNode = RelOptRule.convert(newRight, rightRequiredTrait)
-    val providedTraitSet: RelTraitSet = join.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-
-    val temporalJoin = new StreamExecTemporalJoin(
+  override protected def transform(
+      join: FlinkLogicalJoin,
+      convertedLeft: RelNode,
+      convertedRight: RelNode,
+      providedTraitSet: RelTraitSet): FlinkRelNode = {
+    new StreamExecTemporalJoin(
       join.getCluster,
       providedTraitSet,
-      convLeft,
-      convRight,
+      convertedLeft,
+      convertedRight,
       join.getCondition,
       join.getJoinType)
-
-    call.transformTo(temporalJoin)
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to refactor `StreamExecJoinRule`, `StreamExecIntervalJoinRule` and `StreamExecTemporalJoinRule`, so that we can elimate the duplicate code.


## Brief change log
  - Add  abstract class `StreamExecJoinRuleBase` as base implementation for stream-stream join rules, and elimate duplicate  code in `StreamExecJoinRule`, `StreamExecIntervalJoinRule` and `StreamExecTemporalJoinRule` 


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
