### PR TITLE
[hotfix][python] Remove the type info of args

### DIFF
--- a/flink-python/pyflink/fn_execution/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/aggregate_fast.pyx
@@ -216,7 +216,6 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
         cdef int distinct_index, filter_arg
         cdef int*filter_args
         cdef bint filtered
-        cdef tuple args
         cdef DistinctViewDescriptor distinct_view_descriptor
         cdef object distinct_data_view
         for i in range(self._udf_num):
@@ -259,7 +258,6 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
         cdef size_t i, j, filter_length
         cdef int distinct_index, filter_arg
         cdef bint filtered
-        cdef tuple args
         cdef DistinctViewDescriptor distinct_view_descriptor
         cdef object distinct_data_view
         for i in range(self._udf_num):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Remove the type info of args*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
