### PR TITLE
[FLINK-20719][table-planner-blink] Change BatchExecNode & StreamExecNode to interface and make each node extended from ExecNodeBase directly

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecGraphGenerator.java
@@ -76,7 +76,7 @@ public class ExecGraphGenerator {
 			((LegacyExecNodeBase<?, ?>) execNode).setInputNodes(inputNodes);
 		} else {
 			// connects the input/output nodes
-			((ExecNodeBase<?, ?>) execNode).setInputNodes(inputNodes);
+			((ExecNodeBase<?>) execNode).setInputNodes(inputNodes);
 		}
 
 		visitedRels.put(rel, execNode);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -33,10 +34,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Base class for {@link ExecNode}.
  *
- * @param <P> The {@link Planner} that could translate the node into {@link Transformation}.
  * @param <T> The type of the elements that result from this node.
  */
-public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> {
+public abstract class ExecNodeBase<T> implements ExecNode<T> {
 
 	private final String description;
 	private final List<ExecEdge> inputEdges;
@@ -96,20 +96,17 @@ public abstract class ExecNodeBase<P extends Planner, T> implements ExecNode<T> 
 		inputEdges.set(ordinalInParent, newInputEdge);
 	}
 
-	@SuppressWarnings("unchecked")
 	public Transformation<T> translateToPlan(Planner planner) {
 		if (transformation == null) {
-			transformation = translateToPlanInternal((P) planner);
+			transformation = translateToPlanInternal((PlannerBase) planner);
 		}
 		return transformation;
 	}
 
 	/**
 	 * Internal method, translates this node into a Flink operator.
-	 *
-	 * @param planner The {@link Planner} that could translate the node into {@link Transformation}.
 	 */
-	protected abstract Transformation<T> translateToPlanInternal(P planner);
+	protected abstract Transformation<T> translateToPlanInternal(PlannerBase planner);
 
 	@Override
 	public void accept(ExecNodeVisitor visitor) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecBoundedStreamScan.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.utils.ScanUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.types.DataType;
@@ -33,9 +35,9 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Batch exec node to connect a given bounded {@link DataStream} and consume data from it.
+ * Batch {@link ExecNode} to connect a given bounded {@link DataStream} and consume data from it.
  */
-public class BatchExecBoundedStreamScan extends BatchExecNode<RowData> {
+public class BatchExecBoundedStreamScan extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
 	private final DataStream<?> dataStream;
 	private final DataType sourceType;
 	private final int[] fieldIndexes;
@@ -57,7 +59,7 @@ public class BatchExecBoundedStreamScan extends BatchExecNode<RowData> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final Transformation<?> sourceTransform = dataStream.getTransformation();
 		if (needInternalConversion()) {
 			return ScanUtil.convertToInternalRow(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -18,42 +18,25 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.calcite.rex.RexProgram;
 
-import java.util.Collections;
-
 /**
- * Batch exec node for Calc.
+ * Batch {@link ExecNode} for Calc.
  */
-public class BatchExecCalc extends BatchExecNode<RowData> implements CommonExecCalc {
-	private final RexProgram calcProgram;
+public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowData> {
 
 	public BatchExecCalc(
 			RexProgram calcProgram,
 			ExecEdge inputEdge,
 			RowType outputType,
 			String description) {
-		super(Collections.singletonList(inputEdge), outputType, description);
-		this.calcProgram = calcProgram;
-	}
-
-	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
-		return translateToTransformation(
-				planner,
-				planner.getTableConfig(),
-				calcProgram,
-				TableStreamOperator.class,
-				"BatchExecCalc",
-				false,
-				inputsContainSingleton());
+		super(calcProgram, TableStreamOperator.class, false, inputEdge, outputType, description);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.HashCodeGenerator;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
@@ -44,7 +44,6 @@ import org.apache.flink.table.types.logical.RowType;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -52,14 +51,14 @@ import java.util.Optional;
  *
  * <p>TODO Remove this class once its functionality is replaced by ExecEdge.
  */
-public class BatchExecExchange extends BatchExecNode<RowData> implements CommonExecExchange {
+public class BatchExecExchange extends CommonExecExchange implements BatchExecNode<RowData> {
 	// the required shuffle mode for reusable BatchExecExchange
 	// if it's None, use value from configuration
 	@Nullable
 	private ShuffleMode requiredShuffleMode;
 
 	public BatchExecExchange(ExecEdge inputEdge, RowType outputType, String description) {
-		super(Collections.singletonList(inputEdge), outputType, description);
+		super(inputEdge, outputType, description);
 	}
 
 	public void setRequiredShuffleMode(@Nullable ShuffleMode requiredShuffleMode) {
@@ -92,7 +91,7 @@ public class BatchExecExchange extends BatchExecNode<RowData> implements CommonE
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final ExecNode<?> inputNode = getInputNodes().get(0);
 		final Transformation<RowData> inputTransform = (Transformation<RowData>) inputNode.translateToPlan(planner);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacyTableSourceScan.java
@@ -24,102 +24,72 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLegacyTableSourceScan;
 import org.apache.flink.table.planner.plan.utils.ScanUtil;
 import org.apache.flink.table.planner.sources.TableSourceUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
-import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
-import java.util.Collections;
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Batch exec node to read data from an external source defined by a bounded {@link StreamTableSource}.
+ * Batch {@link ExecNode} to read data from an external source defined by a bounded {@link StreamTableSource}.
  */
 public class BatchExecLegacyTableSourceScan
-		extends BatchExecNode<RowData>
-		implements CommonExecLegacyTableSourceScan {
-	private final TableSource<?> tableSource;
-	private final List<String> qualifiedName;
+		extends CommonExecLegacyTableSourceScan
+		implements BatchExecNode<RowData> {
 
 	public BatchExecLegacyTableSourceScan(
 			TableSource<?> tableSource,
 			List<String> qualifiedName,
 			RowType outputType,
 			String description) {
-		super(Collections.emptyList(), outputType, description);
-		this.tableSource = tableSource;
-		this.qualifiedName = qualifiedName;
+		super(tableSource, qualifiedName, outputType, description);
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
-		final Transformation<?> sourceTransform = getSourceTransformation(planner.getExecEnv(), tableSource);
-
-		final TypeInformation<?> inputType = sourceTransform.getOutputType();
-		final DataType producedDataType = tableSource.getProducedDataType();
-		// check that declared and actual type of table source DataStream are identical
-		if (!inputType.equals(TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(producedDataType))) {
-			throw new TableException(String.format("TableSource of type %s " +
-							"returned a DataStream of data type %s that does not match with the " +
-							"data type %s declared by the TableSource.getProducedDataType() method. " +
-							"Please validate the implementation of the TableSource.",
-					tableSource.getClass().getCanonicalName(), inputType, producedDataType));
-		}
-
-		final RowType outputType = (RowType) getOutputType();
-		final RelDataType relDataType = FlinkTypeFactory.INSTANCE().buildRelNodeRowType(outputType);
-		// get expression to extract rowtime attribute
-		final Optional<RexNode> rowtimeExpression = JavaScalaConversionUtil.toJava(
-				TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, relDataType))
-				.map(desc -> TableSourceUtil.getRowtimeExtractionExpression(
-						desc.getTimestampExtractor(),
-						producedDataType,
-						planner.getRelBuilder(),
-						getNameRemapping(tableSource)
-				));
-
-		final Transformation<RowData> transformation;
-		final int[] fieldIndexes = computeIndexMapping(tableSource, outputType, true);
-		if (needInternalConversion(tableSource, fieldIndexes)) {
+	protected Transformation<RowData> createConversionTransformationIfNeeded(
+			PlannerBase planner,
+			Transformation<?> sourceTransform,
+			@Nullable RexNode rowtimeExpression) {
+		final int[] fieldIndexes = computeIndexMapping(false);
+		if (needInternalConversion(fieldIndexes)) {
 			// the produced type may not carry the correct precision user defined in DDL, because
 			// it may be converted from legacy type. Fix precision using logical schema from DDL.
 			// code generation requires the correct precision of input fields.
 			DataType fixedProducedDataType = TableSourceUtil.fixPrecisionForProducedDataType(
-					tableSource, outputType);
-			transformation = ScanUtil.convertToInternalRow(
+					tableSource, (RowType) getOutputType());
+			return ScanUtil.convertToInternalRow(
 					new CodeGeneratorContext(planner.getTableConfig()),
 					(Transformation<Object>) sourceTransform,
 					fieldIndexes,
 					fixedProducedDataType,
-					outputType,
+					(RowType) getOutputType(),
 					qualifiedName,
-					JavaScalaConversionUtil.toScala(rowtimeExpression),
+					JavaScalaConversionUtil.toScala(Optional.ofNullable(rowtimeExpression)),
 					"",
 					"");
 
 		} else {
-			transformation = (Transformation<RowData>) sourceTransform;
+			return (Transformation<RowData>) sourceTransform;
 		}
-		return transformation;
 	}
 
 	@Override
-	public <IN> Transformation<IN> createInput(
+	protected <IN> Transformation<IN> createInput(
 			StreamExecutionEnvironment env,
 			InputFormat<IN, ? extends InputSplit> inputFormat,
 			TypeInformation<IN> typeInfo) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -22,9 +22,10 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.multipleinput.BatchMultipleInputStreamOperatorFactory;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapperGenerator;
@@ -38,7 +39,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Batch exec node for multiple input which contains a sub-graph of {@link ExecNode}s.
+ * Batch {@link ExecNode} for multiple input which contains a sub-graph of {@link ExecNode}s.
  * The root node of the sub-graph is {@link #rootNode}, and the leaf nodes of the sub-graph are
  * the output nodes of the {@link #getInputNodes()}.
  *
@@ -64,7 +65,7 @@ import java.util.stream.Collectors;
  * `Agg1` and `Agg2` are the leaf nodes of the sub-graph,
  * `Exchange1` and `Exchange2` are the input nodes of the multiple input node.
  */
-public class BatchExecMultipleInput extends BatchExecNode<RowData> {
+public class BatchExecMultipleInput extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
 
 	private final ExecNode<?> rootNode;
 
@@ -77,7 +78,7 @@ public class BatchExecMultipleInput extends BatchExecNode<RowData> {
 	}
 
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final List<Transformation<?>> inputTransforms = new ArrayList<>();
 		for (ExecNode<?> input : getInputNodes()) {
 			inputTransforms.add(input.translateToPlan(planner));

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNode.java
@@ -18,22 +18,10 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
-import org.apache.flink.table.planner.delegation.BatchPlanner;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
-import org.apache.flink.table.types.logical.LogicalType;
-
-import java.util.List;
 
 /**
  * Base class for batch {@link ExecNode}.
  */
-public abstract class BatchExecNode<T> extends ExecNodeBase<BatchPlanner, T> {
-	public BatchExecNode(
-			List<ExecEdge> inputEdges,
-			LogicalType outputType,
-			String description) {
-		super(inputEdges, outputType, description);
-	}
+public interface BatchExecNode<T> extends ExecNode<T> {
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
@@ -24,30 +24,21 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.BatchPlanner;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSourceScan;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.util.Collections;
-
 /**
- * Batch exec node to read data from an external source defined by a bounded {@link ScanTableSource}.
+ * Batch {@link ExecNode} to read data from an external source defined by a bounded {@link ScanTableSource}.
  */
-public class BatchExecTableSourceScan extends BatchExecNode<RowData> implements CommonExecTableSourceScan {
-	private final ScanTableSource tableSource;
+public class BatchExecTableSourceScan extends CommonExecTableSourceScan implements BatchExecNode<RowData> {
 
 	public BatchExecTableSourceScan(
 			ScanTableSource tableSource,
 			RowType outputType,
 			String description) {
-		super(Collections.emptyList(), outputType, description);
-		this.tableSource = tableSource;
-	}
-
-	@Override
-	protected Transformation<RowData> translateToPlanInternal(BatchPlanner planner) {
-		return createSourceTransformation(planner.getExecEnv(), tableSource, (RowType) getOutputType(), getDesc());
+		super(tableSource, outputType, description);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExchange.java
@@ -19,13 +19,22 @@
 package org.apache.flink.table.planner.plan.nodes.exec.common;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Collections;
 
 /**
  * Base class for exec Exchange.
  *
  * <p>TODO Remove this class once its functionality is replaced by ExecEdge.
  */
-public interface CommonExecExchange extends ExecNode<RowData> {
-
+public abstract class CommonExecExchange extends ExecNodeBase<RowData> {
+	public CommonExecExchange(
+			ExecEdge inputEdge,
+			RowType outputType,
+			String description) {
+		super(Collections.singletonList(inputEdge), outputType, description);
+	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacyTableSourceScan.java
@@ -23,65 +23,126 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.utils.ScanUtil;
+import org.apache.flink.table.planner.sources.TableSourceUtil;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
 import org.apache.flink.table.sources.DefinedFieldMapping;
 import org.apache.flink.table.sources.InputFormatTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.TypeMappingUtils;
 
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo;
 
 /**
- * Base exec node to read data from an external source defined by a {@link StreamTableSource}.
+ * Base {@link ExecNode} to read data from an external source defined by a {@link StreamTableSource}.
  */
-public interface CommonExecLegacyTableSourceScan {
+public abstract class CommonExecLegacyTableSourceScan extends ExecNodeBase<RowData> {
+
+	protected final TableSource<?> tableSource;
+	protected final List<String> qualifiedName;
+
+	public CommonExecLegacyTableSourceScan(
+			TableSource<?> tableSource,
+			List<String> qualifiedName,
+			RowType outputType,
+			String description) {
+		super(Collections.emptyList(), outputType, description);
+		this.tableSource = tableSource;
+		this.qualifiedName = qualifiedName;
+	}
 
 	@SuppressWarnings("unchecked")
-	default Transformation<?> getSourceTransformation(
-			StreamExecutionEnvironment env,
-			TableSource<?> tableSource) {
+	@Override
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+		final Transformation<?> sourceTransform;
+		final StreamExecutionEnvironment env = planner.getExecEnv();
 		if (tableSource instanceof InputFormatTableSource) {
 			InputFormatTableSource<Object> inputFormat = (InputFormatTableSource<Object>) tableSource;
 			TypeInformation<Object> typeInfo =
 					(TypeInformation<Object>) fromDataTypeToTypeInfo(inputFormat.getProducedDataType());
 			InputFormat<Object, ?> format = inputFormat.getInputFormat();
-			return createInput(env, format, typeInfo);
+			sourceTransform = createInput(env, format, typeInfo);
 		} else if (tableSource instanceof StreamTableSource) {
-			return ((StreamTableSource<?>) tableSource).getDataStream(env).getTransformation();
+			sourceTransform = ((StreamTableSource<?>) tableSource).getDataStream(env).getTransformation();
 		} else {
 			throw new UnsupportedOperationException(tableSource.getClass().getSimpleName() + " is unsupported.");
 		}
+
+		final TypeInformation<?> inputType = sourceTransform.getOutputType();
+		final DataType producedDataType = tableSource.getProducedDataType();
+		// check that declared and actual type of table source DataStream are identical
+		if (!inputType.equals(TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(producedDataType))) {
+			throw new TableException(String.format("TableSource of type %s " +
+							"returned a DataStream of data type %s that does not match with the " +
+							"data type %s declared by the TableSource.getProducedDataType() method. " +
+							"Please validate the implementation of the TableSource.",
+					tableSource.getClass().getCanonicalName(), inputType, producedDataType));
+		}
+
+		final RowType outputType = (RowType) getOutputType();
+		final RelDataType relDataType = FlinkTypeFactory.INSTANCE().buildRelNodeRowType(outputType);
+		// get expression to extract rowtime attribute
+		final Optional<RexNode> rowtimeExpression = JavaScalaConversionUtil.toJava(
+				TableSourceUtil.getRowtimeAttributeDescriptor(tableSource, relDataType))
+				.map(desc -> TableSourceUtil.getRowtimeExtractionExpression(
+						desc.getTimestampExtractor(),
+						producedDataType,
+						planner.getRelBuilder(),
+						getNameRemapping()
+				));
+
+		return createConversionTransformationIfNeeded(planner, sourceTransform, rowtimeExpression.orElse(null));
 	}
 
-	<IN> Transformation<IN> createInput(
+	protected abstract <IN> Transformation<IN> createInput(
 			StreamExecutionEnvironment env,
 			InputFormat<IN, ? extends InputSplit> inputFormat,
 			TypeInformation<IN> typeInfo);
 
-	default boolean needInternalConversion(TableSource<?> tableSource, int[] fieldIndexes) {
+	protected abstract Transformation<RowData> createConversionTransformationIfNeeded(
+			PlannerBase planner,
+			Transformation<?> sourceTransform,
+			@Nullable RexNode rowtimeExpression);
+
+	protected boolean needInternalConversion(int[] fieldIndexes) {
 		return ScanUtil.hasTimeAttributeField(fieldIndexes) ||
 				ScanUtil.needsConversion(tableSource.getProducedDataType());
 	}
 
-	default int[] computeIndexMapping(TableSource<?> tableSource, RowType outputType, boolean isStreaming) {
+	protected int[] computeIndexMapping(boolean isStreaming) {
 		TableSchema tableSchema = FlinkTypeFactory.toTableSchema(
-				FlinkTypeFactory.INSTANCE().buildRelNodeRowType(outputType));
+				FlinkTypeFactory.INSTANCE().buildRelNodeRowType((RowType) getOutputType()));
 		return TypeMappingUtils.computePhysicalIndicesOrTimeAttributeMarkers(
 				tableSource,
 				tableSchema.getTableColumns(),
 				isStreaming,
-				getNameRemapping(tableSource)
+				getNameRemapping()
 		);
 	}
 
-	default Function<String, String> getNameRemapping(TableSource<?> tableSource) {
+	private Function<String, String> getNameRemapping() {
 		if (tableSource instanceof DefinedFieldMapping) {
 			Map<String, String> mapping = ((DefinedFieldMapping) tableSource).getFieldMapping();
 			if (mapping != null) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -18,42 +18,25 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
-import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.AbstractProcessStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.calcite.rex.RexProgram;
 
-import java.util.Collections;
-
 /**
- * Stream exec node for Calc.
+ * Stream {@link ExecNode} for Calc.
  */
-public class StreamExecCalc extends StreamExecNode<RowData> implements CommonExecCalc {
-	private final RexProgram calcProgram;
+public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {
 
 	public StreamExecCalc(
 			RexProgram calcProgram,
 			ExecEdge inputEdge,
 			RowType outputType,
 			String description) {
-		super(Collections.singletonList(inputEdge), outputType, description);
-		this.calcProgram = calcProgram;
-	}
-
-	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
-		return translateToTransformation(
-				planner,
-				planner.getTableConfig(),
-				calcProgram,
-				AbstractProcessStreamOperator.class,
-				"StreamExecCalc",
-				true,
-				inputsContainSingleton());
+		super(calcProgram, AbstractProcessStreamOperator.class, true, inputEdge, outputType, description);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -26,9 +26,10 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.utils.AggregateUtil;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
@@ -42,11 +43,11 @@ import org.apache.flink.table.types.logical.RowType;
 import java.util.Collections;
 
 /**
- * Stream exec node which normalizes a changelog stream which maybe an upsert stream or
+ * Stream {@link ExecNode} which normalizes a changelog stream which maybe an upsert stream or
  * a changelog stream containing duplicate events. This node normalize such stream into a regular
  * changelog stream that contains INSERT/UPDATE_BEFORE/UPDATE_AFTER/DELETE records without duplication.
  */
-public class StreamExecChangelogNormalize extends StreamExecNode<RowData> {
+public class StreamExecChangelogNormalize extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 	private final int[] uniqueKeys;
 	private final boolean generateUpdateBefore;
 
@@ -63,7 +64,7 @@ public class StreamExecChangelogNormalize extends StreamExecNode<RowData> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final ExecNode<?> inputNode = getInputNodes().get(0);
 		final Transformation<RowData> inputTransform = (Transformation<RowData>) inputNode.translateToPlan(planner);
 		final InternalTypeInfo<RowData> rowTypeInfo = (InternalTypeInfo<RowData>) inputTransform.getOutputType();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDataStreamScan.java
@@ -24,8 +24,10 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.functions.sql.StreamRecordTimestampSqlFunction;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.utils.ScanUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.runtime.operators.AbstractProcessStreamOperator;
@@ -48,9 +50,9 @@ import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.
 import static org.apache.flink.table.typeutils.TimeIndicatorTypeInfo.ROWTIME_STREAM_MARKER;
 
 /**
- * Stream exec node to connect a given {@link DataStream} and consume data from it.
+ * Stream {@link ExecNode} to connect a given {@link DataStream} and consume data from it.
  */
-public class StreamExecDataStreamScan extends StreamExecNode<RowData> {
+public class StreamExecDataStreamScan extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 	private final DataStream<?> dataStream;
 	private final DataType sourceType;
 	private final int[] fieldIndexes;
@@ -75,7 +77,7 @@ public class StreamExecDataStreamScan extends StreamExecNode<RowData> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final Transformation<?> sourceTransform = dataStream.getTransformation();
 		final Optional<RexNode> rowtimeExpr = getRowtimeExpression(planner.getRelBuilder());
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecExchange;
@@ -35,8 +35,6 @@ import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.util.Collections;
-
 import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.DEFAULT_LOWER_BOUND_MAX_PARALLELISM;
 
 /**
@@ -44,18 +42,18 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.DEFAULT_LOW
  *
  * <p>TODO Remove this class once its functionality is replaced by ExecEdge.
  */
-public class StreamExecExchange extends StreamExecNode<RowData> implements CommonExecExchange {
+public class StreamExecExchange extends CommonExecExchange implements StreamExecNode<RowData> {
 
 	public StreamExecExchange(
 			ExecEdge inputEdge,
 			RowType outputType,
 			String description) {
-		super(Collections.singletonList(inputEdge), outputType, description);
+		super(inputEdge, outputType, description);
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final Transformation<RowData> inputTransform =
 				(Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMultipleInput.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMultipleInput.java
@@ -20,14 +20,15 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 
 import java.util.List;
 
 /**
- * Stream exec node for multiple input which contains a sub-graph of {@link ExecNode}s.
+ * Stream {@link ExecNode} for multiple input which contains a sub-graph of {@link ExecNode}s.
  * The root node of the sub-graph is {@link #rootNode}, and the leaf nodes of the sub-graph are
  * the output nodes of the {@link #getInputNodes()}.
  *
@@ -53,7 +54,7 @@ import java.util.List;
  * `Agg1` and `Agg2` are the leaf nodes of the sub-graph,
  * `Exchange1` and `Exchange2` are the input nodes of the multiple input node.
  */
-public class StreamExecMultipleInput extends StreamExecNode<RowData> {
+public class StreamExecMultipleInput extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 
 	private final ExecNode<?> rootNode;
 
@@ -66,7 +67,7 @@ public class StreamExecMultipleInput extends StreamExecNode<RowData> {
 	}
 
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		throw new UnsupportedOperationException("This method is not implemented yet.");
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecNode.java
@@ -18,22 +18,10 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
-import org.apache.flink.table.planner.delegation.StreamPlanner;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
-import org.apache.flink.table.types.logical.LogicalType;
-
-import java.util.List;
 
 /**
  * Base class for stream {@link ExecNode}.
  */
-public abstract class StreamExecNode<T> extends ExecNodeBase<StreamPlanner, T> {
-	public StreamExecNode(
-			List<ExecEdge> inputEdges,
-			LogicalType outputType,
-			String description) {
-		super(inputEdges, outputType, description);
-	}
+public interface StreamExecNode<T> extends ExecNode<T> {
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
@@ -23,30 +23,21 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSourceScan;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import java.util.Collections;
-
 /**
- * Stream exec node to read data from an external source defined by a {@link ScanTableSource}.
+ * Stream {@link ExecNode} to read data from an external source defined by a {@link ScanTableSource}.
  */
-public class StreamExecTableSourceScan extends StreamExecNode<RowData> implements CommonExecTableSourceScan {
-	private final ScanTableSource tableSource;
+public class StreamExecTableSourceScan extends CommonExecTableSourceScan implements StreamExecNode<RowData> {
 
 	public StreamExecTableSourceScan(
 			ScanTableSource tableSource,
 			RowType outputType,
 			String description) {
-		super(Collections.emptyList(), outputType, description);
-		this.tableSource = tableSource;
-	}
-
-	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
-		return createSourceTransformation(planner.getExecEnv(), tableSource, (RowType) getOutputType(), getDesc());
+		super(tableSource, outputType, description);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -24,9 +24,10 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.WatermarkGeneratorCodeGenerator;
-import org.apache.flink.table.planner.delegation.StreamPlanner;
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.runtime.generated.GeneratedWatermarkGenerator;
 import org.apache.flink.table.runtime.operators.wmassigners.WatermarkAssignerOperatorFactory;
@@ -39,9 +40,9 @@ import java.util.Collections;
 import java.util.Optional;
 
 /**
- * Stream exec node which generates watermark based on the input elements.
+ * Stream {@link ExecNode} which generates watermark based on the input elements.
  */
-public class StreamExecWatermarkAssigner extends StreamExecNode<RowData> {
+public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData> implements StreamExecNode<RowData> {
 	private final RexNode watermarkExpr;
 	private final int rowtimeFieldIndex;
 
@@ -58,7 +59,7 @@ public class StreamExecWatermarkAssigner extends StreamExecNode<RowData> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected Transformation<RowData> translateToPlanInternal(StreamPlanner planner) {
+	protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
 		final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
 		final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonCalc.scala
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.plan.nodes.exec.batch
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.BatchPlanner
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecPythonCalc
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNodeBase}
 import org.apache.flink.table.types.logical.RowType
 
 import org.apache.calcite.rex.RexProgram
@@ -42,13 +42,14 @@ class BatchExecPythonCalc(
     inputEdge: ExecEdge,
     outputType: RowType,
     description: String)
-  extends BatchExecNode[RowData](
+  extends ExecNodeBase[RowData](
     util.Collections.singletonList(inputEdge),
     outputType,
     description)
+  with BatchExecNode[RowData]
   with CommonExecPythonCalc {
 
-  override protected def translateToPlanInternal(planner: BatchPlanner): Transformation[RowData] = {
+  override protected def translateToPlanInternal(planner: PlannerBase): Transformation[RowData] = {
     val inputTransform = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
     val ret = createPythonOneInputTransformation(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonCalc.scala
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.core.memory.ManagedMemoryUseCase
 import org.apache.flink.table.data.RowData
-import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecPythonCalc
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNodeBase}
 import org.apache.flink.table.types.logical.RowType
 
 import org.apache.calcite.rex.RexProgram
@@ -42,14 +42,14 @@ class StreamExecPythonCalc(
     inputEdge: ExecEdge,
     outputType: RowType,
     description: String)
-  extends StreamExecNode[RowData](
+  extends ExecNodeBase[RowData](
     util.Collections.singletonList(inputEdge),
     outputType,
     description)
+  with StreamExecNode[RowData]
   with CommonExecPythonCalc {
 
-  override protected def translateToPlanInternal(
-      planner: StreamPlanner): Transformation[RowData] = {
+  override protected def translateToPlanInternal(planner: PlannerBase): Transformation[RowData] = {
     val inputTransform = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
     val ret = createPythonOneInputTransformation(


### PR DESCRIPTION
## What is the purpose of the change

*Change BatchExecNode & StreamExecNode to interface and make each node extended from ExecNodeBase directly*


## Brief change log

  - *Remove type parameter P in ExecNodeBase, use PlannerBase directly*
  - *Change BatchExecNode & StreamExecNode to interface and make each node extended from ExecNodeBase directly*


## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
