### PR TITLE
[FLINK-20666][python] Fix the deserialized Row losing the field_name information in PyFlink

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -117,8 +117,9 @@ class FlattenRowCoderImpl(StreamCoderImpl):
 
 class RowCoderImpl(FlattenRowCoderImpl):
 
-    def __init__(self, field_coders):
+    def __init__(self, field_coders, field_names):
         super(RowCoderImpl, self).__init__(field_coders)
+        self.field_names = field_names
 
     def encode_to_stream(self, value, out_stream, nested):
         field_coders = self._field_coders
@@ -129,7 +130,9 @@ class RowCoderImpl(FlattenRowCoderImpl):
                 field_coders[i].encode_to_stream(item, out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
-        return Row(*self._decode_one_row_from_stream(in_stream, nested))
+        row = Row(*self._decode_one_row_from_stream(in_stream, nested))
+        row.set_field_names(self.field_names)
+        return row
 
     def __repr__(self):
         return 'RowCoderImpl[%s]' % ', '.join(str(c) for c in self._field_coders)

--- a/flink-python/pyflink/fn_execution/fast_coder_impl.pxd
+++ b/flink-python/pyflink/fn_execution/fast_coder_impl.pxd
@@ -215,3 +215,4 @@ cdef class MapCoderImpl(BaseCoder):
 
 cdef class RowCoderImpl(BaseCoder):
     cdef readonly list field_coders
+    cdef readonly list field_names

--- a/flink-python/pyflink/fn_execution/tests/test_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders.py
@@ -149,8 +149,9 @@ class CodersTest(unittest.TestCase):
         from pyflink.table import Row
         field_coder = BigIntCoder()
         field_count = 10
-        coder = RowCoder([field_coder for _ in range(field_count)])
-        v = Row(*[None if i % 2 == 0 else i for i in range(field_count)])
+        field_names = ['f{}'.format(i) for i in range(field_count)]
+        coder = RowCoder([field_coder for _ in range(field_count)], field_names)
+        v = Row(**{field_names[i]: None if i % 2 == 0 else i for i in range(field_count)})
         self.check_coder(coder, v)
 
 

--- a/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
@@ -201,11 +201,14 @@ class CodersTest(unittest.TestCase):
     def test_cython_row_coder(self):
         from pyflink.table import Row
         field_count = 2
-        data = [Row(*[None if i % 2 == 0 else i for i in range(field_count)])]
+        field_names = ['f{}'.format(i) for i in range(field_count)]
+        data = [Row(**{field_names[i]: None if i % 2 == 0 else i for i in range(field_count)})]
         python_field_coders = [coder_impl.RowCoderImpl([coder_impl.BigIntCoderImpl()
-                                                        for _ in range(field_count)])]
+                                                        for _ in range(field_count)],
+                                                       field_names)]
         cython_field_coders = [fast_coder_impl.RowCoderImpl([fast_coder_impl.BigIntCoderImpl()
-                                                             for _ in range(field_count)])]
+                                                             for _ in range(field_count)],
+                                                            field_names)]
         self.check_cython_coder(python_field_coders, cython_field_coders, [data])
 
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -28,6 +28,7 @@ from functools import reduce
 from threading import RLock
 
 from py4j.java_gateway import get_java_class
+from typing import List
 
 from pyflink.util.utils import to_jarray, is_instance_of
 from pyflink.java_gateway import get_gateway
@@ -1964,6 +1965,9 @@ class Row(tuple):
             return dict(zip(self._fields, (conv(o) for o in self)))
         else:
             return dict(zip(self._fields, self))
+
+    def set_field_names(self, field_names: List):
+        self._fields = field_names
 
     def __contains__(self, item):
         if hasattr(self, "_fields"):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Fix the deserialized Row losing the field_name information in PyFlink*


## Brief change log

  - *Add field_names in `RowCoder`*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT in `test_fast_coders.py`*
  - *UT in `test_coders.py`*
  - *Currently IT case*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
