### PR TITLE
[FLINK-19981][core][table] Add name-based field mode for Row

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -95,7 +95,16 @@ under the License.
 
 		<!-- Joda, jackson, and lombok are used to test that serialization and type extraction
 			work with types from those libraries -->
-
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -243,7 +244,11 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
 		for (int i = 0; i < len; i++) {
 			fieldSerializers[i] = types[i].createSerializer(config);
 		}
-		return new RowSerializer(fieldSerializers);
+		final LinkedHashMap<String, Integer> positionByName = new LinkedHashMap<>();
+		for (int i = 0; i < fieldNames.length; i++) {
+			positionByName.put(fieldNames[i], i);
+		}
+		return new RowSerializer(fieldSerializers, positionByName);
 	}
 
 	@Override
@@ -298,7 +303,7 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
 		for (int i = 0; i < len; i++) {
 			fieldSerializers[i] = types[i].createSerializer(config);
 		}
-		return new RowSerializer(fieldSerializers, true);
+		return new RowSerializer(fieldSerializers, null, true);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -25,15 +25,21 @@ import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.RowUtils;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.apache.flink.api.java.typeutils.runtime.MaskUtils.readIntoAndCopyMask;
 import static org.apache.flink.api.java.typeutils.runtime.MaskUtils.readIntoMask;
@@ -54,6 +60,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     bitmask with row kind:  |RK RK F1 F2 ... FN|
  *     bitmask in legacy mode: |F1 F2 ... FN|
  * </pre>
