### PR TITLE
[FLINK-20664][k8s] Support setting service account for TaskManager pod.

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -114,7 +114,7 @@
             <td><h5>kubernetes.jobmanager.service-account</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Service account that is used by jobmanager within kubernetes cluster. The job manager uses this service account when requesting taskmanager pods from the API server.</td>
+            <td>Service account that is used by jobmanager within kubernetes cluster. The job manager uses this service account when requesting taskmanager pods from the API server. If not explicitly configured, config option 'kubernetes.service-account' will be used.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.jobmanager.tolerations</h5></td>
@@ -150,7 +150,7 @@
             <td><h5>kubernetes.service-account</h5></td>
             <td style="word-wrap: break-word;">"default"</td>
             <td>String</td>
-            <td>Service account that is used by jobmanager and taskmanger within kubernetes cluster. if specific JOB_MANAGER_SERVICE_ACCOUNT and/or TASK_MANAGER_SERVICE_ACCOUNT are not defined.</td>
+            <td>Service account that is used by jobmanager and taskmanager within kubernetes cluster. Notice that this can be overwritten by config options 'kubernetes.jobmanager.service-account' and 'kubernetes.taskmanager.service-account' for jobmanager and taskmanager respectively.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.annotations</h5></td>
@@ -180,7 +180,7 @@
             <td><h5>kubernetes.taskmanager.service-account</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Service account that is used by taskmanager within kubernetes cluster. The task manager uses this service account when watching config maps on the API server to retrieve leader address of jobmanager and resourcemanager.</td>
+            <td>Service account that is used by taskmanager within kubernetes cluster. The task manager uses this service account when watching config maps on the API server to retrieve leader address of jobmanager and resourcemanager. If not explicitly configured, config option 'kubernetes.service-account' will be used.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.tolerations</h5></td>

--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -112,7 +112,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.jobmanager.service-account</h5></td>
-            <td style="word-wrap: break-word;">"default"</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Service account that is used by jobmanager within kubernetes cluster. The job manager uses this service account when requesting taskmanager pods from the API server.</td>
         </tr>
@@ -147,6 +147,12 @@
             <td>The user-specified secrets that will be mounted into Flink container. The value should be in the form of <span markdown="span">`foo:/opt/secrets-foo,bar:/opt/secrets-bar`</span>.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.service-account</h5></td>
+            <td style="word-wrap: break-word;">"default"</td>
+            <td>String</td>
+            <td>Service account that is used by jobmanager and taskmanger within kubernetes cluster. if specific JOB_MANAGER_SERVICE_ACCOUNT and/or TASK_MANAGER_SERVICE_ACCOUNT are not defined.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.taskmanager.annotations</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
@@ -169,6 +175,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>The node selector to be set for TaskManager pods. Specified as key:value pairs separated by commas. For example, environment:production,disk:ssd.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.taskmanager.service-account</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Service account that is used by taskmanager within kubernetes cluster. The task manager uses this service account when watching config maps on the API server to retrieve leader address of jobmanager and resourcemanager.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.tolerations</h5></td>

--- a/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/deployment/resource-providers/native_kubernetes.md
@@ -307,7 +307,8 @@ $ kubectl create clusterrolebinding flink-role-binding-default --clusterrole=edi
 {% endhighlight %}
 
 If you do not want to use the `default` service account, use the following command to create a new `flink-service-account` service account and set the role binding.
-Then use the config option `-Dkubernetes.jobmanager.service-account=flink-service-account` to make the JobManager pod use the `flink-service-account` service account to create and delete TaskManager pods.
+Then use the config option `-Dkubernetes.service-account=flink-service-account` to make the JobManager pod use the `flink-service-account` service account to create/delete TaskManager pods and leader ConfigMaps. 
+Also this will allow the TaskManager to watch leader ConfigMaps to retrieve the address of JobManager and ResourceManager.
 
 {% highlight bash %}
 $ kubectl create serviceaccount flink-service-account

--- a/docs/deployment/resource-providers/native_kubernetes.zh.md
+++ b/docs/deployment/resource-providers/native_kubernetes.zh.md
@@ -307,7 +307,8 @@ $ kubectl create clusterrolebinding flink-role-binding-default --clusterrole=edi
 {% endhighlight %}
 
 If you do not want to use the `default` service account, use the following command to create a new `flink-service-account` service account and set the role binding.
