### PR TITLE
[FLINK-20650][k8s] Remove "native-k8s" command and add bash wrapper for JobManager and TaskManager container args

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -88,8 +88,6 @@ public class Constants {
 
 	public static final String RESTART_POLICY_OF_NEVER = "Never";
 
-	public static final String NATIVE_KUBERNETES_COMMAND = "native-k8s";
-
 	// Constants for Kubernetes high availability
 	public static final String LEADER_ADDRESS_KEY = "address";
 	public static final String LEADER_SESSION_ID_KEY = "sessionId";

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -352,6 +353,10 @@ public class KubernetesUtils {
 
 		final String commandTemplate = flinkConfig.getString(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE);
 		return BootstrapTools.getStartCommand(commandTemplate, startCommandValues);
+	}
+
+	public static List<String> getStartCommandWithBashWrapper(String javaCommand) {
+		return Arrays.asList("bash", "-c", javaCommand);
 	}
 
 	public static List<File> checkJarFileForApplicationMode(Configuration configuration) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecoratorTest.java
@@ -25,19 +25,18 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal
 import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessSpec;
 
 import io.fabric8.kubernetes.api.model.Container;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
-import static org.apache.flink.kubernetes.utils.Constants.NATIVE_KUBERNETES_COMMAND;
 import static org.apache.flink.runtime.jobmanager.JobManagerProcessUtils.createDefaultJobManagerProcessSpec;
 import static org.apache.flink.runtime.jobmanager.JobManagerProcessUtils.generateDynamicConfigsStr;
 import static org.apache.flink.runtime.jobmanager.JobManagerProcessUtils.generateJvmParametersStr;
@@ -109,7 +108,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getJobManagerExpectedCommand("", "");
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
@@ -124,7 +123,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getJobManagerExpectedCommand("", log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -138,7 +137,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getJobManagerExpectedCommand("", logback);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -154,7 +153,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 		final String expectedCommand =
 				getJobManagerExpectedCommand("", logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -171,7 +170,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 		final String expectedCommand =
 				getJobManagerExpectedCommand(jvmOpts, logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -186,7 +185,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 		final String expectedCommand = getJobManagerExpectedCommand(jvmOpts, logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -214,7 +213,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 				" " + jmLogfile + " " + logback + " " + log4j +
 				" " + ENTRY_POINT_CLASS + " " + jmDynamicProperties;
 
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -242,7 +241,7 @@ public class JavaCmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase
 				" " + jvmOpts + " " + jmJvmOpts +
 				" " + ENTRY_POINT_CLASS + " " + jmDynamicProperties;
 
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
@@ -24,19 +24,18 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 import org.apache.flink.kubernetes.taskmanager.KubernetesTaskExecutorRunner;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 
 import io.fabric8.kubernetes.api.model.Container;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOGBACK_NAME;
-import static org.apache.flink.kubernetes.utils.Constants.NATIVE_KUBERNETES_COMMAND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -108,7 +107,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getTaskManagerExpectedCommand("", "");
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -122,7 +121,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getTaskManagerExpectedCommand("", log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -136,7 +135,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getTaskManagerExpectedCommand("", logback);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -150,7 +149,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 
 		final String expectedCommand = getTaskManagerExpectedCommand("", logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -167,7 +166,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 		final String expectedCommand =
 				getTaskManagerExpectedCommand(jvmOpts, logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -182,7 +181,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 
 		assertEquals(Collections.singletonList(KUBERNETES_ENTRY_PATH), resultMainContainer.getCommand());
 		final String expectedCommand = getTaskManagerExpectedCommand(jvmOpts, logback + " " + log4j);
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -208,7 +207,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 				" " + jvmOpts + " " + tmJvmOpts +
 				" " + tmLogfile + " " + logback + " " + log4j +
 				" " + mainClass + " " + mainClassArgs;
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 
@@ -235,7 +234,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 				" " + tmLogfile + " " + logback + " " + log4j +
 				" " + jvmOpts + " " + tmJvmOpts + " " + mainClass +
 				" " + mainClassArgs;
-		final List<String> expectedArgs = Arrays.asList(NATIVE_KUBERNETES_COMMAND, expectedCommand);
+		final List<String> expectedArgs = KubernetesUtils.getStartCommandWithBashWrapper(expectedCommand);
 		assertEquals(expectedArgs, resultMainContainer.getArgs());
 	}
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -151,7 +151,8 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		assertEquals(String.valueOf(JOB_MANAGER_MEMORY), requests.get("memory").getAmount());
 
 		assertEquals(1, resultedMainContainer.getCommand().size());
-		assertEquals(2, resultedMainContainer.getArgs().size());
+		// The args list is [bash, -c, 'java -classpath $FLINK_CLASSPATH ...'].
+		assertEquals(3, resultedMainContainer.getArgs().size());
 
 		assertEquals(3, resultedMainContainer.getVolumeMounts().size());
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -92,7 +92,8 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 
 		assertEquals(1, resultMainContainer.getPorts().size());
 		assertEquals(1, resultMainContainer.getCommand().size());
-		assertEquals(2, resultMainContainer.getArgs().size());
+		// The args list is [bash, -c, 'java -classpath $FLINK_CLASSPATH ...'].
+		assertEquals(3, resultMainContainer.getArgs().size());
 		assertEquals(4, resultMainContainer.getVolumeMounts().size());
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`native-k8s` command has been removed in https://github.com/apache/flink-docker/pull/49. So when the Flink client create the JobManager deployment and TaskManager pod, the arguments needs to be changed accordingly.

A typical container spec looks like following.
```
Containers:
  flink-job-manager:
    Container ID:  docker://e3d57ca68e90c2efcbccff5ddf109c3008e292636cca8b9355b7dd2f73c56ae2
    Image:         registry.cn-beijing.aliyuncs.com/streamcompute/flink:1.12.0-debug
    Image ID:      docker-pullable://registry.cn-beijing.aliyuncs.com/streamcompute/flink@sha256:dfed8ea21ae56607286688629211cb29d5aee65fca26402904590383ee968331
    Ports:         8081/TCP, 6123/TCP, 6124/TCP
    Host Ports:    0/TCP, 0/TCP, 0/TCP
    Command:
      /docker-entrypoint.sh
    Args:
      bash
      -c
      $JAVA_HOME/bin/java -classpath $FLINK_CLASSPATH -Xmx654311424 -Xms654311424 -XX:MaxMetaspaceSize=268435456 -Dlog.file=/opt/flink/log/jobmanager.log -Dlogback.configurationFile=file:/opt/flink/conf/logback-console.xml -Dlog4j.configuration=file:/opt/flink/conf/log4j-console.properties -Dlog4j.configurationFile=file:/opt/flink/conf/log4j-console.properties org.apache.flink.kubernetes.entrypoint.KubernetesApplicationClusterEntrypoint -D jobmanager.memory.off-heap.size=134217728b -D jobmanager.memory.jvm-overhead.min=201326592b -D jobmanager.memory.jvm-metaspace.size=268435456b -D jobmanager.memory.heap.size=654311424b -D jobmanager.memory.jvm-overhead.max=201326592b
    State:          Running
      Started:      Fri, 18 Dec 2020 15:10:00 +0800
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  1200Mi
    Requests:
      cpu:     1
      memory:  1200Mi
    Environment:
      ENABLE_BUILT_IN_PLUGINS:  flink-oss-fs-hadoop-1.12.0.jar
      _POD_IP_ADDRESS:           (v1:status.podIP)
    Mounts:
      /opt/flink/conf from flink-config-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-t8nfg (ro)
```


## Brief change log

* Remove "native-k8s" command and add bash wrapper for JobManager and TaskManager container args


## Verifying this change
* The unit tests have been updated to make them pass
* All the K8s e2e tests should work without any change
* Manually test in minikube

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
