### PR TITLE
[FLINK-20690][table-planner-blink] Separate the implementation of BatchExecCorrelate and StreamExecCorrelate

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCorrelate.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCorrelate;
+import org.apache.flink.table.runtime.operators.TableStreamOperator;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+
+import javax.annotation.Nullable;
+
+/**
+ * Batch exec node which matches along with join a Java/Scala user defined table function.
+ */
+public class BatchExecCorrelate extends CommonExecCorrelate implements BatchExecNode<RowData> {
+
+	public BatchExecCorrelate(
+			FlinkJoinType joinType,
+			@Nullable RexProgram project,
+			RexCall invocation,
+			@Nullable RexNode condition,
+			ExecEdge inputEdge,
+			RowType outputType,
+			String description) {
+		super(
+				joinType,
+				project,
+				invocation,
+				condition,
+				TableStreamOperator.class,
+				false,
+				inputEdge,
+				outputType,
+				description);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.common;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.CorrelateCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Base {@link ExecNode} which matches along with join a Java/Scala user defined table function.
+ */
+public abstract class CommonExecCorrelate extends ExecNodeBase<RowData> {
+	private final FlinkJoinType joinType;
+	@Nullable
+	private final RexProgram project;
+	private final RexCall invocation;
+	@Nullable
+	private final RexNode condition;
+	private final Class<?> operatorBaseClass;
+	private final boolean retainHeader;
+
+	public CommonExecCorrelate(
+			FlinkJoinType joinType,
+			@Nullable RexProgram project,
+			RexCall invocation,
+			@Nullable RexNode condition,
+			Class<?> operatorBaseClass,
+			boolean retainHeader,
+			ExecEdge inputEdge,
+			RowType outputType,
+			String description) {
+		super(Collections.singletonList(inputEdge), outputType, description);
+		this.joinType = joinType;
+		this.project = project;
+		this.invocation = invocation;
+		this.condition = condition;
+		this.operatorBaseClass = operatorBaseClass;
+		this.retainHeader = retainHeader;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+		final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
+		final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+		final CodeGeneratorContext ctx = new CodeGeneratorContext(planner.getTableConfig())
+				.setOperatorBaseClass(operatorBaseClass);
+		final Transformation<RowData> transform = CorrelateCodeGenerator.generateCorrelateTransformation(
+				planner.getTableConfig(),
+				ctx,
+				inputTransform,
+				(RowType) inputNode.getOutputType(),
+				JavaScalaConversionUtil.toScala(Optional.ofNullable(project)),
+				invocation,
+				JavaScalaConversionUtil.toScala(Optional.ofNullable(condition)),
+				(RowType) getOutputType(),
+				joinType,
+				inputTransform.getParallelism(),
+				retainHeader,
+				getClass().getSimpleName(),
+				getDesc());
+
+		if (inputsContainSingleton()) {
+			transform.setParallelism(1);
+			transform.setMaxParallelism(1);
+		}
+		return transform;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCorrelate;
+import org.apache.flink.table.runtime.operators.AbstractProcessStreamOperator;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+
+import javax.annotation.Nullable;
+
+/**
+ * Stream {@link ExecNode} which matches along with join a Java/Scala user defined table function.
+ */
+public class StreamExecCorrelate extends CommonExecCorrelate implements StreamExecNode<RowData> {
+
+	public StreamExecCorrelate(
+			FlinkJoinType joinType,
+			@Nullable RexProgram project,
+			RexCall invocation,
+			@Nullable RexNode condition,
+			ExecEdge inputEdge,
+			RowType outputType,
+			String description) {
+		super(
+				joinType,
+				project,
+				invocation,
+				condition,
+				AbstractProcessStreamOperator.class,
+				true,
+				inputEdge,
+				outputType,
+				description);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRule.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCorrelate;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalRel;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
-import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecCorrelateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCorrelateRule;
 import org.apache.flink.table.planner.plan.utils.PythonUtil;
 
 import org.apache.calcite.plan.RelOptRule;
@@ -58,8 +58,8 @@ public class CalcPythonCorrelateTransposeRule extends RelOptRule {
 		FlinkLogicalCorrelate correlate = call.rel(0);
 		FlinkLogicalCalc right = call.rel(2);
 		JoinRelType joinType = correlate.getJoinType();
-		FlinkLogicalCalc mergedCalc = StreamExecCorrelateRule.getMergedCalc(right);
-		FlinkLogicalTableFunctionScan scan = StreamExecCorrelateRule.getTableScan(mergedCalc);
+		FlinkLogicalCalc mergedCalc = StreamPhysicalCorrelateRule.getMergedCalc(right);
+		FlinkLogicalTableFunctionScan scan = StreamPhysicalCorrelateRule.getTableScan(mergedCalc);
 		return joinType == JoinRelType.INNER &&
 			PythonUtil.isPythonCall(scan.getCall(), null) &&
 			mergedCalc.getProgram().getCondition() != null;
@@ -70,8 +70,8 @@ public class CalcPythonCorrelateTransposeRule extends RelOptRule {
 		FlinkLogicalCorrelate correlate = call.rel(0);
 		FlinkLogicalCalc right = call.rel(2);
 		RexBuilder rexBuilder = call.builder().getRexBuilder();
-		FlinkLogicalCalc mergedCalc = StreamExecCorrelateRule.getMergedCalc(right);
-		FlinkLogicalTableFunctionScan tableScan = StreamExecCorrelateRule.getTableScan(mergedCalc);
+		FlinkLogicalCalc mergedCalc = StreamPhysicalCorrelateRule.getMergedCalc(right);
+		FlinkLogicalTableFunctionScan tableScan = StreamPhysicalCorrelateRule.getTableScan(mergedCalc);
 		RexProgram mergedCalcProgram = mergedCalc.getProgram();
 
 		InputRefRewriter inputRefRewriter = new InputRefRewriter(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.rules.logical;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCorrelate;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
-import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecCorrelateRule;
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCorrelateRule;
 import org.apache.flink.table.planner.plan.utils.PythonUtil;
 
 import org.apache.calcite.plan.RelOptRule;
@@ -88,7 +88,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		if (right instanceof FlinkLogicalTableFunctionScan) {
 			tableFunctionScan = (FlinkLogicalTableFunctionScan) right;
 		} else if (right instanceof FlinkLogicalCalc) {
-			tableFunctionScan = StreamExecCorrelateRule.getTableScan((FlinkLogicalCalc) right);
+			tableFunctionScan = StreamPhysicalCorrelateRule.getTableScan((FlinkLogicalCalc) right);
 		} else {
 			return false;
 		}
@@ -237,8 +237,8 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 					scan.getCall()));
 		} else {
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
-			FlinkLogicalTableFunctionScan scan = StreamExecCorrelateRule.getTableScan(calc);
-			FlinkLogicalCalc mergedCalc = StreamExecCorrelateRule.getMergedCalc(calc);
+			FlinkLogicalTableFunctionScan scan = StreamPhysicalCorrelateRule.getTableScan(calc);
+			FlinkLogicalCalc mergedCalc = StreamPhysicalCorrelateRule.getMergedCalc(calc);
 			FlinkLogicalTableFunctionScan newScan = createNewScan(scan,
 				createScalarFunctionSplitter(
 					null,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalPythonCorrelateRule.java
@@ -22,7 +22,7 @@ import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCorrelate;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecPythonCorrelate;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalPythonCorrelate;
 import org.apache.flink.table.planner.plan.utils.PythonUtil;
 
 import org.apache.calcite.plan.RelOptRule;
@@ -38,15 +38,15 @@ import scala.Some;
 
 /**
  * The physical rule is responsible for convert {@link FlinkLogicalCorrelate} to
- * {@link BatchExecPythonCorrelate}.
+ * {@link BatchPhysicalPythonCorrelate}.
  */
-public class BatchExecPythonCorrelateRule extends ConverterRule {
+public class BatchPhysicalPythonCorrelateRule extends ConverterRule {
 
-	public static final RelOptRule INSTANCE = new BatchExecPythonCorrelateRule();
+	public static final RelOptRule INSTANCE = new BatchPhysicalPythonCorrelateRule();
 
-	private BatchExecPythonCorrelateRule() {
+	private BatchPhysicalPythonCorrelateRule() {
 		super(FlinkLogicalCorrelate.class, FlinkConventions.LOGICAL(), FlinkConventions.BATCH_PHYSICAL(),
-			"BatchExecPythonCorrelateRule");
+			"BatchPhysicalPythonCorrelateRule");
 	}
 
 	@Override
@@ -79,7 +79,7 @@ public class BatchExecPythonCorrelateRule extends ConverterRule {
 	}
 
 	/**
-	 * The factory is responsible for creating {@link BatchExecPythonCorrelate}.
+	 * The factory is responsible for creating {@link BatchPhysicalPythonCorrelate}.
 	 */
 	private static class BatchExecPythonCorrelateFactory {
 		private final FlinkLogicalCorrelate correlate;
@@ -95,11 +95,11 @@ public class BatchExecPythonCorrelateRule extends ConverterRule {
 			this.right = correlate.getInput(1);
 		}
 
-		BatchExecPythonCorrelate convertToCorrelate() {
+		BatchPhysicalPythonCorrelate convertToCorrelate() {
 			return convertToCorrelate(right, Option.empty());
 		}
 
-		private BatchExecPythonCorrelate convertToCorrelate(
+		private BatchPhysicalPythonCorrelate convertToCorrelate(
 			RelNode relNode,
 			Option<RexNode> condition) {
 			if (relNode instanceof RelSubset) {
@@ -112,7 +112,7 @@ public class BatchExecPythonCorrelateRule extends ConverterRule {
 					Some.apply(calc.getProgram().expandLocalRef(calc.getProgram().getCondition())));
 			} else {
 				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) relNode;
-				return new BatchExecPythonCorrelate(
+				return new BatchPhysicalPythonCorrelate(
 					correlate.getCluster(),
 					traitSet,
 					convInput,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -622,7 +622,7 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
   }
 
   def areColumnsUnique(
-      rel: BatchExecCorrelate,
+      rel: BatchPhysicalCorrelate,
       mq: RelMetadataQuery,
       columns: ImmutableBitSet,
       ignoreNulls: Boolean): JBoolean = null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -628,7 +628,7 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
       ignoreNulls: Boolean): JBoolean = null
 
   def areColumnsUnique(
-      rel: StreamExecCorrelate,
+      rel: StreamPhysicalCorrelate,
       mq: RelMetadataQuery,
       columns: ImmutableBitSet,
       ignoreNulls: Boolean): JBoolean = null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.plan.`trait`.RelModifiedMonotonicity
 import org.apache.flink.table.planner.plan.metadata.FlinkMetadata.ModifiedMonotonicity
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, TableAggregate, WindowAggregate, WindowTableAggregate}
 import org.apache.flink.table.planner.plan.nodes.logical._
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecCorrelate, BatchExecGroupAggregateBase}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecGroupAggregateBase, BatchPhysicalCorrelate}
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, TableSourceTable}
 import org.apache.flink.table.planner.plan.stats.{WithLower, WithUpper}
@@ -502,7 +502,7 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
   }
 
   def getRelModifiedMonotonicity(
-      rel: BatchExecCorrelate,
+      rel: BatchPhysicalCorrelate,
       mq: RelMetadataQuery): RelModifiedMonotonicity = null
 
   def getRelModifiedMonotonicity(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -506,7 +506,7 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
       mq: RelMetadataQuery): RelModifiedMonotonicity = null
 
   def getRelModifiedMonotonicity(
-      rel: StreamExecCorrelate,
+      rel: StreamPhysicalCorrelate,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
     getMonotonicity(rel.getInput(0), mq, rel.getRowType.getFieldCount)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueGroups.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueGroups.scala
@@ -390,7 +390,7 @@ class FlinkRelMdUniqueGroups private extends MetadataHandler[UniqueGroups] {
       columns: ImmutableBitSet): ImmutableBitSet = columns
 
   def getUniqueGroups(
-      rel: BatchExecCorrelate,
+      rel: BatchPhysicalCorrelate,
       mq: RelMetadataQuery,
       columns: ImmutableBitSet): ImmutableBitSet = columns
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -576,7 +576,7 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
       ignoreNulls: Boolean): util.Set[ImmutableBitSet] = null
 
   def getUniqueKeys(
-      rel: BatchExecCorrelate,
+      rel: BatchPhysicalCorrelate,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): util.Set[ImmutableBitSet] = null
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
@@ -18,20 +18,18 @@
 
 package org.apache.flink.table.planner.plan.nodes.common
 
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.functions.python.PythonFunctionInfo
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate.PYTHON_TABLE_FUNCTION_OPERATOR_NAME
-import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
+
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 
 import scala.collection.mutable
 
@@ -73,18 +71,16 @@ trait CommonPythonCorrelate extends CommonPythonBase {
 
   protected def createPythonOneInputTransformation(
       inputTransform: Transformation[RowData],
-      scan: FlinkLogicalTableFunctionScan,
+      pythonTableFuncRexCall: RexCall,
       name: String,
-      outputRowType: RelDataType,
+      outputRowType: RowType,
       config: Configuration,
       joinType: JoinRelType): OneInputTransformation[RowData, RowData] = {
-    val pythonTableFuncRexCall = scan.getCall.asInstanceOf[RexCall]
     val (pythonUdtfInputOffsets, pythonFunctionInfo) =
       extractPythonTableFunctionInfo(pythonTableFuncRexCall)
     val pythonOperatorInputRowType = inputTransform.getOutputType
       .asInstanceOf[InternalTypeInfo[RowData]]
-    val pythonOperatorOutputRowType = InternalTypeInfo.of(
-      FlinkTypeFactory.toLogicalType(outputRowType).asInstanceOf[RowType])
+    val pythonOperatorOutputRowType = InternalTypeInfo.of(outputRowType)
     val pythonOperator = getPythonTableFunctionOperator(
       config,
       pythonOperatorInputRowType,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCorrelate.scala
@@ -15,74 +15,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.table.planner.plan.nodes.physical.stream
+package org.apache.flink.table.planner.plan.nodes.exec.stream
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate
-import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNodeBase}
+import org.apache.flink.table.types.logical.RowType
 
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexNode, RexProgram}
+import org.apache.calcite.rex.{RexCall, RexNode}
+
+import java.util.Collections
 
 /**
-  * Flink RelNode which matches along with join a python user defined table function.
-  */
+ * Stream exec node which matches along with join a python user defined table function.
+ *
+ * <p>Note: This class can't be ported to Java,
+ * because java class can't extend scala interface with default implementation.
+ * FLINK-20693 will port this class to Java.
+ *
+ * <p>TODO change JoinRelType to FlinkJoinType
+ */
 class StreamExecPythonCorrelate(
-    cluster: RelOptCluster,
-    traitSet: RelTraitSet,
-    inputRel: RelNode,
-    projectProgram: Option[RexProgram],
-    scan: FlinkLogicalTableFunctionScan,
+    joinType: JoinRelType,
+    invocation: RexCall,
     condition: Option[RexNode],
-    outputRowType: RelDataType,
-    joinType: JoinRelType)
-  extends StreamExecCorrelateBase(
-    cluster,
-    traitSet,
-    inputRel,
-    projectProgram,
-    scan,
-    condition,
-    outputRowType,
-    joinType)
+    inputEdge: ExecEdge,
+    outputType: RowType,
+    description: String)
+  extends ExecNodeBase[RowData](Collections.singletonList(inputEdge), outputType, description)
+  with StreamExecNode[RowData]
   with CommonPythonCorrelate {
 
-  if (condition.isDefined) {
+  if (joinType == JoinRelType.LEFT && condition.isDefined) {
     throw new TableException("Currently Python correlate does not support conditions in left join.")
   }
 
-  def copy(
-      traitSet: RelTraitSet,
-      newChild: RelNode,
-      projectProgram: Option[RexProgram],
-      outputType: RelDataType): RelNode = {
-    new StreamExecPythonCorrelate(
-      cluster,
-      traitSet,
-      newChild,
-      projectProgram,
-      scan,
-      condition,
-      outputType,
-      joinType)
-  }
-
-  override protected def translateToPlanInternal(
-      planner: StreamPlanner): Transformation[RowData] = {
+  override protected def translateToPlanInternal(planner: PlannerBase): Transformation[RowData] = {
     val inputTransformation = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
     val ret = createPythonOneInputTransformation(
       inputTransformation,
-      scan,
+      invocation,
       "StreamExecPythonCorrelate",
-      outputRowType,
+      getOutputType.asInstanceOf[RowType],
       getConfig(planner.getExecEnv, planner.getTableConfig),
       joinType)
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.common.CommonPythonCorrelate
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
@@ -28,7 +29,7 @@ import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Correlate, JoinRelType}
-import org.apache.calcite.rex.{RexNode, RexProgram}
+import org.apache.calcite.rex.{RexCall, RexNode, RexProgram}
 
 /**
   * Batch physical RelNode for [[Correlate]] (Python user defined table function).
@@ -75,9 +76,9 @@ class BatchExecPythonCorrelate(
       .asInstanceOf[Transformation[RowData]]
     val ret = createPythonOneInputTransformation(
       inputTransformation,
-      scan,
+      scan.getCall.asInstanceOf[RexCall],
       "BatchExecPythonCorrelate",
-      outputRowType,
+      FlinkTypeFactory.toLogicalRowType(outputRowType),
       getConfig(planner.getExecEnv, planner.getTableConfig),
       joinType)
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCorrelate.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.batch
+
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecCorrelate
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.planner.plan.utils.JoinTypeUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Correlate, JoinRelType}
+import org.apache.calcite.rex.{RexCall, RexNode, RexProgram}
+
+/**
+  * Batch physical RelNode for [[Correlate]] (Java/Scala user defined table function).
+  */
+class BatchPhysicalCorrelate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    scan: FlinkLogicalTableFunctionScan,
+    condition: Option[RexNode],
+    projectProgram: Option[RexProgram],
+    outputRowType: RelDataType,
+    joinType: JoinRelType)
+  extends BatchPhysicalCorrelateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    scan,
+    condition,
+    projectProgram,
+    outputRowType,
+    joinType) {
+
+  def copy(
+      traitSet: RelTraitSet,
+      child: RelNode,
+      projectProgram: Option[RexProgram],
+      outputType: RelDataType): RelNode = {
+    new BatchPhysicalCorrelate(
+      cluster,
+      traitSet,
+      child,
+      scan,
+      condition,
+      projectProgram,
+      outputType,
+      joinType)
+  }
+
+  override def translateToExecNode(): ExecNode[_] = {
+    new BatchExecCorrelate(
+      JoinTypeUtil.getFlinkJoinType(joinType),
+      projectProgram.orNull,
+      scan.getCall.asInstanceOf[RexCall],
+      condition.orNull,
+      ExecEdge.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCorrelateBase.scala
@@ -18,9 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
-import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, TraitUtil}
-import org.apache.flink.table.planner.plan.nodes.exec.{LegacyBatchExecNode, ExecEdge}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
 
@@ -32,14 +30,12 @@ import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.util.mapping.{Mapping, MappingType, Mappings}
 
-import java.util
-
 import scala.collection.JavaConversions._
 
 /**
   * Base Batch physical RelNode for [[Correlate]] (user defined table function).
   */
-abstract class BatchExecCorrelateBase(
+abstract class BatchPhysicalCorrelateBase(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
@@ -49,8 +45,7 @@ abstract class BatchExecCorrelateBase(
     outputRowType: RelDataType,
     joinType: JoinRelType)
   extends SingleRel(cluster, traitSet, inputRel)
-  with BatchPhysicalRel
-  with LegacyBatchExecNode[RowData] {
+  with BatchPhysicalRel {
 
   require(joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT)
 
@@ -153,8 +148,4 @@ abstract class BatchExecCorrelateBase(
     val newInput = RelOptRule.convert(getInput, inputRequiredTraits)
     Some(copy(providedTraits, Seq(newInput)))
   }
-
-  //~ ExecNode methods -----------------------------------------------------------
-
-  override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCorrelateBase.scala
@@ -17,8 +17,6 @@
  */
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.plan.nodes.exec.LegacyStreamExecNode
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
 
@@ -33,7 +31,7 @@ import scala.collection.JavaConversions._
 /**
   * Base Flink RelNode which matches along with join a user defined table function.
   */
-abstract class StreamExecCorrelateBase(
+abstract class StreamPhysicalCorrelateBase(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
@@ -43,8 +41,7 @@ abstract class StreamExecCorrelateBase(
     outputRowType: RelDataType,
     joinType: JoinRelType)
   extends SingleRel(cluster, traitSet, inputRel)
-  with StreamPhysicalRel
-  with LegacyStreamExecNode[RowData] {
+  with StreamPhysicalRel {
 
   require(joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -271,8 +271,8 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         val leftTrait = children.head.getTraitSet.getTrait(ModifyKindSetTraitDef.INSTANCE)
         createNewNode(temporalJoin, children, leftTrait, requiredTrait, requester)
 
-      case _: StreamPhysicalCalcBase | _: StreamExecCorrelate |
-           _: StreamExecPythonCorrelate | _: StreamExecLookupJoin | _: StreamPhysicalExchange |
+      case _: StreamPhysicalCalcBase | _: StreamPhysicalCorrelateBase |
+           _: StreamExecLookupJoin | _: StreamPhysicalExchange |
            _: StreamExecExpand | _: StreamExecMiniBatchAssigner |
            _: StreamPhysicalWatermarkAssigner =>
         // transparent forward requiredTrait to children
@@ -571,7 +571,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
           }
         }
 
-      case _: StreamExecCorrelate | _: StreamExecPythonCorrelate | _: StreamExecLookupJoin |
+      case _: StreamPhysicalCorrelateBase | _: StreamExecLookupJoin |
            _: StreamPhysicalExchange | _: StreamExecExpand | _: StreamExecMiniBatchAssigner |
            _: StreamPhysicalWatermarkAssigner =>
         // transparent forward requiredTrait to children

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -431,9 +431,9 @@ object FlinkBatchRuleSets {
     BatchExecLookupJoinRule.SNAPSHOT_ON_TABLESCAN,
     BatchExecLookupJoinRule.SNAPSHOT_ON_CALC_TABLESCAN,
     // correlate
-    BatchExecConstantTableFunctionScanRule.INSTANCE,
-    BatchExecCorrelateRule.INSTANCE,
-    BatchExecPythonCorrelateRule.INSTANCE,
+    BatchPhysicalConstantTableFunctionScanRule.INSTANCE,
+    BatchPhysicalCorrelateRule.INSTANCE,
+    BatchPhysicalPythonCorrelateRule.INSTANCE,
     // sink
     BatchExecSinkRule.INSTANCE,
     BatchExecLegacySinkRule.INSTANCE

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -437,9 +437,9 @@ object FlinkStreamRuleSets {
     // CEP
     StreamExecMatchRule.INSTANCE,
     // correlate
-    StreamExecConstantTableFunctionScanRule.INSTANCE,
-    StreamExecCorrelateRule.INSTANCE,
-    StreamExecPythonCorrelateRule.INSTANCE,
+    StreamPhysicalConstantTableFunctionScanRule.INSTANCE,
+    StreamPhysicalCorrelateRule.INSTANCE,
+    StreamPhysicalPythonCorrelateRule.INSTANCE,
     // sink
     StreamExecSinkRule.INSTANCE,
     StreamExecLegacySinkRule.INSTANCE

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
@@ -18,14 +18,15 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalRel, FlinkLogicalTableFunctionScan}
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamPhysicalCorrelateRule
+import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsPythonCall, isNonPythonCall}
+import org.apache.flink.table.planner.plan.utils.RexDefaultVisitor
+
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
 import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex._
-import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalRel, FlinkLogicalTableFunctionScan}
-import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecCorrelateRule
-import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsPythonCall, isNonPythonCall}
-import org.apache.flink.table.planner.plan.utils.RexDefaultVisitor
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -51,8 +52,8 @@ class SplitPythonConditionFromCorrelateRule
     val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
     val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
     val joinType: JoinRelType = correlate.getJoinType
-    val mergedCalc = StreamExecCorrelateRule.getMergedCalc(right)
-    val tableScan = StreamExecCorrelateRule
+    val mergedCalc = StreamPhysicalCorrelateRule.getMergedCalc(right)
+    val tableScan = StreamPhysicalCorrelateRule
       .getTableScan(mergedCalc)
       .asInstanceOf[FlinkLogicalTableFunctionScan]
     joinType == JoinRelType.INNER &&
@@ -66,7 +67,7 @@ class SplitPythonConditionFromCorrelateRule
     val correlate: FlinkLogicalCorrelate = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
     val right: FlinkLogicalCalc = call.rel(2).asInstanceOf[FlinkLogicalCalc]
     val rexBuilder = call.builder().getRexBuilder
-    val mergedCalc = StreamExecCorrelateRule.getMergedCalc(right)
+    val mergedCalc = StreamPhysicalCorrelateRule.getMergedCalc(right)
     val mergedCalcProgram = mergedCalc.getProgram
     val input = mergedCalc.getInput
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalConstantTableFunctionScanRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecCorrelate, BatchExecValues}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCorrelate, BatchExecValues}
 
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptRule._
@@ -31,7 +31,7 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
 /**
   * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
   * {{{
-  *                    [[BatchExecCorrelate]]
+  *                    [[BatchPhysicalCorrelate]]
   *                          /       \
   * empty [[BatchExecValues]]  [[FlinkLogicalTableFunctionScan]]
   * }}}
@@ -39,15 +39,15 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
   * Add the rule to support select from a UDF directly, such as the following SQL:
   * SELECT * FROM LATERAL TABLE(func()) as T(c)
   *
-  * Note: [[BatchExecCorrelateRule]] is responsible for converting a reasonable physical plan for
-  * the normal correlate query, such as the following SQL:
+  * Note: [[BatchPhysicalCorrelateRule]] is responsible for converting a reasonable physical plan
+  * for the normal correlate query, such as the following SQL:
   * example1: SELECT * FROM T, LATERAL TABLE(func()) as T(c)
   * example2: SELECT a, c FROM T, LATERAL TABLE(func(a)) as T(c)
   */
-class BatchExecConstantTableFunctionScanRule
+class BatchPhysicalConstantTableFunctionScanRule
   extends RelOptRule(
     operand(classOf[FlinkLogicalTableFunctionScan], any),
-    "BatchExecTableFunctionScanRule") {
+    "BatchPhysicalConstantTableFunctionScanRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val scan: FlinkLogicalTableFunctionScan = call.rel(0)
@@ -66,7 +66,7 @@ class BatchExecConstantTableFunctionScanRule
       ImmutableList.of(ImmutableList.of[RexLiteral]()),
       cluster.getTypeFactory.createStructType(ImmutableList.of(), ImmutableList.of()))
 
-    val correlate = new BatchExecCorrelate(
+    val correlate = new BatchPhysicalCorrelate(
       cluster,
       traitSet,
       values,
@@ -80,6 +80,6 @@ class BatchExecConstantTableFunctionScanRule
 
 }
 
-object BatchExecConstantTableFunctionScanRule {
-  val INSTANCE = new BatchExecConstantTableFunctionScanRule
+object BatchPhysicalConstantTableFunctionScanRule {
+  val INSTANCE = new BatchPhysicalConstantTableFunctionScanRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalCorrelateRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecCorrelate
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalCorrelate
 import org.apache.flink.table.planner.plan.utils.PythonUtil
 
 import org.apache.calcite.plan.volcano.RelSubset
@@ -29,11 +29,11 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rex.RexNode
 
-class BatchExecCorrelateRule extends ConverterRule(
+class BatchPhysicalCorrelateRule extends ConverterRule(
   classOf[FlinkLogicalCorrelate],
   FlinkConventions.LOGICAL,
   FlinkConventions.BATCH_PHYSICAL,
-  "BatchExecCorrelateRule") {
+  "BatchPhysicalCorrelateRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val join = call.rel(0).asInstanceOf[FlinkLogicalCorrelate]
@@ -60,7 +60,7 @@ class BatchExecCorrelateRule extends ConverterRule(
     val convInput: RelNode = RelOptRule.convert(join.getInput(0), FlinkConventions.BATCH_PHYSICAL)
     val right: RelNode = join.getInput(1)
 
-    def convertToCorrelate(relNode: RelNode, condition: Option[RexNode]): BatchExecCorrelate = {
+    def convertToCorrelate(relNode: RelNode, condition: Option[RexNode]): BatchPhysicalCorrelate = {
       relNode match {
         case rel: RelSubset =>
           convertToCorrelate(rel.getRelList.get(0), condition)
@@ -71,7 +71,7 @@ class BatchExecCorrelateRule extends ConverterRule(
             Some(calc.getProgram.expandLocalRef(calc.getProgram.getCondition)))
 
         case scan: FlinkLogicalTableFunctionScan =>
-          new BatchExecCorrelate(
+          new BatchPhysicalCorrelate(
             rel.getCluster,
             traitSet,
             convInput,
@@ -86,6 +86,6 @@ class BatchExecCorrelateRule extends ConverterRule(
   }
 }
 
-object BatchExecCorrelateRule {
-  val INSTANCE: RelOptRule = new BatchExecCorrelateRule
+object BatchPhysicalCorrelateRule {
+  val INSTANCE: RelOptRule = new BatchPhysicalCorrelateRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalConstantTableFunctionScanRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecCorrelate, StreamExecValues}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalCorrelate, StreamExecValues}
 
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptRule._
@@ -31,7 +31,7 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
 /**
   * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
   * {{{
-  *                    [[StreamExecCorrelate]]
+  *                    [[StreamPhysicalCorrelate]]
   *                          /       \
   * empty [[StreamExecValues]]  [[FlinkLogicalTableFunctionScan]]
   * }}}
@@ -39,15 +39,15 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
   * Add the rule to support select from a UDF directly, such as the following SQL:
   * SELECT * FROM LATERAL TABLE(func()) as T(c)
   *
-  * Note: [[StreamExecCorrelateRule]] is responsible for converting a reasonable physical plan for
-  * the normal correlate query, such as the following SQL:
+  * Note: [[StreamPhysicalCorrelateRule]] is responsible for converting a reasonable physical plan
+ * for the normal correlate query, such as the following SQL:
   * example1: SELECT * FROM T, LATERAL TABLE(func()) as T(c)
   * example2: SELECT a, c FROM T, LATERAL TABLE(func(a)) as T(c)
   */
-class StreamExecConstantTableFunctionScanRule
+class StreamPhysicalConstantTableFunctionScanRule
   extends RelOptRule(
     operand(classOf[FlinkLogicalTableFunctionScan], any),
-    "StreamExecConstantTableFunctionScanRule") {
+    "StreamPhysicalConstantTableFunctionScanRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val scan: FlinkLogicalTableFunctionScan = call.rel(0)
@@ -66,7 +66,7 @@ class StreamExecConstantTableFunctionScanRule
       ImmutableList.of(ImmutableList.of[RexLiteral]()),
       cluster.getTypeFactory.createStructType(ImmutableList.of(), ImmutableList.of()))
 
-    val correlate = new StreamExecCorrelate(
+    val correlate = new StreamPhysicalCorrelate(
       cluster,
       traitSet,
       values,
@@ -80,6 +80,6 @@ class StreamExecConstantTableFunctionScanRule
 
 }
 
-object StreamExecConstantTableFunctionScanRule {
-  val INSTANCE = new StreamExecConstantTableFunctionScanRule
+object StreamPhysicalConstantTableFunctionScanRule {
+  val INSTANCE = new StreamPhysicalConstantTableFunctionScanRule
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataHandlerConsistencyTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataHandlerConsistencyTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecCorrelate, BatchExecGroupAggregateBase}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecGroupAggregateBase, BatchPhysicalCorrelate}
 
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Aggregate, Correlate}
@@ -145,6 +145,6 @@ object MetadataHandlerConsistencyTest {
   def parameters(): util.Collection[Array[Any]] = {
     Seq[Array[Any]](
       Array(classOf[Aggregate], classOf[BatchExecGroupAggregateBase]),
-      Array(classOf[Correlate], classOf[BatchExecCorrelate]))
+      Array(classOf[Correlate], classOf[BatchPhysicalCorrelate]))
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Separate the implementation of BatchExecCorrelate and StreamExecCorrelate*


## Brief change log

  - *Introduce StreamPhysicalCorrelate & StreamPhysicalPythonCorrelate, and make StreamExecCorrelate & StreamExecPythonCorrelate only extended from ExecNode*
  - *Introduce BatchPhysicalCorrelate & BatchPhysicalPythonCorrelate, and make BatchExecCorrelate & BatchExecPythonCorrelate only extended from ExecNode*


## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
