### PR TITLE
[FLINK-20623][table-planner-blink] Introduce StreamPhysicalWatermarkAssigner, and make StreamExecWatermarkAssigner only extended from ExecNode

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.WatermarkGeneratorCodeGenerator;
+import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
+import org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperatorFactory;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexNode;
+
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Stream exec node which generates watermark based on the input elements.
+ */
+public class StreamExecWatermarkAssigner extends StreamExecNode<RowData> {
+	private final RexNode watermarkExpr;
+	private final int rowtimeFieldIndex;
+
+	public StreamExecWatermarkAssigner(
+			RexNode watermarkExpr,
+			int rowtimeFieldIndex,
+			ExecEdge inputEdge,
+			RowType outputType,
+			String description) {
+		super(Collections.singletonList(inputEdge), outputType, description);
+		this.watermarkExpr = watermarkExpr;
+		this.rowtimeFieldIndex = rowtimeFieldIndex;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+		final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
+		final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+
+		final TableConfig tableConfig = planner.getTableConfig();
+
+		final GeneratedWatermarkGenerator watermarkGenerator =
+				WatermarkGeneratorCodeGenerator.generateWatermarkGenerator(
+						tableConfig,
+						(RowType) inputNode.getOutputType(),
+						watermarkExpr,
+						JavaScalaConversionUtil.toScala(Optional.empty()));
+
+		final long idleTimeout = tableConfig.getConfiguration().get(
+				ExecutionConfigOptions.TABLE_EXEC_SOURCE_IDLE_TIMEOUT).toMillis();
+
+		final WatermarkAssignerOperatorFactory operatorFactory = new WatermarkAssignerOperatorFactory(
+				rowtimeFieldIndex,
+				idleTimeout,
+				watermarkGenerator);
+
+		return new OneInputTransformation<>(
+				inputTransform,
+				getDesc(),
+				operatorFactory,
+				InternalTypeInfo.of(getOutputType()),
+				inputTransform.getParallelism());
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.planner.plan.rules.physical.stream;
 
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecWatermarkAssigner;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalc;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalChangelogNormalize;
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWatermarkAssigner;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
@@ -34,7 +34,7 @@ import java.util.Collections;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * Transpose {@link StreamExecWatermarkAssigner} past into {@link StreamPhysicalChangelogNormalize}.
+ * Transpose {@link StreamPhysicalWatermarkAssigner} past into {@link StreamPhysicalChangelogNormalize}.
  */
 public class WatermarkAssignerChangelogNormalizeTransposeRule
 	extends RelRule<WatermarkAssignerChangelogNormalizeTransposeRule.Config> {
@@ -57,7 +57,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 
 	@Override
 	public void onMatch(RelOptRuleCall call) {
-		final StreamExecWatermarkAssigner watermark = call.rel(0);
+		final StreamPhysicalWatermarkAssigner watermark = call.rel(0);
 		final RelNode node = call.rel(1);
 		if (node instanceof StreamPhysicalCalc) {
 			// with calc
@@ -114,7 +114,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 
 		default Config withCalc() {
 			return withOperandSupplier(b0 ->
-				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
+				b0.operand(StreamPhysicalWatermarkAssigner.class).oneInput(
 					b1 -> b1.operand(StreamPhysicalCalc.class).oneInput(
 						b2 -> b2.operand(StreamPhysicalChangelogNormalize.class).oneInput(
 							b3 -> b3.operand(StreamPhysicalExchange.class).anyInputs()))))
@@ -123,7 +123,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
 
 		default Config withoutCalc() {
 			return withOperandSupplier(b0 ->
-				b0.operand(StreamExecWatermarkAssigner.class).oneInput(
+				b0.operand(StreamPhysicalWatermarkAssigner.class).oneInput(
 					b1 -> b1.operand(StreamPhysicalChangelogNormalize.class).oneInput(
 						b2 -> b2.operand(StreamPhysicalExchange.class).anyInputs())))
 				.as(Config.class);

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -233,7 +233,7 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
   }
 
   def getRelModifiedMonotonicity(
-      rel: StreamExecWatermarkAssigner,
+      rel: StreamPhysicalWatermarkAssigner,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
     getMonotonicity(rel.getInput, mq, rel.getRowType.getFieldCount)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -18,18 +18,11 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.flink.api.dag.Transformation
-import org.apache.flink.streaming.api.transformations.OneInputTransformation
-import org.apache.flink.table.api.config.ExecutionConfigOptions
-import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.codegen.WatermarkGeneratorCodeGenerator
-import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
-import org.apache.flink.table.planner.plan.nodes.exec.LegacyStreamExecNode
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNode}
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil.preferExpressionFormat
-import org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperatorFactory
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, RelWriter}
@@ -38,17 +31,16 @@ import org.apache.calcite.rex.RexNode
 import scala.collection.JavaConversions._
 
 /**
-  * Stream physical RelNode for [[WatermarkAssigner]].
-  */
-class StreamExecWatermarkAssigner(
+ * Stream physical RelNode for [[WatermarkAssigner]].
+ */
+class StreamPhysicalWatermarkAssigner(
     cluster: RelOptCluster,
     traits: RelTraitSet,
     inputRel: RelNode,
     rowtimeFieldIndex: Int,
     watermarkExpr: RexNode)
   extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkExpr)
-  with StreamPhysicalRel
-  with LegacyStreamExecNode[RowData] {
+  with StreamPhysicalRel {
 
   override def requireWatermark: Boolean = false
 
@@ -57,12 +49,12 @@ class StreamExecWatermarkAssigner(
       input: RelNode,
       rowtime: Int,
       watermark: RexNode): RelNode = {
-    new StreamExecWatermarkAssigner(cluster, traitSet, input, rowtime, watermark)
+    new StreamPhysicalWatermarkAssigner(cluster, traitSet, input, rowtime, watermark)
   }
 
   /**
-    * Fully override this method to have a better display name of this RelNode.
-    */
+   * Fully override this method to have a better display name of this RelNode.
+   */
   override def explainTerms(pw: RelWriter): RelWriter = {
     val inFieldNames = inputRel.getRowType.getFieldNames.toList
     val rowtimeFieldName = inFieldNames(rowtimeFieldIndex)
@@ -75,35 +67,12 @@ class StreamExecWatermarkAssigner(
         preferExpressionFormat(pw)))
   }
 
-  //~ ExecNode methods -----------------------------------------------------------
-
-  override protected def translateToPlanInternal(
-      planner: StreamPlanner): Transformation[RowData] = {
-    val inputTransformation = getInputNodes.get(0).translateToPlan(planner)
-      .asInstanceOf[Transformation[RowData]]
-
-    val config = planner.getTableConfig
-    val idleTimeout = config.getConfiguration.get(
-      ExecutionConfigOptions.TABLE_EXEC_SOURCE_IDLE_TIMEOUT).toMillis
-
-    val watermarkGenerator = WatermarkGeneratorCodeGenerator.generateWatermarkGenerator(
-      config,
-      FlinkTypeFactory.toLogicalRowType(inputRel.getRowType),
-      watermarkExpr)
-
-    val operatorFactory = new WatermarkAssignerOperatorFactory(
-        rowtimeFieldIndex,
-        idleTimeout,
-        watermarkGenerator)
-
-    val outputRowTypeInfo = InternalTypeInfo.of(FlinkTypeFactory.toLogicalRowType(getRowType))
-    val transformation = new OneInputTransformation[RowData, RowData](
-      inputTransformation,
-      getRelDetailedDescription,
-      operatorFactory,
-      outputRowTypeInfo,
-      inputTransformation.getParallelism)
-    transformation
+  override def translateToExecNode(): ExecNode[_] = {
+    new StreamExecWatermarkAssigner(
+      watermarkExpr,
+      rowtimeFieldIndex,
+      ExecEdge.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription)
   }
-
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -274,7 +274,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
       case _: StreamPhysicalCalcBase | _: StreamExecCorrelate |
            _: StreamExecPythonCorrelate | _: StreamExecLookupJoin | _: StreamPhysicalExchange |
            _: StreamExecExpand | _: StreamExecMiniBatchAssigner |
-           _: StreamExecWatermarkAssigner =>
+           _: StreamPhysicalWatermarkAssigner =>
         // transparent forward requiredTrait to children
         val children = visitChildren(rel, requiredTrait, requester)
         val childrenTrait = children.head.getTraitSet.getTrait(ModifyKindSetTraitDef.INSTANCE)
@@ -573,7 +573,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
 
       case _: StreamExecCorrelate | _: StreamExecPythonCorrelate | _: StreamExecLookupJoin |
            _: StreamPhysicalExchange | _: StreamExecExpand | _: StreamExecMiniBatchAssigner |
-           _: StreamExecWatermarkAssigner =>
+           _: StreamPhysicalWatermarkAssigner =>
         // transparent forward requiredTrait to children
         visitChildren(rel, requiredTrait) match {
           case None => None

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -399,7 +399,7 @@ object FlinkStreamRuleSets {
     StreamPhysicalTableSourceScanRule.INSTANCE,
     StreamPhysicalLegacyTableSourceScanRule.INSTANCE,
     StreamExecIntermediateTableScanRule.INSTANCE,
-    StreamExecWatermarkAssignerRule.INSTANCE,
+    StreamPhysicalWatermarkAssignerRule.INSTANCE,
     StreamExecValuesRule.INSTANCE,
     // calc
     StreamPhysicalCalcRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/MiniBatchIntervalInferRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/MiniBatchIntervalInferRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode}
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecGroupWindowAggregate, StreamExecMiniBatchAssigner, StreamExecWatermarkAssigner, StreamPhysicalDataStreamScan, StreamPhysicalLegacyTableSourceScan, StreamPhysicalRel, StreamPhysicalTableSourceScan}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecGroupWindowAggregate, StreamExecMiniBatchAssigner, StreamPhysicalDataStreamScan, StreamPhysicalLegacyTableSourceScan, StreamPhysicalRel, StreamPhysicalTableSourceScan, StreamPhysicalWatermarkAssigner}
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 
 import org.apache.calcite.plan.RelOptRule._
@@ -39,7 +39,7 @@ import scala.collection.JavaConversions._
   * created if not exist, and the interval value will be set as
   * [[ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ALLOW_LATENCY]].
   * 2. supports operators which requires watermark, e.g. window join, window aggregate.
-  * In this case, [[StreamExecWatermarkAssigner]] already exists, and its MiniBatchIntervalTrait
+  * In this case, [[StreamPhysicalWatermarkAssigner]] already exists, and its MiniBatchIntervalTrait
   * will be updated as the merged intervals from its outputs.
   * Currently, mini-batched window aggregate is not supported, and will be introduced later.
   *
@@ -72,7 +72,7 @@ class MiniBatchIntervalInferRule extends RelOptRule(
         // TODO introduce mini-batch window aggregate later
         MiniBatchIntervalTrait.NO_MINIBATCH
 
-      case _: StreamExecWatermarkAssigner => MiniBatchIntervalTrait.NONE
+      case _: StreamPhysicalWatermarkAssigner => MiniBatchIntervalTrait.NONE
 
       case _: StreamExecMiniBatchAssigner => MiniBatchIntervalTrait.NONE
 
@@ -127,7 +127,7 @@ class MiniBatchIntervalInferRule extends RelOptRule(
            _: StreamPhysicalTableSourceScan =>
         // append minibatch node if the mode is not NONE and reach a source leaf node
         mode == MiniBatchMode.RowTime || mode == MiniBatchMode.ProcTime
-      case _: StreamExecWatermarkAssigner  =>
+      case _: StreamPhysicalWatermarkAssigner  =>
         // append minibatch node if it is rowtime mode and the child is watermark assigner
         // TODO: if it is ProcTime mode, we also append a minibatch node for now.
         //  Because the downstream can be a regular aggregate and the watermark assigner

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWatermarkAssignerRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWatermarkAssignerRule.scala
@@ -22,17 +22,17 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWatermarkAssigner
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecWatermarkAssigner
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWatermarkAssigner
 
 /**
-  * Rule that converts [[FlinkLogicalWatermarkAssigner]] to [[StreamExecWatermarkAssigner]].
+  * Rule that converts [[FlinkLogicalWatermarkAssigner]] to [[StreamPhysicalWatermarkAssigner]].
   */
-class StreamExecWatermarkAssignerRule
+class StreamPhysicalWatermarkAssignerRule
   extends ConverterRule(
     classOf[FlinkLogicalWatermarkAssigner],
     FlinkConventions.LOGICAL,
     FlinkConventions.STREAM_PHYSICAL,
-    "StreamExecWatermarkAssignerRule") {
+    "StreamPhysicalWatermarkAssignerRule") {
 
   override def convert(rel: RelNode): RelNode = {
     val watermarkAssigner = rel.asInstanceOf[FlinkLogicalWatermarkAssigner]
@@ -40,7 +40,7 @@ class StreamExecWatermarkAssignerRule
       watermarkAssigner.getInput, FlinkConventions.STREAM_PHYSICAL)
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
 
-    new StreamExecWatermarkAssigner(
+    new StreamPhysicalWatermarkAssigner(
       watermarkAssigner.getCluster,
       traitSet,
       convertInput,
@@ -50,6 +50,6 @@ class StreamExecWatermarkAssignerRule
   }
 }
 
-object StreamExecWatermarkAssignerRule {
-  val INSTANCE = new StreamExecWatermarkAssignerRule
+object StreamPhysicalWatermarkAssignerRule {
+  val INSTANCE = new StreamPhysicalWatermarkAssignerRule
 }


### PR DESCRIPTION
## What is the purpose of the change

*Separate the implementation of StreamExecWatermarkAssigner*


## Brief change log

  - *Introduce StreamPhysicalWatermarkAssigner, and make StreamExecWatermarkAssigner only extended from ExecNode*


## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