-Then use the config option `-Dkubernetes.jobmanager.service-account=flink-service-account` to make the JobManager pod use the `flink-service-account` service account to create and delete TaskManager pods.
+Then use the config option `-Dkubernetes.service-account=flink-service-account` to make the JobManager pod use the `flink-service-account` service account to create/delete TaskManager pods and leader ConfigMaps. 
+Also this will allow the TaskManager to watch leader ConfigMaps to retrieve the address of JobManager and ResourceManager.
 
 {% highlight bash %}
 $ kubectl create serviceaccount flink-service-account

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -38,6 +38,8 @@ import static org.apache.flink.configuration.description.TextElement.code;
 @PublicEvolving
 public class KubernetesConfigOptions {
 
+	private static final String KUBERNETES_SERVICE_ACCOUNT_KEY = "kubernetes.service-account";
+
 	public static final ConfigOption<String> CONTEXT =
 		key("kubernetes.context")
 		.stringType()
@@ -53,26 +55,30 @@ public class KubernetesConfigOptions {
 		.withDescription("The type of the rest service (ClusterIP or NodePort or LoadBalancer). " +
 			"When set to ClusterIP, the rest service will not be created.");
 
-	public static final ConfigOption<String> KUBERNETES_SERVICE_ACCOUNT =
-		key("kubernetes.service-account")
-		.stringType()
-		.defaultValue("default")
-		.withDescription("Service account that is used by jobmanager and taskmanger within kubernetes cluster. " +
-			"if specific JOB_MANAGER_SERVICE_ACCOUNT and/or TASK_MANAGER_SERVICE_ACCOUNT are not defined.");
-
 	public static final ConfigOption<String> JOB_MANAGER_SERVICE_ACCOUNT =
 		key("kubernetes.jobmanager.service-account")
 		.stringType()
 		.noDefaultValue()
 		.withDescription("Service account that is used by jobmanager within kubernetes cluster. " +
-			"The job manager uses this service account when requesting taskmanager pods from the API server.");
+			"The job manager uses this service account when requesting taskmanager pods from the API server. " +
+			"If not explicitly configured, config option '" + KUBERNETES_SERVICE_ACCOUNT_KEY + "' will be used.");
 
 	public static final ConfigOption<String> TASK_MANAGER_SERVICE_ACCOUNT =
 		key("kubernetes.taskmanager.service-account")
 		.stringType()
 		.noDefaultValue()
 		.withDescription("Service account that is used by taskmanager within kubernetes cluster. " +
-		"The task manager uses this service account when watching config maps on the API server to retrieve leader address of jobmanager and resourcemanager.");
+			"The task manager uses this service account when watching config maps on the API server to retrieve " +
+			"leader address of jobmanager and resourcemanager. If not explicitly configured, config option '" +
+			KUBERNETES_SERVICE_ACCOUNT_KEY + "' will be used.");
+
+	public static final ConfigOption<String> KUBERNETES_SERVICE_ACCOUNT =
+		key(KUBERNETES_SERVICE_ACCOUNT_KEY)
+			.stringType()
+			.defaultValue("default")
+			.withDescription("Service account that is used by jobmanager and taskmanager within kubernetes cluster. " +
+				"Notice that this can be overwritten by config options '" + JOB_MANAGER_SERVICE_ACCOUNT.key() +
+				"' and '" + TASK_MANAGER_SERVICE_ACCOUNT.key() + "' for jobmanager and taskmanager respectively.");
 
 	public static final ConfigOption<Double> JOB_MANAGER_CPU =
 		key("kubernetes.jobmanager.cpu")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -53,12 +53,26 @@ public class KubernetesConfigOptions {
 		.withDescription("The type of the rest service (ClusterIP or NodePort or LoadBalancer). " +
 			"When set to ClusterIP, the rest service will not be created.");
 
+	public static final ConfigOption<String> KUBERNETES_SERVICE_ACCOUNT =
+		key("kubernetes.service-account")
+		.stringType()
+		.defaultValue("default")
+		.withDescription("Service account that is used by jobmanager and taskmanger within kubernetes cluster. " +
+			"if specific JOB_MANAGER_SERVICE_ACCOUNT and/or TASK_MANAGER_SERVICE_ACCOUNT are not defined.");
+
 	public static final ConfigOption<String> JOB_MANAGER_SERVICE_ACCOUNT =
 		key("kubernetes.jobmanager.service-account")
 		.stringType()
-		.defaultValue("default")
+		.noDefaultValue()
 		.withDescription("Service account that is used by jobmanager within kubernetes cluster. " +
 			"The job manager uses this service account when requesting taskmanager pods from the API server.");
+
+	public static final ConfigOption<String> TASK_MANAGER_SERVICE_ACCOUNT =
+		key("kubernetes.taskmanager.service-account")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Service account that is used by taskmanager within kubernetes cluster. " +
+		"The task manager uses this service account when watching config maps on the API server to retrieve leader address of jobmanager and resourcemanager.");
 
 	public static final ConfigOption<Double> JOB_MANAGER_CPU =
 		key("kubernetes.jobmanager.cpu")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -58,6 +58,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
 				.withAnnotations(kubernetesTaskManagerParameters.getAnnotations())
 				.endMetadata()
 			.editOrNewSpec()
