### PR TITLE
[FLINK-20703][table] HiveSinkCompactionITCase test timeout

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/CompactionITCaseBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/CompactionITCaseBase.java
@@ -90,7 +90,17 @@ public abstract class CompactionITCaseBase extends StreamingTestBase {
 	protected abstract void createPartitionTable(String path);
 
 	@Test
+	public void testSingleParallelism() throws Exception {
+		innerTestNonPartition(1);
+	}
+
+	@Test
 	public void testNonPartition() throws Exception {
+		innerTestNonPartition(3);
+	}
+
+	public void innerTestNonPartition(int parallelism) throws Exception {
+		env().setParallelism(parallelism);
 		createTable(resultPath);
 		tEnv().executeSql("insert into sink_table select * from my_table").await();
 


### PR DESCRIPTION

## What is the purpose of the change

HiveSinkCompactionITCase test timeout
The phenomenon is:

All failure are related to the hive tests.
All tests timeout when fail.

## Brief change log

In `CompactOperator`:

Some writer not support RecoverableWriter, so fallback to per record moving.
For example, see the constructor of HadoopRecoverableWriter. Although it not support
RecoverableWriter, but HadoopPathBasedBulkFormatBuilder can support streaming writing.

Catch unsupportedException, fallback to `doMultiFilesCompact`.

## Verifying this change

`HiveSinkCompactionITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no