### PR TITLE
[FLINK-20749] Add DeclarativeSlotPool.registerNewSlotsListener

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPool.java
@@ -153,4 +153,40 @@ public interface DeclarativeSlotPool {
      * @param currentTimeMillis current time
      */
     void releaseIdleSlots(long currentTimeMillis);
+
+    /**
+     * Registers a listener which is called whenever new slots become available.
+     *
+     * @param listener which is called whenever new slots become available
+     */
+    void registerNewSlotsListener(NewSlotsListener listener);
+
+    /**
+     * Listener interface for newly available slots.
+     *
+     * <p>Implementations of the {@link DeclarativeSlotPool} will call {@link
+     * #notifyNewSlotsAreAvailable} whenever newly offered slots are accepted or if an allocated
+     * slot should become free after it is being {@link #freeReservedSlot freed}.
+     */
+    interface NewSlotsListener {
+
+        /**
+         * Notifies the listener about newly available slots.
+         *
+         * <p>This method will be called whenever newly offered slots are accepted or if an
+         * allocated slot should become free after it is being {@link #freeReservedSlot freed}.
+         *
+         * @param newlyAvailableSlots are the newly available slots
+         */
+        void notifyNewSlotsAreAvailable(Collection<? extends PhysicalSlot> newlyAvailableSlots);
+    }
+
+    /** No-op {@link NewSlotsListener} implementation. */
+    enum NoOpNewSlotsListener implements NewSlotsListener {
+        INSTANCE;
+
+        @Override
+        public void notifyNewSlotsAreAvailable(
+                Collection<? extends PhysicalSlot> newlyAvailableSlots) {}
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -113,11 +113,8 @@ public class DeclarativeSlotPoolBridge implements SlotPool {
                 NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
         this.declarativeSlotPool =
                 declarativeSlotPoolFactory.create(
-                        jobId,
-                        this::declareResourceRequirements,
-                        this::newSlotsAreAvailable,
-                        idleSlotTimeout,
-                        rpcTimeout);
+                        jobId, this::declareResourceRequirements, idleSlotTimeout, rpcTimeout);
+        this.declarativeSlotPool.registerNewSlotsListener(this::newSlotsAreAvailable);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolFactory.java
@@ -30,7 +30,6 @@ public interface DeclarativeSlotPoolFactory {
     DeclarativeSlotPool create(
             JobID jobId,
             Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
-            Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
             Time idleSlotTimeout,
             Time rpcTimeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolFactory.java
@@ -32,14 +32,12 @@ public class DefaultDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFac
     public DeclarativeSlotPool create(
             JobID jobId,
             Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
-            Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
             Time idleSlotTimeout,
             Time rpcTimeout) {
         return new DefaultDeclarativeSlotPool(
                 jobId,
                 new DefaultAllocatedSlotPool(),
                 notifyNewResourceRequirements,
-                notifyNewSlots,
                 idleSlotTimeout,
                 rpcTimeout);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -230,7 +230,6 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
         public DeclarativeSlotPool create(
                 JobID jobId,
                 Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
-                Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots,
                 Time idleSlotTimeout,
                 Time rpcTimeout) {
             return builder.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolBuilder.java
@@ -30,7 +30,6 @@ final class DefaultDeclarativeSlotPoolBuilder {
     private AllocatedSlotPool allocatedSlotPool = new DefaultAllocatedSlotPool();
     private Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements =
             ignored -> {};
-    private Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots = ignored -> {};
     private Time idleSlotTimeout = Time.seconds(20);
     private Time rpcTimeout = Time.seconds(20);
 
@@ -46,12 +45,6 @@ final class DefaultDeclarativeSlotPoolBuilder {
         return this;
     }
 
-    public DefaultDeclarativeSlotPoolBuilder setNotifyNewSlots(
-            Consumer<? super Collection<? extends PhysicalSlot>> notifyNewSlots) {
-        this.notifyNewSlots = notifyNewSlots;
-        return this;
-    }
-
     public DefaultDeclarativeSlotPoolBuilder setIdleSlotTimeout(Time idleSlotTimeout) {
         this.idleSlotTimeout = idleSlotTimeout;
         return this;
@@ -62,7 +55,6 @@ final class DefaultDeclarativeSlotPoolBuilder {
                 new JobID(),
                 allocatedSlotPool,
                 notifyNewResourceRequirements,
-                notifyNewSlots,
                 idleSlotTimeout,
                 rpcTimeout);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPool.java
@@ -172,6 +172,11 @@ final class TestingDeclarativeSlotPool implements DeclarativeSlotPool {
         releaseIdleSlotsConsumer.accept(currentTimeMillis);
     }
 
+    @Override
+    public void registerNewSlotsListener(NewSlotsListener listener) {
+        // noop
+    }
+
     public static TestingDeclarativeSlotPoolBuilder builder() {
         return new TestingDeclarativeSlotPoolBuilder();
     }


### PR DESCRIPTION
The DeclarativeSlotPool.registerNewSlotsListener can be used to register a
DeclarativeSlotPool.NewSlotsListener which is notified whenever the
DeclarativeSlotPool receives new slots or reserved slots are freed.