### PR TITLE
[FLINK-20639][python] Use list to optimize the Row used by Python UDAF intermediate results

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -76,7 +76,7 @@ class FlattenRowCoderImpl(StreamCoderImpl):
 
     def encode_nested(self, value: List):
         data_out_stream = self.data_out_stream
-        self._encode_one_list_to_stream(value, data_out_stream, True)
+        self._encode_one_row_to_stream(value, data_out_stream, True)
         result = data_out_stream.get()
         data_out_stream._clear()
         return result
@@ -86,17 +86,12 @@ class FlattenRowCoderImpl(StreamCoderImpl):
             in_stream.read_var_int64()
             yield self._decode_one_row_from_stream(in_stream, nested)[1]
 
-    def _encode_one_row_to_stream(self, value: Row, out_stream, nested):
+    def _encode_one_row_to_stream(self, value, out_stream, nested):
         field_coders = self._field_coders
-        self._write_mask(value, out_stream, value.get_row_kind().value)
-        for i in range(self._field_count):
-            item = value[i]
-            if item is not None:
-                field_coders[i].encode_to_stream(item, out_stream, nested)
-
-    def _encode_one_list_to_stream(self, value: List, out_stream, nested):
-        field_coders = self._field_coders
-        self._write_mask(value, out_stream, 0)
+        if isinstance(value, Row):
+            self._write_mask(value, out_stream, value.get_row_kind().value)
+        else:
+            self._write_mask(value, out_stream)
         for i in range(self._field_count):
             item = value[i]
             if item is not None:

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -731,17 +731,8 @@ class RemoteKeyedStateBackend(object):
         self._state_handler = state_handler
         self._map_state_handler = CachingMapStateHandler(
             state_handler, map_state_read_cache_size)
-
-        try:
-            from pyflink.fn_execution import coder_impl_fast
-            is_fast = True if coder_impl_fast else False
-        except:
-            is_fast = False
-        if not is_fast:
-            self._key_coder_impl = key_coder.get_impl()
-        else:
-            from pyflink.fn_execution.coders import FlattenRowCoder
-            self._key_coder_impl = FlattenRowCoder(key_coder._field_coders).get_impl()
+        from pyflink.fn_execution.coders import FlattenRowCoder
+        self._key_coder_impl = FlattenRowCoder(key_coder._field_coders).get_impl()
         self._state_cache_size = state_cache_size
         self._map_state_write_cache_size = map_state_write_cache_size
         self._all_states = {}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will use Use list to optimize the Row used by Python UDAF intermediate results*


## Brief change log

  - *Use list to optimize the Row used by Python UDAF intermediate results*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

## How does this patch test
### Test UDAF

class MeanAggregateFunction(AggregateFunction):

    def get_value(self, accumulator: ACC) -> T:
        if accumulator[1] == 0:
            return None
        else:
            return accumulator[0] / accumulator[1]

    def create_accumulator(self) -> ACC:
        return [0, 0]

    def accumulate(self, accumulator: ACC, *args):
        accumulator[0] += args[0]
        accumulator[1] += 1

    def retract(self, accumulator: ACC, *args):
        accumulator[0] -= args[0]
        accumulator[1] -= 1

    def merge(self, accumulator: ACC, accumulators):
        for other_acc in accumulators:
            accumulator[0] += other_acc[0]
            accumulator[1] += other_acc[1]

    def get_accumulator_type(self) -> DataType:
        return DataTypes.ARRAY(DataTypes.BIGINT())

    def get_result_type(self) -> DataType:
        return DataTypes.FLOAT()

### Test Code
    env = StreamExecutionEnvironment.get_execution_environment()
    env.set_parallelism(1)
    env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
    environment_settings = EnvironmentSettings.new_instance().use_blink_planner().build()
    t_env = StreamTableEnvironment.create(env, environment_settings=environment_settings)
    t_env.get_config().get_configuration().set_integer("python.fn-execution.bundle.time", 1000) 
     t_env.get_config().get_configuration().set_boolean("pipeline.object-reuse", True)

    t_env.create_temporary_function("python_avg", MeanAggregateFunction())
    t_env.create_java_temporary_system_function("java_avg", "com.alibaba.flink.function.JavaAvg")

    num_rows = 10000000

    t_env.execute_sql(f"""
        CREATE TABLE source (
            id INT,
            num INT,
            rowtime TIMESTAMP(3),
            WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
        ) WITH (
          'connector' = 'Range',
          'start' = '1',
          'end' = '{num_rows}',
          'step' = '1',
          'partition' = '200'
        )
    """)
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["value"],
            [DataTypes.FLOAT(False)], 1000000))
    result = t_env.from_path("source") \
        .select("python_avg(id)")
    result.insert_into("sink")
    beg_time = time.time()
    t_env.execute("Python UDF")
    print("PyFlink stream group agg consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
1000w,3                      |     331.15                          |   220.03

