### PR TITLE
[FLINK-20710][Hive] HiveTableInputFormat and HiveSourceFileEnumerator will throw IllegalArgumentException when creating splits for tables with partitions on different hdfs nameservices

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -62,13 +62,10 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
 			List<HiveTablePartition> partitions,
 			JobConf jobConf) throws IOException {
 		List<HiveSourceSplit> hiveSplits = new ArrayList<>();
-		FileSystem fs = null;
 		for (HiveTablePartition partition : partitions) {
 			StorageDescriptor sd = partition.getStorageDescriptor();
 			org.apache.hadoop.fs.Path inputPath = new org.apache.hadoop.fs.Path(sd.getLocation());
-			if (fs == null) {
-				fs = inputPath.getFileSystem(jobConf);
-			}
+			FileSystem fs = inputPath.getFileSystem(jobConf);
 			// it's possible a partition exists in metastore but the data has been removed
 			if (!fs.exists(inputPath)) {
 				continue;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -285,13 +285,10 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 			JobConf jobConf) throws IOException {
 		List<HiveTableInputSplit> hiveSplits = new ArrayList<>();
 		int splitNum = 0;
-		FileSystem fs = null;
 		for (HiveTablePartition partition : partitions) {
 			StorageDescriptor sd = partition.getStorageDescriptor();
 			Path inputPath = new Path(sd.getLocation());
-			if (fs == null) {
-				fs = inputPath.getFileSystem(jobConf);
-			}
+			FileSystem fs = inputPath.getFileSystem(jobConf);
 			// it's possible a partition exists in metastore but the data has been removed
 			if (!fs.exists(inputPath)) {
 				continue;


### PR DESCRIPTION

## What is the purpose of the change

HiveTableInputFormat will throws the IllegalArgumentException if partitions of a table are in different HDFS nameservices:
```java
Caused by: java.lang.IllegalArgumentException: Wrong FS: hdfs://ns1/hive/warehouse/test.db/flink_test/day=4, expected: hdfs://ns2
        at org.apache.hadoop.fs.FileSystem.checkPath(FileSystem.java:662)
        at org.apache.hadoop.hdfs.DistributedFileSystem.getPathName(DistributedFileSystem.java:222)
        at org.apache.hadoop.hdfs.DistributedFileSystem.access$000(DistributedFileSystem.java:114)
        at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1266)
        at org.apache.hadoop.hdfs.DistributedFileSystem$20.doCall(DistributedFileSystem.java:1262)
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
        at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1262)
        at org.apache.hadoop.fs.FileSystem.exists(FileSystem.java:1418)
        at org.apache.flink.connectors.hive.read.HiveTableInputFormat.createInputSplits(HiveTableInputFormat.java:299)
        at org.apache.flink.connectors.hive.read.HiveTableInputFormat.createInputSplits(HiveTableInputFormat.java:282)
        at org.apache.flink.connectors.hive.HiveTableSource.createBatchSource(HiveTableSource.java:214)
        at org.apache.flink.connectors.hive.HiveTableSource.getDataStream(HiveTableSource.java:188)
```
The FLINK-16197 introduced this issue.

## Brief change log

  - Use inputPath to get FileSystem when checking the input existence


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *TableEnvHiveConnectorITCase.testNonExistingPartitionFolder()*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializer:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
