### PR TITLE
[FLINK-20673][table-planner-blink] ExecNode#getOutputType method should return LogicalType instead of RowType

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.List;
 
@@ -41,9 +41,11 @@ public interface ExecNode<T> {
 	String getDesc();
 
 	/**
-	 * Returns the output {@link RowType} of this node.
+	 * Returns the output {@link LogicalType} of this node,
+	 * this type should be consistent with the type parameter {@link T}.
+	 * Such as, T is RowData, the output type should be RowType.
 	 */
-	RowType getOutputType();
+	LogicalType getOutputType();
 
 	/**
 	 * Returns a list of this node's input nodes.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
@@ -19,10 +19,12 @@
 package org.apache.flink.table.planner.plan.nodes.exec;
 
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.List;
 
@@ -43,7 +45,10 @@ public interface ExecNode<T> {
 	/**
 	 * Returns the output {@link LogicalType} of this node,
 	 * this type should be consistent with the type parameter {@link T}.
-	 * Such as, T is RowData, the output type should be RowType.
+	 *
+	 * <p>Such as, if T is {@link RowData}, the output type should be {@link RowType}.
+	 * please refer to the JavaDoc of {@link RowData} for more info about
+	 * mapping of logical types to internal data structures.
 	 */
 	LogicalType getOutputType();
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,7 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 
 	private final String description;
 	private final List<ExecEdge> inputEdges;
-	private final RowType outputType;
+	private final LogicalType outputType;
 	// TODO remove this field once edge support `source` and `target`,
 	//  and then we can get/set `inputNodes` through `inputEdges`.
 	private List<ExecNode<?>> inputNodes;
@@ -48,7 +48,7 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 
 	protected ExecNodeBase(
 			List<ExecEdge> inputEdges,
-			RowType outputType,
+			LogicalType outputType,
 			String description) {
 		this.inputEdges = new ArrayList<>(checkNotNull(inputEdges));
 		this.outputType = checkNotNull(outputType);
@@ -61,7 +61,7 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 	}
 
 	@Override
-	public RowType getOutputType() {
+	public LogicalType getOutputType() {
 		return outputType;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -77,7 +77,7 @@ public class BatchExecExchange extends BatchExecNode<RowData> implements CommonE
 		}
 		sb.append("distribution=[").append(type);
 		if (requiredShuffle.getType() == ExecEdge.ShuffleType.HASH) {
-			RowType inputRowType = getInputNodes().get(0).getOutputType();
+			RowType inputRowType = (RowType) getInputNodes().get(0).getOutputType();
 			String[] fieldNames = Arrays.stream(requiredShuffle.getKeys())
 					.mapToObj(i -> inputRowType.getFieldNames().get(i))
 					.toArray(String[]::new);
@@ -115,8 +115,9 @@ public class BatchExecExchange extends BatchExecNode<RowData> implements CommonE
 				break;
 			case HASH:
 				int[] keys = inputEdge.getRequiredShuffle().getKeys();
+				RowType inputType = (RowType) inputNode.getOutputType();
 				String[] fieldNames = Arrays.stream(keys)
-						.mapToObj(i -> inputNode.getOutputType().getFieldNames().get(i))
+						.mapToObj(i -> inputType.getFieldNames().get(i))
 						.toArray(String[]::new);
 				partitioner = new BinaryHashPartitioner(
 						HashCodeGenerator.generateRowHash(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.delegation.BatchPlanner;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.List;
 
@@ -32,7 +32,7 @@ import java.util.List;
 public abstract class BatchExecNode<T> extends ExecNodeBase<BatchPlanner, T> {
 	public BatchExecNode(
 			List<ExecEdge> inputEdges,
-			RowType outputType,
+			LogicalType outputType,
 			String description) {
 		super(inputEdges, outputType, description);
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Collections;
 import java.util.List;
@@ -80,7 +81,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 				// we should split it into two nodes
 				BatchExecExchange newExchange = new BatchExecExchange(
 					execEdge,
-					exchange.getOutputType(),
+					(RowType) exchange.getOutputType(),
 					"Exchange");
 				newExchange.setRequiredShuffleMode(shuffleMode);
 				newExchange.setInputNodes(exchange.getInputNodes());
@@ -120,7 +121,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 				.build();
 		BatchExecExchange exchange = new BatchExecExchange(
 				execEdge,
-				inputNode.getOutputType(),
+				(RowType) inputNode.getOutputType(),
 				"Exchange");
 		exchange.setInputNodes(Collections.singletonList(inputNode));
 		exchange.setRequiredShuffleMode(shuffleMode);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.delegation.StreamPlanner;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
-import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.List;
 
@@ -32,7 +32,7 @@ import java.util.List;
 public abstract class StreamExecNode<T> extends ExecNodeBase<StreamPlanner, T> {
 	public StreamExecNode(
 			List<ExecEdge> inputEdges,
-			RowType outputType,
+			LogicalType outputType,
 			String description) {
 		super(inputEdges, outputType, description);
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/LegacyExecNodeBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/LegacyExecNodeBase.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.delegation.Planner
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
-import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.util.Preconditions.{checkArgument, checkNotNull}
 
 import org.apache.calcite.rel.RelDistribution
@@ -58,7 +58,7 @@ trait LegacyExecNodeBase[P <: Planner, T] extends ExecNode[T] {
     this.asInstanceOf[FlinkPhysicalRel].getRelDetailedDescription
   }
 
-  override def getOutputType: RowType = {
+  override def getOutputType: LogicalType = {
     FlinkTypeFactory.toLogicalRowType(this.asInstanceOf[FlinkPhysicalRel].getRowType)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.TestingBatchExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -104,7 +105,7 @@ public class InputPriorityConflictResolverTest {
 
 		BatchExecExchange exchange = new BatchExecExchange(
 			ExecEdge.builder().requiredShuffle(ExecEdge.RequiredShuffle.any()).build(),
-			nodes[0].getOutputType(),
+			(RowType) nodes[0].getOutputType(),
 			"Exchange");
 		exchange.setRequiredShuffleMode(ShuffleMode.BATCH);
 		exchange.setInputNodes(Collections.singletonList(nodes[0]));

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/nodes/exec/TestingBatchExecNode.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/nodes/exec/TestingBatchExecNode.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.calcite.{FlinkContextImpl, FlinkRelOptClusterFactory, FlinkRexBuilder, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRel
-import org.apache.flink.table.types.logical.RowType
+import org.apache.flink.table.types.logical.{LogicalType, RowType}
 
 import org.apache.calcite.plan.hep.{HepPlanner, HepProgram}
 import org.apache.calcite.plan.{RelOptCluster, RelOptPlanner, RelTraitSet}
@@ -52,7 +52,7 @@ class TestingBatchExecNode
     inputEdges.add(edge)
   }
 
-  override def getOutputType: RowType = RowType.of()
+  override def getOutputType: LogicalType = RowType.of()
 
   override def getInputNodes: util.List[ExecNode[_]] = inputNodes
 


### PR DESCRIPTION

## What is the purpose of the change

*Currently, ExecNode#getOutputType always returns RowType. But some nodes do not return RowData, such as BatchExecSink and StreamExecSink. The output type of ExecNode should be consistent with the type parameter T. So ExecNode#getOutputType should return LogicalType instead of RowType, each subclass cast the LogicalType to specific type when using it.*


## Brief change log

  - *Change ExecNode#getOutputType's return type from RowType to LogicalType*


## Verifying this change


This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
