### PR TITLE
[FLINK-20657][connectors/jdbc] Migrate jdbc InputFormat/LookupFunction to SimpleJdbcConnectionProvider for connection establishment

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcInputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcInputFormat.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.jdbc.internal.connection.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.split.JdbcParameterValuesProvider;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.core.io.InputSplit;
@@ -102,19 +104,15 @@ import java.util.Arrays;
 @Experimental
 public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements ResultTypeQueryable<Row> {
 
-	protected static final long serialVersionUID = 1L;
+	protected static final long serialVersionUID = 2L;
 	protected static final Logger LOG = LoggerFactory.getLogger(JdbcInputFormat.class);
 
-	protected String username;
-	protected String password;
-	protected String drivername;
-	protected String dbURL;
+	protected JdbcConnectionProvider connectionProvider;
 	protected String queryTemplate;
 	protected int resultSetType;
 	protected int resultSetConcurrency;
 	protected RowTypeInfo rowTypeInfo;
 
-	protected transient Connection dbConn;
 	protected transient PreparedStatement statement;
 	protected transient ResultSet resultSet;
 	protected int fetchSize;
@@ -141,18 +139,7 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 	public void openInputFormat() {
 		//called once per inputFormat (on open)
 		try {
-			// Load DriverManager first to avoid deadlock between DriverManager's
-			// static initialization block and specific driver class's static
-			// initialization block.
-			//
-			// See comments in SimpleJdbcConnectionProvider for more details.
-			DriverManager.getDrivers();
-			Class.forName(drivername);
-			if (username == null) {
-				dbConn = DriverManager.getConnection(dbURL);
-			} else {
-				dbConn = DriverManager.getConnection(dbURL, username, password);
-			}
+			Connection dbConn = connectionProvider.getOrEstablishConnection();
 
 			// set autoCommit mode only if it was explicitly configured.
 			// keep connection default otherwise.
@@ -184,15 +171,7 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 			statement = null;
 		}
 
-		try {
-			if (dbConn != null) {
-				dbConn.close();
-			}
-		} catch (SQLException se) {
-			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-		} finally {
-			dbConn = null;
-		}
+		connectionProvider.closeConnection();
 
 		parameterValues = null;
 	}
@@ -342,7 +321,7 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 
 	@VisibleForTesting
 	protected Connection getDbConn() {
-		return dbConn;
+		return connectionProvider.getConnection();
 	}
 
 	/**
@@ -357,10 +336,11 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 	 * Builder for {@link JdbcInputFormat}.
 	 */
 	public static class JdbcInputFormatBuilder {
-
+		private final JdbcConnectionOptions.JdbcConnectionOptionsBuilder connOptionsBuilder;
 		private final JdbcInputFormat format;
 
 		public JdbcInputFormatBuilder() {
+			this.connOptionsBuilder = new JdbcConnectionOptions.JdbcConnectionOptionsBuilder();
 			this.format = new JdbcInputFormat();
 			//using TYPE_FORWARD_ONLY for high performance reads
 			this.format.resultSetType = ResultSet.TYPE_FORWARD_ONLY;
@@ -368,22 +348,22 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 		}
 
 		public JdbcInputFormatBuilder setUsername(String username) {
-			format.username = username;
+			connOptionsBuilder.withUsername(username);
 			return this;
 		}
 
 		public JdbcInputFormatBuilder setPassword(String password) {
-			format.password = password;
+			connOptionsBuilder.withPassword(password);
 			return this;
 		}
 
 		public JdbcInputFormatBuilder setDrivername(String drivername) {
-			format.drivername = drivername;
+			connOptionsBuilder.withDriverName(drivername);
 			return this;
 		}
 
 		public JdbcInputFormatBuilder setDBUrl(String dbURL) {
-			format.dbURL = dbURL;
+			connOptionsBuilder.withUrl(dbURL);
 			return this;
 		}
 
@@ -425,23 +405,12 @@ public class JdbcInputFormat extends RichInputFormat<Row, InputSplit> implements
 		}
 
 		public JdbcInputFormat finish() {
-			if (format.username == null) {
-				LOG.info("Username was not supplied separately.");
-			}
-			if (format.password == null) {
-				LOG.info("Password was not supplied separately.");
-			}
-			if (format.dbURL == null) {
-				throw new IllegalArgumentException("No database URL supplied");
-			}
+			format.connectionProvider = new SimpleJdbcConnectionProvider(connOptionsBuilder.build());
 			if (format.queryTemplate == null) {
-				throw new IllegalArgumentException("No query supplied");
-			}
-			if (format.drivername == null) {
-				throw new IllegalArgumentException("No driver supplied");
+				throw new NullPointerException("No query supplied");
 			}
 			if (format.rowTypeInfo == null) {
-				throw new IllegalArgumentException("No " + RowTypeInfo.class.getSimpleName() + " supplied");
+				throw new NullPointerException("No " + RowTypeInfo.class.getSimpleName() + " supplied");
 			}
 			if (format.parameterValues == null) {
 				LOG.debug("No input splitting configured (data will be read with parallelism 1).");

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/AbstractJdbcOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/AbstractJdbcOutputFormat.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.Flushable;
 import java.io.IOException;
 import java.sql.Connection;
-import java.sql.SQLException;
 
 /**
  * Base jdbc outputFormat.
@@ -42,7 +41,6 @@ public abstract class AbstractJdbcOutputFormat<T> extends RichOutputFormat<T> im
 	public static final long DEFAULT_FLUSH_INTERVAL_MILLS = 0L;
 
 	private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcOutputFormat.class);
-	protected transient Connection connection;
 	protected final JdbcConnectionProvider connectionProvider;
 
 	public AbstractJdbcOutputFormat(JdbcConnectionProvider connectionProvider) {
@@ -56,31 +54,15 @@ public abstract class AbstractJdbcOutputFormat<T> extends RichOutputFormat<T> im
 	@Override
 	public void open(int taskNumber, int numTasks) throws IOException {
 		try {
-			establishConnection();
+			connectionProvider.getOrEstablishConnection();
 		} catch (Exception e) {
 			throw new IOException("unable to open JDBC writer", e);
 		}
 	}
 
-	protected void establishConnection() throws Exception {
-		connection = connectionProvider.getConnection();
-	}
-
 	@Override
 	public void close() {
-		closeDbConnection();
-	}
-
-	private void closeDbConnection() {
-		if (connection != null) {
-			try {
-				connection.close();
-			} catch (SQLException se) {
-				LOG.warn("JDBC connection could not be closed: " + se.getMessage());
-			} finally {
-				connection = null;
-			}
-		}
+		connectionProvider.closeConnection();
 	}
 
 	@Override
@@ -89,6 +71,6 @@ public abstract class AbstractJdbcOutputFormat<T> extends RichOutputFormat<T> im
 
 	@VisibleForTesting
 	public Connection getConnection() {
-		return connection;
+		return connectionProvider.getConnection();
 	}
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/JdbcBatchingOutputFormat.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.concurrent.Executors;
@@ -131,7 +132,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 	private JdbcExec createAndOpenStatementExecutor(StatementExecutorFactory<JdbcExec> statementExecutorFactory) throws IOException {
 		JdbcExec exec = statementExecutorFactory.apply(getRuntimeContext());
 		try {
-			exec.prepareStatements(connection);
+			exec.prepareStatements(connectionProvider.getConnection());
 		} catch (SQLException e) {
 			throw new IOException("unable to open JDBC writer", e);
 		}
@@ -179,13 +180,13 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
 				}
 				try {
 					if (!connectionProvider.isConnectionValid()){
-						connection = connectionProvider.reestablishConnection();
 						jdbcStatementExecutor.closeStatements();
+						Connection connection = connectionProvider.reestablishConnection();
 						jdbcStatementExecutor.prepareStatements(connection);
 					}
-				} catch (Exception excpetion) {
-					LOG.error("JDBC connection is not valid, and reestablish connection failed.", excpetion);
-					throw new IOException("Reestablish JDBC connection failed", excpetion);
+				} catch (Exception exception) {
+					LOG.error("JDBC connection is not valid, and reestablish connection failed.", exception);
+					throw new IOException("Reestablish JDBC connection failed", exception);
 				}
 				try {
 					Thread.sleep(1000 * i);

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/TableJdbcUpsertOutputFormat.java
@@ -56,7 +56,7 @@ class TableJdbcUpsertOutputFormat extends JdbcBatchingOutputFormat<Tuple2<Boolea
 		super.open(taskNumber, numTasks);
 		deleteExecutor = createDeleteExecutor();
 		try {
-			deleteExecutor.prepareStatements(connection);
+			deleteExecutor.prepareStatements(connectionProvider.getConnection());
 		} catch (SQLException e) {
 			throw new IOException(e);
 		}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionProvider.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/connection/JdbcConnectionProvider.java
@@ -19,16 +19,52 @@ package org.apache.flink.connector.jdbc.internal.connection;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
+
 import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * JDBC connection provider.
  */
 @Internal
 public interface JdbcConnectionProvider {
-	Connection getConnection() throws Exception;
+	/**
+	 * Get existing connection.
+	 *
+	 * @return existing connection
+	 */
+	@Nullable
+	Connection getConnection();
 
-	Connection reestablishConnection() throws Exception;
+	/**
+	 * Check whether possible existing connection is valid or not through {@link Connection#isValid(int)}.
+	 *
+	 * @return true if existing connection is valid
+	 * @throws SQLException sql exception throw from {@link Connection#isValid(int)}
+	 */
+	boolean isConnectionValid() throws SQLException;
 
-	boolean isConnectionValid() throws Exception;
+	/**
+	 * Get existing connection or establish an new one if there is none.
+	 *
+	 * @return existing connection or newly established connection
+	 * @throws SQLException sql exception
+	 * @throws ClassNotFoundException driver class not found
+	 */
+	Connection getOrEstablishConnection() throws SQLException, ClassNotFoundException;
+
+	/**
+	 * Close possible existing connection.
+	 */
+	void closeConnection();
+
+	/**
+	 * Close possible existing connection and establish an new one.
+	 *
+	 * @return newly established connection
+	 * @throws SQLException sql exception
+	 * @throws ClassNotFoundException driver class not found
+	 */
+	Connection reestablishConnection() throws SQLException, ClassNotFoundException;
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcInputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcInputFormatTest.java
@@ -26,7 +26,9 @@ import org.apache.flink.types.Row;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -48,6 +50,9 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
  */
 public class JdbcInputFormatTest extends JdbcDataTestBase {
 
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
 	private JdbcInputFormat jdbcInputFormat;
 
 	@After
@@ -59,10 +64,12 @@ public class JdbcInputFormatTest extends JdbcDataTestBase {
 		jdbcInputFormat = null;
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testUntypedRowInfo() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("No RowTypeInfo supplied");
 		jdbcInputFormat = JdbcInputFormat.buildJdbcInputFormat()
-			.setDrivername("org.apache.derby.jdbc.idontexist")
+			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
 			.finish();
@@ -102,11 +109,24 @@ public class JdbcInputFormatTest extends JdbcDataTestBase {
 		jdbcInputFormat.openInputFormat();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testIncompleteConfiguration() throws IOException {
+	@Test
+	public void testNoUrl() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("jdbc url is empty");
 		jdbcInputFormat = JdbcInputFormat.buildJdbcInputFormat()
 			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setQuery(SELECT_ALL_BOOKS)
+			.setRowTypeInfo(ROW_TYPE_INFO)
+			.finish();
+	}
+
+	@Test
+	public void testNoQuery() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("No query supplied");
+		jdbcInputFormat = JdbcInputFormat.buildJdbcInputFormat()
+			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
+			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
 			.setRowTypeInfo(ROW_TYPE_INFO)
 			.finish();
 	}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderDriverClassConcurrentLoadingTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderDriverClassConcurrentLoadingTest.java
@@ -75,7 +75,7 @@ public class SimpleJdbcConnectionProviderDriverClassConcurrentLoadingTest {
 				public void go() throws Exception {
 					startLatch.await();
 					JdbcConnectionProvider connectionProvider = new SimpleJdbcConnectionProvider(options);
-					Connection connection = connectionProvider.getConnection();
+					Connection connection = connectionProvider.getOrEstablishConnection();
 					connection.close();
 				}
 			};

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal.connection;
+
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.fakedb.FakeDBUtils;
+import org.apache.flink.connector.jdbc.fakedb.driver.FakeConnection;
+import org.apache.flink.connector.jdbc.fakedb.driver.FakeConnection1;
+import org.apache.flink.connector.jdbc.fakedb.driver.FakeConnection2;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.sql.Connection;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link SimpleJdbcConnectionProvider}.
+ */
+public class SimpleJdbcConnectionProviderTest {
+
+	private static JdbcConnectionProvider newFakeConnectionProviderWithDriverName(String driverName) {
+		JdbcConnectionOptions options = new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+			.withUrl(FakeDBUtils.TEST_DB_URL)
+			.withDriverName(driverName)
+			.build();
+		return new SimpleJdbcConnectionProvider(options);
+	}
+
+	private static JdbcConnectionProvider newFakeConnectionProvider() {
+		return newFakeConnectionProviderWithDriverName(FakeDBUtils.DRIVER1_CLASS_NAME);
+	}
+
+	@Test
+	public void testEstablishConnection() throws Exception {
+		JdbcConnectionProvider provider = newFakeConnectionProvider();
+		assertNull(provider.getConnection());
+		assertFalse(provider.isConnectionValid());
+
+		Connection connection = provider.getOrEstablishConnection();
+		assertNotNull(connection);
+		assertFalse(connection.isClosed());
+		assertTrue(provider.isConnectionValid());
+		assertThat(connection, instanceOf(FakeConnection.class));
+
+		assertNotNull(provider.getConnection());
+		assertSame(connection, provider.getConnection());
+		assertSame(connection, provider.getOrEstablishConnection());
+	}
+
+	@Test
+	@Ignore("FLINK-20658")
+	public void testEstablishDriverConnection() throws Exception {
+		JdbcConnectionProvider provider1 = newFakeConnectionProviderWithDriverName(FakeDBUtils.DRIVER1_CLASS_NAME);
+		Connection connection1 = provider1.getOrEstablishConnection();
+		assertThat(connection1, instanceOf(FakeConnection1.class));
+
+		JdbcConnectionProvider provider2 = newFakeConnectionProviderWithDriverName(FakeDBUtils.DRIVER2_CLASS_NAME);
+		Connection connection2 = provider2.getOrEstablishConnection();
+		assertThat(connection2, instanceOf(FakeConnection2.class));
+	}
+
+	@Test
+	public void testCloseNullConnection() throws Exception {
+		JdbcConnectionProvider provider = newFakeConnectionProvider();
+		provider.closeConnection();
+		assertNull(provider.getConnection());
+		assertFalse(provider.isConnectionValid());
+	}
+
+	@Test
+	public void testCloseConnection() throws Exception {
+		JdbcConnectionProvider provider = newFakeConnectionProvider();
+
+		Connection connection1 = provider.getOrEstablishConnection();
+		provider.closeConnection();
+		assertNull(provider.getConnection());
+		assertFalse(provider.isConnectionValid());
+		assertTrue(connection1.isClosed());
+
+		Connection connection2 = provider.getOrEstablishConnection();
+		assertNotSame(connection1, connection2);
+		assertFalse(connection2.isClosed());
+
+		connection2.close();
+		assertNotNull(provider.getConnection());
+		assertFalse(provider.isConnectionValid());
+	}
+
+	@Test
+	public void testReestablishCachedConnection() throws Exception {
+		JdbcConnectionProvider provider = newFakeConnectionProvider();
+
+		Connection connection1 = provider.reestablishConnection();
+		assertNotNull(connection1);
+		assertFalse(connection1.isClosed());
+		assertSame(connection1, provider.getConnection());
+		assertSame(connection1, provider.getOrEstablishConnection());
+
+		Connection connection2 = provider.reestablishConnection();
+		assertNotNull(connection2);
+		assertFalse(connection2.isClosed());
+		assertSame(connection2, provider.getConnection());
+		assertSame(connection2, provider.getOrEstablishConnection());
+
+		assertTrue(connection1.isClosed());
+		assertNotSame(connection1, connection2);
+	}
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcRowDataInputFormatTest.java
@@ -36,7 +36,9 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -55,6 +57,9 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
  * Test suite for {@link JdbcRowDataInputFormat}.
  */
 public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	private JdbcRowDataInputFormat inputFormat;
 	private static String[] fieldNames = new String[]{"id", "title", "author", "price", "qty"};
@@ -84,10 +89,12 @@ public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
 		inputFormat = null;
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testUntypedRowInfo() throws IOException {
+	@Test
+	public void testNoRowConverter() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("No row converter supplied");
 		inputFormat = JdbcRowDataInputFormat.builder()
-			.setDrivername("org.apache.derby.jdbc.idontexist")
+			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
 			.build();
@@ -100,6 +107,7 @@ public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
 			.setDrivername("org.apache.derby.jdbc.idontexist")
 			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
+			.setRowConverter(dialect.getRowConverter(rowType))
 			.build();
 		inputFormat.openInputFormat();
 	}
@@ -110,6 +118,7 @@ public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
 			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
 			.setQuery(SELECT_ALL_BOOKS)
+			.setRowConverter(dialect.getRowConverter(rowType))
 			.build();
 		inputFormat.openInputFormat();
 	}
@@ -120,15 +129,30 @@ public class JdbcRowDataInputFormatTest extends JdbcDataTestBase {
 			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery("iamnotsql")
+			.setRowConverter(dialect.getRowConverter(rowType))
 			.build();
 		inputFormat.openInputFormat();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testIncompleteConfiguration() throws IOException {
+	@Test
+	public void testNoQuery() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("No query supplied");
+		inputFormat = JdbcRowDataInputFormat.builder()
+			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
+			.setDBUrl(DERBY_EBOOKSHOP_DB.getUrl())
+			.setRowConverter(dialect.getRowConverter(rowType))
+			.build();
+	}
+
+	@Test
+	public void testNoUrl() throws IOException {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("jdbc url is empty");
 		inputFormat = JdbcRowDataInputFormat.builder()
 			.setDrivername(DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setQuery(SELECT_ALL_BOOKS)
+			.setRowConverter(dialect.getRowConverter(rowType))
 			.build();
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
Reuse `SimpleJdbcConnectionProvider` for jdbc connection establishment.

## Brief change log
- Add `SimpleJdbcConnectionProvider.closeConnection` to close cached connection and declare that `SimpleJdbcConnectionProvider` is `NotThreadSafe`.
- Migrate jdbc InputFormat/LookupFunction to `SimpleJdbcConnectionProvider` for connection establishment.
- Throw `NullPointerException` instead of `IllegalArgumentException` if required arguments is null in `JdbcInputFormatBuilder` and `JdbcRowDataInputFormat.Builder`.


## Verifying this change
This change is already covered by existing tests:
* `JdbcInputFormatTest`
* `JdbcRowDataInputFormatTest`

This change added tests and can be verified as follows:
* `SimpleJdbcConnectionProviderTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## Found other issues:
* Name inconsistence: `drivername` or `driverName` ?
* 0 is valid for `Statement.setFetchSize`, but `JdbcInputFormat` and `JdbcRowDataInputFormat` complains on this. It may not be important if all its usages are internal, but noticed that`JdbcInputFormat` is `Experimental`.