### PR TITLE
[FLINK-16005][yarn] Support yarn and hadoop config override

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -15,6 +15,18 @@
             <td>If configured, Flink will add this key to the resource profile of container request to Yarn. The value will be set to the value of external-resource.&lt;resource_name&gt;.amount.</td>
         </tr>
         <tr>
+            <td><h5>flink.hadoop.&lt;key&gt;</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A general option to probe Hadoop configuration through prefix 'flink.hadoop.'. Flink will remove the prefix to get &lt;key&gt; (from <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/core-default.xml">core-default.xml</a> and <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml">hdfs-default.xml</a>) then set the &lt;key&gt; and value to Hadoop configuration. For example, flink.hadoop.dfs.replication=5 in Flink configuration and convert to dfs.replication=5 in Hadoop configuration.</td>
+        </tr>
+        <tr>
+            <td><h5>flink.yarn.&lt;key&gt;</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A general option to probe Yarn configuration through prefix 'flink.yarn.'. Flink will remove the prefix 'flink.' to get yarn.&lt;key&gt; (from <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml">yarn-default.xml</a>) then set the yarn.&lt;key&gt; and value to Yarn configuration. For example, flink.yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Flink configuration and convert to yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Yarn configuration.</td>
+        </tr>
+        <tr>
             <td><h5>yarn.application-attempt-failures-validity-interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
@@ -24,7 +36,7 @@
             <td><h5>yarn.application-attempts</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Number of ApplicationMaster restarts. By default, the value will be set to 1. If high availability is enabled, then the default value will be 2. The restart number is also limited by YARN (configured via <a href="https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml">yarn.resourcemanager.am.max-attempts</a>). Note that that the entire Flink cluster will restart and the YARN Client will lose the connection.</td>
+            <td>Number of ApplicationMaster restarts. By default, the value will be set to 1. If high availability is enabled, then the default value will be 2. The restart number is also limited by YARN (configured via <a href="https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml">yarn.resourcemanager.am.max-attempts</a>). Note that that the entire Flink cluster will restart and the YARN Client will lose the connection.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-master.port</h5></td>

--- a/docs/deployment/resource-providers/yarn.md
+++ b/docs/deployment/resource-providers/yarn.md
@@ -192,7 +192,7 @@ High-Availability on YARN is achieved through a combination of YARN and a [high 
 
 Once a HA service is configured, it will persist JobManager metadata and perform leader elections.
 
-YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
+YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
 
 Note that Flink is managing the `high-availability.cluster-id` configuration parameter when deploying on YARN.
 Flink sets it per default to the YARN application id.

--- a/docs/deployment/resource-providers/yarn.zh.md
+++ b/docs/deployment/resource-providers/yarn.zh.md
@@ -192,7 +192,7 @@ High-Availability on YARN is achieved through a combination of YARN and a [high 
 
 Once a HA service is configured, it will persist JobManager metadata and perform leader elections.
 
-YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.zh.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
+YARN is taking care of restarting failed JobManagers. The maximum number of JobManager restarts is defined through two configuration parameters. First Flink's [yarn.application-attempts]({% link deployment/config.zh.md %}#yarn-application-attempts) configuration will default 2. This value is limited by YARN's [yarn.resourcemanager.am.max-attempts](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml), which also defaults to 2.
 
 Note that Flink is managing the `high-availability.cluster-id` configuration parameter when deploying on YARN.
 Flink sets it per default to the YARN application id.

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
@@ -265,6 +265,45 @@ public class HadoopConfigLoadingTest {
         assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
     }
 
+    @Test
+    public void loadFromFlinkConfEntry() throws Exception {
+        final String prefix = "flink.hadoop.";
+
+        final String k1 = "brooklyn";
+        final String v1 = "nets";
+
+        final String k2 = "miami";
+        final String v2 = "heat";
+
+        final String k3 = "philadelphia";
+        final String v3 = "76ers";
+
+        final String k4 = "golden.state";
+        final String v4 = "warriors";
+
+        final String k5 = "oklahoma.city";
+        final String v5 = "thunders";
+
+        final Configuration cfg = new Configuration();
+        cfg.setString(prefix + k1, v1);
+        cfg.setString(prefix + k2, v2);
+        cfg.setString(prefix + k3, v3);
+        cfg.setString(prefix + k4, v4);
+        cfg.setString(k5, v5);
+
+        org.apache.hadoop.conf.Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(cfg);
+
+        // contains extra entries
+        assertEquals(v1, hadoopConf.get(k1, null));
+        assertEquals(v2, hadoopConf.get(k2, null));
+        assertEquals(v3, hadoopConf.get(k3, null));
+        assertEquals(v4, hadoopConf.get(k4, null));
+        assertTrue(hadoopConf.get(k5) == null);
+
+        // also contains classpath defaults
+        assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
+    }
+
     private static void printConfig(File file, String key, String value) throws IOException {
         Map<String, String> map = new HashMap<>(1);
         map.put(key, value);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -76,7 +76,8 @@ public class YarnClusterClientFactory
 
     private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {
         final YarnClient yarnClient = YarnClient.createYarnClient();
-        final YarnConfiguration yarnConfiguration = new YarnConfiguration();
+        final YarnConfiguration yarnConfiguration =
+                Utils.getYarnAndHadoopConfiguration(configuration);
 
         yarnClient.init(yarnConfiguration);
         yarnClient.start();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -123,7 +123,7 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
             YarnNodeManagerClientFactory yarnNodeManagerClientFactory) {
         super(flinkConfig, GlobalConfiguration.loadConfiguration(configuration.getCurrentDir()));
 
-        this.yarnConfig = new YarnConfiguration();
+        this.yarnConfig = Utils.getYarnAndHadoopConfiguration(flinkConfig);
         this.requestResourceFutures = new HashMap<>();
         this.configuration = configuration;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -94,7 +94,7 @@ public class YarnConfigOptions {
                                                     + "The restart number is also limited by YARN (configured via %s). "
                                                     + "Note that that the entire Flink cluster will restart and the YARN Client will lose the connection.",
                                             link(
-                                                    "https://hadoop.apache.org/docs/r2.4.1/hadoop-yarn/hadoop-yarn-common/yarn-default.xml",
+                                                    "https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml",
                                                     "yarn.resourcemanager.am.max-attempts"))
                                     .build());
 
@@ -327,6 +327,39 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "A comma-separated list of additional Kerberos-secured Hadoop filesystems Flink is going to access. For example, yarn.security.kerberos.additionalFileSystems=hdfs://namenode2:9002,hdfs://namenode3:9003. The client submitting to YARN needs to have access to these file systems to retrieve the security tokens.");
+
+    @SuppressWarnings("unused")
+    public static final ConfigOption<String> HADOOP_CONFIG_KEY =
+            key("flink.hadoop.<key>")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "A general option to probe Hadoop configuration through prefix 'flink.hadoop.'. Flink will remove the prefix to get <key> (from %s and %s) then set the <key> and value to Hadoop configuration."
+                                                    + " For example, flink.hadoop.dfs.replication=5 in Flink configuration and convert to dfs.replication=5 in Hadoop configuration.",
+                                            link(
+                                                    "https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/core-default.xml",
+                                                    "core-default.xml"),
+                                            link(
+                                                    "https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml",
+                                                    "hdfs-default.xml"))
+                                    .build());
+
+    @SuppressWarnings("unused")
+    public static final ConfigOption<String> YARN_CONFIG_KEY =
+            key("flink.yarn.<key>")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "A general option to probe Yarn configuration through prefix 'flink.yarn.'. Flink will remove the prefix 'flink.' to get yarn.<key> (from %s) then set the yarn.<key> and value to Yarn configuration."
+                                                    + " For example, flink.yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Flink configuration and convert to yarn.resourcemanager.container.liveness-monitor.interval-ms=300000 in Yarn configuration.",
+                                            link(
+                                                    "https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml",
+                                                    "yarn-default.xml"))
+                                    .build());
 
     /**
      * Defines the configuration key of that external resource in Yarn. This is used as a suffix in

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -40,7 +40,9 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests for {@link Utils}. */
@@ -128,6 +130,32 @@ public class UtilsTest extends TestLogger {
                             + "contain dirs accessible from all worker nodes";
             assertThat(ex, FlinkMatchers.containsMessage(msg));
         }
