### PR TITLE
[FLINK-20213][fs-connector] Partition commit is delayed when records keep coming

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/AbstractStreamingWriter.java
@@ -67,6 +67,11 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
 	}
 
 	/**
+	 * Notifies a partition created.
+	 */
+	protected abstract void partitionCreated(String partition);
+
+	/**
 	 * Notifies a partition become inactive. A partition becomes inactive after all
 	 * the records received so far have been committed.
 	 */
@@ -97,6 +102,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
 
 			@Override
 			public void bucketCreated(Bucket<IN, String> bucket) {
+				AbstractStreamingWriter.this.partitionCreated(bucket.getBucketId());
 			}
 
 			@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriter.java
@@ -40,6 +40,10 @@ public class CompactFileWriter<T> extends AbstractStreamingWriter<T, CompactMess
 	}
 
 	@Override
+	protected void partitionCreated(String partition) {
+	}
+
+	@Override
 	protected void partitionInactive(String partition) {
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

When set partition-commit.delay=0, Users expect partitions to be committed immediately.

However, if the record of this partition continues to flow in, the bucket for the partition will be activated, and no inactive bucket will appear.

## Brief change log

Consider listening to bucket created.

Collect partitions from bucket created listener. Emit partitions when notify checkpoint complete.

## Verifying this change

`StreamingFileWriterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no