### PR TITLE
[FLINK-20654][tests] Temporarily ignore UnalignedCheckpointITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
 import org.apache.flink.util.Collector;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -154,6 +155,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 	}
 
 	@Test
+	@Ignore
 	public void execute() throws Exception {
 		execute(settings);
 	}


### PR DESCRIPTION
Temporarily ignore `UnalignedCheckpointITCase` until fixed (to prevent failing builds of un-related changes).
