### PR TITLE
[FLINK-20630][dynamodb]  DynamoDB Streams Consumer fails to consume from Latest

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcher.java
@@ -17,13 +17,17 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.KinesisShardAssigner;
-import org.apache.flink.streaming.connectors.kinesis.metrics.ShardConsumerMetricsReporter;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisherFactory;
+import org.apache.flink.streaming.connectors.kinesis.internals.publisher.polling.PollingRecordPublisherFactory;
 import org.apache.flink.streaming.connectors.kinesis.model.DynamoDBStreamsShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
+import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.DynamoDBStreamsProxy;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
@@ -38,7 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <T> type of fetched data.
  */
 public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
-	private boolean shardIdFormatCheck = false;
+	private final RecordPublisherFactory recordPublisherFactory;
 
 	/**
 	 * Constructor.
@@ -57,6 +61,17 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 		KinesisDeserializationSchema<T> deserializationSchema,
 		KinesisShardAssigner shardAssigner) {
 
+		this(streams, sourceContext, runtimeContext, configProps, deserializationSchema, shardAssigner, DynamoDBStreamsProxy::create);
+	}
+
+	@VisibleForTesting
+	DynamoDBStreamsDataFetcher(List<String> streams,
+		SourceFunction.SourceContext<T> sourceContext,
+		RuntimeContext runtimeContext,
+		Properties configProps,
+		KinesisDeserializationSchema<T> deserializationSchema,
+		KinesisShardAssigner shardAssigner,
+		FlinkKinesisProxyFactory flinkKinesisProxyFactory) {
 		super(streams,
 			sourceContext,
 			sourceContext.getCheckpointLock(),
@@ -69,9 +84,10 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 			new AtomicReference<>(),
 			new ArrayList<>(),
 			createInitialSubscribedStreamsToLastDiscoveredShardsState(streams),
-			// use DynamoDBStreamsProxy
-			DynamoDBStreamsProxy::create,
+			flinkKinesisProxyFactory,
 			null);
+
+		this.recordPublisherFactory = new PollingRecordPublisherFactory(flinkKinesisProxyFactory);
 	}
 
 	@Override
@@ -85,30 +101,13 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 		return true;
 	}
 
-	/**
-	 * Create a new DynamoDB streams shard consumer.
-	 *
-	 * @param subscribedShardStateIndex the state index of the shard this consumer is subscribed to
-	 * @param handle stream handle
-	 * @param lastSeqNum last sequence number
-	 * @param metricGroup the metric group to report metrics to
-	 * @return
-	 */
 	@Override
-	protected ShardConsumer<T> createShardConsumer(
-		Integer subscribedShardStateIndex,
-		StreamShardHandle handle,
-		SequenceNumber lastSeqNum,
-		MetricGroup metricGroup,
-		KinesisDeserializationSchema<T> shardDeserializer) throws InterruptedException {
-
-		return new ShardConsumer<T>(
-			this,
-			createRecordPublisher(lastSeqNum, getConsumerConfiguration(), metricGroup, handle),
-			subscribedShardStateIndex,
-			handle,
-			lastSeqNum,
-			new ShardConsumerMetricsReporter(metricGroup),
-			shardDeserializer);
+	protected RecordPublisher createRecordPublisher(
+		SequenceNumber sequenceNumber,
+		Properties configProps, MetricGroup metricGroup,
+		StreamShardHandle subscribedShard) throws InterruptedException {
+		StartingPosition startingPosition = StartingPosition.continueFromSequenceNumber(sequenceNumber);
+		return recordPublisherFactory.create(startingPosition, getConsumerConfiguration(), metricGroup, subscribedShard);
 	}
+
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcherTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.internals;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.LATEST;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher.DEFAULT_SHARD_ASSIGNER;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link DynamoDBStreamsDataFetcher}.
+ */
+public class DynamoDBStreamsDataFetcherTest {
+
+	@Test
+	public void testCreateRecordPublisherRespectsShardIteratorTypeLatest() throws Exception {
+		RuntimeContext runtimeContext = TestUtils.getMockedRuntimeContext(1, 0);
+		KinesisProxyInterface kinesis = mock(KinesisProxyInterface.class);
+
+		DynamoDBStreamsDataFetcher<String> fetcher = new DynamoDBStreamsDataFetcher<>(
+			singletonList("fakeStream"),
+			new TestSourceContext<>(),
+			runtimeContext,
+			TestUtils.getStandardProperties(),
+			new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+			DEFAULT_SHARD_ASSIGNER,
+			config -> kinesis);
+
+		StreamShardHandle dummyStreamShardHandle = TestUtils.createDummyStreamShardHandle("dummy-stream", "0");
+
+		fetcher.createRecordPublisher(
+			SENTINEL_LATEST_SEQUENCE_NUM.get(),
+			new Properties(),
+			runtimeContext.getMetricGroup(),
+			dummyStreamShardHandle);
+
+		verify(kinesis).getShardIterator(dummyStreamShardHandle, LATEST.toString(), null);
+	}
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
@@ -17,7 +17,9 @@
 
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordBatch;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher;
@@ -33,6 +35,7 @@ import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -48,6 +51,7 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static org.mockito.Mockito.mock;
 
 /**
  * General test utils.
@@ -132,6 +136,22 @@ public class TestUtils {
 		consumerConfig.setProperty(EFO_REGISTRATION_TYPE, NONE.name());
 		consumerConfig.setProperty(EFO_CONSUMER_ARN_PREFIX + "." + "fakeStream", "stream-consumer-arn");
 		return consumerConfig;
+	}
+
+	public static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {
+		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
+
+		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(fakeTotalCountOfSubtasks);
+		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(fakeIndexOfThisSubtask);
+		Mockito.when(mockedRuntimeContext.getTaskName()).thenReturn("Fake Task");
+		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(
+			"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
+		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
+			Thread.currentThread().getContextClassLoader());
+
+		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
+
+		return mockedRuntimeContext;
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -17,9 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
-import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
@@ -28,7 +26,6 @@ import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyV2Interface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
 import java.util.HashMap;
@@ -97,7 +94,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 			fakeStreams,
 			sourceContext,
 			sourceContext.getCheckpointLock(),
-			getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
+			TestUtils.getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
 			fakeConfiguration,
 			deserializationSchema,
 			DEFAULT_SHARD_ASSIGNER,
@@ -166,19 +163,4 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 		initialDiscoveryWaiter.await();
 	}
 
-	private static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {
-		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
-
-		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(fakeTotalCountOfSubtasks);
-		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(fakeIndexOfThisSubtask);
-		Mockito.when(mockedRuntimeContext.getTaskName()).thenReturn("Fake Task");
-		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(
-				"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
-		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
-				Thread.currentThread().getContextClassLoader());
-
-		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
-
-		return mockedRuntimeContext;
-	}
 }


### PR DESCRIPTION
## What is the purpose of the change

When consuming from `LATEST`, the `KinesisDataFetcher` converts the shard iterator type into an `AT_TIMESTAMP` to ensure all shards start from the same position. When `LATEST` is used each shared would effectively start from a different point in the time.

DynamoDB streams do not support `AT_TIMESTAMP` iterator type and consuming from latest is broken


## Brief change log

- Remove shard iterator type transform for DynamoDB streams consumer to fix consume from `LATEST`


## Verifying this change

- Added unit test: `DynamoDBStreamsDataFetcherTest`
- Deployed application to local Flink cluster and verified consumer works as expected

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