+ *
+ * <p>Field names are an optional part of this serializer. They allow to use rows in named-based field
+ * mode. However, the support for name-based rows is limited. Usually, name-based mode should not be
+ * used in state but only for in-flight data. For now, names are not part of serializer snapshot or
+ * equals/hashCode (similar to {@link RowTypeInfo}).
  */
 @Internal
 public final class RowSerializer extends TypeSerializer<Row> {
@@ -71,19 +82,34 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 	private final int arity;
 
+	private final @Nullable LinkedHashMap<String, Integer> positionByName;
+
 	private transient boolean[] mask;
 
+	private transient Row reuseRowPositionBased;
+
 	public RowSerializer(TypeSerializer<?>[] fieldSerializers) {
-		this(fieldSerializers, false);
+		this(fieldSerializers, null, false);
+	}
+
+	public RowSerializer(
+			TypeSerializer<?>[] fieldSerializers,
+			@Nullable LinkedHashMap<String, Integer> positionByName) {
+		this(fieldSerializers, positionByName, false);
 	}
 
 	@SuppressWarnings("unchecked")
-	public RowSerializer(TypeSerializer<?>[] fieldSerializers, boolean legacyModeEnabled) {
+	public RowSerializer(
+			TypeSerializer<?>[] fieldSerializers,
+			@Nullable LinkedHashMap<String, Integer> positionByName,
+			boolean legacyModeEnabled) {
 		this.legacyModeEnabled = legacyModeEnabled;
 		this.legacyOffset = legacyModeEnabled ? 0 : ROW_KIND_OFFSET;
 		this.fieldSerializers = (TypeSerializer<Object>[]) checkNotNull(fieldSerializers);
 		this.arity = fieldSerializers.length;
+		this.positionByName = positionByName;
 		this.mask = new boolean[legacyOffset + fieldSerializers.length];
+		this.reuseRowPositionBased = new Row(fieldSerializers.length);
 	}
 
 	@Override
@@ -97,68 +123,136 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		for (int i = 0; i < fieldSerializers.length; i++) {
 			duplicateFieldSerializers[i] = fieldSerializers[i].duplicate();
 		}
-		return new RowSerializer(duplicateFieldSerializers, legacyModeEnabled);
+		return new RowSerializer(duplicateFieldSerializers, positionByName, legacyModeEnabled);
 	}
 
 	@Override
 	public Row createInstance() {
-		return new Row(fieldSerializers.length);
+		return RowUtils.createRowWithNamedPositions(
+			RowKind.INSERT,
+			new Object[fieldSerializers.length],
+			positionByName);
 	}
 
 	@Override
 	public Row copy(Row from) {
-		int len = fieldSerializers.length;
-
-		if (from.getArity() != len) {
-			throw new RuntimeException("Row arity of from (" + from.getArity() +
-				") does not match this serializers field length (" + len + ").");
+		final Set<String> fieldNames = from.getFieldNames(false);
+		if (fieldNames == null) {
+			return copyPositionBased(from);
+		} else {
+			return copyNameBased(from, fieldNames);
 		}
+	}
 
-		Row result = new Row(from.getKind(), len);
-		for (int i = 0; i < len; i++) {
-			Object fromField = from.getField(i);
+	private Row copyPositionBased(Row from) {
+		final int length = fieldSerializers.length;
+		if (from.getArity() != length) {
+			throw new RuntimeException(
+				"Row arity of from (" + from.getArity() + ") does not match "
+					+ "this serializer's field length (" + length + ").");
+		}
+		final Object[] fieldByPosition = new Object[length];
+		for (int i = 0; i < length; i++) {
+			final Object fromField = from.getField(i);
 			if (fromField != null) {
-				Object copy = fieldSerializers[i].copy(fromField);
-				result.setField(i, copy);
-			}
-			else {
-				result.setField(i, null);
+				final Object copy = fieldSerializers[i].copy(fromField);
+				fieldByPosition[i] = copy;
 			}
 		}
-		return result;
+		return RowUtils.createRowWithNamedPositions(
+			from.getKind(),
+			fieldByPosition,
+			positionByName);
+	}
+
+	private Row copyNameBased(Row from, Set<String> fieldNames) {
+		if (positionByName == null) {
+			throw new RuntimeException("Serializer does not support named field positions.");
+		}
+		final Row newRow = Row.withNames(from.getKind());
+		for (String fieldName : fieldNames) {
+			final int targetPos = getPositionByName(fieldName);
+			final Object fromField = from.getField(fieldName);
+			if (fromField != null) {
+				final Object copy = fieldSerializers[targetPos].copy(fromField);
+				newRow.setField(fieldName, copy);
+			} else {
+				newRow.setField(fieldName, null);
+			}
+		}
+		return newRow;
 	}
 
 	@Override
 	public Row copy(Row from, Row reuse) {
-		int len = fieldSerializers.length;
-
 		// cannot reuse, do a non-reuse copy
 		if (reuse == null) {
 			return copy(from);
 		}
 
-		if (from.getArity() != len || reuse.getArity() != len) {
-			throw new RuntimeException(
-				"Row arity of reuse (" + reuse.getArity() + ") or from (" + from.getArity() + ") is incompatible with this serializers field length (" + len + ").");
+		final Set<String> fieldNames = from.getFieldNames(false);
+		if (fieldNames == null) {
+			// reuse uses name-based field mode, do a non-reuse copy
+			if (reuse.getFieldNames(false) != null) {
+				return copy(from);
+			}
+			return copyPositionBased(from, reuse);
+		} else {
+			// reuse uses position-based field mode, do a non-reuse copy
+			if (reuse.getFieldNames(false) == null) {
+				return copy(from);
+			}
+			return copyNameBased(from, fieldNames, reuse);
 		}
+	}
 
+	private Row copyPositionBased(Row from, Row reuse) {
+		final int length = fieldSerializers.length;
+		if (from.getArity() != length || reuse.getArity() != length) {
+			throw new RuntimeException(
+				"Row arity of reuse (" + reuse.getArity() + ") or from (" + from.getArity() + ") is "
+					+ "incompatible with this serializer's field length (" + length + ").");
+		}
 		reuse.setKind(from.getKind());
-
-		for (int i = 0; i < len; i++) {
-			Object fromField = from.getField(i);
+		for (int i = 0; i < length; i++) {
+			final Object fromField = from.getField(i);
 			if (fromField != null) {
-				Object reuseField = reuse.getField(i);
+				final Object reuseField = reuse.getField(i);
 				if (reuseField != null) {
-					Object copy = fieldSerializers[i].copy(fromField, reuseField);
+					final Object copy = fieldSerializers[i].copy(fromField, reuseField);
 					reuse.setField(i, copy);
 				}
 				else {
-					Object copy = fieldSerializers[i].copy(fromField);
+					final Object copy = fieldSerializers[i].copy(fromField);
 					reuse.setField(i, copy);
 				}
 			}
 			else {
 				reuse.setField(i, null);
+			}
+		}
+		return reuse;
+	}
+
+	private Row copyNameBased(Row from, Set<String> fieldNames, Row reuse) {
+		if (positionByName == null) {
+			throw new RuntimeException("Serializer does not support named field positions.");
+		}
+		reuse.clear();
+		reuse.setKind(from.getKind());
+		for (String fieldName : fieldNames) {
+			final int targetPos = getPositionByName(fieldName);
+			final Object fromField = from.getField(fieldName);
+			if (fromField != null) {
+				final Object reuseField = reuse.getField(fieldName);
+				if (reuseField != null) {
+					final Object copy = fieldSerializers[targetPos].copy(fromField, reuseField);
+					reuse.setField(fieldName, copy);
+				}
+				else {
+					final Object copy = fieldSerializers[targetPos].copy(fromField);
+					reuse.setField(fieldName, copy);
+				}
 			}
 		}
 		return reuse;
@@ -175,18 +269,28 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 	@Override
 	public void serialize(Row record, DataOutputView target) throws IOException {
-		final int len = fieldSerializers.length;
+		final Set<String> fieldNames = record.getFieldNames(false);
+		if (fieldNames == null) {
+			serializePositionBased(record, target);
+		} else {
+			serializeNameBased(record, fieldNames, target);
+		}
+	}
 
-		if (record.getArity() != len) {
-			throw new RuntimeException("Row arity of record (" + record.getArity() + ") does not match this serializers field length (" + len + ").");
+	private void serializePositionBased(Row record, DataOutputView target) throws IOException {
+		final int length = fieldSerializers.length;
+		if (record.getArity() != length) {
+			throw new RuntimeException(
+				"Row arity of record (" + record.getArity() + ") does not match this "
+					+ "serializer's field length (" + length + ").");
 		}
 
 		// write bitmask
-		fillMask(len, record, mask, legacyModeEnabled, legacyOffset);
+		fillMask(length, record, mask, legacyModeEnabled, legacyOffset);
 		writeMask(mask, target);
 
 		// serialize non-null fields
-		for (int fieldPos = 0; fieldPos < len; fieldPos++) {
+		for (int fieldPos = 0; fieldPos < length; fieldPos++) {
 			final Object o = record.getField(fieldPos);
 			if (o != null) {
 				fieldSerializers[fieldPos].serialize(o, target);
@@ -194,35 +298,58 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		}
 	}
 
+	private void serializeNameBased(Row record, Set<String> fieldNames, DataOutputView target) throws IOException {
+		if (positionByName == null) {
+			throw new RuntimeException("Serializer does not support named field positions.");
+		}
+		reuseRowPositionBased.clear();
+		reuseRowPositionBased.setKind(record.getKind());
+		for (String fieldName : fieldNames) {
+			final int targetPos = getPositionByName(fieldName);
+			final Object value = record.getField(fieldName);
+			reuseRowPositionBased.setField(targetPos, value);
+		}
+		serializePositionBased(reuseRowPositionBased, target);
+	}
+
 	@Override
 	public Row deserialize(DataInputView source) throws IOException {
-		final int len = fieldSerializers.length;
+		final int length = fieldSerializers.length;
 
 		// read bitmask
 		readIntoMask(source, mask);
-		final Row result;
+
+		// read row kind
+		final RowKind kind;
 		if (legacyModeEnabled) {
-			result = new Row(len);
+			kind = RowKind.INSERT;
 		} else {
-			result = new Row(readKindFromMask(mask), len);
+			kind = readKindFromMask(mask);
 		}
 
 		// deserialize fields
-		for (int fieldPos = 0; fieldPos < len; fieldPos++) {
+		final Object[] fieldByPosition = new Object[length];
+		for (int fieldPos = 0; fieldPos < length; fieldPos++) {
 			if (!mask[legacyOffset + fieldPos]) {
-				result.setField(fieldPos, fieldSerializers[fieldPos].deserialize(source));
+				fieldByPosition[fieldPos]= fieldSerializers[fieldPos].deserialize(source);
 			}
 		}
 
-		return result;
+		return RowUtils.createRowWithNamedPositions(kind, fieldByPosition, positionByName);
 	}
 
 	@Override
 	public Row deserialize(Row reuse, DataInputView source) throws IOException {
-		final int len = fieldSerializers.length;
+		// reuse uses name-based field mode, do a non-reuse deserialize
+		if (reuse == null || reuse.getFieldNames(false) != null) {
+			return deserialize(source);
+		}
+		final int length = fieldSerializers.length;
 
-		if (reuse.getArity() != len) {
-			throw new RuntimeException("Row arity of reuse (" + reuse.getArity() + ") does not match this serializers field length (" + len + ").");
+		if (reuse.getArity() != length) {
+			throw new RuntimeException(
+				"Row arity of reuse (" + reuse.getArity() + ") does not match "
+					+ "this serializer's field length (" + length + ").");
 		}
 
 		// read bitmask
@@ -232,15 +359,14 @@ public final class RowSerializer extends TypeSerializer<Row> {
 		}
 
 		// deserialize fields
-		for (int fieldPos = 0; fieldPos < len; fieldPos++) {
+		for (int fieldPos = 0; fieldPos < length; fieldPos++) {
 			if (mask[legacyOffset + fieldPos]) {
 				reuse.setField(fieldPos, null);
 			} else {
 				Object reuseField = reuse.getField(fieldPos);
 				if (reuseField != null) {
 					reuse.setField(fieldPos, fieldSerializers[fieldPos].deserialize(reuseField, source));
-				}
-				else {
+				} else {
 					reuse.setField(fieldPos, fieldSerializers[fieldPos].deserialize(source));
 				}
 			}
@@ -286,9 +412,24 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 	// --------------------------------------------------------------------------------------------
 
+	private int getPositionByName(String fieldName) {
+		assert positionByName != null;
+		final Integer targetPos = positionByName.get(fieldName);
+		if (targetPos == null) {
+			throw new RuntimeException(
+				String.format(
+					"Unknown field name '%s' for mapping to a row position. "
+						+ "Available names are: %s",
+					fieldName,
+					positionByName.keySet()));
+		}
+		return targetPos;
+	}
+
 	private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
 		in.defaultReadObject();
 		this.mask = new boolean[legacyOffset + fieldSerializers.length];
+		this.reuseRowPositionBased = new Row(fieldSerializers.length);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -413,7 +554,10 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
 		@Override
 		protected RowSerializer createOuterSerializerWithNestedSerializers(TypeSerializer<?>[] nestedSerializers) {
-			return new RowSerializer(nestedSerializers, readVersion <= LAST_VERSION_WITHOUT_ROW_KIND);
+			return new RowSerializer(
+				nestedSerializers,
+				null,
+				readVersion <= LAST_VERSION_WITHOUT_ROW_KIND);
 		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -18,12 +18,17 @@
 package org.apache.flink.types;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.types.RowUtils.deepEqualsRow;
 import static org.apache.flink.types.RowUtils.deepHashCodeRow;
@@ -37,11 +42,38 @@ import static org.apache.flink.types.RowUtils.deepHashCodeRow;
  * <p>The main purpose of rows is to bridge between Flink's Table and SQL ecosystem and other APIs. Therefore,
  * a row does not only consist of a schema part (containing the fields) but also attaches a {@link RowKind}
  * for encoding a change in a changelog. Thus, a row can be considered as an entry in a changelog. For example,
- * in regular batch scenarios, a changelog would consist of a bounded stream of {@link RowKind#INSERT} rows.
+ * in regular batch scenarios, a changelog would consist of a bounded stream of {@link RowKind#INSERT}
+ * rows. The row kind is kept separate from the fields and can be accessed by using {@link #getKind()}
+ * and {@link #setKind(RowKind)}.
  *
- * <p>The fields of a row can be accessed by position (zero-based) using {@link #getField(int)} and
- * {@link #setField(int, Object)}. The row kind is kept separate from the fields and can be accessed
- * by using {@link #getKind()} and {@link #setKind(RowKind)}.
+ * <p>Fields of a row can be accessed either position-based or name-based. An implementer can decide
+ * in which field mode a row should operate during creation. Rows that were produced by the framework
+ * support a hybrid of both field modes (i.e. named positions):
+ *
+ * <h1>Position-based field mode</h1>
+ *
+ * <p>{@link Row#withPositions(int)} creates a fixed-length row. The fields can be accessed by position
+ * (zero-based) using {@link #getField(int)} and {@link #setField(int, Object)}. Every field is initialized
+ * with {@code null} by default.
+ *
+ * <h1>Name-based field mode</h1>
+ *
+ * <p>{@link Row#withNames()} creates a variable-length row. The fields can be accessed by name using
+ * {@link #getField(String)} and {@link #setField(String, Object)}. Every field is initialized during
+ * the first call to {@link #setField(String, Object)} for the given name. However, the framework will
+ * initialize missing fields with {@code null} and reorder all fields once more type information is
+ * available during serialization or input conversion. Thus, even name-based rows eventually become
+ * fixed-length composite types with a deterministic field order.
+ *
+ * <h1>Hybrid / named-position field mode</h1>
+ *
+ * <p>Rows that were produced by the framework (after deserialization or output conversion) are fixed-length
+ * rows with a deterministic field order that can map static field names to field positions. Thus, fields
+ * can be accessed both via {@link #getField(int)} and {@link #getField(String)}. Both {@link #setField(int, Object)}
+ * and {@link #setField(String, Object)} are supported for existing fields. However, adding new field
+ * names via {@link #setField(String, Object)} is not allowed. A hybrid row's {@link #equals(Object)}
+ * supports comparing to all kinds of rows. A hybrid row's {@link #hashCode()} is only valid for position-based
+ * rows.
  *
  * <p>A row instance is in principle {@link Serializable}. However, it may contain non-serializable fields
  * in which case serialization will fail if the row is not serialized with Flink's serialization stack.
@@ -52,36 +84,117 @@ import static org.apache.flink.types.RowUtils.deepHashCodeRow;
 @PublicEvolving
 public final class Row implements Serializable {
 
-	private static final long serialVersionUID = 2L;
+	private static final long serialVersionUID = 3L;
 
 	/** The kind of change a row describes in a changelog. */
 	private RowKind kind;
 
-	/** The array to store actual values. */
-	private final Object[] fields;
+	/** Fields organized by position. Either this or {@link #fieldByName} is set. */
+	private final @Nullable Object[] fieldByPosition;
 
-	/**
-	 * Create a new row instance.
-	 *
-	 * <p>By default, a row describes an {@link RowKind#INSERT} change.
-	 *
-	 * @param kind kind of change a row describes in a changelog
-	 * @param arity The number of fields in the row.
-	 */
-	public Row(RowKind kind, int arity) {
-		this.kind = Preconditions.checkNotNull(kind, "Row kind must not be null.");
-		this.fields = new Object[arity];
+	/** Fields organized by name. Either this or {@link #fieldByPosition} is set. */
+	private final @Nullable Map<String, Object> fieldByName;
+
+	/** Mapping from field names to positions. Requires {@link #fieldByPosition} semantics. */
+	private final @Nullable LinkedHashMap<String, Integer> positionByName;
+
+	Row(
+			RowKind kind,
+			@Nullable Object[] fieldByPosition,
+			@Nullable Map<String, Object> fieldByName,
+			@Nullable LinkedHashMap<String, Integer> positionByName) {
+		this.kind = kind;
+		this.fieldByPosition = fieldByPosition;
+		this.fieldByName = fieldByName;
+		this.positionByName = positionByName;
 	}
 
 	/**
-	 * Create a new row instance.
+	 * Creates a fixed-length row in position-based field mode.
 	 *
-	 * <p>By default, a row describes an {@link RowKind#INSERT} change.
+	 * <p>The semantics are equivalent to {@link Row#withPositions(RowKind, int)}. This constructor
+	 * exists for backwards compatibility.
 	 *
-	 * @param arity The number of fields in the row.
+	 * @param kind kind of change a row describes in a changelog
+	 * @param arity the number of fields in the row
+	 */
+	public Row(RowKind kind, int arity) {
+		this.kind = Preconditions.checkNotNull(kind, "Row kind must not be null.");
+		this.fieldByPosition = new Object[arity];
+		this.fieldByName = null;
+		this.positionByName = null;
+	}
+
+	/**
+	 * Creates a fixed-length row in position-based field mode.
+	 *
+	 * <p>The semantics are equivalent to {@link Row#withPositions(int)}. This constructor exists for
+	 * backwards compatibility.
+	 *
+	 * @param arity the number of fields in the row
 	 */
 	public Row(int arity) {
 		this(RowKind.INSERT, arity);
+	}
+
+	/**
+	 * Creates a fixed-length row in position-based field mode.
+	 *
+	 * <p>Fields can be accessed by position via {@link #setField(int, Object)} and {@link #getField(int)}.
+	 *
+	 * <p>See the class documentation of {@link Row} for more information.
+	 *
+	 * @param kind kind of change a row describes in a changelog
+	 * @param arity the number of fields in the row
+	 * @return a new row instance
+	 */
+	public static Row withPositions(RowKind kind, int arity) {
+		return new Row(kind, new Object[arity], null, null);
+	}
+
+	/**
+	 * Creates a fixed-length row in position-based field mode.
+	 *
+	 * <p>Fields can be accessed by position via {@link #setField(int, Object)} and {@link #getField(int)}.
+	 *
+	 * <p>By default, a row describes an {@link RowKind#INSERT} change.
+	 *
+	 * <p>See the class documentation of {@link Row} for more information.
+	 *
+	 * @param arity the number of fields in the row
+	 * @return a new row instance
+	 */
+	public static Row withPositions(int arity) {
+		return withPositions(RowKind.INSERT, arity);
+	}
+
+	/**
+	 * Creates a variable-length row in name-based field mode.
+	 *
+	 * <p>Fields can be accessed by name via {@link #setField(String, Object)} and {@link #getField(String)}.
+	 *
+	 * <p>See the class documentation of {@link Row} for more information.
+	 *
+	 * @param kind kind of change a row describes in a changelog
+	 * @return a new row instance
+	 */
+	public static Row withNames(RowKind kind) {
+		return new Row(kind, null, new HashMap<>(), null);
+	}
+
+	/**
+	 * Creates a variable-length row in name-based field mode.
+	 *
+	 * <p>Fields can be accessed by name via {@link #setField(String, Object)} and {@link #getField(String)}.
+	 *
+	 * <p>By default, a row describes an {@link RowKind#INSERT} change.
+	 *
+	 * <p>See the class documentation of {@link Row} for more information.
+	 *
+	 * @return a new row instance
+	 */
+	public static Row withNames() {
+		return withNames(RowKind.INSERT);
 	}
 
 	/**
@@ -112,42 +225,172 @@ public final class Row implements Serializable {
 	 *
 	 * <p>Note: The row kind is kept separate from the fields and is not included in this number.
 	 *
-	 * @return The number of fields in the row.
+	 * @return the number of fields in the row
 	 */
 	public int getArity() {
-		return fields.length;
+		if (fieldByPosition != null) {
+			return fieldByPosition.length;
+		} else {
+			assert fieldByName != null;
+			return fieldByName.size();
+		}
 	}
 
 	/**
-	 * Returns the field's content at the specified position.
+	 * Returns the field's content at the specified field position.
 	 *
-	 * @param pos The position of the field, 0-based.
-	 * @return The field's content at the specified position.
+	 * <p>Note: The row must operate in position-based field mode.
+	 *
+	 * @param pos the position of the field, 0-based
+	 * @return the field's content at the specified position
 	 */
 	public @Nullable Object getField(int pos) {
-		return fields[pos];
+		if (fieldByPosition != null) {
+			return fieldByPosition[pos];
+		} else {
+			throw new IllegalArgumentException(
+				"Accessing a field by position is not supported in name-based field mode.");
+		}
+	}
+
+	/**
+	 * Returns the field's content at the specified field position.
+	 *
+	 * <p>Note: The row must operate in position-based field mode.
+	 *
+	 * <p>This method avoids a lot of manual casting in the user implementation.
+	 *
+	 * @param pos the position of the field, 0-based
+	 * @return the field's content at the specified position
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getFieldAs(int pos) {
+		return (T) getField(pos);
+	}
+
+	/**
+	 * Returns the field's content using the specified field name.
+	 *
+	 * <p>Note: The row must operate in name-based field mode.
+	 *
+	 * @param name the name of the field or null if not set previously
+	 * @return the field's content
+	 */
+	public @Nullable Object getField(String name) {
+		if (fieldByName != null) {
+			return fieldByName.get(name);
+		} else if (positionByName != null) {
+			final Integer pos = positionByName.get(name);
+			if (pos == null) {
+				throw new IllegalArgumentException(
+					String.format("Unknown field name '%s' for mapping to a position.", name));
+			}
+			assert fieldByPosition != null;
+			return fieldByPosition[pos];
+		} else {
+			throw new IllegalArgumentException(
+				"Accessing a field by name is not supported in position-based field mode.");
+		}
+	}
+
+	/**
+	 * Returns the field's content using the specified field name.
+	 *
+	 * <p>Note: The row must operate in name-based field mode.
+	 *
+	 * <p>This method avoids a lot of manual casting in the user implementation.
+	 *
+	 * @param name the name of the field, set previously
+	 * @return the field's content
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getFieldAs(String name) {
+		return (T) getField(name);
 	}
 
 	/**
 	 * Sets the field's content at the specified position.
 	 *
-	 * @param pos The position of the field, 0-based.
-	 * @param value The value to be assigned to the field at the specified position.
+	 * <p>Note: The row must operate in position-based field mode.
+	 *
+	 * @param pos the position of the field, 0-based
+	 * @param value the value to be assigned to the field at the specified position
 	 */
 	public void setField(int pos, @Nullable Object value) {
-		fields[pos] = value;
+		if (fieldByPosition != null) {
+			fieldByPosition[pos] = value;
+		} else {
+			throw new IllegalArgumentException(
+				"Accessing a field by position is not supported in name-based field mode.");
+		}
+	}
+
+	/**
+	 * Sets the field's content using the specified field name.
+	 *
+	 * <p>Note: The row must operate in name-based field mode.
+	 *
+	 * @param name the name of the field
+	 * @param value the value to be assigned to the field
+	 */
+	public void setField(String name, @Nullable Object value) {
+		if (fieldByName != null) {
+			fieldByName.put(name, value);
+		} else if (positionByName != null) {
+			final Integer pos = positionByName.get(name);
+			if (pos == null) {
+				throw new IllegalArgumentException(
+					String.format(
+						"Unknown field name '%s' for mapping to a row position. "
+							+ "Available names are: %s",
+						name,
+						positionByName.keySet()));
+			}
+			assert fieldByPosition != null;
+			fieldByPosition[pos] = value;
+		} else {
+			throw new IllegalArgumentException(
+				"Accessing a field by name is not supported in position-based field mode.");
+		}
+	}
+
+	/**
+	 * Returns the set of field names if this row operates in name-based field mode, otherwise null.
+	 *
+	 * <p>This method is a helper method for serializers and converters but can also be useful for
+	 * other row transformations.
+	 *
+	 * @param includeNamedPositions whether or not to include named positions when this row operates
+	 *                              in a hybrid field mode
+	 */
+	public @Nullable Set<String> getFieldNames(boolean includeNamedPositions) {
+		if (fieldByName != null) {
+			return fieldByName.keySet();
+		}
+		if (includeNamedPositions && positionByName != null) {
+			return positionByName.keySet();
+		}
+		return null;
+	}
+
+	/**
+	 * Clears all fields of this row.
+	 */
+	public void clear() {
+		if (fieldByPosition != null) {
+			Arrays.fill(fieldByPosition, null);
+		} else {
+			assert fieldByName != null;
+			fieldByName.clear();
+		}
 	}
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < fields.length; i++) {
-			if (i > 0) {
-				sb.append(",");
-			}
-			sb.append(StringUtils.arrayAwareToString(fields[i]));
-		}
-		return sb.toString();
+		return RowUtils.deepToStringRow(
+			kind,
+			fieldByPosition,
+			fieldByName);
 	}
 
 	@Override
@@ -158,13 +401,24 @@ public final class Row implements Serializable {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		final Row row = (Row) o;
-		return deepEqualsRow(this, row);
+		final Row other = (Row) o;
+		return deepEqualsRow(
+			kind,
+			fieldByPosition,
+			fieldByName,
+			positionByName,
+			other.kind,
+			other.fieldByPosition,
+			other.fieldByName,
+			other.positionByName);
 	}
 
 	@Override
 	public int hashCode() {
-		return deepHashCodeRow(this);
+		return deepHashCodeRow(
+			kind,
+			fieldByPosition,
+			fieldByName);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -172,8 +426,10 @@ public final class Row implements Serializable {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Creates a new row and assigns the given values to the row's fields.
-	 * This is more convenient than using the constructor.
+	 * Creates a fixed-length row in position-based field mode and assigns the given values to the
+	 * row's fields.
+	 *
+	 * <p>This method should be more convenient than {@link Row#withPositions(int)} in many cases.
 	 *
 	 * <p>For example:
 	 * <pre>
@@ -181,7 +437,7 @@ public final class Row implements Serializable {
 	 * </pre>
 	 * instead of
 	 * <pre>
-	 *     Row row = new Row(3);
+	 *     Row row = Row.withPositions(3);
 	 *     row.setField(0, "hello");
 	 *     row.setField(1, true);
 	 *     row.setField(2, 1L);
@@ -190,7 +446,7 @@ public final class Row implements Serializable {
 	 * <p>By default, a row describes an {@link RowKind#INSERT} change.
 	 */
 	public static Row of(Object... values) {
-		Row row = new Row(values.length);
+		final Row row = new Row(values.length);
 		for (int i = 0; i < values.length; i++) {
 			row.setField(i, values[i]);
 		}
@@ -198,8 +454,11 @@ public final class Row implements Serializable {
 	}
 
 	/**
-	 * Creates a new row with given kind and assigns the given values to the row's fields.
-	 * This is more convenient than using the constructor.
+	 * Creates a fixed-length row in position-based field mode with given kind and assigns the given
+	 * values to the row's fields.
+	 *
+	 * <p>This method should be more convenient than {@link Row#withPositions(RowKind, int)} in many
+	 * cases.
 	 *
 	 * <p>For example:
 	 * <pre>
@@ -207,15 +466,14 @@ public final class Row implements Serializable {
 	 * </pre>
 	 * instead of
 	 * <pre>
-	 *     Row row = new Row(3);
-	 *     row.setKind(RowKind.INSERT);
+	 *     Row row = Row.withPositions(RowKind.INSERT, 3);
 	 *     row.setField(0, "hello");
 	 *     row.setField(1, true);
 	 *     row.setField(2, 1L);
 	 * </pre>
 	 */
 	public static Row ofKind(RowKind kind, Object... values) {
-		Row row = new Row(kind, values.length);
+		final Row row = new Row(kind, values.length);
 		for (int i = 0; i < values.length; i++) {
 			row.setField(i, values[i]);
 		}
@@ -225,11 +483,46 @@ public final class Row implements Serializable {
 	/**
 	 * Creates a new row which is copied from another row (including its {@link RowKind}).
 	 *
-	 * <p>This method does not perform a deep copy.
+	 * <p>This method does not perform a deep copy. Use {@link RowSerializer#copy(Row)} if required.
 	 */
 	public static Row copy(Row row) {
-		final Row newRow = new Row(row.kind, row.fields.length);
-		System.arraycopy(row.fields, 0, newRow.fields, 0, row.fields.length);
+		final Object[] newFieldByPosition;
+		if (row.fieldByPosition != null) {
+			newFieldByPosition = new Object[row.fieldByPosition.length];
+			System.arraycopy(row.fieldByPosition, 0, newFieldByPosition, 0, newFieldByPosition.length);
+		} else {
+			newFieldByPosition = null;
+		}
+
+		final Map<String, Object> newFieldByName;
+		if (row.fieldByName != null) {
+			newFieldByName = new HashMap<>(row.fieldByName);
+		} else {
+			newFieldByName = null;
+		}
+
+		return new Row(
+			row.kind,
+			newFieldByPosition,
+			newFieldByName,
+			row.positionByName
+		);
+	}
+
+	/**
+	 * Creates a new row with projected fields and identical {@link RowKind} from another row.
+	 *
+	 * <p>This method does not perform a deep copy.
+	 *
+	 * <p>Note: The row must operate in position-based field mode. Field names are not projected.
+	 *
+	 * @param fieldPositions field indices to be projected
+	 */
+	public static Row project(Row row, int[] fieldPositions) {
+		final Row newRow = Row.withPositions(row.kind, fieldPositions.length);
+		for (int i = 0; i < fieldPositions.length; i++) {
+			newRow.setField(i, row.getField(fieldPositions[i]));
+		}
 		return newRow;
 	}
 
@@ -238,12 +531,14 @@ public final class Row implements Serializable {
 	 *
 	 * <p>This method does not perform a deep copy.
 	 *
-	 * @param fields field indices to be projected
+	 * <p>Note: The row must operate in name-based field mode.
+	 *
+	 * @param fieldNames field names to be projected
 	 */
-	public static Row project(Row row, int[] fields) {
-		final Row newRow = new Row(row.kind, fields.length);
-		for (int i = 0; i < fields.length; i++) {
-			newRow.fields[i] = row.fields[fields[i]];
+	public static Row project(Row row, String[] fieldNames) {
+		final Row newRow = Row.withNames(row.getKind());
+		for (String fieldName : fieldNames) {
+			newRow.setField(fieldName, row.getField(fieldName));
 		}
 		return newRow;
 	}
@@ -254,24 +549,40 @@ public final class Row implements Serializable {
 	 * the result.
 	 *
 	 * <p>This method does not perform a deep copy.
+	 *
+	 * <p>Note: All rows must operate in position-based field mode.
 	 */
 	public static Row join(Row first, Row... remainings) {
-		int newLength = first.fields.length;
+		Preconditions.checkArgument(
+			first.fieldByPosition != null,
+			"All rows must operate in position-based field mode.");
+		int newLength = first.fieldByPosition.length;
 		for (Row remaining : remainings) {
-			newLength += remaining.fields.length;
+			Preconditions.checkArgument(
+				remaining.fieldByPosition != null,
+				"All rows must operate in position-based field mode.");
+			newLength += remaining.fieldByPosition.length;
 		}
 
 		final Row joinedRow = new Row(first.kind, newLength);
 		int index = 0;
 
 		// copy the first row
-		System.arraycopy(first.fields, 0, joinedRow.fields, index, first.fields.length);
-		index += first.fields.length;
+		assert joinedRow.fieldByPosition != null;
+		System.arraycopy(
+			first.fieldByPosition, 0,
+			joinedRow.fieldByPosition, index,
+			first.fieldByPosition.length);
+		index += first.fieldByPosition.length;
 
 		// copy the remaining rows
 		for (Row remaining : remainings) {
-			System.arraycopy(remaining.fields, 0, joinedRow.fields, index, remaining.fields.length);
-			index += remaining.fields.length;
+			assert remaining.fieldByPosition != null;
+			System.arraycopy(
+				remaining.fieldByPosition, 0,
+				joinedRow.fieldByPosition, index,
+				remaining.fieldByPosition.length);
+			index += remaining.fieldByPosition.length;
 		}
 
 		return joinedRow;

--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -63,7 +63,8 @@ import static org.apache.flink.types.RowUtils.deepHashCodeRow;
  * the first call to {@link #setField(String, Object)} for the given name. However, the framework will
  * initialize missing fields with {@code null} and reorder all fields once more type information is
  * available during serialization or input conversion. Thus, even name-based rows eventually become
- * fixed-length composite types with a deterministic field order.
+ * fixed-length composite types with a deterministic field order. Name-based rows perform worse than
+ * position-based rows but simplify row creation and code readability.
  *
  * <h1>Hybrid / named-position field mode</h1>
  *

--- a/flink-core/src/main/java/org/apache/flink/types/RowUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/types/RowUtils.java
@@ -18,10 +18,15 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.StringUtils;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +70,25 @@ public final class RowUtils {
 	}
 
 	// --------------------------------------------------------------------------------------------
+	// Internal utilities
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Internal utility for creating a row in static named-position field mode.
+	 */
+	@Internal
+	public static Row createRowWithNamedPositions(
+			RowKind kind,
+			Object[] fieldByPosition,
+			LinkedHashMap<String, Integer> positionByName) {
+		return new Row(
+			kind,
+			fieldByPosition,
+			null,
+			positionByName);
+	}
+
+	// --------------------------------------------------------------------------------------------
 	// Default scoped for Row class only
 	// --------------------------------------------------------------------------------------------
 
@@ -72,46 +96,103 @@ public final class RowUtils {
 	 * Compares two objects with proper (nested) equality semantics. This method supports all external
 	 * and most internal conversion classes of the table ecosystem.
 	 */
-	static boolean deepEqualsRow(Row row1, Row row2) {
-		if (row1.getKind() != row2.getKind()) {
+	static boolean deepEqualsRow(
+			RowKind kind1,
+			@Nullable Object[] fieldByPosition1,
+			@Nullable Map<String, Object> fieldByName1,
+			@Nullable LinkedHashMap<String, Integer> positionByName1,
+			RowKind kind2,
+			@Nullable Object[] fieldByPosition2,
+			@Nullable Map<String, Object> fieldByName2,
+			@Nullable LinkedHashMap<String, Integer> positionByName2) {
+		if (kind1 != kind2) {
 			return false;
 		}
-		if (row1.getArity() != row2.getArity()) {
-			return false;
+		// positioned == positioned
+		else if (fieldByPosition1 != null && fieldByPosition2 != null) {
+			// positionByName is not included
+			return deepEqualsInternal(fieldByPosition1, fieldByPosition2);
 		}
-		for (int pos = 0; pos < row1.getArity(); pos++) {
-			final Object f1 = row1.getField(pos);
-			final Object f2 = row2.getField(pos);
-			if (!deepEqualsInternal(f1, f2)) {
-				return false;
-			}
+		// named == named
+		else if (fieldByName1 != null && fieldByName2 != null) {
+			return deepEqualsInternal(fieldByName1, fieldByName2);
 		}
-		return true;
+		// named positioned == named
+		else if (positionByName1 != null && fieldByName2 != null) {
+			return deepEqualsNamedRows(fieldByPosition1, positionByName1, fieldByName2);
+		}
+		// named == named positioned
+		else if (positionByName2 != null && fieldByName1 != null) {
+			return deepEqualsNamedRows(fieldByPosition2, positionByName2, fieldByName1);
+		}
+		return false;
 	}
 
 	/**
 	 * Hashes two objects with proper (nested) equality semantics. This method supports all external
 	 * and most internal conversion classes of the table ecosystem.
 	 */
-	static int deepHashCodeRow(Row row) {
-		int result = row.getKind().toByteValue(); // for stable hash across JVM instances
-		for (int i = 0; i < row.getArity(); i++) {
-			result = 31 * result + deepHashCodeInternal(row.getField(i));
+	static int deepHashCodeRow(
+			RowKind kind,
+			@Nullable Object[] fieldByPosition,
+			@Nullable Map<String, Object> fieldByName) {
+		int result = kind.toByteValue(); // for stable hash across JVM instances
+		if (fieldByPosition != null) {
+			// positionByName is not included
+			result = 31 * result + deepHashCodeInternal(fieldByPosition);
+		} else {
+			result = 31 * result + deepHashCodeInternal(fieldByName);
 		}
 		return result;
 	}
 
+	/**
+	 * Converts a row to a string representation. This method supports all external and most internal
+	 * conversion classes of the table ecosystem.
+	 */
+	static String deepToStringRow(
+			RowKind kind,
+			@Nullable Object[] fieldByPosition,
+			@Nullable Map<String, Object> fieldByName) {
+		final StringBuilder sb = new StringBuilder();
+		if (fieldByPosition != null) {
+			// TODO enable this for FLINK-18090
+			// sb.append(kind.shortString());
+			// deepToStringArray(sb, fieldByPosition);
+			deepToStringArrayLegacy(sb, fieldByPosition);
+		} else {
+			assert fieldByName != null;
+			sb.append(kind.shortString());
+			deepToStringMap(sb, fieldByName);
+		}
+		return sb.toString();
+	}
+
 	// --------------------------------------------------------------------------------------------
-	// Internal utilities
+	// Helper methods
 	// --------------------------------------------------------------------------------------------
+
+	private static boolean deepEqualsNamedRows(
+			Object[] fieldByPosition1,
+			LinkedHashMap<String, Integer> positionByName1,
+			Map<String, Object> fieldByName2) {
+		for (Map.Entry<String, Object> entry : fieldByName2.entrySet()) {
+			final Integer pos = positionByName1.get(entry.getKey());
+			if (pos == null) {
+				return false;
+			}
+			if (!deepEqualsInternal(fieldByPosition1[pos], entry.getValue())) {
+				return false;
+			}
+		}
+		return true;
+	}
 
 	private static boolean deepEqualsInternal(Object o1, Object o2) {
 		if (o1 == o2) {
 			return true;
 		} else if (o1 == null || o2 == null) {
 			return false;
-		} else if (o1 instanceof Row && o2 instanceof Row) {
-			return deepEqualsRow((Row) o1, (Row) o2);
 		} else if (o1 instanceof Object[] && o2 instanceof Object[]) {
 			return deepEqualsArray((Object[]) o1, (Object[]) o2);
 		} else if (o1 instanceof Map && o2 instanceof Map) {
@@ -204,9 +285,7 @@ public final class RowUtils {
 		if (o == null) {
 			return 0;
 		}
-		if (o instanceof Row) {
-			return deepHashCodeRow((Row) o);
-		} else if (o instanceof Object[]) {
+		if (o instanceof Object[]) {
 			return deepHashCodeArray((Object[]) o);
 		} else if (o instanceof Map) {
 			return deepHashCodeMap((Map<?, ?>) o);
@@ -237,7 +316,72 @@ public final class RowUtils {
 		for (Object e : l) {
 			result = 31 * result + deepHashCodeInternal(e);
 		}
-        return result;
+		return result;
+	}
+
+	private static void deepToStringInternal(StringBuilder sb, Object o) {
+		if (o instanceof Object[]) {
+			deepToStringArray(sb, (Object[]) o);
+		} else if (o instanceof Map) {
+			deepToStringMap(sb, (Map<?, ?>) o);
+		} else if (o instanceof List) {
+			deepToStringList(sb, (List<?>) o);
+		} else {
+			sb.append(StringUtils.arrayAwareToString(o));
+		}
+	}
+
+	private static void deepToStringArray(StringBuilder sb, Object[] a) {
+		sb.append('[');
+		boolean isFirst = true;
+		for (Object o : a) {
+			if (isFirst) {
+				isFirst = false;
+			} else {
+				sb.append(", ");
+			}
+			deepToStringInternal(sb, o);
+		}
+		sb.append(']');
+	}
+
+	private static void deepToStringArrayLegacy(StringBuilder sb, Object[] a) {
+		for (int i = 0; i < a.length; i++) {
+			if (i > 0) {
+				sb.append(",");
+			}
+			sb.append(StringUtils.arrayAwareToString(a[i]));
+		}
+	}
+
+	private static <K, V> void deepToStringMap(StringBuilder sb, Map<K, V> m) {
+		sb.append('{');
+		boolean isFirst = true;
+		for (Map.Entry<K, V> entry : m.entrySet()) {
+			if (isFirst) {
+				isFirst = false;
+			} else {
+				sb.append(", ");
+			}
+			deepToStringInternal(sb, entry.getKey());
+			sb.append('=');
+			deepToStringInternal(sb, entry.getValue());
+		}
+		sb.append('}');
+	}
+
+	private static <E> void deepToStringList(StringBuilder sb, List<E> l) {
+		sb.append('[');
+		boolean isFirst = true;
+		for (E element : l) {
+			if (isFirst) {
+				isFirst = false;
+			} else {
+				sb.append(", ");
+			}
+			deepToStringInternal(sb, element);
+		}
+		sb.append(']');
 	}
 
 	private RowUtils() {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.typeutils.runtime;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -28,31 +29,65 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.RowUtils;
 
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Objects;
 
 public class RowSerializerTest {
 
 	@Test
 	public void testRowSerializer() {
-		TypeInformation<Row> typeInfo = new RowTypeInfo(
-			BasicTypeInfo.INT_TYPE_INFO,
-			BasicTypeInfo.STRING_TYPE_INFO);
-		Row row1 = new Row(2);
-		row1.setKind(RowKind.UPDATE_BEFORE);
-		row1.setField(0, 1);
-		row1.setField(1, "a");
+		final TypeInformation<Row> rowTypeInfo = Types.ROW_NAMED(
+			new String[]{"a", "b", "c", "d"},
+			Types.INT,
+			Types.STRING,
+			Types.DOUBLE,
+			Types.BOOLEAN
+		);
 
-		Row row2 = new Row(2);
-		row2.setKind(RowKind.INSERT);
-		row2.setField(0, 2);
-		row2.setField(1, null);
+		final Row positionedRow = Row.withPositions(RowKind.UPDATE_BEFORE, 4);
+		positionedRow.setKind(RowKind.UPDATE_BEFORE);
+		positionedRow.setField(0, 1);
+		positionedRow.setField(1, "a");
+		positionedRow.setField(2, null);
+		positionedRow.setField(3, false);
 
-		TypeSerializer<Row> serializer = typeInfo.createSerializer(new ExecutionConfig());
-		RowSerializerTestInstance instance = new RowSerializerTestInstance(serializer, row1, row2);
+		final Row namedRow = Row.withNames(RowKind.UPDATE_BEFORE);
+		namedRow.setField("a", 1);
+		namedRow.setField("b", "a");
+		namedRow.setField("c", null);
+		namedRow.setField("d", false);
+
+		final Row sparseNamedRow = Row.withNames(RowKind.UPDATE_BEFORE);
+		namedRow.setField("a", 1);
+		namedRow.setField("b", "a");
+		namedRow.setField("d", false); // "c" is missing
+
+		final LinkedHashMap<String, Integer> positionByName = new LinkedHashMap<>();
+		positionByName.put("a", 0);
+		positionByName.put("b", 1);
+		positionByName.put("c", 2);
+		positionByName.put("d", 3);
+		final Row namedPositionedRow = RowUtils.createRowWithNamedPositions(
+			RowKind.UPDATE_BEFORE,
+			new Object[4],
+			positionByName);
+		namedPositionedRow.setField("a", 1);
+		namedPositionedRow.setField(1, "a");
+		namedPositionedRow.setField(2, null);
+		namedPositionedRow.setField("d", false);
+
+		final TypeSerializer<Row> serializer = rowTypeInfo.createSerializer(new ExecutionConfig());
+		final RowSerializerTestInstance instance = new RowSerializerTestInstance(
+			serializer,
+			positionedRow,
+			namedRow,
+			sparseNamedRow,
+			namedPositionedRow);
 		instance.testAll();
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/testutils/DeeplyEqualsChecker.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/DeeplyEqualsChecker.java
@@ -20,7 +20,6 @@ package org.apache.flink.testutils;
 
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.types.Row;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -33,7 +32,6 @@ import java.util.function.BiFunction;
  * <ul>
  *     <li>{@link Tuple}s</li>
  *     <li>Java arrays</li>
- *     <li>{@link Row}</li>
  *     <li>{@link Throwable}</li>
  * </ul>
  *
@@ -90,8 +88,6 @@ public class DeeplyEqualsChecker {
 			return deepEqualsArray(e1, e2);
 		} else if (e1 instanceof Tuple && e2 instanceof Tuple) {
 			return deepEqualsTuple((Tuple) e1, (Tuple) e2);
-		} else if (e1 instanceof Row && e2 instanceof Row) {
-			return deepEqualsRow((Row) e1, (Row) e2);
 		} else if (e1 instanceof Throwable && e2 instanceof Throwable) {
 			return ((Throwable) e1).getMessage().equals(((Throwable) e2).getMessage());
 		} else {
@@ -129,24 +125,6 @@ public class DeeplyEqualsChecker {
 			Object o2 = Array.get(array2, i);
 
 			if (!deepEquals(o1, o2)) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	private boolean deepEqualsRow(Row row1, Row row2) {
-		int arity = row1.getArity();
-
-		if (row1.getArity() != row2.getArity()) {
-			return false;
-		}
-
-		for (int i = 0; i < arity; i++) {
-			Object copiedValue = row1.getField(i);
-			Object element = row2.getField(i);
-			if (!deepEquals(copiedValue, element)) {
 				return false;
 			}
 		}

--- a/flink-core/src/test/java/org/apache/flink/types/RowBenchmark.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RowBenchmark.java
@@ -1,0 +1,480 @@
+package org.apache.flink.types;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.openjdk.jmh.annotations.Mode.Throughput;
+
+@State(Scope.Benchmark)
+public class RowBenchmark {
+
+	private TypeSerializer<Row> rowSerializer;
+
+	private TypeSerializer<MyPojo> pojoSerializer;
+
+
+	@Setup(Level.Trial)
+	public void setUp() {
+		rowSerializer = Types
+			.ROW(
+				Types.STRING,
+				Types.INT,
+				Types.BOOLEAN,
+				Types.STRING,
+				Types.DOUBLE,
+				Types.STRING,
+				Types.STRING,
+				Types.STRING,
+				Types.STRING,
+				Types.LONG)
+			.createSerializer(new ExecutionConfig());
+		pojoSerializer = Types.POJO(MyPojo.class).createSerializer(new ExecutionConfig());
+	}
+
+//	@Benchmark
+//	@OutputTimeUnit(SECONDS)
+//	@BenchmarkMode(Throughput)
+//	@Fork(3)
+//	@Warmup(iterations = 10)
+//	@Measurement(iterations = 15)
+//	public void testBefore(Blackhole blackhole) throws IOException {
+//		for (int i = 0; i < 500_000; i++) {
+//			// create
+//			final Row row = new Row(10);
+//			row.setField(0, "String");
+//			row.setField(1, i);
+//			row.setField(2, true);
+//			row.setField(3, null);
+//			row.setField(4, 1.0);
+//			row.setField(5, "String 2");
+//			row.setField(6, null);
+//			row.setField(7, null);
+//			row.setField(8, null);
+//			row.setField(9, 300L);
+//			// serialize/deserialize/copy/equals
+//			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+//			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+//			final Row copied = rowSerializer.copy(deserialized);
+//			if (!copied.equals(row)) {
+//				throw new RuntimeException();
+//			}
+//			// access
+//			blackhole.consume(copied.getField(0));
+//			blackhole.consume(copied.getField(1));
+//			blackhole.consume(copied.getField(2));
+//			blackhole.consume(copied.getField(3));
+//			blackhole.consume(copied.getField(4));
+//			blackhole.consume(copied.getField(5));
+//			blackhole.consume(copied.getField(6));
+//			blackhole.consume(copied.getField(7));
+//			blackhole.consume(copied.getField(8));
+//			blackhole.consume(copied.getField(9));
+//		}
+//	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testPositioned(Blackhole blackhole) throws IOException {
+		for (int i = 0; i < 500_000; i++) {
+			// create
+			final Row row = Row.withPositions(10);
+			row.setField(0, "String");
+			row.setField(1, i);
+			row.setField(2, true);
+			row.setField(3, null);
+			row.setField(4, 1.0);
+			row.setField(5, "String 2");
+			row.setField(6, null);
+			row.setField(7, null);
+			row.setField(8, null);
+			row.setField(9, 300L);
+			// serialize/deserialize/copy/equals
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			final Row copied = rowSerializer.copy(deserialized);
+			if (!copied.equals(row)) {
+				throw new RuntimeException();
+			}
+			// access
+			blackhole.consume(copied.getField(0));
+			blackhole.consume(copied.getField(1));
+			blackhole.consume(copied.getField(2));
+			blackhole.consume(copied.getField(3));
+			blackhole.consume(copied.getField(4));
+			blackhole.consume(copied.getField(5));
+			blackhole.consume(copied.getField(6));
+			blackhole.consume(copied.getField(7));
+			blackhole.consume(copied.getField(8));
+			blackhole.consume(copied.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testNamed(Blackhole blackhole) throws IOException {
+		for (int i = 0; i < 500_000; i++) {
+			// create
+			final Row row = Row.withNames();
+			row.setField("f0", "String");
+			row.setField("f1", i);
+			row.setField("f2", true);
+			row.setField("f3", null);
+			row.setField("f4", 1.0);
+			row.setField("f5", "String 2");
+			row.setField("f6", null);
+			row.setField("f7", null);
+			row.setField("f8", null);
+			row.setField("f9", 300L);
+			// serialize/deserialize/copy/equals
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			final Row copied = rowSerializer.copy(deserialized);
+			if (!copied.equals(row)) {
+				throw new RuntimeException();
+			}
+			// access
+			blackhole.consume(copied.getField(0));
+			blackhole.consume(copied.getField(1));
+			blackhole.consume(copied.getField(2));
+			blackhole.consume(copied.getField(3));
+			blackhole.consume(copied.getField(4));
+			blackhole.consume(copied.getField(5));
+			blackhole.consume(copied.getField(6));
+			blackhole.consume(copied.getField(7));
+			blackhole.consume(copied.getField(8));
+			blackhole.consume(copied.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testNamedNotCopy(Blackhole blackhole) throws IOException {
+		for (int i = 0; i < 500_000; i++) {
+			// create
+			final Row row = Row.withNames();
+			row.setField("f0", "String");
+			row.setField("f1", i);
+			row.setField("f2", true);
+			row.setField("f3", null);
+			row.setField("f4", 1.0);
+			row.setField("f5", "String 2");
+			row.setField("f6", null);
+			row.setField("f7", null);
+			row.setField("f8", null);
+			row.setField("f9", 300L);
+			// serialize/deserialize
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			// access
+			blackhole.consume(deserialized.getField(0));
+			blackhole.consume(deserialized.getField(1));
+			blackhole.consume(deserialized.getField(2));
+			blackhole.consume(deserialized.getField(3));
+			blackhole.consume(deserialized.getField(4));
+			blackhole.consume(deserialized.getField(5));
+			blackhole.consume(deserialized.getField(6));
+			blackhole.consume(deserialized.getField(7));
+			blackhole.consume(deserialized.getField(8));
+			blackhole.consume(deserialized.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testPositionedNotCopy(Blackhole blackhole) throws IOException {
+		for (int i = 0; i < 500_000; i++) {
+			// create
+			final Row row = Row.withPositions(10);
+			row.setField(0, "String");
+			row.setField(1, i);
+			row.setField(2, true);
+			row.setField(3, null);
+			row.setField(4, 1.0);
+			row.setField(5, "String 2");
+			row.setField(6, null);
+			row.setField(7, null);
+			row.setField(8, null);
+			row.setField(9, 300L);
+			// serialize/deserialize
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			// access
+			blackhole.consume(deserialized.getField(0));
+			blackhole.consume(deserialized.getField(1));
+			blackhole.consume(deserialized.getField(2));
+			blackhole.consume(deserialized.getField(3));
+			blackhole.consume(deserialized.getField(4));
+			blackhole.consume(deserialized.getField(5));
+			blackhole.consume(deserialized.getField(6));
+			blackhole.consume(deserialized.getField(7));
+			blackhole.consume(deserialized.getField(8));
+			blackhole.consume(deserialized.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testPositionedSerialization(Blackhole blackhole) throws IOException {
+		// create
+		final Row row = Row.withPositions(10);
+		row.setField(0, "String");
+		row.setField(2, true);
+		row.setField(3, null);
+		row.setField(4, 1.0);
+		row.setField(5, "String 2");
+		row.setField(6, null);
+		row.setField(7, null);
+		row.setField(8, null);
+		row.setField(9, 300L);
+		for (int i = 0; i < 500_000; i++) {
+			row.setField(1, i);
+			// serialize/deserialize
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			// access
+			blackhole.consume(deserialized.getField(0));
+			blackhole.consume(deserialized.getField(1));
+			blackhole.consume(deserialized.getField(2));
+			blackhole.consume(deserialized.getField(3));
+			blackhole.consume(deserialized.getField(4));
+			blackhole.consume(deserialized.getField(5));
+			blackhole.consume(deserialized.getField(6));
+			blackhole.consume(deserialized.getField(7));
+			blackhole.consume(deserialized.getField(8));
+			blackhole.consume(deserialized.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testNamedSerialization(Blackhole blackhole) throws IOException {
+		// create
+		final Row row = Row.withNames();
+		row.setField("f0", "String");
+		row.setField("f2", true);
+		row.setField("f3", null);
+		row.setField("f4", 1.0);
+		row.setField("f5", "String 2");
+		row.setField("f6", null);
+		row.setField("f7", null);
+		row.setField("f8", null);
+		row.setField("f9", 300L);
+		for (int i = 0; i < 500_000; i++) {
+			row.setField("f1", i);
+			// serialize/deserialize
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(rowSerializer, row);
+			final Row deserialized = InstantiationUtil.deserializeFromByteArray(rowSerializer, serialized);
+			// access
+			blackhole.consume(deserialized.getField(0));
+			blackhole.consume(deserialized.getField(1));
+			blackhole.consume(deserialized.getField(2));
+			blackhole.consume(deserialized.getField(3));
+			blackhole.consume(deserialized.getField(4));
+			blackhole.consume(deserialized.getField(5));
+			blackhole.consume(deserialized.getField(6));
+			blackhole.consume(deserialized.getField(7));
+			blackhole.consume(deserialized.getField(8));
+			blackhole.consume(deserialized.getField(9));
+		}
+	}
+
+	@Benchmark
+	@OutputTimeUnit(SECONDS)
+	@BenchmarkMode(Throughput)
+	@Fork(3)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 15)
+	public void testPojo(Blackhole blackhole) throws IOException {
+		for (int i = 0; i < 500_000; i++) {
+			// create
+			final MyPojo pojo = new MyPojo();
+			pojo.setF0("String");
+			pojo.setF1(i);
+			pojo.setF2(true);
+			pojo.setF3(null);
+			pojo.setF4(1.0);
+			pojo.setF5("String 2");
+			pojo.setF6(null);
+			pojo.setF7(null);
+			pojo.setF8(null);
+			pojo.setF9(300L);
+			// serialize/deserialize/copy/equals
+			final byte[] serialized = InstantiationUtil.serializeToByteArray(pojoSerializer, pojo);
+			final MyPojo deserialized = InstantiationUtil.deserializeFromByteArray(pojoSerializer, serialized);
+			final MyPojo copied = pojoSerializer.copy(deserialized);
+			if (!copied.equals(pojo)) {
+				throw new RuntimeException();
+			}
+			// access
+			blackhole.consume(copied.getF0());
+			blackhole.consume(copied.getF1());
+			blackhole.consume(copied.getF2());
+			blackhole.consume(copied.getF3());
+			blackhole.consume(copied.getF4());
+			blackhole.consume(copied.getF5());
+			blackhole.consume(copied.getF6());
+			blackhole.consume(copied.getF7());
+			blackhole.consume(copied.getF8());
+			blackhole.consume(copied.getF9());
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public static class MyPojo {
+		private String f0;
+		private Integer f1;
+		private Boolean f2;
+		private String f3;
+		private Double f4;
+		private String f5;
+		private String f6;
+		private String f7;
+		private String f8;
+		private Long f9;
+
+		public String getF0() {
+			return f0;
+		}
+
+		public void setF0(String f0) {
+			this.f0 = f0;
+		}
+
+		public Integer getF1() {
+			return f1;
+		}
+
+		public void setF1(Integer f1) {
+			this.f1 = f1;
+		}
+
+		public Boolean getF2() {
+			return f2;
+		}
+
+		public void setF2(Boolean f2) {
+			this.f2 = f2;
+		}
+
+		public String getF3() {
+			return f3;
+		}
+
+		public void setF3(String f3) {
+			this.f3 = f3;
+		}
+
+		public Double getF4() {
+			return f4;
+		}
+
+		public void setF4(Double f4) {
+			this.f4 = f4;
+		}
+
+		public String getF5() {
+			return f5;
+		}
+
+		public void setF5(String f5) {
+			this.f5 = f5;
+		}
+
+		public String getF6() {
+			return f6;
+		}
+
+		public void setF6(String f6) {
+			this.f6 = f6;
+		}
+
+		public String getF7() {
+			return f7;
+		}
+
+		public void setF7(String f7) {
+			this.f7 = f7;
+		}
+
+		public String getF8() {
+			return f8;
+		}
+
+		public void setF8(String f8) {
+			this.f8 = f8;
+		}
+
+		public Long getF9() {
+			return f9;
+		}
+
+		public void setF9(Long f9) {
+			this.f9 = f9;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			MyPojo myPojo = (MyPojo) o;
+			return Objects.equals(f0, myPojo.f0) && Objects.equals(f1, myPojo.f1) && Objects.equals(
+				f2,
+				myPojo.f2) && Objects.equals(f3, myPojo.f3) && Objects.equals(f4, myPojo.f4)
+				&& Objects.equals(f5, myPojo.f5) && Objects.equals(f6, myPojo.f6) && Objects.equals(
+				f7,
+				myPojo.f7) && Objects.equals(f8, myPojo.f8) && Objects.equals(f9, myPojo.f9);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/types/RowTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RowTest.java
@@ -24,71 +24,315 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
+/**
+ * Tests for {@link Row} and {@link RowUtils}.
+ */
 public class RowTest {
-	@Test
-	public void testRowToString() {
-		Row row = new Row(5);
-		row.setField(0, 1);
-		row.setField(1, "hello");
-		row.setField(2, null);
-		row.setField(3, new Tuple2<>(2, "hi"));
-		row.setField(4, "hello world");
 
-		assertEquals("1,hello,null,(2,hi),hello world", row.toString());
+	@Test
+	public void testRowNamed() {
+		final Row row = Row.withNames(RowKind.DELETE);
+
+		// test getters and setters
+		row.setField("a", 42);
+		row.setField("b", true);
+		row.setField("c", null);
+		assertThat(row.getFieldNames(false), containsInAnyOrder("a", "b", "c"));
+		assertThat(row.getArity(), equalTo(3));
+		assertThat(row.getKind(), equalTo(RowKind.DELETE));
+		assertThat(row.getField("a"), equalTo(42));
+		assertThat(row.getField("b"), equalTo(true));
+		assertThat(row.getField("c"), equalTo(null));
+
+		// test toString
+		assertThat(row.toString(), equalTo("-D{a=42, b=true, c=null}"));
+
+		// test override
+		row.setField("a", 13);
+		row.setField("c", "Hello");
+		assertThat(row.getField("a"), equalTo(13));
+		assertThat(row.getField("b"), equalTo(true));
+		assertThat(row.getField("c"), equalTo("Hello"));
+
+		// test equality
+		final Row otherRow1 = Row.withNames(RowKind.DELETE);
+		otherRow1.setField("a", 13);
+		otherRow1.setField("b", true);
+		otherRow1.setField("c", "Hello");
+		assertThat(row.hashCode(), equalTo(otherRow1.hashCode()));
+		assertThat(row, equalTo(otherRow1));
+
+		// test inequality
+		final Row otherRow2 = Row.withNames(RowKind.DELETE);
+		otherRow2.setField("a", 13);
+		otherRow2.setField("b", false); // diff here
+		otherRow2.setField("c", "Hello");
+		assertThat(row.hashCode(), not(equalTo(otherRow2.hashCode())));
+		assertThat(row, not(equalTo(otherRow2)));
+
+		// test clear
+		row.clear();
+		assertThat(row.getArity(), equalTo(0));
+		assertThat(row.getFieldNames(false), empty());
+		assertThat(row.toString(), equalTo("-D{}"));
+
+		// test invalid setter
+		try {
+			row.setField(0, 13);
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("not supported in name-based field mode")));
+		}
+
+		// test invalid getter
+		try {
+			assertNull(row.getField(0));
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("not supported in name-based field mode")));
+		}
+	}
+
+	@Test
+	public void testRowPositioned() {
+		final Row row = Row.withPositions(RowKind.DELETE, 3);
+
+		// test getters and setters
+		row.setField(0, 42);
+		row.setField(1, true);
+		row.setField(2, null);
+		assertThat(row.getFieldNames(false), equalTo(null));
+		assertThat(row.getArity(), equalTo(3));
+		assertThat(row.getKind(), equalTo(RowKind.DELETE));
+		assertThat(row.getField(0), equalTo(42));
+		assertThat(row.getField(1), equalTo(true));
+		assertThat(row.getField(2), equalTo(null));
+
+		// test toString
+		// TODO enable this for FLINK-18090
+		//assertThat(row.toString(), equalTo("-D[42, true, null]"));
+		assertThat(row.toString(), equalTo("42,true,null"));
+
+		// test override
+		row.setField(0, 13);
+		row.setField(2, "Hello");
+		assertThat(row.getField(0), equalTo(13));
+		assertThat(row.getField(1), equalTo(true));
+		assertThat(row.getField(2), equalTo("Hello"));
+
+		// test equality
+		final Row otherRow1 = Row.withPositions(RowKind.DELETE, 3);
+		otherRow1.setField(0, 13);
+		otherRow1.setField(1, true);
+		otherRow1.setField(2, "Hello");
+		assertThat(row.hashCode(), equalTo(otherRow1.hashCode()));
+		assertThat(row, equalTo(otherRow1));
+
+		// test inequality
+		final Row otherRow2 = Row.withPositions(RowKind.DELETE, 3);
+		otherRow2.setField(0, 13);
+		otherRow2.setField(1, false); // diff here
+		otherRow2.setField(2, "Hello");
+		assertThat(row.hashCode(), not(equalTo(otherRow2.hashCode())));
+		assertThat(row, not(equalTo(otherRow2)));
+
+		// test clear
+		row.clear();
+		assertThat(row.getArity(), equalTo(3));
+		assertThat(row.getFieldNames(false), equalTo(null));
+		// TODO enable this for FLINK-18090
+		// assertThat(row.toString(), equalTo("-D[null, null, null]"));
+		assertThat(row.toString(), equalTo("null,null,null"));
+
+		// test invalid setter
+		try {
+			row.setField("a", 13);
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("not supported in position-based field mode")));
+		}
+
+		// test invalid getter
+		try {
+			assertNull(row.getField("a"));
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("not supported in position-based field mode")));
+		}
+	}
+
+	@Test
+	public void testRowNamedPositioned() {
+		final LinkedHashMap<String, Integer> positionByName = new LinkedHashMap<>();
+		positionByName.put("a", 0);
+		positionByName.put("b", 1);
+		positionByName.put("c", 2);
+		final Row row = RowUtils.createRowWithNamedPositions(RowKind.DELETE, new Object[3], positionByName);
+
+		// test getters and setters
+		row.setField(0, 42);
+		row.setField("b", true);
+		row.setField(2, null);
+		assertThat(row.getFieldNames(false), equalTo(null));
+		assertThat(row.getFieldNames(true), contains("a", "b", "c"));
+		assertThat(row.getArity(), equalTo(3));
+		assertThat(row.getKind(), equalTo(RowKind.DELETE));
+		assertThat(row.getField(0), equalTo(42));
+		assertThat(row.getField(1), equalTo(true));
+		assertThat(row.getField("c"), equalTo(null));
+
+		// test toString
+		// TODO enable this for FLINK-18090
+		//assertThat(row.toString(), equalTo("-D[42, true, null]"));
+		assertThat(row.toString(), equalTo("42,true,null"));
+
+		// test override
+		row.setField("a", 13);
+		row.setField(2, "Hello");
+		assertThat(row.getField(0), equalTo(13));
+		assertThat(row.getField("b"), equalTo(true));
+		assertThat(row.getField(2), equalTo("Hello"));
+
+		// test equality
+		final Row otherRow1 = Row.withPositions(RowKind.DELETE, 3);
+		otherRow1.setField(0, 13);
+		otherRow1.setField(1, true);
+		otherRow1.setField(2, "Hello");
+		assertThat(row.hashCode(), equalTo(otherRow1.hashCode()));
+		assertThat(row, equalTo(otherRow1));
+
+		// test inequality
+		final Row otherRow2 = Row.withPositions(RowKind.DELETE, 3);
+		otherRow2.setField(0, 13);
+		otherRow2.setField(1, false); // diff here
+		otherRow2.setField(2, "Hello");
+		assertThat(row.hashCode(), not(equalTo(otherRow2.hashCode())));
+		assertThat(row, not(equalTo(otherRow2)));
+
+		// test clear
+		row.clear();
+		assertThat(row.getArity(), equalTo(3));
+		assertThat(row.getFieldNames(true), contains("a", "b", "c"));
+		// TODO enable this for FLINK-18090
+		// assertThat(row.toString(), equalTo("-D[null, null, null]"));
+		assertThat(row.toString(), equalTo("null,null,null"));
+
+		// test invalid setter
+		try {
+			row.setField("DOES_NOT_EXIST", 13);
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("Unknown field name 'DOES_NOT_EXIST'")));
+		}
+
+		// test invalid getter
+		try {
+			assertNull(row.getField("DOES_NOT_EXIST"));
+			fail();
+		} catch (Throwable t) {
+			assertThat(t, hasMessage(containsString("Unknown field name 'DOES_NOT_EXIST'")));
+		}
 	}
 
 	@Test
 	public void testRowOf() {
-		Row row1 = Row.of(1, "hello", null, Tuple2.of(2L, "hi"), true);
-		Row row2 = new Row(5);
+		final Row row1 = Row.of(1, "hello", null, Tuple2.of(2L, "hi"), true);
+
+		final Row row2 = Row.withPositions(5);
 		row2.setField(0, 1);
 		row2.setField(1, "hello");
 		row2.setField(2, null);
 		row2.setField(3, new Tuple2<>(2L, "hi"));
 		row2.setField(4, true);
+
 		assertEquals(row1, row2);
 	}
 
 	@Test
-	public void testRowCopy() {
-		Row row = new Row(5);
+	public void testRowCopyPositioned() {
+		final Row row = Row.withPositions(5);
 		row.setField(0, 1);
 		row.setField(1, "hello");
 		row.setField(2, null);
 		row.setField(3, new Tuple2<>(2, "hi"));
 		row.setField(4, "hello world");
 
-		Row copy = Row.copy(row);
+		final Row copy = Row.copy(row);
 		assertEquals(row, copy);
 		assertNotSame(row, copy);
 	}
 
 	@Test
-	public void testRowProject() {
-		Row row = new Row(5);
+	public void testRowCopyNamed() {
+		final Row row = Row.withNames();
+		row.setField("a", 1);
+		row.setField("b", "hello");
+		row.setField("c", null);
+		row.setField("d", new Tuple2<>(2, "hi"));
+		row.setField("e", "hello world");
+
+		final Row copy = Row.copy(row);
+		assertEquals(row, copy);
+		assertNotSame(row, copy);
+	}
+
+	@Test
+	public void testRowProjectPositioned() {
+		final Row row = Row.withPositions(5);
 		row.setField(0, 1);
 		row.setField(1, "hello");
 		row.setField(2, null);
 		row.setField(3, new Tuple2<>(2, "hi"));
 		row.setField(4, "hello world");
 
-		Row projected = Row.project(row, new int[]{0, 2, 4});
+		final Row projected = Row.project(row, new int[]{0, 2, 4});
 
-		Row expected = new Row(3);
+		final Row expected = Row.withPositions(3);
 		expected.setField(0, 1);
 		expected.setField(1, null);
 		expected.setField(2, "hello world");
+
 		assertEquals(expected, projected);
 	}
 
 	@Test
-	public void testRowJoin() {
+	public void testRowProjectNamed() {
+		final Row row = Row.withNames();
+		row.setField("a", 1);
+		row.setField("b", "hello");
+		row.setField("c", null);
+		row.setField("d", new Tuple2<>(2, "hi"));
+		row.setField("e", "hello world");
+
+		final Row projected = Row.project(row, new String[]{"a", "c", "e"});
+
+		final Row expected = Row.withNames();
+		expected.setField("a", 1);
+		expected.setField("c", null);
+		expected.setField("e", "hello world");
+
+		assertEquals(expected, projected);
+	}
+
+	@Test
+	public void testRowJoinPositioned() {
 		Row row1 = new Row(2);
 		row1.setField(0, 1);
 		row1.setField(1, "hello");
@@ -112,7 +356,7 @@ public class RowTest {
 	}
 
 	@Test
-	public void testDeepEqualsAndHashCode() {
+	public void testDeepEqualsAndHashCodePositioned() {
 		final Map<String, byte[]> originalMap = new HashMap<>();
 		originalMap.put("k1", new byte[]{1, 2, 3});
 		originalMap.put("k2", new byte[]{3, 4, 6});
@@ -202,5 +446,61 @@ public class RowTest {
 			assertNotEquals(row, originalRow);
 			assertNotEquals(row.hashCode(), originalRow.hashCode());
 		}
+	}
+
+	@Test
+	public void testDeepEqualsCodeNamed() {
+		final Row named = Row.withNames(RowKind.DELETE);
+		named.setField("a", 12); // "b" is missing due to sparsity
+		named.setField("c", true);
+
+		final LinkedHashMap<String, Integer> positionByName = new LinkedHashMap<>();
+		positionByName.put("a", 0);
+		positionByName.put("b", 1);
+		positionByName.put("c", 2);
+		final Row namedPositioned = RowUtils.createRowWithNamedPositions(
+			RowKind.DELETE,
+			new Object[3],
+			positionByName);
+		namedPositioned.setField("a", 12);
+		namedPositioned.setField("b", null);
+		namedPositioned.setField("c", true);
+
+		assertThat(named, equalTo(namedPositioned));
+		assertThat(namedPositioned, equalTo(named));
+
+		named.setField("b", "Hello");
+		assertThat(named, not(equalTo(namedPositioned)));
+		assertThat(namedPositioned, not(equalTo(named)));
+	}
+
+	@Test
+	public void testDeepToString() {
+		final Row row = Row.withNames(RowKind.UPDATE_BEFORE);
+		row.setField("a", 1);
+		row.setField("b", "hello");
+		row.setField("c", null);
+		row.setField("d", new Tuple2<>(2, "hi"));
+		row.setField("e", "hello world");
+		row.setField("f", new int[][]{{1}, null, {3, 4}});
+		row.setField("g", new Boolean[][]{{true}, null, {false, false}});
+		final Map<String, Integer[]> map = new HashMap<>();
+		map.put("a", new Integer[]{1, 2, 3, 4});
+		map.put("b", new Integer[]{});
+		map.put("c", null);
+		row.setField("h", map);
+
+		assertThat(
+			row.toString(),
+			equalTo("-U{"
+					+ "a=1, "
+					+ "b=hello, "
+					+ "c=null, "
+					+ "d=(2,hi), "
+					+ "e=hello world, "
+					+ "f=[[1], null, [3, 4]], "
+					+ "g=[[true], null, [false, false]], "
+					+ "h={a=[1, 2, 3, 4], b=[], c=null}"
+					+ "}"));
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -137,7 +137,10 @@ public class PythonTypeUtilsTest {
 		TypeInformation rowTypeInfo = Types.ROW(Types.INT);
 		convertedTypeSerializer = PythonTypeUtils.TypeInfoToSerializerConverter
 			.typeInfoSerializerConverter(rowTypeInfo);
-		assertEquals(convertedTypeSerializer, new RowSerializer(new TypeSerializer[]{IntSerializer.INSTANCE}, false));
+		assertEquals(
+			convertedTypeSerializer,
+			new RowSerializer(
+				new TypeSerializer[]{IntSerializer.INSTANCE}));
 
 		TupleTypeInfo tupleTypeInfo = (TupleTypeInfo) Types.TUPLE(Types.INT);
 		convertedTypeSerializer = PythonTypeUtils.TypeInfoToSerializerConverter

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunctionTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunctionTest.java
@@ -52,7 +52,7 @@ public class RowArrowSourceFunctionTest extends ArrowSourceFunctionTestBase<Row>
 
 	public RowArrowSourceFunctionTest() {
 		super(VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator),
-			new RowSerializer(new TypeSerializer[]{StringSerializer.INSTANCE}, false),
+			new RowSerializer(new TypeSerializer[]{StringSerializer.INSTANCE}),
 			Comparator.comparing(o -> (String) (o.getField(0))));
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/RowFunctionITCase.java
@@ -96,7 +96,7 @@ public class RowFunctionITCase extends BuiltInFunctionTestBase {
 	 */
 	public static class TakesRow extends ScalarFunction {
 		public @DataTypeHint("ROW<i INT, s STRING>") Row eval(@DataTypeHint("ROW<i INT, s STRING>") Row row, Integer i) {
-			row.setField(0, (int) row.getField(0) + i);
+			row.setField("i", (int) row.getField("i") + i);
 			return row;
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
@@ -25,7 +25,7 @@ LogicalJoin(condition=[=($3, $1)], joinType=[inner])
 :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
 :        :- LogicalProject(o_rowtime=[AS($0, _UTF-16LE'o_rowtime')], o_comment=[AS($1, _UTF-16LE'o_comment')], o_amount=[AS($2, _UTF-16LE'o_amount')], o_currency=[AS($3, _UTF-16LE'o_currency')], o_secondary_key=[AS($4, _UTF-16LE'o_secondary_key')])
 :        :  +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-:        +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$87edb49a77e545ed3da6318629a54024($0)], rowType=[RecordType(TIMESTAMP(3) rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)], elementType=[class [Ljava.lang.Object;])
+:        +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$11da53fa5c705009c63c1059f9311821($0)], rowType=[RecordType(TIMESTAMP(3) rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)], elementType=[class [Ljava.lang.Object;])
 +- LogicalTableScan(table=[[default_catalog, default_database, ThirdTable]])
 ]]>
     </Resource>
@@ -53,7 +53,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$9f8cd64a3b5a060e7794a65524cd070a($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(ROWTIME) rowtime)], elementType=[class [Ljava.lang.Object;])
+      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$7b64fb5334c47de8df24f3ab20394c19($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(ROWTIME) rowtime)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -95,7 +95,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, ProctimeOrders]])
-      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$5e34ee5bc251237bdaefabb25bfc63dc($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(PROCTIME) proctime)], elementType=[class [Ljava.lang.Object;])
+      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$3f15d21732a0cca300e47b78077046df($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(PROCTIME) proctime)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -116,7 +116,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$9f8cd64a3b5a060e7794a65524cd070a($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(ROWTIME) rowtime)], elementType=[class [Ljava.lang.Object;])
+      +- LogicalTableFunctionScan(invocation=[org$apache$flink$table$functions$TemporalTableFunctionImpl$7b64fb5334c47de8df24f3ab20394c19($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIME ATTRIBUTE(ROWTIME) rowtime)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
     <Resource name="planAfter">

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RowRowConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/RowRowConverter.java
@@ -24,9 +24,14 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowUtils;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldNames;
 
 /**
  * Converter for {@link RowType} of {@link Row} external type.
@@ -40,11 +45,15 @@ public class RowRowConverter implements DataStructureConverter<RowData, Row> {
 
 	private final RowData.FieldGetter[] fieldGetters;
 
+	private final LinkedHashMap<String, Integer> positionByName;
+
 	private RowRowConverter(
 			DataStructureConverter<Object, Object>[] fieldConverters,
-			RowData.FieldGetter[] fieldGetters) {
+			RowData.FieldGetter[] fieldGetters,
+			LinkedHashMap<String, Integer> positionByName) {
 		this.fieldConverters = fieldConverters;
 		this.fieldGetters = fieldGetters;
+		this.positionByName = positionByName;
 	}
 
 	@Override
@@ -58,22 +67,48 @@ public class RowRowConverter implements DataStructureConverter<RowData, Row> {
 	public RowData toInternal(Row external) {
 		final int length = fieldConverters.length;
 		final GenericRowData genericRow = new GenericRowData(external.getKind(), length);
-		for (int pos = 0; pos < length; pos++) {
-			final Object value = external.getField(pos);
-			genericRow.setField(pos, fieldConverters[pos].toInternalOrNull(value));
+
+		final Set<String> fieldNames = external.getFieldNames(false);
+
+		// position-based field access
+		if (fieldNames == null) {
+			for (int pos = 0; pos < length; pos++) {
+				final Object value = external.getField(pos);
+				genericRow.setField(pos, fieldConverters[pos].toInternalOrNull(value));
+			}
 		}
+		// name-based field access
+		else {
+			for (String fieldName : fieldNames) {
+				final Integer targetPos = positionByName.get(fieldName);
+				if (targetPos == null) {
+					throw new IllegalArgumentException(
+						String.format(
+							"Unknown field name '%s' for mapping to a row position. "
+								+ "Available names are: %s",
+							fieldName,
+							positionByName.keySet()));
+				}
+				final Object value = external.getField(fieldName);
+				genericRow.setField(targetPos, fieldConverters[targetPos].toInternalOrNull(value));
+			}
+		}
+
 		return genericRow;
 	}
 
 	@Override
 	public Row toExternal(RowData internal) {
 		final int length = fieldConverters.length;
-		final Row row = new Row(internal.getRowKind(), length);
+		final Object[] fieldByPosition = new Object[length];
 		for (int pos = 0; pos < length; pos++) {
 			final Object value = fieldGetters[pos].getFieldOrNull(internal);
-			row.setField(pos, fieldConverters[pos].toExternalOrNull(value));
+			fieldByPosition[pos] = fieldConverters[pos].toExternalOrNull(value);
 		}
-		return row;
+		return RowUtils.createRowWithNamedPositions(
+			internal.getRowKind(),
+			fieldByPosition,
+			positionByName);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -90,6 +125,11 @@ public class RowRowConverter implements DataStructureConverter<RowData, Row> {
 			.range(0, fields.size())
 			.mapToObj(pos -> RowData.createFieldGetter(fields.get(pos).getLogicalType(), pos))
 			.toArray(RowData.FieldGetter[]::new);
-		return new RowRowConverter(fieldConverters, fieldGetters);
+		final List<String> fieldNames = getFieldNames(dataType.getLogicalType());
+		final LinkedHashMap<String, Integer> positionByName = new LinkedHashMap<>();
+		for (int i = 0; i < fieldNames.size(); i++) {
+			positionByName.put(fieldNames.get(i), i);
+		}
+		return new RowRowConverter(fieldConverters, fieldGetters, positionByName);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -254,6 +254,16 @@ public class DataStructureConvertersTest {
 								FIELD("b_1", DOUBLE()),
 								FIELD("b_2", BOOLEAN())))))
 				.convertedTo(Row.class, Row.ofKind(RowKind.DELETE, 12, Row.of(2.0, null)))
+				.convertedToSupplier(
+					Row.class,
+					() -> {
+						final Row namedRow = Row.withNames(RowKind.DELETE);
+						namedRow.setField("a", 12);
+						final Row sparseNamedRow = Row.withNames();
+						sparseNamedRow.setField("b_1", 2.0); // "b_2" is omitted
+						namedRow.setField("b", sparseNamedRow);
+						return namedRow;
+					})
 				.convertedTo(RowData.class, GenericRowData.ofKind(RowKind.DELETE, 12, GenericRowData.of(2.0, null))),
 
 			TestSpec


### PR DESCRIPTION
## What is the purpose of the change

This adds a name-based field mode to the `Row` class. It simplifies the handling of large rows (possibly with hundreds of fields) and will make it easier to switch between DataStream API and Table API.

See the documentation of Row:

```
 * <p>Fields of a row can be accessed either position-based or name-based. An implementer can decide
 * in which field mode a row should operate during creation. Rows that were produced by the framework
 * support a hybrid of both field modes (i.e. named positions):
 *
 * <h1>Position-based field mode</h1>
 *
 * <p>{@link Row#withPositions(int)} creates a fixed-length row. The fields can be accessed by position
 * (zero-based) using {@link #getField(int)} and {@link #setField(int, Object)}. Every field is initialized
 * with {@code null} by default.
 *
 * <h1>Name-based field mode</h1>
 *
 * <p>{@link Row#withNames()} creates a variable-length row. The fields can be accessed by name using
 * {@link #getField(String)} and {@link #setField(String, Object)}. Every field is initialized during
 * the first call to {@link #setField(String, Object)} for the given name. However, the framework will
 * initialize missing fields with {@code null} and reorder all fields once more type information is
 * available during serialization or input conversion. Thus, even name-based rows eventually become
 * fixed-length composite types with a deterministic field order.
 *
 * <h1>Hybrid / named-position field mode</h1>
 *
 * <p>Rows that were produced by the framework (after deserialization or output conversion) are fixed-length
 * rows with a deterministic field order that can map static field names to field positions. Thus, fields
 * can be accessed both via {@link #getField(int)} and {@link #getField(String)}. Both {@link #setField(int, Object)}
 * and {@link #setField(String, Object)} are supported for existing fields. However, adding new field
 * names via {@link #setField(String, Object)} is not allowed. A hybrid row's {@link #equals(Object)}
 * supports comparing to all kinds of rows. A hybrid row's {@link #hashCode()} is only valid for position-based
 * rows.
```


## Brief change log

- Update `Row`
- Update `RowSerializer`
- Update `RowRowConverter`

## Verifying this change

This change added tests and can be verified as follows:

- `RowTest`
- `RowSerializerTest`
- `DataStructureConverterTest`
- `RowFunctionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
