### PR TITLE
[FLINK-20648][coordination][k8s] Start leader election service before creating JobMaster

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_itcases.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_itcases.sh
@@ -31,3 +31,4 @@ run_mvn test -Dtest=org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClien
 run_mvn test -Dtest=org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElectorITCase
 run_mvn test -Dtest=org.apache.flink.kubernetes.highavailability.KubernetesLeaderElectionAndRetrievalITCase
 run_mvn test -Dtest=org.apache.flink.kubernetes.highavailability.KubernetesStateHandleStoreITCase
+run_mvn test -Dtest=org.apache.flink.kubernetes.highavailability.KubernetesHighAvailabilityRecoverFromSavepointITCase

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityRecoverFromSavepointITCase.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.highavailability;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.kubernetes.KubernetesResource;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for recovering from savepoint when Kubernetes HA is enabled. The savepoint will be persisted as a checkpoint
+ * and stored in the ConfigMap when recovered successfully.
+ */
+public class KubernetesHighAvailabilityRecoverFromSavepointITCase extends TestLogger {
+
+	private static final long TIMEOUT = 60 * 1000;
+
+	private static final String CLUSTER_ID = "flink-on-k8s-cluster-" + System.currentTimeMillis();
+
+	private static final String FLAT_MAP_UID = "my-flat-map";
+
+	@ClassRule
+	public static KubernetesResource kubernetesResource = new KubernetesResource();
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Rule
+	public MiniClusterWithClientResource miniClusterResource = new MiniClusterWithClientResource(
+		new MiniClusterResourceConfiguration.Builder()
+			.setConfiguration(getConfiguration())
+			.setNumberTaskManagers(1)
+			.setNumberSlotsPerTaskManager(1)
+			.build());
+
+	private FlinkKubeClient flinkKubeClient;
+
+	private ClusterClient<?> clusterClient;
+
+	private String savepointPath;
+
+	@Before
+	public void setup() throws Exception {
+		clusterClient = miniClusterResource.getClusterClient();
+		flinkKubeClient = kubernetesResource.getFlinkKubeClient();
+		savepointPath = temporaryFolder.newFolder("savepoints").getAbsolutePath();
+	}
+
+	@After
+	public void teardown() throws Exception {
+		flinkKubeClient.deleteConfigMapsByLabels(
+			KubernetesUtils.getConfigMapLabels(CLUSTER_ID, LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY)).get();
+	}
+
+	@Test
+	public void testRecoverFromSavepoint() throws Exception {
+		final JobGraph jobGraph = createJobGraph();
+		clusterClient.submitJob(jobGraph).get(TIMEOUT, TimeUnit.MILLISECONDS);
+
+		// Wait until all tasks running and getting a successful savepoint
+		CommonTestUtils.waitUntilCondition(
+			() -> triggerSavepoint(clusterClient, jobGraph.getJobID(), savepointPath) != null,
+			Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
+			1000);
+
+		// Trigger savepoint 2
+		final String savepoint2Path = triggerSavepoint(clusterClient, jobGraph.getJobID(), savepointPath);
+
+		// Cancel the old job
+		clusterClient.cancel(jobGraph.getJobID());
+		CommonTestUtils.waitUntilCondition(
+			() -> clusterClient.getJobStatus(jobGraph.getJobID()).get() == JobStatus.CANCELED,
+			Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
+			1000);
+
+		// Start a new job with savepoint 2
+		final JobGraph jobGraphWithSavepoint = createJobGraph();
+		final JobID jobId = jobGraphWithSavepoint.getJobID();
+		jobGraphWithSavepoint.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepoint2Path));
+		clusterClient.submitJob(jobGraphWithSavepoint).get(TIMEOUT, TimeUnit.MILLISECONDS);
+		CommonTestUtils.waitUntilCondition(
+			() -> clusterClient.getJobStatus(jobId).get() == JobStatus.RUNNING,
+			Deadline.fromNow(Duration.ofMillis(TIMEOUT)),
+			1000);
+
+		// The savepoint 2 should be added to jobmanager leader ConfigMap
+		final String jobManagerConfigMapName = CLUSTER_ID + "-" + jobId + "-jobmanager-leader";
+		final Optional<KubernetesConfigMap> optional = flinkKubeClient.getConfigMap(jobManagerConfigMapName);
+		assertThat(optional.isPresent(), is(true));
+		final String checkpointIdKey = KubernetesCheckpointStoreUtil.INSTANCE.checkpointIDToName(2L);
+		assertThat(optional.get().getData().get(checkpointIdKey), is(notNullValue()));
+		assertThat(optional.get().getData().get(Constants.CHECKPOINT_COUNTER_KEY), is("3"));
+	}
+
+	private Configuration getConfiguration() {
+		Configuration configuration = new Configuration();
+		configuration.set(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+		configuration.set(HighAvailabilityOptions.HA_MODE, KubernetesHaServicesFactory.class.getCanonicalName());
+		try {
+			configuration.set(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getAbsolutePath());
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("Failed to create HA storage", e);
+		}
+		return configuration;
+	}
+
+	private String triggerSavepoint(ClusterClient<?> clusterClient, JobID jobID, String path) {
+		try {
+			return String.valueOf(clusterClient.triggerSavepoint(jobID, path).get(TIMEOUT, TimeUnit.MILLISECONDS));
+		} catch (Exception ex) {
+			// ignore
+		}
+		return null;
+	}
+
+	private JobGraph createJobGraph() throws Exception {
+		final StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		final StateBackend stateBackend = new FsStateBackend(temporaryFolder.newFolder().toURI(), 1);
+		sEnv.setStateBackend(stateBackend);
+
+		sEnv.addSource(new InfiniteSourceFunction())
+			.keyBy(e -> e)
+			.flatMap(new RichFlatMapFunction<Integer, Integer>() {
+				private static final long serialVersionUID = 1L;
+				ValueState<Integer> state;
+
+				@Override
+				public void open(Configuration parameters) throws Exception {
+					super.open(parameters);
+
+					ValueStateDescriptor<Integer> descriptor = new ValueStateDescriptor<>("total", Types.INT);
+					state = getRuntimeContext().getState(descriptor);
+				}
+
+				@Override
+				public void flatMap(Integer value, Collector<Integer> out) throws Exception {
+					final Integer current = state.value();
+					if (current != null) {
+						value += current;
+					}
+
+					state.update(value);
+					out.collect(value);
+				}
+			})
+			.uid(FLAT_MAP_UID)
+			.addSink(new DiscardingSink<>());
+
+		return sEnv.getStreamGraph().getJobGraph();
+	}
+
+	private static final class InfiniteSourceFunction extends RichParallelSourceFunction<Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceContext<Integer> ctx) throws Exception {
+			final Random random = new Random();
+			while (running) {
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(random.nextInt());
+				}
+
+				Thread.sleep(5L);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -40,6 +40,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,6 +185,8 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
 				.setWatchConfigMapsFunction((ignore, handler) -> {
 					final CompletableFuture<FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>> future =
 						CompletableFuture.completedFuture(handler);
+					handler.onAdded(Collections.singletonList(
+						new TestingFlinkKubeClient.MockKubernetesConfigMap(LEADER_CONFIGMAP_NAME)));
 					configMapCallbackFutures.add(future);
 					return new TestingFlinkKubeClient.MockKubernetesWatch();
 				})

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -85,6 +85,8 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	private final CompletableFuture<Void> terminationFuture;
 
+	private final CompletableFuture<Void> jobMasterCreationFuture;
+
 	private CompletableFuture<Void> leadershipOperation;
 
 	/** flag marking the runner as shut down. */
@@ -136,9 +138,20 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 		this.leaderElectionService = haServices.getJobManagerLeaderElectionService(jobGraph.getJobID());
 
 		this.leaderGatewayFuture = new CompletableFuture<>();
+		this.jobMasterCreationFuture = new CompletableFuture<>();
 
-		// now start the JobManager
-		this.jobMasterService = jobMasterFactory.createJobMasterService(jobGraph, this, userCodeLoader, initializationTimestamp);
+		synchronized (lock) {
+			try {
+				leaderElectionService.start(this);
+			} catch (Exception e) {
+				log.error("Could not start the JobManager because the leader election service did not start.", e);
+				throw new Exception("Could not start the leader election service.", e);
+			}
+			// now start the JobManager
+			this.jobMasterService = jobMasterFactory.createJobMasterService(
+				jobGraph, this, userCodeLoader, initializationTimestamp);
+			jobMasterCreationFuture.complete(null);
+		}
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -166,12 +179,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	@Override
 	public void start() throws Exception {
-		try {
-			leaderElectionService.start(this);
-		} catch (Exception e) {
-			log.error("Could not start the JobManager because the leader election service did not start.", e);
-			throw new Exception("Could not start the leader election service.", e);
-		}
+		// noop
 	}
 
 	@Override
@@ -268,21 +276,27 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	@Override
 	public void grantLeadership(final UUID leaderSessionID) {
-		synchronized (lock) {
-			if (shutdown) {
-				log.debug("JobManagerRunner cannot be granted leadership because it is already shut down.");
-				return;
-			}
-
-			leadershipOperation = leadershipOperation.thenCompose(
-				(ignored) -> {
-					synchronized (lock) {
-						return verifyJobSchedulingStatusAndStartJobManager(leaderSessionID);
+		jobMasterCreationFuture.whenComplete(
+			(ignore, throwable) -> {
+				if (throwable != null) {
+					handleJobManagerRunnerError(new FlinkException(throwable));
+				}
+				synchronized (lock) {
+					if (shutdown) {
+						log.debug("JobManagerRunner cannot be granted leadership because it is already shut down.");
+						return;
 					}
-				});
 
-			handleException(leadershipOperation, "Could not start the job manager.");
-		}
+					leadershipOperation = leadershipOperation.thenCompose(
+						(ignored) -> {
+							synchronized (lock) {
+								return verifyJobSchedulingStatusAndStartJobManager(leaderSessionID);
+							}
+						});
+
+					handleException(leadershipOperation, "Could not start the job manager.");
+				}
+			});
 	}
 
 	private CompletableFuture<Void> verifyJobSchedulingStatusAndStartJobManager(UUID leaderSessionId) {
@@ -361,21 +375,27 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	@Override
 	public void revokeLeadership() {
-		synchronized (lock) {
-			if (shutdown) {
-				log.debug("Ignoring revoking leadership because JobManagerRunner is already shut down.");
-				return;
-			}
-
-			leadershipOperation = leadershipOperation.thenCompose(
-				(ignored) -> {
-					synchronized (lock) {
-						return revokeJobMasterLeadership();
+		jobMasterCreationFuture.whenComplete(
+			(ignore, throwable) -> {
+				if (throwable != null) {
+					handleJobManagerRunnerError(new FlinkException(throwable));
+				}
+				synchronized (lock) {
+					if (shutdown) {
+						log.debug("Ignoring revoking leadership because JobManagerRunner is already shut down.");
+						return;
 					}
-				});
 
-			handleException(leadershipOperation, "Could not suspend the job manager.");
-		}
+					leadershipOperation = leadershipOperation.thenCompose(
+						(ignored) -> {
+							synchronized (lock) {
+								return revokeJobMasterLeadership();
+							}
+						});
+
+					handleException(leadershipOperation, "Could not suspend the job manager.");
+				}
+			});
 	}
 
 	private CompletableFuture<Void> revokeJobMasterLeadership() {
@@ -417,7 +437,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 
 	@Override
 	public String getDescription() {
-		return jobMasterService.getAddress();
+		return jobMasterService == null ? LeaderContender.super.getDescription() : jobMasterService.getAddress();
 	}
 
 	@Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When creating JobMaster service, we may recover from savepoints and update the HA storage(e.g. ConfigMap, ZooKeeper). So leader election service needs to be started first. Also we should guarantee that ConfigMap has been created after `leaderElectionService#start`. Then We need to block the constructor of KubernetesLeaderElectionDriver until the ConfigMap exists.

**Note:** This PR only applies to branch 1.12. In the master branch, we have a more graceful fix. Refer FLINK-11719 for more information.

The new added ITCase `KubernetesHighAvailabilityRecoverFromSavepointITCase` needs to be picked to master branch. It should pass without any production code change. 

## Brief change log

This PR will have the following major changes.
* Start leader election service before creating `JobMasterService` in `JobManagerRunnerImpl`
* `grantLeadership` and `revokeLeadership` should be called after creating `JobMasterService` in `JobManagerRunnerImpl`
* Make constructor of `KubernetesLeaderElectionDriver` blocking until the leader ConfigMap is created


## Verifying this change

* Update some related tests to pass
* Add a new ITCase `KubernetesHighAvailabilityRecoverFromSavepointITCase` for recovering from savepoints when HA is enabled

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
