### PR TITLE
[FLINK-19369][tests] Disable BlobClientSslTest.testGetFailsDuringStreaming*

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -92,6 +92,11 @@ public class BlobClientSslTest extends BlobClientTest {
 		}
 	}
 
+	@Override
+	protected boolean isSSLEnabled() {
+		return true;
+	}
+
 	protected Configuration getBlobClientConfig() {
 		return sslClientConfig;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * This class contains unit tests for the {@link BlobClient}.
@@ -231,6 +232,10 @@ public class BlobClientTest extends TestLogger {
 	@SuppressWarnings("WeakerAccess")
 	static void validateGetAndClose(final InputStream actualInputStream, final File expectedFile) throws IOException {
 		validateGetAndClose(actualInputStream, new FileInputStream(expectedFile));
+	}
+
+	protected boolean isSSLEnabled() {
+		return false;
 	}
 
 	@Test
@@ -419,6 +424,8 @@ public class BlobClientTest extends TestLogger {
 	 */
 	private void testGetFailsDuringStreaming(@Nullable final JobID jobId, BlobKey.BlobType blobType)
 			throws IOException {
+
+		assumeFalse("This test can deadlock when using SSL. See FLINK-19369.", isSSLEnabled());
 
 		try (BlobClient client = new BlobClient(
 			new InetSocketAddress("localhost", getBlobServer().getPort()), getBlobClientConfig())) {


### PR DESCRIPTION
The test cases BlobClientSslTest.testGetFailsDuringStreamingForJobPermanentBlob,
.testGetFailsDuringStreamingNoJobTransientBlob and .testgetFailsDuringStreamingForJobTransientBlob
can deadlock when being used with SSL enabled because an SSL stream can deadlock when
not being consumed and closed at the same time.

cc @NicoK 