### PR TITLE
[hotfix][util] fix partition utility

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CollectionUtil.java
@@ -75,6 +75,7 @@ public final class CollectionUtil {
 		for (T element : elements) {
 			int bucket = index % numBuckets;
 			buckets.computeIfAbsent(bucket, key -> new ArrayList<>(initialCapacity)).add(element);
+			index++;
 		}
 
 		return buckets.values();

--- a/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CollectionUtilTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Tests for java collection utilities.
+ */
+public class CollectionUtilTest {
+
+	@Test
+	public void testPartition() {
+		List<Integer> list = Arrays.asList(1, 2, 3, 4);
+		Collection<List<Integer>> partitioned = CollectionUtil.partition(list, 4);
+
+		Assert.assertEquals("List partitioned into the an incorrect number of partitions", 4, partitioned.size());
+		for (List<Integer> partition : partitioned) {
+			Assert.assertEquals("Unexpected number of elements in partition", 1, partition.size());
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes the partition utility method to actually partition collections

## Verifying this change

Added a UT. I also checked its usages and the only caller simply uses it as a performance optimization so there aren't any other correctness issues that need to be addressed. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
