### PR TITLE
[FLINK-20704][table-planner] Some rel data type does not implement th…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/GenericRelDataType.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/GenericRelDataType.scala
@@ -39,7 +39,6 @@ class GenericRelDataType(
     typeSystem,
     SqlTypeName.ANY) {
 
-  isNullable = nullable
   computeDigest()
 
   override def toString = s"RAW($genericType)"
@@ -58,6 +57,8 @@ class GenericRelDataType(
   override def hashCode(): Int = {
     genericType.hashCode()
   }
+
+  override def isNullable: Boolean = nullable
 
   /**
     * [[ArraySqlType]], [[MapSqlType]]... use generateTypeString to equals and hashcode.

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/ArrayRelDataType.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/ArrayRelDataType.scala
@@ -51,4 +51,7 @@ class ArrayRelDataType(
     typeInfo.hashCode()
   }
 
+  override def generateTypeString(sb: java.lang.StringBuilder, withDetail: Boolean): Unit = {
+    sb.append(s"$elementType ARRAY($typeInfo)")
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/GenericRelDataType.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/GenericRelDataType.scala
@@ -37,8 +37,6 @@ class GenericRelDataType(
     typeSystem,
     SqlTypeName.ANY) {
 
-  isNullable = nullable
-
   override def toString = s"ANY($typeInfo)"
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[GenericRelDataType]
@@ -54,5 +52,11 @@ class GenericRelDataType(
 
   override def hashCode(): Int = {
     typeInfo.hashCode()
+  }
+
+  override def isNullable: Boolean = nullable
+
+  override def generateTypeString(sb: java.lang.StringBuilder, withDetail: Boolean): Unit = {
+    sb.append(s"ANY($typeInfo)")
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/MapRelDataType.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/MapRelDataType.scala
@@ -45,5 +45,4 @@ class MapRelDataType(
   override def hashCode(): Int = {
     Objects.hashCode(keyType, valueType)
   }
-
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/MultisetRelDataType.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/schema/MultisetRelDataType.scala
@@ -47,4 +47,7 @@ class MultisetRelDataType(
     typeInfo.hashCode()
   }
 
+  override def generateTypeString(sb: java.lang.StringBuilder, withDetail: Boolean): Unit = {
+    sb.append(s"$elementType MULTISET($typeInfo)")
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/calcite/FlinkTypeFactoryTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import org.apache.flink.api.scala.typeutils.Types
+
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+/** Test cases for [[FlinkTypeFactory]]. */
+class FlinkTypeFactoryTest {
+
+  @Test
+  def testCanonizeType(): Unit = {
+    val typeFactory = FlinkTypeFactory.INSTANCE
+    val genericRelType = typeFactory
+        .createTypeFromTypeInfo(Types.GENERIC(classOf[TestClass]), isNullable = true)
+    val genericRelType2 = typeFactory
+        .createTypeFromTypeInfo(Types.GENERIC(classOf[TestClass]), isNullable = true)
+    val genericRelType3 = typeFactory
+        .createTypeFromTypeInfo(Types.GENERIC(classOf[TestClass2]), isNullable = true)
+
+    assertTrue("The type expect to be canonized", genericRelType eq genericRelType2)
+    assertFalse("The type expect to be not canonized", genericRelType eq genericRelType3)
+    assertFalse("The type expect to be not canonized",
+      typeFactory.builder().add("f0", genericRelType).build()
+          eq typeFactory.builder().add("f0", genericRelType3).build())
+
+    val varchar20Type = typeFactory.createSqlType(SqlTypeName.VARCHAR, 20)
+    val bigintType = typeFactory.createSqlType(SqlTypeName.BIGINT)
+
+    val arrayRelType = typeFactory.createArrayType(varchar20Type, 10)
+    val arrayRelType2 = typeFactory.createArrayType(varchar20Type, 10)
+    val arrayRelType3 = typeFactory.createArrayType(bigintType, 10)
+    assertTrue("The type expect to be canonized", arrayRelType eq arrayRelType2)
+    assertFalse("The type expect to be not canonized", arrayRelType eq arrayRelType3)
+    assertFalse("The type expect to be not canonized",
+      typeFactory.builder().add("f0", arrayRelType).build()
+          eq typeFactory.builder().add("f0", arrayRelType3).build())
+
+    val multisetRelType = typeFactory.createMultisetType(varchar20Type, 10)
+    val multisetRelType2 = typeFactory.createMultisetType(varchar20Type, 10)
+    val multisetRelType3 = typeFactory.createMultisetType(bigintType, 10)
+    assertTrue("The type expect to be canonized", multisetRelType eq multisetRelType2)
+    assertFalse("The type expect to be not canonized", multisetRelType eq multisetRelType3)
+    assertFalse("The type expect to be not canonized",
+      typeFactory.builder().add("f0", multisetRelType).build()
+          eq typeFactory.builder().add("f0", multisetRelType3).build())
+  }
+
+  case class TestClass(f0: Int, f1: String)
+
+  case class TestClass2(f0: Int, f1: String)
+}


### PR DESCRIPTION
…e digest correctly

## What is the purpose of the change

Some of the rel data types for legacy planner:

- `GenericRelDataType`
- `ArrayRelDataType`
- `MapRelDataType`
- `MultisetRelDataType`

Does not implement the digest correctly, especially for
`GenericRelDataType` , the `RelDataTypeFactory` caches the type instances
based on its digest, a wrong digest impl would mess up the type instance
creation, e.g. without this patch, all the `GenericRelDataType` instances
have same digest `ANY`.


## Brief change log

- Fix the digest of `GenericRelDataType`, `ArrayRelDataType`, `MapRelDataType`, `MultisetRelDataType`

## Verifying this change

No tests needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
