### PR TITLE
[FLINK-20666][python] Fix the deserialized Row losing the field_name information in PyFlink

### DIFF
--- a/flink-python/pyflink/common/types.py
+++ b/flink-python/pyflink/common/types.py
@@ -18,6 +18,8 @@
 
 from enum import Enum
 
+from typing import List
+
 __all__ = ['Row', 'RowKind']
 
 
@@ -135,6 +137,9 @@ class Row(object):
 
     def set_row_kind(self, row_kind: RowKind):
         self._row_kind = row_kind
+
+    def set_field_names(self, field_names: List):
+        self._fields = field_names
 
     def __contains__(self, item):
         return item in self._values

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -208,9 +208,10 @@ class DataStreamTests(PyFlinkTestCase):
 
         self.env.execute('key_by_test')
         results = self.test_sink.get_results(True)
-        expected = ["<Row('e', 2)>", "<Row('a', 0)>", "<Row('b', 0)>", "<Row('c', 1)>",
-                    "<Row('d', 1)>", "<Row('e', 2)>", "<Row('a', 0)>", "<Row('b', 0)>",
-                    "<Row('c', 1)>", "<Row('d', 1)>"]
+        expected = ["Row(f0='e', f1=2)", "Row(f0='a', f1=0)", "Row(f0='b', f1=0)",
+                    "Row(f0='c', f1=1)", "Row(f0='d', f1=1)", "Row(f0='e', f1=2)",
+                    "Row(f0='a', f1=0)", "Row(f0='b', f1=0)", "Row(f0='c', f1=1)",
+                    "Row(f0='d', f1=1)"]
         results.sort()
         expected.sort()
         self.assertEqual(expected, results)
@@ -391,8 +392,8 @@ class DataStreamTests(PyFlinkTestCase):
         keyed_stream.map(AssertKeyMapFunction()).add_sink(self.test_sink)
         self.env.execute('key_by_test')
         results = self.test_sink.get_results(True)
-        expected = ["<Row('e', 2)>", "<Row('a', 0)>", "<Row('b', 0)>", "<Row('c', 1)>",
-                    "<Row('d', 1)>"]
+        expected = ["Row(f0='e', f1=2)", "Row(f0='a', f1=0)", "Row(f0='b', f1=0)",
+                    "Row(f0='c', f1=1)", "Row(f0='d', f1=1)"]
         results.sort()
         expected.sort()
         self.assertEqual(expected, results)
@@ -685,13 +686,13 @@ class DataStreamTests(PyFlinkTestCase):
         self.env.execute('test time stamp assigner with keyed process function')
         result = self.test_sink.get_results()
         expected_result = ["current key: 1, current timestamp: 1603708211000, current watermark: "
-                           "9223372036854775807, current_value: <Row(1, '1603708211000')>",
+                           "9223372036854775807, current_value: Row(f0=1, f1='1603708211000')",
                            "current key: 2, current timestamp: 1603708224000, current watermark: "
-                           "9223372036854775807, current_value: <Row(2, '1603708224000')>",
+                           "9223372036854775807, current_value: Row(f0=2, f1='1603708224000')",
                            "current key: 3, current timestamp: 1603708226000, current watermark: "
-                           "9223372036854775807, current_value: <Row(3, '1603708226000')>",
+                           "9223372036854775807, current_value: Row(f0=3, f1='1603708226000')",
                            "current key: 4, current timestamp: 1603708289000, current watermark: "
-                           "9223372036854775807, current_value: <Row(4, '1603708289000')>"]
+                           "9223372036854775807, current_value: Row(f0=4, f1='1603708289000')"]
         result.sort()
         expected_result.sort()
         self.assertEqual(expected_result, result)
@@ -729,13 +730,13 @@ class DataStreamTests(PyFlinkTestCase):
         self.env.execute('test process function')
         result = self.test_sink.get_results()
         expected_result = ["current timestamp: 1603708211000, current watermark: "
-                           "9223372036854775807, current_value: <Row(1, '1603708211000')>",
+                           "9223372036854775807, current_value: Row(f0=1, f1='1603708211000')",
                            "current timestamp: 1603708224000, current watermark: "
-                           "9223372036854775807, current_value: <Row(2, '1603708224000')>",
+                           "9223372036854775807, current_value: Row(f0=2, f1='1603708224000')",
                            "current timestamp: 1603708226000, current watermark: "
-                           "9223372036854775807, current_value: <Row(3, '1603708226000')>",
+                           "9223372036854775807, current_value: Row(f0=3, f1='1603708226000')",
                            "current timestamp: 1603708289000, current watermark: "
-                           "9223372036854775807, current_value: <Row(4, '1603708289000')>"]
+                           "9223372036854775807, current_value: Row(f0=4, f1='1603708289000')"]
         result.sort()
         expected_result.sort()
         self.assertEqual(expected_result, result)

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -154,7 +154,7 @@ class RowCoderImpl(FlattenRowCoderImpl):
     def decode_from_stream(self, in_stream, nested):
         row_kind_value, fields = self._decode_one_row_from_stream(in_stream, nested)
         row = Row(*fields)
-        row._fields = self.field_names
+        row.set_field_names(self.field_names)
         row.set_row_kind(RowKind(row_kind_value))
         return row
 

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -144,8 +144,9 @@ class FlattenRowCoderImpl(StreamCoderImpl):
 
 class RowCoderImpl(FlattenRowCoderImpl):
 
-    def __init__(self, field_coders):
+    def __init__(self, field_coders, field_names):
         super(RowCoderImpl, self).__init__(field_coders)
+        self.field_names = field_names
 
     def encode_to_stream(self, value: Row, out_stream, nested):
         self._encode_one_row_to_stream(value, out_stream, nested)
@@ -153,6 +154,7 @@ class RowCoderImpl(FlattenRowCoderImpl):
     def decode_from_stream(self, in_stream, nested):
         row_kind_value, fields = self._decode_one_row_from_stream(in_stream, nested)
         row = Row(*fields)
+        row._fields = self.field_names
         row.set_row_kind(RowKind(row_kind_value))
         return row
 

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -207,6 +207,7 @@ cdef class MapCoderImpl(FieldCoder):
 
 cdef class RowCoderImpl(FieldCoder):
     cdef readonly list field_coders
+    cdef readonly list field_names
 
 cdef class TupleCoderImpl(FieldCoder):
     cdef readonly list field_coders

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -446,7 +446,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
                             row_field_coders[i].type_name(),
                             row_field_coders[i])
                         for i in range(row_field_count)])
-            row._fields = row_field_names
+            row.set_field_names(row_field_names)
             row_kind_value = 0
             for i in range(ROW_KIND_BIT_SIZE):
                 row_kind_value += mask[i] * 2 ** i

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -434,6 +434,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
         elif field_type == ROW:
             # Row
             row_field_coders = (<RowCoderImpl> field_coder).field_coders
+            row_field_names = (<RowCoderImpl> field_coder).field_names
             row_field_count = len(row_field_coders)
             mask = <bint*> malloc((row_field_count + ROW_KIND_BIT_SIZE) * sizeof(bint))
             leading_complete_bytes_num = (row_field_count + ROW_KIND_BIT_SIZE) // 8
@@ -445,6 +446,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
                             row_field_coders[i].type_name(),
                             row_field_coders[i])
                         for i in range(row_field_count)])
+            row._fields = row_field_names
             row_kind_value = 0
             for i in range(ROW_KIND_BIT_SIZE):
                 row_kind_value += mask[i] * 2 ** i
@@ -878,8 +880,9 @@ cdef class MapCoderImpl(FieldCoder):
         return MAP
 
 cdef class RowCoderImpl(FieldCoder):
-    def __cinit__(self, field_coders):
+    def __cinit__(self, field_coders, field_names):
         self.field_coders = field_coders