+				.withServiceAccountName(kubernetesTaskManagerParameters.getServiceAccount())
 				.withRestartPolicy(Constants.RESTART_POLICY_OF_NEVER)
 				.withImagePullSecrets(kubernetesTaskManagerParameters.getImagePullSecrets())
 				.withNodeSelector(kubernetesTaskManagerParameters.getNodeSelector())

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -120,7 +120,8 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
 	}
 
 	public String getServiceAccount() {
-		return flinkConfig.getString(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT);
+		return flinkConfig.getOptional(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT)
+			.orElse(flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT));
 	}
 
 	public String getEntrypointClass() {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -106,6 +106,12 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 		return containeredTaskManagerParameters.getTaskExecutorProcessSpec().getCpuCores().getValue().doubleValue();
 	}
 
+	public String getServiceAccount() {
+		return flinkConfig.getOptional(KubernetesConfigOptions.TASK_MANAGER_SERVICE_ACCOUNT)
+			.orElse(flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT));
+
+	}
+
 	public Map<String, Long> getTaskManagerExternalResources() {
 		return taskManagerExternalResources;
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorAccountTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorAccountTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * General tests for the {@link InitJobManagerDecorator}.
+ */
+public class InitJobManagerDecoratorAccountTest extends KubernetesJobManagerTestBase {
+
+	private static final String SERVICE_ACCOUNT_NAME = "service-test";
+	private static final String JOB_MANGER_SERVICE_ACCOUNT_NAME = "jm-service-test";
+
+	private Pod resultPod;
+	private Container resultMainContainer;
+
+	@Override
+	protected void setupFlinkConfig() {
+		super.setupFlinkConfig();
+
+		this.flinkConfig.set(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
+		this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, JOB_MANGER_SERVICE_ACCOUNT_NAME);
+	}
+
+	@Override
+	protected void onSetup() throws Exception {
+		super.onSetup();
+
+		final InitJobManagerDecorator initJobManagerDecorator =
+			new InitJobManagerDecorator(this.kubernetesJobManagerParameters);
+		final FlinkPod resultFlinkPod = initJobManagerDecorator.decorateFlinkPod(this.baseFlinkPod);
+
+		this.resultPod = resultFlinkPod.getPod();
+		this.resultMainContainer = resultFlinkPod.getMainContainer();
+	}
+
+	@Test
+	public void testPodServiceAccountName() {
+		assertEquals(JOB_MANGER_SERVICE_ACCOUNT_NAME, this.resultPod.getSpec().getServiceAccountName());
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorAccountTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorAccountTest.java
@@ -22,14 +22,14 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
 
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
- * General tests for the {@link InitJobManagerDecorator}.
+ * Tests for {@link InitJobManagerDecorator} decorating service account.
  */
 public class InitJobManagerDecoratorAccountTest extends KubernetesJobManagerTestBase {
 
@@ -37,7 +37,6 @@ public class InitJobManagerDecoratorAccountTest extends KubernetesJobManagerTest
 	private static final String JOB_MANGER_SERVICE_ACCOUNT_NAME = "jm-service-test";
 
 	private Pod resultPod;
-	private Container resultMainContainer;
 
 	@Override
 	protected void setupFlinkConfig() {
@@ -56,11 +55,10 @@ public class InitJobManagerDecoratorAccountTest extends KubernetesJobManagerTest
 		final FlinkPod resultFlinkPod = initJobManagerDecorator.decorateFlinkPod(this.baseFlinkPod);
 
 		this.resultPod = resultFlinkPod.getPod();
-		this.resultMainContainer = resultFlinkPod.getMainContainer();
 	}
 
 	@Test
 	public void testPodServiceAccountName() {
-		assertEquals(JOB_MANGER_SERVICE_ACCOUNT_NAME, this.resultPod.getSpec().getServiceAccountName());
+		assertThat(this.resultPod.getSpec().getServiceAccountName(), is(JOB_MANGER_SERVICE_ACCOUNT_NAME));
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -74,7 +74,7 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
 	protected void setupFlinkConfig() {
 		super.setupFlinkConfig();
 
-		this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
+		this.flinkConfig.set(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_SECRETS, IMAGE_PULL_SECRETS);
 		this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, ANNOTATIONS);
 		this.flinkConfig.setString(KubernetesConfigOptions.JOB_MANAGER_TOLERATIONS.key(), TOLERATION_STRING);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorAccountTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorAccountTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * General tests for the {@link InitJobManagerDecorator}.
+ */
+public class InitTaskManagerDecoratorAccountTest extends KubernetesTaskManagerTestBase {
+
+	private static final String SERVICE_ACCOUNT_NAME = "service-test";
+	private static final String TASK_MANAGER_SERVICE_ACCOUNT_NAME = "tm-service-test";
+
+	private Pod resultPod;
+	private Container resultMainContainer;
+
+	@Override
+	protected void setupFlinkConfig() {
+		super.setupFlinkConfig();
+
+		this.flinkConfig.set(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
+		this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_SERVICE_ACCOUNT, TASK_MANAGER_SERVICE_ACCOUNT_NAME);
+	}
+
+	@Override
+	protected void onSetup() throws Exception {
+		super.onSetup();
+
+		final InitTaskManagerDecorator initTaskManagerDecorator =
+			new InitTaskManagerDecorator(kubernetesTaskManagerParameters);
+
+		final FlinkPod resultFlinkPod = initTaskManagerDecorator.decorateFlinkPod(this.baseFlinkPod);
+		this.resultPod = resultFlinkPod.getPod();
+		this.resultMainContainer = resultFlinkPod.getMainContainer();
+	}
+
+	@Test
+	public void testPodServiceAccountName() {
+		assertThat(TASK_MANAGER_SERVICE_ACCOUNT_NAME, is(this.resultPod.getSpec().getServiceAccountName()));
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorAccountTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorAccountTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
- * General tests for the {@link InitJobManagerDecorator}.
+ * Tests for {@link InitTaskManagerDecorator} decorating service account.
  */
 public class InitTaskManagerDecoratorAccountTest extends KubernetesTaskManagerTestBase {
 
@@ -38,7 +37,6 @@ public class InitTaskManagerDecoratorAccountTest extends KubernetesTaskManagerTe
 	private static final String TASK_MANAGER_SERVICE_ACCOUNT_NAME = "tm-service-test";
 
 	private Pod resultPod;
-	private Container resultMainContainer;
 
 	@Override
 	protected void setupFlinkConfig() {
@@ -57,11 +55,10 @@ public class InitTaskManagerDecoratorAccountTest extends KubernetesTaskManagerTe
 
 		final FlinkPod resultFlinkPod = initTaskManagerDecorator.decorateFlinkPod(this.baseFlinkPod);
 		this.resultPod = resultFlinkPod.getPod();
-		this.resultMainContainer = resultFlinkPod.getMainContainer();
 	}
 
 	@Test
 	public void testPodServiceAccountName() {
-		assertThat(TASK_MANAGER_SERVICE_ACCOUNT_NAME, is(this.resultPod.getSpec().getServiceAccountName()));
+		assertThat(this.resultPod.getSpec().getServiceAccountName(), is(TASK_MANAGER_SERVICE_ACCOUNT_NAME));
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -191,7 +191,7 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 
 	@Test
 	public void testPodServiceAccountName() {
-		assertThat(SERVICE_ACCOUNT_NAME, is(this.resultPod.getSpec().getServiceAccountName()));
+		assertThat(this.resultPod.getSpec().getServiceAccountName(), is(SERVICE_ACCOUNT_NAME));
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertThat;
  */
 public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
 
+	private static final String SERVICE_ACCOUNT_NAME = "service-test";
 	private static final List<String> IMAGE_PULL_SECRETS = Arrays.asList("s1", "s2", "s3");
 	private static final Map<String, String> ANNOTATIONS = new HashMap<String, String>() {
 		{
@@ -77,6 +78,7 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 	protected void setupFlinkConfig() {
 		super.setupFlinkConfig();
 
+		this.flinkConfig.set(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
 		this.flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_SECRETS, IMAGE_PULL_SECRETS);
 		this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_ANNOTATIONS, ANNOTATIONS);
 		this.flinkConfig.setString(KubernetesConfigOptions.TASK_MANAGER_TOLERATIONS.key(), TOLERATION_STRING);
@@ -185,6 +187,11 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 	public void testPodAnnotations() {
 		final Map<String, String> resultAnnotations = kubernetesTaskManagerParameters.getAnnotations();
 		assertThat(resultAnnotations, is(equalTo(ANNOTATIONS)));
+	}
+
+	@Test
+	public void testPodServiceAccountName() {
+		assertThat(SERVICE_ACCOUNT_NAME, is(this.resultPod.getSpec().getServiceAccountName()));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, we only set the service account for JobManager. The TaskManager is using the default service account. Before the KubernetesHAService is introduced, it works because the TaskManager does not need to access the K8s resource(e.g. ConfigMap) directly. But now the TaskManager needs to watch ConfigMap and retrieve leader address. So if the default service account does not have enough permission, users could not specify a valid service account for TaskManager.


## Brief change log

- New configuration parameter TASK_MANAGER_SERVICE_ACCOUNT created
- Method getServiceAccount added to KubernetesTaskManagerParameters
- Service account added to the pod creation in InitTaskManagerDecorator
- InitTaskManagerDecoratorTest is extended to incorporate service account test

## Verifying this change

This change added tests and can be verified by running unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) yes
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented
