### PR TITLE
[docs/javadoc][hotfix] Explicitly Document task cancellation timeout …

### DIFF
--- a/docs/_includes/generated/all_taskmanager_section.html
+++ b/docs/_includes/generated/all_taskmanager_section.html
@@ -18,7 +18,7 @@
             <td><h5>task.cancellation.timeout</h5></td>
             <td style="word-wrap: break-word;">180000</td>
             <td>Long</td>
-            <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog.</td>
+            <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog. Notice that a task cancellation is different from both a task failure and a clean shutdown.  Task cancellation timeout only applies to task cancellation and does not apply to task closing/clean-up caused by a task failure or a clean shutdown.</td>
         </tr>
         <tr>
             <td><h5>task.cancellation.timers.timeout</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>task.cancellation.timeout</h5></td>
             <td style="word-wrap: break-word;">180000</td>
             <td>Long</td>
-            <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog.</td>
+            <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog. Notice that a task cancellation is different from both a task failure and a clean shutdown.  Task cancellation timeout only applies to task cancellation and does not apply to task closing/clean-up caused by a task failure or a clean shutdown.</td>
         </tr>
         <tr>
             <td><h5>task.cancellation.timers.timeout</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -559,7 +559,10 @@ public class TaskManagerOptions {
 
     /**
      * Timeout in milliseconds after which a task cancellation times out and leads to a fatal
-     * TaskManager error. A value of <code>0</code> deactivates the watch dog.
+     * TaskManager error. A value of <code>0</code> deactivates the watch dog. Notice that a task
+     * cancellation is different from both a task failure and a clean shutdown. Task cancellation
+     * timeout only applies to task cancellation and does not apply to task closing/clean-up caused
+     * by a task failure or a clean shutdown.
      */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
     public static final ConfigOption<Long> TASK_CANCELLATION_TIMEOUT =
@@ -569,7 +572,10 @@ public class TaskManagerOptions {
                     .withDescription(
                             "Timeout in milliseconds after which a task cancellation times out and"
                                     + " leads to a fatal TaskManager error. A value of 0 deactivates"
-                                    + " the watch dog.");
+                                    + " the watch dog. Notice that a task cancellation is different from"
+                                    + " both a task failure and a clean shutdown. "
+                                    + " Task cancellation timeout only applies to task cancellation and does not apply to"
+                                    + " task closing/clean-up caused by a task failure or a clean shutdown.");
     /**
      * This configures how long we wait for the timers in milliseconds to finish all pending timer
      * threads when the stream task is cancelled.


### PR DESCRIPTION
…does not apply to task failure

## What is the purpose of the change

Document explicitly that "task cancellation timeout does not apply to task closing/clean-up caused by a task failure" to avoid confusions as mentioned in FLINK-18983