+        self.field_names = field_names
 
     cpdef CoderType coder_type(self):
         return COMPLEX

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -254,18 +254,20 @@ class RowCoder(FieldCoder, BaseCoder):
     Coder for Row.
     """
 
-    def __init__(self, field_coders):
+    def __init__(self, field_coders, field_names):
         self._field_coders = field_coders
+        self._field_names = field_names
 
     def get_impl(self):
-        return coder_impl.RowCoderImpl([c.get_impl() for c in self._field_coders])
+        return coder_impl.RowCoderImpl([c.get_impl() for c in self._field_coders],
+                                       self._field_names)
 
     def __repr__(self):
         return 'RowCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__
-                and len(self._field_coders) == len(other._field_coders)
+                and self._field_names == other._field_names
                 and [self._field_coders[i] == other._field_coders[i] for i in
                      range(len(self._field_coders))])
 
@@ -552,7 +554,8 @@ def from_proto(field_type):
     if coder is not None:
         return coder
     if field_type_name == type_name.ROW:
-        return RowCoder([from_proto(f.type) for f in field_type.row_schema.fields])
+        return RowCoder([from_proto(f.type) for f in field_type.row_schema.fields],
+                        [f.name for f in field_type.row_schema.fields])
     if field_type_name == type_name.TIMESTAMP:
         return TimestampCoder(field_type.timestamp_info.precision)
     if field_type_name == type_name.LOCAL_ZONED_TIMESTAMP:
@@ -597,7 +600,8 @@ def from_type_info_proto(field_type):
         return _type_info_name_mappings[field_type_name]
     except KeyError:
         if field_type_name == type_info_name.ROW:
-            return RowCoder([from_type_info_proto(f.type) for f in field_type.row_type_info.field])
+            return RowCoder([from_type_info_proto(f.type) for f in field_type.row_type_info.field],
+                            [f.name for f in field_type.row_type_info.field])
 
         if field_type_name == type_info_name.PRIMITIVE_ARRAY:
             return PrimitiveArrayCoder(from_type_info_proto(field_type.collection_element_type))

--- a/flink-python/pyflink/fn_execution/tests/test_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders.py
@@ -157,8 +157,9 @@ class CodersTest(PyFlinkTestCase):
         from pyflink.common import Row, RowKind
         field_coder = BigIntCoder()
         field_count = 10
-        coder = RowCoder([field_coder for _ in range(field_count)])
-        v = Row(*[None if i % 2 == 0 else i for i in range(field_count)])
+        field_names = ['f{}'.format(i) for i in range(field_count)]
+        coder = RowCoder([field_coder for _ in range(field_count)], field_names)
+        v = Row(**{field_names[i]: None if i % 2 == 0 else i for i in range(field_count)})
         v.set_row_kind(RowKind.INSERT)
         self.check_coder(coder, v)
         v.set_row_kind(RowKind.UPDATE_BEFORE)

--- a/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
@@ -212,12 +212,15 @@ class CodersTest(PyFlinkTestCase):
     def test_cython_row_coder(self):
         from pyflink.common import Row, RowKind
         field_count = 2
-        row = Row(*[None if i % 2 == 0 else i for i in range(field_count)])
+        field_names = ['f{}'.format(i) for i in range(field_count)]
+        row = Row(**{field_names[i]: None if i % 2 == 0 else i for i in range(field_count)})
         data = [row]
         python_field_coders = [coder_impl.RowCoderImpl([coder_impl.BigIntCoderImpl()
-                                                        for _ in range(field_count)])]
+                                                        for _ in range(field_count)],
+                                                       field_names)]
         cython_field_coders = [coder_impl_fast.RowCoderImpl([coder_impl_fast.BigIntCoderImpl()
-                                                             for _ in range(field_count)])]
+                                                             for _ in range(field_count)],
+                                                            field_names)]
         row.set_row_kind(RowKind.INSERT)
         self.check_cython_coder(python_field_coders, cython_field_coders, data)
         row.set_row_kind(RowKind.UPDATE_BEFORE)

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -454,8 +454,8 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         ds.map(lambda x: x).add_sink(test_sink)
         self.env.execute("test_to_retract_stream")
         result = test_sink.get_results(True)
-        expected = ["(True, <Row(1, 'Hello')>)", "(False, <Row(1, 'Hello')>)",
-                    "(True, <Row(2, 'Hello')>)"]
+        expected = ["(True, Row(f0=1, f1='Hello'))", "(False, Row(f0=1, f1='Hello'))",
+                    "(True, Row(f0=2, f1='Hello'))"]
         self.assertEqual(result, expected)
 
     def test_collect_null_value_result(self):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Fix the deserialized Row losing the field_name information in PyFlink*


## Brief change log

  - *Add field_names in `RowCoder`*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT in `test_fast_coders.py`*
  - *UT in `test_coders.py`*
  - *Currently IT case*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
