### PR TITLE
[FLINK-11719] Do not reuse JobMaster instances across leader sessions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -425,13 +425,4 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 		log.error("Leader Election Service encountered a fatal error.", exception);
 		handleJobManagerRunnerError(exception);
 	}
-
-	//----------------------------------------------------------------------------------------------
-	// Testing
-	//----------------------------------------------------------------------------------------------
-
-	@VisibleForTesting
-	boolean isShutdown() {
-		return shutdown;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -186,11 +186,16 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId> impleme
 
 	private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
 
+	// -------- Misc ---------
+
+	private final Map<String, Object> accumulators;
+
+	private final JobMasterPartitionTracker partitionTracker;
+
+	private final ExecutionDeploymentTracker executionDeploymentTracker;
+	private final ExecutionDeploymentReconciler executionDeploymentReconciler;
+
 	// -------- Mutable fields ---------
-
-	private HeartbeatManager<TaskExecutorToJobManagerHeartbeatPayload, AllocatedSlotReport> taskManagerHeartbeatManager;
-
-	private HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
 	@Nullable
 	private ResourceManagerAddress resourceManagerAddress;
@@ -201,12 +206,9 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId> impleme
 	@Nullable
 	private EstablishedResourceManagerConnection establishedResourceManagerConnection;
 
-	private Map<String, Object> accumulators;
+	private HeartbeatManager<TaskExecutorToJobManagerHeartbeatPayload, AllocatedSlotReport> taskManagerHeartbeatManager;
 
-	private final JobMasterPartitionTracker partitionTracker;
-
-	private final ExecutionDeploymentTracker executionDeploymentTracker;
-	private final ExecutionDeploymentReconciler executionDeploymentReconciler;
+	private HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterService.java
@@ -18,33 +18,12 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.util.AutoCloseableAsync;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface which specifies the JobMaster service.
  */
 public interface JobMasterService extends AutoCloseableAsync {
-
-	/**
-	 * Start the JobMaster service with the given {@link JobMasterId}.
-	 *
-	 * @param jobMasterId to start the service with
-	 * @return Future which is completed once the JobMaster service has been started
-	 * @throws Exception if the JobMaster service could not be started
-	 */
-	CompletableFuture<Acknowledge> start(JobMasterId jobMasterId) throws Exception;
-
-	/**
-	 * Suspend the JobMaster service. This means that the service will stop to react
-	 * to messages.
-	 *
-	 * @param cause for the suspension
-	 * @return Future which is completed once the JobMaster service has been suspended
-	 */
-	CompletableFuture<Acknowledge> suspend(Exception cause);
 
 	/**
 	 * Get the {@link JobMasterGateway} belonging to this service.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -94,6 +94,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
 		final JobMaster jobMaster = new JobMaster(
 			rpcService,
+			jobMasterId,
 			jobMasterConfiguration,
 			ResourceID.generate(),
 			jobGraph,
@@ -116,7 +117,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 			DefaultExecutionDeploymentReconciler::new,
 			initializationTimestamp);
 
-		jobMaster.start(jobMasterId).join();
+		jobMaster.start();
 
 		return jobMaster;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -86,11 +87,12 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 	@Override
 	public JobMaster createJobMasterService(
 			JobGraph jobGraph,
+			JobMasterId jobMasterId,
 			OnCompletionActions jobCompletionActions,
 			ClassLoader userCodeClassloader,
 			long initializationTimestamp) throws Exception {
 
-		return new JobMaster(
+		final JobMaster jobMaster = new JobMaster(
 			rpcService,
 			jobMasterConfiguration,
 			ResourceID.generate(),
@@ -113,5 +115,9 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 			new DefaultExecutionDeploymentTracker(),
 			DefaultExecutionDeploymentReconciler::new,
 			initializationTimestamp);
+
+		jobMaster.start(jobMasterId).join();
+
+		return jobMaster;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster.factories;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterService;
 
 /**
@@ -29,6 +30,7 @@ public interface JobMasterServiceFactory {
 
 	JobMasterService createJobMasterService(
 		JobGraph jobGraph,
+		JobMasterId jobMasterId,
 		OnCompletionActions jobCompletionActions,
 		ClassLoader userCodeClassloader,
 		long initializationTimestamp) throws Exception;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -438,6 +438,7 @@ public class DispatcherTest extends TestLogger {
 	@Test
 	public void testErrorDuringInitialization() throws Exception {
 		dispatcher = createAndStartDispatcher(heartbeatServices, haServices, new ExpectedJobIdJobManagerRunnerFactory(TEST_JOB_ID, createdJobManagerRunnerLatch));
+		jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
 		DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
 		// create a job graph that fails during initialization
@@ -588,6 +589,7 @@ public class DispatcherTest extends TestLogger {
 	@Test
 	public void testFatalErrorIfRecoveredJobsCannotBeStarted() throws Exception {
 		final FlinkException testException = new FlinkException("Test exception");
+		jobMasterLeaderElectionService.isLeader(UUID.randomUUID());
 
 		final JobGraph failingJobGraph = createFailingJobGraph(testException);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
@@ -169,7 +169,7 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
 			.withOnCompletionActions(onCompletionActions)
 			.createJobMaster();
 
-		jobMaster.start(JobMasterId.generate()).get();
+		jobMaster.start();
 
 		return jobMaster;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -199,7 +199,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 				.withPartitionTrackerFactory(ignored -> partitionTracker)
 				.createJobMaster();
 
-			jobMaster.start(JobMasterId.generate()).get();
+			jobMaster.start();
 
 			registerTaskExecutorAtJobMaster(
 				rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -26,17 +26,13 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
-import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
-import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
-import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
@@ -44,11 +40,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -60,32 +55,27 @@ public class JobMasterSchedulerTest extends TestLogger {
 	@ClassRule
 	public static final TestingRpcServiceResource TESTING_RPC_SERVICE_RESOURCE = new TestingRpcServiceResource();
 
-	private final Duration testingTimeout = Duration.ofSeconds(10L);
-
-
 	/**
-	 * Tests that we fail fatally if we cannot start the scheduling. See FLINK-20382.
+	 * Tests that the JobMaster fails if we cannot start the scheduling. See FLINK-20382.
 	 */
 	@Test
-	public void testIfStartSchedulingFailsJobMasterFailsFatally() throws Exception {
-		final SystemExitTrackingSecurityManager trackingSecurityManager = new SystemExitTrackingSecurityManager();
-		System.setSecurityManager(trackingSecurityManager);
-
+	public void testIfStartSchedulingFailsJobMasterFails() throws Exception {
 		final SchedulerNGFactory schedulerFactory = new FailingSchedulerFactory();
-		final JobMaster jobMaster = new JobMasterBuilder(new JobGraph(), TESTING_RPC_SERVICE_RESOURCE
-			.getTestingRpcService())
+		final JobMasterBuilder.TestingOnCompletionActions onCompletionActions = new JobMasterBuilder.TestingOnCompletionActions();
+		final JobMaster jobMaster = new JobMasterBuilder(new JobGraph(), TESTING_RPC_SERVICE_RESOURCE.getTestingRpcService())
 			.withSchedulerFactory(schedulerFactory)
+			.withOnCompletionActions(onCompletionActions)
 			.createJobMaster();
 
-		final CompletableFuture<Acknowledge> startFuture = jobMaster.start(JobMasterId.generate());
+		jobMaster.start();
 
+		assertThat(onCompletionActions.getJobMasterFailedFuture().join(), is(instanceOf(JobMasterException.class)));
+
+		// close the jobMaster to remove it from the testing rpc service so that it can shut down cleanly
 		try {
-			startFuture.join();
-
-			assertThat(trackingSecurityManager.getSystemExitFuture().join(), is(FatalExitExceptionHandler.EXIT_CODE));
-		} finally {
-			RpcUtils.terminateRpcEndpoint(jobMaster, Time.milliseconds(testingTimeout.toMillis()));
-			System.setSecurityManager(null);
+			jobMaster.close();
+		} catch (Exception expected) {
+			// expected
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -65,7 +65,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
@@ -83,7 +82,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobgraph.utils.JobGraphTestUtils;
-import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
@@ -108,6 +106,8 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
+import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
+import org.apache.flink.runtime.scheduler.TestingSchedulerNGFactory;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -140,7 +140,6 @@ import akka.actor.ActorSystem;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -282,66 +281,6 @@ public class JobMasterTest extends TestLogger {
 		}
 	}
 
-	/**
-	 * This test ensures that the bookkeeping of TaskExecutors in the JobMaster handles cases where TaskExecutors with the same
-	 * ID re-register properly. FLINK-19237 was a bug where the TaskExecutors and the SlotPool got out of sync, and
-	 * slot offers were rejected.
-	 */
-	@Test
-	public void testAcceptSlotOfferAfterLeaderChange() throws Exception {
-
-		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
-		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
-
-		final SchedulerNGFactory schedulerNGFactory = SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration);
-
-		final JobMaster testingJobMaster = new JobMaster(
-			rpcService,
-			jobMasterConfiguration,
-			jmResourceId,
-			JobGraphTestUtils.createSingleVertexJobGraph(),
-			haServices,
-			SlotPoolFactory.fromConfiguration(configuration),
-			jobManagerSharedServices,
-			heartbeatServices,
-			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
-			new JobMasterBuilder.TestingOnCompletionActions(),
-			testingFatalErrorHandler,
-			JobMasterTest.class.getClassLoader(),
-			schedulerNGFactory,
-			NettyShuffleMaster.INSTANCE,
-			NoOpJobMasterPartitionTracker.FACTORY,
-			new DefaultExecutionDeploymentTracker(),
-			DefaultExecutionDeploymentReconciler::new,
-			System.currentTimeMillis());
-
-		testingJobMaster.start(jobMasterId).get();
-
-		JobMasterGateway jobMasterGateway = testingJobMaster.getSelfGateway(JobMasterGateway.class);
-
-		log.info("Register TaskManager");
-
-		String testingTaskManagerAddress = "fake";
-		UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
-		TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
-		rpcService.registerGateway(testingTaskManagerAddress, testingTaskExecutorGateway);
-		Assert.assertThat(jobMasterGateway.registerTaskManager(testingTaskManagerAddress, unresolvedTaskManagerLocation, testingTimeout).get(), instanceOf(RegistrationResponse.Success.class));
-
-		log.info("Revoke leadership & re-grant leadership");
-		testingJobMaster.suspend(new FlinkException("Lost leadership")).get();
-
-		testingJobMaster.start(JobMasterId.generate()).get();
-
-		log.info("re-register same TaskManager");
-		Assert.assertThat(jobMasterGateway.registerTaskManager(testingTaskManagerAddress, unresolvedTaskManagerLocation, testingTimeout).get(), instanceOf(RegistrationResponse.Success.class));
-
-		log.info("Ensure JobMaster accepts slot offer");
-		final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY);
-
-		Collection<SlotOffer> acceptedSlots = jobMasterGateway.offerSlots(unresolvedTaskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout).get();
-		Assert.assertThat(acceptedSlots.size(), is(1));
-	}
-
 	@Test
 	public void testDeclineCheckpointInvocationWithUserException() throws Exception {
 		RpcService rpcService1 = null;
@@ -363,6 +302,7 @@ public class JobMasterTest extends TestLogger {
 
 			final JobMaster jobMaster = new JobMaster(
 				rpcService1,
+				JobMasterId.generate(),
 				jobMasterConfiguration,
 				jmResourceId,
 				jobGraph,
@@ -386,7 +326,7 @@ public class JobMasterTest extends TestLogger {
 				}
 			};
 
-			jobMaster.start(jobMasterId).get();
+			jobMaster.start();
 
 			final String className = "UserException";
 			final URLClassLoader userClassLoader = ClassLoaderUtils.compileAndLoadJava(
@@ -430,20 +370,16 @@ public class JobMasterTest extends TestLogger {
 
 		rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withResourceId(jmResourceId)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(fastHeartbeatServices)
+			.createJobMaster();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			jobManagerSharedServices);
-
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 			// register task manager will trigger monitor heartbeat target, schedule heartbeat request at interval time
@@ -463,7 +399,6 @@ public class JobMasterTest extends TestLogger {
 
 			assertThat(heartbeatResourceId, anyOf(nullValue(), equalTo(jmResourceId)));
 		} finally {
-			jobManagerSharedServices.shutdown();
 			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
 		}
 	}
@@ -508,12 +443,9 @@ public class JobMasterTest extends TestLogger {
 			.withSlotPoolFactory(new TestingSlotPoolFactory(hasReceivedSlotOffers))
 			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 			// register task manager will trigger monitor heartbeat target, schedule heartbeat request at interval time
@@ -725,20 +657,18 @@ public class JobMasterTest extends TestLogger {
 
 		rpcService.registerGateway(resourceManagerAddress, resourceManagerGateway);
 
-		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			jobManagerSharedServices);
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withJobMasterId(jobMasterId)
+			.withResourceId(jmResourceId)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(fastHeartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 
 		try {
-			// wait for the start operation to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// define a leader and see that a registration happens
 			rmLeaderRetrievalService.notifyListener(resourceManagerAddress, resourceManagerId.toUUID());
 
@@ -759,7 +689,6 @@ public class JobMasterTest extends TestLogger {
 			// the JobMaster should try to reconnect to the RM
 			registrationAttempts.await();
 		} finally {
-			jobManagerSharedServices.shutdown();
 			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
 		}
 	}
@@ -784,11 +713,10 @@ public class JobMasterTest extends TestLogger {
 		final StandaloneCompletedCheckpointStore completedCheckpointStore = new StandaloneCompletedCheckpointStore(1);
 		final CheckpointRecoveryFactory testingCheckpointRecoveryFactory = useSameServicesForAllJobs(completedCheckpointStore, new StandaloneCheckpointIDCounter());
 		haServices.setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory);
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withHighAvailabilityServices(haServices)
+			.createJobMaster();
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -829,11 +757,9 @@ public class JobMasterTest extends TestLogger {
 		haServices.setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory);
 
 		try {
-			createJobMaster(
-				configuration,
-				jobGraphWithNewOperator,
-				haServices,
-				new TestingJobManagerSharedServicesBuilder().build());
+			new JobMasterBuilder(jobGraphWithNewOperator, rpcService)
+				.withHighAvailabilityServices(haServices)
+				.createJobMaster();
 			fail("Should fail because we cannot resume the changed JobGraph from the savepoint.");
 		} catch (IllegalStateException expected) {
 			// that was expected :-)
@@ -845,11 +771,9 @@ public class JobMasterTest extends TestLogger {
 				savepointFile.getAbsolutePath(),
 				true));
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraphWithNewOperator,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraphWithNewOperator, rpcService)
+			.withHighAvailabilityServices(haServices)
+			.createJobMaster();
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -898,11 +822,7 @@ public class JobMasterTest extends TestLogger {
 		final CheckpointRecoveryFactory testingCheckpointRecoveryFactory = useSameServicesForAllJobs(completedCheckpointStore, new StandaloneCheckpointIDCounter());
 		haServices.setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory);
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService).createJobMaster();
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -927,18 +847,17 @@ public class JobMasterTest extends TestLogger {
 		final long slotRequestTimeout = 10L;
 		configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout);
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			restartingJobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(restartingJobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
 			final long start = System.nanoTime();
-			jobMaster.start(JobMasterId.generate()).get();
+			jobMaster.start();
 
 			final CompletableFuture<TaskDeploymentDescriptor> submittedTaskFuture = new CompletableFuture<>();
 			final LocalUnresolvedTaskManagerLocation taskManagerUnresolvedLocation = new LocalUnresolvedTaskManagerLocation();
@@ -983,14 +902,13 @@ public class JobMasterTest extends TestLogger {
 	 */
 	@Test
 	public void testCloseUnestablishedResourceManagerConnection() throws Exception {
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.createJobMaster();
 
 		try {
-			jobMaster.start(JobMasterId.generate()).get();
+			jobMaster.start();
 
 			final TestingResourceManagerGateway firstResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
 			final TestingResourceManagerGateway secondResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
@@ -1030,20 +948,18 @@ public class JobMasterTest extends TestLogger {
 	 */
 	@Test
 	public void testReconnectionAfterDisconnect() throws Exception {
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withJobMasterId(jobMasterId)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
+
+		jobMaster.start();
 
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
-
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 			final TestingResourceManagerGateway testingResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
 			final BlockingQueue<JobMasterId> registrationsQueue = new ArrayBlockingQueue<>(1);
 
@@ -1074,20 +990,15 @@ public class JobMasterTest extends TestLogger {
 	 * Tests that the a JM connects to the leading RM after regaining leadership.
 	 */
 	@Test
-	public void testResourceManagerConnectionAfterRegainingLeadership() throws Exception {
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
-
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+	public void testResourceManagerConnectionAfterStart() throws Exception {
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withJobMasterId(jobMasterId)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			final TestingResourceManagerGateway testingResourceManagerGateway = createAndRegisterTestingResourceManagerGateway();
 
 			final BlockingQueue<JobMasterId> registrationQueue = new ArrayBlockingQueue<>(1);
@@ -1098,19 +1009,11 @@ public class JobMasterTest extends TestLogger {
 
 			notifyResourceManagerLeaderListeners(testingResourceManagerGateway);
 
+			jobMaster.start();
+
 			final JobMasterId firstRegistrationAttempt = registrationQueue.take();
 
 			assertThat(firstRegistrationAttempt, equalTo(jobMasterId));
-
-			jobMaster.suspend(new FlinkException("Test exception.")).get();
-
-			final JobMasterId jobMasterId2 = JobMasterId.generate();
-
-			jobMaster.start(jobMasterId2).get();
-
-			final JobMasterId secondRegistrationAttempt = registrationQueue.take();
-
-			assertThat(secondRegistrationAttempt, equalTo(jobMasterId2));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
 		}
@@ -1166,19 +1069,15 @@ public class JobMasterTest extends TestLogger {
 		executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(100, 0));
 		inputSplitJobGraph.setExecutionConfig(executionConfig);
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			inputSplitJobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(inputSplitJobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 			final JobVertexID sourceId = source.getID();
@@ -1377,20 +1276,17 @@ public class JobMasterTest extends TestLogger {
 	public void testRequestKvStateWithoutRegistration() throws Exception {
 		final JobGraph graph = createKvJobGraph();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			graph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(graph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
+
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// lookup location
 			try {
 				jobMasterGateway.requestKvStateLocation(graph.getJobID(), "unknown").get();
@@ -1407,20 +1303,17 @@ public class JobMasterTest extends TestLogger {
 	public void testRequestKvStateOfWrongJob() throws Exception {
 		final JobGraph graph = createKvJobGraph();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			graph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(graph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
+
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// lookup location
 			try {
 				jobMasterGateway.requestKvStateLocation(new JobID(), "unknown").get();
@@ -1452,20 +1345,17 @@ public class JobMasterTest extends TestLogger {
 	public void testRequestKvStateWithIrrelevantRegistration() throws Exception {
 		final JobGraph graph = createKvJobGraph();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			graph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(graph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
+
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// register an irrelevant KvState
 			try {
 				jobMasterGateway.notifyKvStateRegistered(
@@ -1490,20 +1380,17 @@ public class JobMasterTest extends TestLogger {
 		final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
 		final JobVertex vertex1 = jobVertices.get(0);
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			graph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(graph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
+
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// register a KvState
 			final String registrationName = "register-me";
 			final KvStateID kvStateID = new KvStateID();
@@ -1553,20 +1440,17 @@ public class JobMasterTest extends TestLogger {
 		final JobVertex vertex1 = jobVertices.get(0);
 		final JobVertex vertex2 = jobVertices.get(1);
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			graph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(graph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
+
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			// duplicate registration fails task
 
 			// register a KvState
@@ -1608,19 +1492,15 @@ public class JobMasterTest extends TestLogger {
 	@Test
 	public void testRequestPartitionState() throws Exception {
 		final JobGraph producerConsumerJobGraph = producerConsumerJobGraph();
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			producerConsumerJobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(producerConsumerJobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			final CompletableFuture<TaskDeploymentDescriptor> tddFuture = new CompletableFuture<>();
 			final TestingTaskExecutorGateway testingTaskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
 				.setSubmitTaskConsumer((taskDeploymentDescriptor, jobMasterId) -> {
@@ -1698,43 +1578,17 @@ public class JobMasterTest extends TestLogger {
 	 */
 	@Test
 	public void testTriggerSavepointTimeout() throws Exception {
-		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
-		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
+		final TestingSchedulerNG testingSchedulerNG = TestingSchedulerNG.newBuilder()
+			.setTriggerSavepointFunction((ignoredA, ignoredB) -> new CompletableFuture<>())
+			.build();
 
-		final SchedulerNGFactory schedulerNGFactory = SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration);
-
-		final JobMaster jobMaster = new JobMaster(
-			rpcService,
-			jobMasterConfiguration,
-			jmResourceId,
-			jobGraph,
-			haServices,
-			SlotPoolFactory.fromConfiguration(configuration),
-			jobManagerSharedServices,
-			heartbeatServices,
-			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
-			new JobMasterBuilder.TestingOnCompletionActions(),
-			testingFatalErrorHandler,
-			JobMasterTest.class.getClassLoader(),
-			schedulerNGFactory,
-			NettyShuffleMaster.INSTANCE,
-			NoOpJobMasterPartitionTracker.FACTORY,
-			new DefaultExecutionDeploymentTracker(),
-			DefaultExecutionDeploymentReconciler::new,
-			System.currentTimeMillis()) {
-
-			@Override
-			public CompletableFuture<String> triggerSavepoint(
-				@Nullable final String targetDirectory,
-				final boolean cancelJob,
-				final Time timeout) {
-				return new CompletableFuture<>();
-			}
-		};
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withFatalErrorHandler(testingFatalErrorHandler)
+			.withSchedulerFactory(new TestingSchedulerNGFactory(testingSchedulerNG))
+			.createJobMaster();
 
 		try {
-			final CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			jobMaster.start();
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 			final CompletableFuture<String> savepointFutureLowTimeout = jobMasterGateway.triggerSavepoint("/tmp", false, Time.milliseconds(1));
@@ -1759,16 +1613,14 @@ public class JobMasterTest extends TestLogger {
 	 */
 	@Test
 	public void testReleasingTaskExecutorIfNoMoreSlotsRegistered() throws Exception {
-		final JobManagerSharedServices jobManagerSharedServices = new TestingJobManagerSharedServicesBuilder().build();
 
 		final JobGraph jobGraph = createSingleVertexJobWithRestartStrategy();
 
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			jobManagerSharedServices,
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
 		final CompletableFuture<JobID> disconnectTaskExecutorFuture = new CompletableFuture<>();
 		final CompletableFuture<AllocationID> freedSlotFuture = new CompletableFuture<>();
@@ -1783,7 +1635,7 @@ public class JobMasterTest extends TestLogger {
 		final LocalUnresolvedTaskManagerLocation taskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 
 		try {
-			jobMaster.start(jobMasterId).get();
+			jobMaster.start();
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
@@ -1836,7 +1688,7 @@ public class JobMasterTest extends TestLogger {
 			.createTestingTaskExecutorGateway();
 
 		try {
-			jobMaster.start(jobMasterId).get();
+			jobMaster.start();
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
@@ -1864,20 +1716,16 @@ public class JobMasterTest extends TestLogger {
 	 */
 	@Test
 	public void testJobMasterAggregatesValuesCorrectly() throws Exception {
-		final JobMaster jobMaster = createJobMaster(
-			configuration,
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withConfiguration(configuration)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.createJobMaster();
 
-		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
+		jobMaster.start();
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
 		try {
-			// wait for the start to complete
-			startFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-
 			CompletableFuture<Object> updateAggregateFuture;
 
 			AggregateFunction<Integer, Integer, Integer> aggregateFunction = createAggregateFunction();
@@ -1976,16 +1824,16 @@ public class JobMasterTest extends TestLogger {
 			BiFunction<JobMasterGateway, ResourceID, BiConsumer<ResourceID, AllocatedSlotReport>> heartbeatConsumerFunction) throws Exception {
 		final JobGraph jobGraph = JobGraphTestUtils.createSingleVertexJobGraph();
 		final JobMasterBuilder.TestingOnCompletionActions onCompletionActions = new JobMasterBuilder.TestingOnCompletionActions();
-		final JobMaster jobMaster = createJobMaster(
-			new Configuration(),
-			jobGraph,
-			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices,
-			onCompletionActions);
+
+		final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService)
+			.withResourceId(jmResourceId)
+			.withHighAvailabilityServices(haServices)
+			.withHeartbeatServices(heartbeatServices)
+			.withOnCompletionActions(onCompletionActions)
+			.createJobMaster();
 
 		try {
-			jobMaster.start(jobMasterId).get();
+			jobMaster.start();
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
@@ -2111,56 +1959,6 @@ public class JobMasterTest extends TestLogger {
 		jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
 
 		return jobGraph;
-	}
-
-	@Nonnull
-	private JobMaster createJobMaster(
-			Configuration configuration,
-			JobGraph jobGraph,
-			HighAvailabilityServices highAvailabilityServices,
-			JobManagerSharedServices jobManagerSharedServices) throws Exception {
-		return createJobMaster(
-			configuration,
-			jobGraph,
-			highAvailabilityServices,
-			jobManagerSharedServices,
-			fastHeartbeatServices);
-	}
-
-	@Nonnull
-	private JobMaster createJobMaster(
-			Configuration configuration,
-			JobGraph jobGraph,
-			HighAvailabilityServices highAvailabilityServices,
-			JobManagerSharedServices jobManagerSharedServices,
-			HeartbeatServices heartbeatServices) throws Exception {
-
-		return createJobMaster(
-			configuration,
-			jobGraph,
-			highAvailabilityServices,
-			jobManagerSharedServices,
-			heartbeatServices,
-			new JobMasterBuilder.TestingOnCompletionActions());
-	}
-
-	@Nonnull
-	private JobMaster createJobMaster(
-			Configuration configuration,
-			JobGraph jobGraph,
-			HighAvailabilityServices highAvailabilityServices,
-			JobManagerSharedServices jobManagerSharedServices,
-			HeartbeatServices heartbeatServices,
-			OnCompletionActions onCompletionActions) throws Exception {
-
-		return new JobMasterBuilder(jobGraph, rpcService)
-			.withConfiguration(configuration)
-			.withHighAvailabilityServices(highAvailabilityServices)
-			.withJobManagerSharedServices(jobManagerSharedServices)
-			.withHeartbeatServices(heartbeatServices)
-			.withOnCompletionActions(onCompletionActions)
-			.withResourceId(jmResourceId)
-			.createJobMaster();
 	}
 
 	private JobGraph createSingleVertexJobWithRestartStrategy() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.factories;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterService;
 import org.apache.flink.runtime.jobmaster.TestingJobMasterService;
 
@@ -42,7 +43,7 @@ public class TestingJobMasterServiceFactory implements JobMasterServiceFactory {
 	}
 
 	@Override
-	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader, long initializationTimestamp) {
+	public JobMasterService createJobMasterService(JobGraph jobGraph, JobMasterId jobMasterId, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader, long initializationTimestamp) {
 		return jobMasterServiceSupplier.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerSharedServicesBuilder;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
@@ -63,6 +64,8 @@ public class JobMasterBuilder {
 
 	private final JobGraph jobGraph;
 	private final RpcService rpcService;
+
+	private JobMasterId jobMasterId = JobMasterId.generate();
 
 	private HighAvailabilityServices highAvailabilityServices;
 
@@ -168,11 +171,17 @@ public class JobMasterBuilder {
 		return this;
 	}
 
+	public JobMasterBuilder withJobMasterId(JobMasterId jobMasterId) {
+		this.jobMasterId = jobMasterId;
+		return this;
+	}
+
 	public JobMaster createJobMaster() throws Exception {
 		final JobMasterConfiguration jobMasterConfiguration = JobMasterConfiguration.fromConfiguration(configuration);
 
 		return new JobMaster(
 			rpcService,
+			jobMasterId,
 			jobMasterConfiguration,
 			jmResourceId,
 			jobGraph,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -225,8 +225,8 @@ public class JobMasterBuilder {
 			return jobReachedGloballyTerminalStateFuture;
 		}
 
-		public CompletableFuture<ArchivedExecutionGraph> getJobMasterFailedFuture() {
-			return jobReachedGloballyTerminalStateFuture;
+		public CompletableFuture<Throwable> getJobMasterFailedFuture() {
+			return jobMasterFailedFuture;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Testing implementation of {@link SchedulerNGFactory} which returns a configurable
+ * {@link SchedulerNG} instance.
+ */
+public class TestingSchedulerNGFactory implements SchedulerNGFactory {
+	private final SchedulerNG schedulerNG;
+
+	public TestingSchedulerNGFactory(SchedulerNG schedulerNG) {
+		this.schedulerNG = schedulerNG;
+	}
+
+	@Override
+	public SchedulerNG createInstance(
+			Logger log,
+			JobGraph jobGraph,
+			BackPressureStatsTracker backPressureStatsTracker,
+			Executor ioExecutor,
+			Configuration jobMasterConfiguration,
+			SlotPool slotPool,
+			ScheduledExecutorService futureExecutor,
+			ClassLoader userCodeLoader,
+			CheckpointRecoveryFactory checkpointRecoveryFactory,
+			Time rpcTimeout,
+			BlobWriter blobWriter,
+			JobManagerJobMetricGroup jobManagerJobMetricGroup,
+			Time slotRequestTimeout,
+			ShuffleMaster<?> shuffleMaster,
+			JobMasterPartitionTracker partitionTracker,
+			ExecutionDeploymentTracker executionDeploymentTracker,
+			long initializationTimestamp) throws Exception {
+		return schedulerNG;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR changes how the `JobMaster` is used by the `JobManagerRunnerImpl`. Instead of reusing the `JobMaster` across different leader sessions, the `JobManagerRunnerImpl` will create a new instance for every leader session. This makes the state management in the `JobMaster` easier because we don't have to make sure that the components are always in a cleaned up state when starting a new leader session. Moreover, it simplifies the state management because there are fewer mutable components in the `JobMaster`.

This PR is based on #14430.

## Brief change log

- 8faba3b: This commit changes how the JobManagerRunnerImpl uses JobMasterServices.
Now we use a JobMasterService per leader session.

- 436aa53: This commit changes the JobMaster to have a permanent fencing token.

- 1ab27e0: Since the JobMaster is now a PermanentlyFencedRpcEndpoint we no longer
need to make the scheduler resettable.

- 7b74054: Since we are no longer reusing the JobMaster across different leader sessions,
we can make the heartbeat managers final.

- aec1ac9: Make starting and stopping of JobMaster services symmetric

## Verifying this change

I adjusted several test to the new model. The test class `JobMasterTest` was mainly affected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
