### PR TITLE
[FLINK-20668][table-planner-blink] Introduce translateToExecNode method for FlinkPhysicalRel

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -67,6 +67,7 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 
 	@Override
 	public List<ExecNode<?>> getInputNodes() {
+		checkNotNull(inputNodes, "inputNodes should not be null, please call setInputNodes first.");
 		return inputNodes;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -38,20 +38,19 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> {
 
 	private final String description;
-	private final List<ExecNode<?>> inputNodes;
 	private final List<ExecEdge> inputEdges;
 	private final RowType outputType;
+	// TODO remove this field once edge support `source` and `target`,
+	//  and then we can get/set `inputNodes` through `inputEdges`.
+	private List<ExecNode<?>> inputNodes;
 
 	private transient Transformation<T> transformation;
 
 	protected ExecNodeBase(
-			List<ExecNode<?>> inputNodes,
 			List<ExecEdge> inputEdges,
 			RowType outputType,
 			String description) {
-		checkArgument(checkNotNull(inputNodes).size() == checkNotNull(inputEdges).size());
-		this.inputNodes = new ArrayList<>(inputNodes);
-		this.inputEdges = new ArrayList<>(inputEdges);
+		this.inputEdges = new ArrayList<>(checkNotNull(inputEdges));
 		this.outputType = checkNotNull(outputType);
 		this.description = checkNotNull(description);
 	}
@@ -73,7 +72,14 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 
 	@Override
 	public List<ExecEdge> getInputEdges() {
-		return inputEdges;
+		return checkNotNull(inputEdges, "inputEdges should not be null.");
+	}
+
+	// TODO remove this method once edge support `source` and `target`,
+	//  and then we can get/set `inputNodes` through `inputEdges`.
+	public void setInputNodes(List<ExecNode<?>> inputNodes) {
+		checkArgument(checkNotNull(inputNodes).size() == checkNotNull(inputEdges).size());
+		this.inputNodes = new ArrayList<>(inputNodes);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -53,16 +53,13 @@ import java.util.Optional;
  * <p>TODO Remove this class once its functionality is replaced by ExecEdge.
  */
 public class BatchExecExchange extends BatchExecNode<RowData> implements CommonExecExchange {
-	// the required shuffle mode for reusable ExchangeBatchExec
-	// if it's None, use value from getShuffleMode
+	// the required shuffle mode for reusable BatchExecExchange
+	// if it's None, use value from configuration
 	@Nullable
 	private ShuffleMode requiredShuffleMode;
 
-	public BatchExecExchange(
-			ExecNode<?> inputNode,
-			ExecEdge inputEdge,
-			RowType outputType) {
-		super(Collections.singletonList(inputNode), Collections.singletonList(inputEdge), outputType, "Exchange");
+	public BatchExecExchange(ExecEdge inputEdge, RowType outputType, String description) {
+		super(Collections.singletonList(inputEdge), outputType, description);
 	}
 
 	public void setRequiredShuffleMode(@Nullable ShuffleMode requiredShuffleMode) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -69,11 +69,10 @@ public class BatchExecMultipleInput extends BatchExecNode<RowData> {
 	private final ExecNode<?> rootNode;
 
 	public BatchExecMultipleInput(
-			List<ExecNode<?>> inputNodes,
 			List<ExecEdge> inputEdges,
 			ExecNode<?> rootNode,
 			String description) {
-		super(inputNodes, inputEdges, rootNode.getOutputType(), description);
+		super(inputEdges, rootNode.getOutputType(), description);
 		this.rootNode = rootNode;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
@@ -31,10 +31,9 @@ import java.util.List;
  */
 public abstract class BatchExecNode<T> extends ExecNodeBase<BatchPlanner, T> {
 	public BatchExecNode(
-			List<ExecNode<?>> inputNodes,
 			List<ExecEdge> inputEdges,
 			RowType outputType,
 			String description) {
-		super(inputNodes, inputEdges, outputType, description);
+		super(inputEdges, outputType, description);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A {@link DAGProcessor} which organize {@link ExecNode}s into multiple input nodes.
@@ -478,10 +479,12 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 		}
 
 		String description = ExecNodeUtil.getMultipleInputDescription(rootNode, inputNodes, new ArrayList<>());
-		return new StreamExecMultipleInput(
-				inputNodes,
+		StreamExecMultipleInput multipleInput = new StreamExecMultipleInput(
+				inputNodes.stream().map(i -> ExecEdge.DEFAULT).collect(Collectors.toList()),
 				rootNode,
 				description);
+		multipleInput.setInputNodes(inputNodes);
+		return multipleInput;
 	}
 
 	private BatchExecMultipleInput createBatchMultipleInputNode(
@@ -514,11 +517,12 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
 		}
 
 		String description = ExecNodeUtil.getMultipleInputDescription(rootNode, inputNodes, inputEdges);
-		return new BatchExecMultipleInput(
-				inputNodes,
+		BatchExecMultipleInput multipleInput = new BatchExecMultipleInput(
 				inputEdges,
 				rootNode,
 				description);
+		multipleInput.setInputNodes(inputNodes);
+		return multipleInput;
 	}
 
 	// --------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
@@ -79,10 +79,11 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 				// special case: if exchange is exactly the reuse node,
 				// we should split it into two nodes
 				BatchExecExchange newExchange = new BatchExecExchange(
-					exchange.getInputNodes().get(0),
 					execEdge,
-					exchange.getOutputType());
+					exchange.getOutputType(),
+					"Exchange");
 				newExchange.setRequiredShuffleMode(shuffleMode);
+				newExchange.setInputNodes(exchange.getInputNodes());
 				node.replaceInputNode(lowerInput, newExchange);
 			} else {
 				exchange.setRequiredShuffleMode(shuffleMode);
@@ -118,9 +119,10 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 				.damBehavior(getDamBehavior())
 				.build();
 		BatchExecExchange exchange = new BatchExecExchange(
-				inputNode,
 				execEdge,
-				inputNode.getOutputType());
+				inputNode.getOutputType(),
+				"Exchange");
+		exchange.setInputNodes(Collections.singletonList(inputNode));
 		exchange.setRequiredShuffleMode(shuffleMode);
 		return exchange;
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -47,11 +47,10 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.DEFAULT_LOW
 public class StreamExecExchange extends StreamExecNode<RowData> implements CommonExecExchange {
 
 	public StreamExecExchange(
-			ExecNode<?> inputNode,
 			ExecEdge inputEdge,
 			RowType outputType,
 			String description) {
-		super(Collections.singletonList(inputNode), Collections.singletonList(inputEdge), outputType, description);
+		super(Collections.singletonList(inputEdge), outputType, description);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMultipleInput.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMultipleInput.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Stream exec node for multiple input which contains a sub-graph of {@link ExecNode}s.
@@ -59,14 +58,10 @@ public class StreamExecMultipleInput extends StreamExecNode<RowData> {
 	private final ExecNode<?> rootNode;
 
 	public StreamExecMultipleInput(
-			List<ExecNode<?>> inputNodes,
+			List<ExecEdge> inputEdges,
 			ExecNode<?> rootNode,
 			String description) {
-		super(
-				inputNodes,
-				inputNodes.stream().map(i -> ExecEdge.DEFAULT).collect(Collectors.toList()),
-				rootNode.getOutputType(),
-				description);
+		super(inputEdges, rootNode.getOutputType(), description);
 		this.rootNode = rootNode;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
@@ -31,10 +31,9 @@ import java.util.List;
  */
 public abstract class StreamExecNode<T> extends ExecNodeBase<StreamPlanner, T> {
 	public StreamExecNode(
-			List<ExecNode<?>> inputNodes,
 			List<ExecEdge> inputEdges,
 			RowType outputType,
 			String description) {
-		super(inputNodes, inputEdges, outputType, description);
+		super(inputEdges, outputType, description);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -315,7 +315,7 @@ abstract class PlannerBase(
     // reuse subplan
     val reusedPlan = SubplanReuser.reuseDuplicatedSubplan(relsWithoutSameObj, config)
     // convert FlinkPhysicalRel DAG to ExecNode DAG
-    val generator = new ExecGraphGenerator(getTableConfig)
+    val generator = new ExecGraphGenerator()
     generator.generate(reusedPlan.map(_.asInstanceOf[FlinkPhysicalRel]))
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/FlinkPhysicalRel.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/FlinkPhysicalRel.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical
 
 import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 
 import org.apache.calcite.plan.RelTraitSet
 import org.apache.calcite.rel.RelNode
@@ -38,4 +39,18 @@ trait FlinkPhysicalRel extends FlinkRelNode {
     *         Returns None if required traits cannot be satisfied.
     */
   def satisfyTraits(requiredTraitSet: RelTraitSet): Option[RelNode] = None
+
+  /**
+   * Translate this physical RelNode into an [[ExecNode]].
+   *
+   * NOTE: This method only needs to create the corresponding ExecNode,
+   * the connection to its input/output nodes will be done by ExecGraphGenerator.
+   * Because some physical rels need not be translated to a real ExecNode,
+   * such as Exchange will be translated to edge in the future.
+   *
+   * TODO remove the implementation once all sub-classes do not extend from ExecNode
+   */
+  def translateToExecNode(): ExecNode[_] = {
+    this.asInstanceOf[ExecNode[_]]
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
@@ -18,7 +18,14 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+import org.apache.flink.streaming.api.transformations.ShuffleMode
+import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNode}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalExchange
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelDistribution, RelNode}
@@ -39,5 +46,39 @@ class BatchPhysicalExchange(
       newInput: RelNode,
       newDistribution: RelDistribution): BatchPhysicalExchange = {
     new BatchPhysicalExchange(cluster, traitSet, newInput, relDistribution)
+  }
+
+  override def translateToExecNode(): ExecNode[_] = {
+    new BatchExecExchange(
+      getExecEdge,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription)
+  }
+
+  private def getExecEdge: ExecEdge = {
+    if (distribution.getType == RelDistribution.Type.RANGE_DISTRIBUTED) {
+      throw new UnsupportedOperationException("Range sort is not supported.")
+    }
+
+    val damBehavior = if (getShuffleMode eq ShuffleMode.BATCH) {
+      ExecEdge.DamBehavior.BLOCKING
+    } else {
+      ExecEdge.DamBehavior.PIPELINED
+    }
+
+    ExecEdge.builder.
+      requiredShuffle(getRequiredShuffle)
+      .damBehavior(damBehavior)
+      .build
+  }
+
+  private def getShuffleMode: ShuffleMode = {
+    val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
+    if (tableConfig.getConfiguration.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE)
+      .equalsIgnoreCase(GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString)) {
+      ShuffleMode.BATCH
+    } else {
+      ShuffleMode.UNDEFINED
+    }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalExchange.scala
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNode}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalExchange
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -41,5 +44,12 @@ class StreamPhysicalExchange(
       newInput: RelNode,
       newDistribution: RelDistribution): StreamPhysicalExchange = {
     new StreamPhysicalExchange(cluster, traitSet, newInput, newDistribution)
+  }
+
+  override def translateToExecNode(): ExecNode[_] = {
+    new StreamExecExchange(
+      ExecEdge.builder.requiredShuffle(getRequiredShuffle).build,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -105,7 +105,7 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
 		Table table = util.tableEnv().sqlQuery(sql);
 		RelNode relNode = TableTestUtil.toRelNode(table);
 		FlinkPhysicalRel optimizedRel = (FlinkPhysicalRel) util.getPlanner().optimize(relNode);
-		ExecGraphGenerator generator = new ExecGraphGenerator(TableConfig.getDefault());
+		ExecGraphGenerator generator = new ExecGraphGenerator();
 		List<ExecNode<?>> execNodes = generator.generate(Collections.singletonList(optimizedRel));
 		ExecNode<?> execNode = execNodes.get(0);
 		while (!execNode.getInputNodes().isEmpty()) {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
@@ -103,10 +103,11 @@ public class InputPriorityConflictResolverTest {
 		}
 
 		BatchExecExchange exchange = new BatchExecExchange(
-			nodes[0],
 			ExecEdge.builder().requiredShuffle(ExecEdge.RequiredShuffle.any()).build(),
-			nodes[0].getOutputType());
+			nodes[0].getOutputType(),
+			"Exchange");
 		exchange.setRequiredShuffleMode(ShuffleMode.BATCH);
+		exchange.setInputNodes(Collections.singletonList(nodes[0]));
 
 		nodes[1].addInput(exchange, ExecEdge.builder().priority(0).build());
 		nodes[1].addInput(exchange, ExecEdge.builder().priority(1).build());


### PR DESCRIPTION

## What is the purpose of the change

*Currently, we introduce ExecGraphGenerator to translate a graph of FlinkPhysicalRel to a ExecNode graph. While as more and more ExecNode supported, ExecGraphGenerator is hard to maintain. So we introduce FlinkPhysicalRel#translateToExecNode to create specific ExecNode in each physical RelNode, and ExecGraphGenerator is used to build the whole graph based on the translated ExecNode, including connecting the input/output nodes, handling the rel visitor, handle some special nodes (such as, Exchange), etc.*


## Brief change log

  - *Introduce translateToExecNode method for FlinkPhysicalRel*
  - *ExecGraphGenerator does not create ExecNode any more*
  - *add setInputNodes method for ExecNodeBase, which could help ExecGraphGenerator building ExecNode graph before ExecEdge supports `source`/`target`*


## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
