### PR TITLE
[FLINK-20678] Let JobManagerRunnerImpl fail if the JobMasterService fails unexpectedly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -337,12 +337,25 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 		checkState(jobMasterService == null, "JobMasterService must be null before being started.");
 
 		try {
-			jobMasterService = jobMasterServiceFactory.createJobMasterService(
+			final JobMasterService newJobMasterService = jobMasterServiceFactory.createJobMasterService(
 				jobGraph,
 				new JobMasterId(leaderSessionId),
 				this,
 				userCodeClassLoader,
 				initializationTimestamp);
+
+			jobMasterService = newJobMasterService;
+
+			jobMasterService.getTerminationFuture().whenComplete((unused, throwable) -> {
+				if (throwable != null) {
+					synchronized (lock) {
+						// check that we are still running and the valid JobMasterService
+						if (!shutdown && newJobMasterService == jobMasterService) {
+							handleJobManagerRunnerError(throwable);
+						}
+					}
+				}
+			});
 		} catch (Exception e) {
 			resultFuture.complete(
 				JobManagerRunnerResult.forInitializationFailure(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterService.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.util.AutoCloseableAsync;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Interface which specifies the JobMaster service.
  */
@@ -38,4 +40,11 @@ public interface JobMasterService extends AutoCloseableAsync {
 	 * @return Address of the JobMaster service
 	 */
 	String getAddress();
+
+	/**
+	 * Get the termination future of this job master service.
+	 *
+	 * @return future which is completed once the JobMasterService completes termination
+	 */
+	CompletableFuture<Void> getTerminationFuture();
 }


### PR DESCRIPTION
## What is the purpose of the change

This is a safety net which ensures that the JobManagerRunnerImpl will fail if the
JobMasterService fails unexpectedly.

This PR is based on #14431.

## Verifying this change

I added `JobManagerRunnerImplTest.testJobMasterServiceTerminatesUnexpectedlyTriggersFailure`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