+    }
+
+    @Test
+    public void testGetYarnConfiguration() {
+        final String flinkPrefix = "flink.yarn.";
+        final String yarnPrefix = "yarn.";
+
+        final String k1 = "brooklyn";
+        final String v1 = "nets";
+
+        final String k2 = "golden.state";
+        final String v2 = "warriors";
+
+        final String k3 = "miami";
+        final String v3 = "heat";
+
+        final Configuration flinkConfig = new Configuration();
+        flinkConfig.setString(flinkPrefix + k1, v1);
+        flinkConfig.setString(flinkPrefix + k2, v2);
+        flinkConfig.setString(k3, v3);
+
+        final YarnConfiguration yarnConfig = Utils.getYarnConfiguration(flinkConfig);
+
+        assertEquals(v1, yarnConfig.get(yarnPrefix + k1, null));
+        assertEquals(v2, yarnConfig.get(yarnPrefix + k2, null));
+        assertTrue(yarnConfig.get(yarnPrefix + k3) == null);
     }
 
     private static void verifyUnitResourceVariousSchedulers(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request allow users to overwrite hadoop (keys in [core-default.xml](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/core-default.xml) and [hdfs-default.xml](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml)) / yarn (keys in [yarn-default.xml](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-common/yarn-default.xml)) configuration by corresponding set flink configuration started with prefix "flink.hadoop." / "flink.yarn.". It is convenient for users to set hadoop / yarn configuration, because they can only focus on flink configuration.


## Brief change log

  - *Add all configuration key with prefix `flink.hadoop.` in flink conf to hadoop conf*
  - *Add all configuration key with prefix `flink.yarn.` in flink conf to yarn conf*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
