### PR TITLE
[FLINK-20705][table-planner-blink] Separate the implementation of BatchExecValues and StreamExecValues

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecValues;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.List;
+
+/**
+ * Batch {@link ExecNode} that read records from given values.
+ */
+public class BatchExecValues extends CommonExecValues implements BatchExecNode<RowData> {
+
+	public BatchExecValues(List<List<RexLiteral>> tuples, RowType outputType, String description) {
+		super(tuples, outputType, description);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecValues.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.common;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.ValuesCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.runtime.operators.values.ValuesInputFormat;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Base {@link ExecNode} that read records from given values.
+ */
+public abstract class CommonExecValues extends ExecNodeBase<RowData> {
+	private final List<List<RexLiteral>> tuples;
+
+	public CommonExecValues(List<List<RexLiteral>> tuples, RowType outputType, String description) {
+		super(Collections.emptyList(), outputType, description);
+		this.tuples = tuples;
+	}
+
+	@Override
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+		final ValuesInputFormat inputFormat = ValuesCodeGenerator.generatorInputFormat(
+				planner.getTableConfig(),
+				(RowType) getOutputType(),
+				tuples,
+				getClass().getSimpleName());
+		final Transformation<RowData> transformation =
+				planner.getExecEnv().createInput(inputFormat, inputFormat.getProducedType()).getTransformation();
+		transformation.setName(getDesc());
+		transformation.setParallelism(1);
+		transformation.setMaxParallelism(1);
+		return transformation;
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecValues;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.List;
+
+/**
+ * Stream {@link ExecNode} that read records from given values.
+ */
+public class StreamExecValues extends CommonExecValues implements StreamExecNode<RowData>  {
+
+	public StreamExecValues(List<List<RexLiteral>> tuples, RowType outputType, String description) {
+		super(tuples, outputType, description);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ValuesCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ValuesCodeGenerator.scala
@@ -20,13 +20,13 @@ package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.data.{GenericRowData, RowData}
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.runtime.operators.values.ValuesInputFormat
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.types.logical.RowType
 
-import com.google.common.collect.ImmutableList
-import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex.RexLiteral
+
+import java.util
 
 import scala.collection.JavaConversions._
 
@@ -34,11 +34,9 @@ object ValuesCodeGenerator {
 
   def generatorInputFormat(
     config: TableConfig,
-    rowType: RelDataType,
-    tuples: ImmutableList[ImmutableList[RexLiteral]],
+    outputType: RowType,
+    tuples: util.List[util.List[RexLiteral]],
     description: String): ValuesInputFormat = {
-    val outputType = FlinkTypeFactory.toLogicalRowType(rowType)
-
     val ctx = CodeGeneratorContext(config)
     val exprGenerator = new ExprCodeGenerator(ctx, false)
     // generate code for every record

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecValues.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecValues.scala
@@ -20,9 +20,10 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.data.RowData
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.ValuesCodeGenerator
 import org.apache.flink.table.planner.delegation.BatchPlanner
-import org.apache.flink.table.planner.plan.nodes.exec.{LegacyBatchExecNode, ExecEdge}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, LegacyBatchExecNode}
 
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -66,8 +67,8 @@ class BatchExecValues(
       planner: BatchPlanner): Transformation[RowData] = {
     val inputFormat = ValuesCodeGenerator.generatorInputFormat(
       planner.getTableConfig,
-      getRowType,
-      tuples,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      tuples.asList().map(_.asList()),
       getRelTypeName)
     val transformation = planner.getExecEnv.createInput(inputFormat,
       inputFormat.getProducedType).getTransformation

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -302,7 +302,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         createNewNode(ts, List(), providedTrait, requiredTrait, requester)
 
       case _: StreamPhysicalDataStreamScan | _: StreamPhysicalLegacyTableSourceScan |
-           _: StreamExecValues =>
+           _: StreamPhysicalValues =>
         // DataStream, TableSource and Values only support producing insert-only messages
         createNewNode(
           rel, List(), ModifyKindSetTrait.INSERT_ONLY, requiredTrait, requester)
@@ -642,7 +642,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         }
 
       case _: StreamPhysicalDataStreamScan | _: StreamPhysicalLegacyTableSourceScan |
-           _: StreamExecValues =>
+           _: StreamPhysicalValues =>
         createNewNode(rel, Some(List()), UpdateKindTrait.NONE)
 
       case scan: StreamExecIntermediateTableScan =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -396,7 +396,7 @@ object FlinkBatchRuleSets {
     BatchPhysicalTableSourceScanRule.INSTANCE,
     BatchPhysicalLegacyTableSourceScanRule.INSTANCE,
     BatchExecIntermediateTableScanRule.INSTANCE,
-    BatchExecValuesRule.INSTANCE,
+    BatchPhysicalValuesRule.INSTANCE,
     // calc
     BatchPhysicalCalcRule.INSTANCE,
     BatchPhysicalPythonCalcRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -400,7 +400,7 @@ object FlinkStreamRuleSets {
     StreamPhysicalLegacyTableSourceScanRule.INSTANCE,
     StreamExecIntermediateTableScanRule.INSTANCE,
     StreamPhysicalWatermarkAssignerRule.INSTANCE,
-    StreamExecValuesRule.INSTANCE,
+    StreamPhysicalValuesRule.INSTANCE,
     // calc
     StreamPhysicalCalcRule.INSTANCE,
     StreamPhysicalPythonCalcRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalConstantTableFunctionScanRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCorrelate, BatchExecValues}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCorrelate, BatchPhysicalValues}
 
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptRule._
@@ -31,9 +31,9 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
 /**
   * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
   * {{{
-  *                    [[BatchPhysicalCorrelate]]
-  *                          /       \
-  * empty [[BatchExecValues]]  [[FlinkLogicalTableFunctionScan]]
+  *                         [[BatchPhysicalCorrelate]]
+  *                            /             \
+  * empty [[BatchPhysicalValuesRule]]  [[FlinkLogicalTableFunctionScan]]
   * }}}
   *
   * Add the rule to support select from a UDF directly, such as the following SQL:
@@ -60,7 +60,7 @@ class BatchPhysicalConstantTableFunctionScanRule
     // create correlate left
     val cluster = scan.getCluster
     val traitSet = call.getPlanner.emptyTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
-    val values = new BatchExecValues(
+    val values = new BatchPhysicalValues(
       cluster,
       traitSet,
       ImmutableList.of(ImmutableList.of[RexLiteral]()),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalValuesRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalValuesRule.scala
@@ -20,26 +20,26 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalValues
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecValues
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalValues
 
 import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 
 /**
-  * Rule that converts [[FlinkLogicalValues]] to [[BatchExecValues]].
+  * Rule that converts [[FlinkLogicalValues]] to [[BatchPhysicalValues]].
   */
-class BatchExecValuesRule extends ConverterRule(
+class BatchPhysicalValuesRule extends ConverterRule(
   classOf[FlinkLogicalValues],
   FlinkConventions.LOGICAL,
   FlinkConventions.BATCH_PHYSICAL,
-  "BatchExecValuesRule") {
+  "BatchPhysicalValuesRule") {
 
   def convert(rel: RelNode): RelNode = {
     val values: FlinkLogicalValues = rel.asInstanceOf[FlinkLogicalValues]
     val providedTraitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
 
-    new BatchExecValues(
+    new BatchPhysicalValues(
       rel.getCluster,
       providedTraitSet,
       values.getTuples,
@@ -47,6 +47,6 @@ class BatchExecValuesRule extends ConverterRule(
   }
 }
 
-object BatchExecValuesRule {
-  val INSTANCE: RelOptRule = new BatchExecValuesRule
+object BatchPhysicalValuesRule {
+  val INSTANCE: RelOptRule = new BatchPhysicalValuesRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalConstantTableFunctionScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalConstantTableFunctionScanRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalCorrelate, StreamExecValues}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalCorrelate, StreamPhysicalValues}
 
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptRule._
@@ -32,8 +32,8 @@ import org.apache.calcite.rex.{RexLiteral, RexUtil}
   * Converts [[FlinkLogicalTableFunctionScan]] with constant RexCall to
   * {{{
   *                    [[StreamPhysicalCorrelate]]
-  *                          /       \
-  * empty [[StreamExecValues]]  [[FlinkLogicalTableFunctionScan]]
+  *                          /          \
+  * empty [[StreamPhysicalValues]]  [[FlinkLogicalTableFunctionScan]]
   * }}}
   *
   * Add the rule to support select from a UDF directly, such as the following SQL:
@@ -60,7 +60,7 @@ class StreamPhysicalConstantTableFunctionScanRule
     // create correlate left
     val cluster = scan.getCluster
     val traitSet = call.getPlanner.emptyTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    val values = new StreamExecValues(
+    val values = new StreamPhysicalValues(
       cluster,
       traitSet,
       ImmutableList.of(ImmutableList.of[RexLiteral]()),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalValuesRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalValuesRule.scala
@@ -20,27 +20,27 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalValues
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecValues
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalValues
 
 import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 
 /**
-  * Rule that converts [[FlinkLogicalValues]] to [[StreamExecValues]].
+  * Rule that converts [[FlinkLogicalValues]] to [[StreamPhysicalValues]].
   */
-class StreamExecValuesRule
+class StreamPhysicalValuesRule
   extends ConverterRule(
     classOf[FlinkLogicalValues],
     FlinkConventions.LOGICAL,
     FlinkConventions.STREAM_PHYSICAL,
-    "StreamExecValuesRule") {
+    "StreamPhysicalValuesRule") {
 
   def convert(rel: RelNode): RelNode = {
     val values: FlinkLogicalValues = rel.asInstanceOf[FlinkLogicalValues]
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
 
-    new StreamExecValues(
+    new StreamPhysicalValues(
       rel.getCluster,
       traitSet,
       values.getTuples,
@@ -48,6 +48,6 @@ class StreamExecValuesRule
   }
 }
 
-object StreamExecValuesRule {
-  val INSTANCE: RelOptRule = new StreamExecValuesRule
+object StreamPhysicalValuesRule {
+  val INSTANCE: RelOptRule = new StreamPhysicalValuesRule
 }


### PR DESCRIPTION
## What is the purpose of the change

*Separate the implementation of BatchExecValues and StreamExecValues*


## Brief change log

  - *Introduce StreamPhysicalValues, and make StreamExecValues only extended from ExecNode*
  - *Introduce BatchPhysicalValues, and make BatchExecValues only extended from ExecNode*


## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
