### PR TITLE
[FLINK-20694][coordination] Do not rematch freed slots 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -115,6 +115,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
 		this.registeredTaskManagers = new HashSet<>();
 		this.declareResourceRequirementServiceConnectionManager = NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
 		this.declarativeSlotPool = declarativeSlotPoolFactory.create(
+				jobId,
 				this::declareResourceRequirements,
 				this::newSlotsAreAvailable,
 				idleSlotTimeout,
@@ -357,8 +358,6 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
 
 	private void declareResourceRequirements(Collection<ResourceRequirement> resourceRequirements) {
 		assertRunningInMainThread();
-
-		LOG.debug("Declare new resource requirements for job {}: {}.", jobId, resourceRequirements);
 
 		declareResourceRequirementServiceConnectionManager.declareResourceRequirements(ResourceRequirements.create(jobId, jobManagerAddress, resourceRequirements));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -167,9 +167,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
 			}
 		}
 
-		if (!decreasedResourceRequirements.isEmpty()) {
-			declarativeSlotPool.decreaseResourceRequirementsBy(decreasedResourceRequirements);
-		}
+		declarativeSlotPool.decreaseResourceRequirementsBy(decreasedResourceRequirements);
 	}
 
 	private void clearState() {
@@ -375,9 +373,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
 		Preconditions.checkNotNull(resourceId, "This slot pool only supports failAllocation calls coming from the TaskExecutor.");
 
 		ResourceCounter previouslyFulfilledRequirements = declarativeSlotPool.releaseSlot(allocationID, cause);
-		if (!previouslyFulfilledRequirements.isEmpty()) {
-			declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirements);
-		}
+		declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirements);
 
 		if (declarativeSlotPool.containsSlots(resourceId)) {
 			return Optional.empty();
@@ -403,9 +399,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
 
 			if (allocationId != null) {
 				ResourceCounter previouslyFulfilledRequirement = declarativeSlotPool.freeReservedSlot(allocationId, cause, clock.relativeTimeMillis());
-				if (!previouslyFulfilledRequirement.isEmpty()) {
-					declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
-				}
+				declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
 			} else {
 				LOG.debug("Could not find slot which has fulfilled slot request {}. Ignoring the release operation.", slotRequestId);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 
@@ -29,6 +30,7 @@ import java.util.function.Consumer;
  */
 public interface DeclarativeSlotPoolFactory {
 	DeclarativeSlotPool create(
+		JobID jobId,
 		Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
 		Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
 		Time idleSlotTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -409,32 +409,4 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 	ResourceCounter getFulfilledResourceRequirements() {
 		return fulfilledResourceRequirements;
 	}
-
-	private static final class SlotOfferMatching {
-		private final SlotOffer slotOffer;
-
-		@Nullable
-		private final ResourceProfile matching;
-
-		private SlotOfferMatching(SlotOffer slotOffer, @Nullable ResourceProfile matching) {
-			this.slotOffer = slotOffer;
-			this.matching = matching;
-		}
-
-		private SlotOffer getSlotOffer() {
-			return slotOffer;
-		}
-
-		private Optional<ResourceProfile> getMatching() {
-			return Optional.ofNullable(matching);
-		}
-
-		private static SlotOfferMatching createMatching(SlotOffer slotOffer, ResourceProfile matching) {
-			return new SlotOfferMatching(slotOffer, matching);
-		}
-
-		private static SlotOfferMatching createMismatch(SlotOffer slotOffer) {
-			return new SlotOfferMatching(slotOffer, null);
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -132,7 +132,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 	private void declareResourceRequirements() {
 		final Collection<ResourceRequirement> resourceRequirements = getResourceRequirements();
 
-		LOG.debug("Declare new resource requirements for job {}: {}.", jobId, resourceRequirements);
+		LOG.debug("Declare new resource requirements for job {}.{}\trequired resources: {}{}\tacquired resources: {}", jobId, System.lineSeparator(), resourceRequirements, System.lineSeparator(), fulfilledResourceRequirements);
 		notifyNewResourceRequirements.accept(resourceRequirements);
 	}
 
@@ -167,6 +167,8 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 				if (acceptedSlot.isPresent()) {
 					acceptedSlotOffers.add(offer);
 					acceptedSlots.add(acceptedSlot.get());
+				} else {
+					LOG.debug("Could not match offer {} to any outstanding requirement.", offer.getAllocationId());
 				}
 			}
 		}
@@ -174,6 +176,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 		slotPool.addSlots(acceptedSlots, currentTime);
 
 		if (!acceptedSlots.isEmpty()) {
+			LOG.debug("Acquired new resources; new total acquired resources: {}", fulfilledResourceRequirements);
 			notifyNewSlots.accept(acceptedSlots);
 		}
 
@@ -359,6 +362,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 		}
 
 		releaseSlots(slotsToReturnToOwner, new FlinkException("Returning idle slots to their owners."));
+		LOG.debug("Idle slots have been returned; new total acquired resources: {}", fulfilledResourceRequirements);
 	}
 
 	private void releaseSlots(Iterable<AllocatedSlot> slotsToReturnToOwner, Throwable cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -272,15 +272,10 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
 		freedSlot.ifPresent(allocatedSlot -> {
 			releasePayload(Collections.singleton(allocatedSlot), cause);
-			tryToFulfillResourceRequirement(allocatedSlot);
 			notifyNewSlots.accept(Collections.singletonList(allocatedSlot));
 		});
 
 		return previouslyFulfilledRequirement.orElseGet(ResourceCounter::empty);
-	}
-
-	private void tryToFulfillResourceRequirement(AllocatedSlot allocatedSlot) {
-		matchOfferWithOutstandingRequirements(allocatedSlotToSlotOffer(allocatedSlot), allocatedSlot.getTaskManagerLocation(), allocatedSlot.getTaskManagerGateway());
 	}
 
 	private void updateSlotToRequirementProfileMapping(AllocationID allocationId, ResourceProfile matchedResourceProfile) {
@@ -296,11 +291,6 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 		// be able to fulfill the total requirements
 		decreaseResourceRequirementsBy(ResourceCounter.withResource(newResourceProfile, 1));
 		increaseResourceRequirementsBy(ResourceCounter.withResource(oldResourceProfile, 1));
-	}
-
-	@Nonnull
-	private SlotOffer allocatedSlotToSlotOffer(AllocatedSlot allocatedSlot) {
-		return new SlotOffer(allocatedSlot.getAllocationId(), allocatedSlot.getPhysicalSlotNumber(), allocatedSlot.getResourceProfile());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -111,6 +111,9 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
 	@Override
 	public void increaseResourceRequirementsBy(ResourceCounter increment) {
+		if (increment.isEmpty()) {
+			return;
+		}
 		totalResourceRequirements = totalResourceRequirements.add(increment);
 
 		declareResourceRequirements();
@@ -118,6 +121,9 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
 	@Override
 	public void decreaseResourceRequirementsBy(ResourceCounter decrement) {
+		if (decrement.isEmpty()) {
+			return;
+		}
 		totalResourceRequirements = totalResourceRequirements.subtract(decrement);
 
 		declareResourceRequirements();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -78,6 +79,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 	private final Time idleSlotTimeout;
 	private final Time rpcTimeout;
 
+	private final JobID jobId;
 	private final AllocatedSlotPool slotPool;
 
 	private final Map<AllocationID, ResourceProfile> slotToRequirementProfileMappings;
@@ -89,12 +91,14 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 	private final RequirementMatcher requirementMatcher = new DefaultRequirementMatcher();
 
 	public DefaultDeclarativeSlotPool(
+		JobID jobId,
 		AllocatedSlotPool slotPool,
 		Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
 		Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
 		Time idleSlotTimeout,
 		Time rpcTimeout) {
 
+		this.jobId = jobId;
 		this.slotPool = slotPool;
 		this.notifyNewResourceRequirements = notifyNewResourceRequirements;
 		this.notifyNewSlots = notifyNewSlots;
@@ -120,7 +124,10 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 	}
 
 	private void declareResourceRequirements() {
-		notifyNewResourceRequirements.accept(getResourceRequirements());
+		final Collection<ResourceRequirement> resourceRequirements = getResourceRequirements();
+
+		LOG.debug("Declare new resource requirements for job {}: {}.", jobId, resourceRequirements);
+		notifyNewResourceRequirements.accept(resourceRequirements);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 
@@ -31,11 +32,13 @@ public class DefaultDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFac
 
 	@Override
 	public DeclarativeSlotPool create(
+			JobID jobId,
 			Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
 			Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
 			Time idleSlotTimeout,
 			Time rpcTimeout) {
 		return new DefaultDeclarativeSlotPool(
+			jobId,
 			new DefaultAllocatedSlotPool(),
 			notifyNewResourceRequirements,
 			notifyNewSlots,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -197,7 +197,7 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
 		}
 
 		@Override
-		public DeclarativeSlotPool create(Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements, Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots, Time idleSlotTimeout, Time rpcTimeout) {
+		public DeclarativeSlotPool create(JobID jobId, Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements, Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots, Time idleSlotTimeout, Time rpcTimeout) {
 			return builder.build();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.jobmaster.slotpool;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 
@@ -56,6 +57,7 @@ final class DefaultDeclarativeSlotPoolBuilder {
 
 	public DefaultDeclarativeSlotPool build() {
 		return new DefaultDeclarativeSlotPool(
+				new JobID(),
 				allocatedSlotPool,
 				notifyNewResourceRequirements,
 				notifyNewSlots,


### PR DESCRIPTION
When a slot was freed the slot pool was trying to find another requirement it could potentially fulfill, using the same code paths as for newly offered slots, which also includes an increase in acquired resources.
As a result we were potentially counting a single slot as multiple resources, causing an inconsistent state. The slot pool hence believed it had enough slots to fulfill the requirements, causing it to reject slots, while the Scheduler was waiting for enough slots to arrive and the RM repeatedly trying to provide the actually required slots.

While it is not necessarily a bad thing to try an find another matching requirement, it is currently not necessary to do so, since the scheduler will use slots however it sees fit anyway. In the worst case we go through another slot allocation cycle.
As such freed slots now remain assigned to the originally matched requirement, and this mapping will only change when the slot is explicitly reserved for a different requirement.

In the long-term it would be desirable for the slot pool to automatically adjust the matching if a slot was freed. This could prevent cases where we request new slots although we still have idling slots around that we could use, or release slots as idle although there are still outstanding requirements.
However this needs a more sophisticated approach, it has to account for cases where:
- a freed slot could not be matched to another requirement (i.e., it is truly an excess resource)
- a freed slot was matched against another profile, which should go through the same codepath as for slot reservations for a different profile
- also try to re-assign currently excess resources if the requirements are increased