### PR TITLE
[FLINK-20646] Update memory requirements for ReduceTransformation

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -39,7 +39,7 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
 		implements TransformationTranslator<OUT, T> {
 
 	@Override
-	public Collection<Integer> translateForBatch(final T transformation, final Context context) {
+	public final Collection<Integer> translateForBatch(final T transformation, final Context context) {
 		checkNotNull(transformation);
 		checkNotNull(context);
 
@@ -51,7 +51,7 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
 	}
 
 	@Override
-	public Collection<Integer> translateForStreaming(final T transformation, final Context context) {
+	public final Collection<Integer> translateForStreaming(final T transformation, final Context context) {
 		checkNotNull(transformation);
 		checkNotNull(context);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -56,6 +56,8 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
 		this.reducer = reducer;
 		this.keySelector = keySelector;
 		this.keyTypeInfo = keyTypeInfo;
+
+		updateManagedMemoryStateBackendUseCase(true);
 	}
 
 	@Override


### PR DESCRIPTION
## Verifying this change

This is not covered by existing tests. I think we need ITCases to verify the memory requirement behaviour of all the transformations but I'm hesitant to do this now for this small change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
