### PR TITLE
[FLINK-20642][python] Introduce InternalRow to optimize Row used in Python UDAF

### DIFF
--- a/flink-python/pyflink/fn_execution/aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/aggregate_fast.pxd
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 # cython: language_level=3
+from pyflink.fn_execution.coder_impl_fast cimport InternalRow, InternalRowKind
 
 cdef class DistinctViewDescriptor:
     cdef object input_extractor
@@ -83,10 +84,10 @@ cdef class GroupAggFunctionBase:
 
     cpdef void open(self, function_context)
     cpdef void close(self)
-    cpdef list process_element(self, object input_data)
-    cpdef void on_timer(self, object key)
-    cdef bint is_retract_msg(self, object input_data)
-    cdef bint is_accumulate_msg(self, object input_data)
+    cpdef list process_element(self, InternalRow input_data)
+    cpdef void on_timer(self, InternalRow key)
+    cdef bint is_retract_msg(self, InternalRowKind row_kind)
+    cdef bint is_accumulate_msg(self, InternalRowKind row_kind)
 
 cdef class GroupAggFunction(GroupAggFunctionBase):
     pass

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -21,6 +21,16 @@ cimport libc.stdint
 
 from pyflink.fn_execution.stream cimport LengthPrefixInputStream, LengthPrefixOutputStream
 
+cdef enum InternalRowKind:
+    INSERT = 0
+    UPDATE_BEFORE = 1
+    UPDATE_AFTER = 2
+    DELETE = 3
+
+cdef class InternalRow:
+    cdef readonly list values
+    cdef readonly InternalRowKind row_kind
+
 cdef class BaseCoderImpl:
     cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream)
     cpdef decode_from_stream(self, LengthPrefixInputStream input_stream)
@@ -91,11 +101,13 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
     cdef float _decode_float(self) except? -1
     cdef double _decode_double(self) except? -1
     cdef bytes _decode_bytes(self)
+    cdef object _decode_field_row(self, RowCoderImpl field_coder)
 
 cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
     cdef bint _is_row_data
     cdef bint _is_first_row
     cdef void _encode_list_value(self, list list_value, LengthPrefixOutputStream output_stream)
+    cdef void _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream)
 
 cdef class TableFunctionRowCoderImpl(FlattenRowCoderImpl):
     cdef char* _end_message
@@ -210,6 +222,7 @@ cdef class MapCoderImpl(FieldCoder):
 cdef class RowCoderImpl(FieldCoder):
     cdef readonly list field_coders
     cdef readonly list field_names
+    cdef readonly size_t field_count
 
 cdef class TupleCoderImpl(FieldCoder):
     cdef readonly list field_coders

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -28,6 +28,22 @@ import decimal
 from pyflink.table import Row
 from pyflink.table.types import RowKind
 
+cdef class InternalRow:
+    def __cinit__(self, list values, InternalRowKind row_kind):
+        self.values = values
+        self.row_kind = row_kind
+
+    def __eq__(self, other):
+        if not other:
+            return False
+        return self.values == other.values
+
+    def __getitem__(self, item):
+        return self.values[item]
+
+    def __iter__(self):
+        return self.values
+
 cdef class BaseCoderImpl:
     cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
         pass
@@ -71,17 +87,48 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
 
     cdef void _encode_list_value(self, list results, LengthPrefixOutputStream output_stream):
         cdef list result
+        cdef InternalRow value
         if self._is_first_row and results:
-            self._is_row_data = isinstance(results[0], Row)
+            self._is_row_data = isinstance(results[0], InternalRow)
             self._is_first_row = False
         if self._is_row_data:
             for value in results:
-                self._encode_one_row_with_row_kind(value, output_stream, value.get_row_kind().value)
+                self._encode_internal_row(value, output_stream)
         else:
             for result in results:
-                for item in result:
-                    self._encode_one_row_with_row_kind(
-                        item, output_stream, item.get_row_kind().value)
+                for value in result:
+                    self._encode_internal_row(value, output_stream)
+
+    cdef void _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream):
+        self._encode_one_row_to_buffer(row.values, row.row_kind)
+        output_stream.write(self._tmp_output_data, self._tmp_output_pos)
+        self._tmp_output_pos = 0
+
+    cdef InternalRow _decode_field_row(self, RowCoderImpl field_coder):
+        cdef list row_field_coders
+        cdef size_t row_field_count, leading_complete_bytes_num, remaining_bits_num
+        cdef bint*mask
+        cdef unsigned char row_kind_value
+        cdef libc.stdint.int32_t i
+        cdef InternalRow row
+        cdef FieldCoder row_field_coder
+        row_field_coders = field_coder.field_coders
+        row_field_count = field_coder.field_count
+        mask = <bint*> malloc((row_field_count + ROW_KIND_BIT_SIZE) * sizeof(bint))
+        leading_complete_bytes_num = (row_field_count + ROW_KIND_BIT_SIZE) // 8
+        remaining_bits_num = (row_field_count + ROW_KIND_BIT_SIZE) % 8
+        self._read_mask(mask, leading_complete_bytes_num, remaining_bits_num)
+        row_kind_value = 0
+        for i in range(ROW_KIND_BIT_SIZE):
+            row_kind_value += mask[i] * 2 ** i
+        row = InternalRow([None if mask[i + ROW_KIND_BIT_SIZE] else
+                    self._decode_field(
+                        row_field_coders[i].coder_type(),
+                        row_field_coders[i].type_name(),
+                        row_field_coders[i])
+                    for i in range(row_field_count)], row_kind_value)
+        free(mask)
+        return row
 
 
 cdef class DataStreamFlatMapCoderImpl(BaseCoderImpl):
@@ -371,13 +418,10 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
 
     cdef object _decode_field_complex(self, TypeName field_type, FieldCoder field_coder):
         cdef libc.stdint.int32_t nanoseconds, microseconds, seconds, length
-        cdef libc.stdint.int32_t i, row_field_count, leading_complete_bytes_num, remaining_bits_num
         cdef libc.stdint.int64_t milliseconds
-        cdef bint*null_mask
         cdef FieldCoder value_coder, key_coder
         cdef TypeName value_type, key_type
         cdef CoderType value_coder_type, key_coder_type
-        cdef list row_field_coders
 
         if field_type == DECIMAL:
             # decimal
@@ -446,26 +490,33 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
             return map_value
         elif field_type == ROW:
             # Row
-            row_field_coders = (<RowCoderImpl> field_coder).field_coders
-            row_field_names = (<RowCoderImpl> field_coder).field_names
-            row_field_count = len(row_field_coders)
-            mask = <bint*> malloc((row_field_count + ROW_KIND_BIT_SIZE) * sizeof(bint))
-            leading_complete_bytes_num = (row_field_count + ROW_KIND_BIT_SIZE) // 8
-            remaining_bits_num = (row_field_count + ROW_KIND_BIT_SIZE) % 8
-            self._read_mask(mask, leading_complete_bytes_num, remaining_bits_num)
-            row = Row(*[None if mask[i + ROW_KIND_BIT_SIZE] else
-                        self._decode_field(
-                            row_field_coders[i].coder_type(),
-                            row_field_coders[i].type_name(),
-                            row_field_coders[i])
-                        for i in range(row_field_count)])
-            row.set_field_names(row_field_names)
-            row_kind_value = 0
-            for i in range(ROW_KIND_BIT_SIZE):
-                row_kind_value += mask[i] * 2 ** i
-            row.set_row_kind(RowKind(row_kind_value))
-            free(mask)
-            return row
+            return self._decode_field_row(field_coder)
+
+    cdef object _decode_field_row(self, RowCoderImpl field_coder):
+        cdef list row_field_coders, row_field_names
+        cdef size_t row_field_count, leading_complete_bytes_num, remaining_bits_num, i
+        cdef bint*mask
+        cdef unsigned char row_kind_value
+        row_field_coders = (<RowCoderImpl> field_coder).field_coders
+        row_field_names = (<RowCoderImpl> field_coder).field_names
+        row_field_count = len(row_field_coders)
+        mask = <bint*> malloc((row_field_count + ROW_KIND_BIT_SIZE) * sizeof(bint))
+        leading_complete_bytes_num = (row_field_count + ROW_KIND_BIT_SIZE) // 8
+        remaining_bits_num = (row_field_count + ROW_KIND_BIT_SIZE) % 8
+        self._read_mask(mask, leading_complete_bytes_num, remaining_bits_num)
+        row = Row(*[None if mask[i + ROW_KIND_BIT_SIZE] else
+                    self._decode_field(
+                        row_field_coders[i].coder_type(),
+                        row_field_coders[i].type_name(),
+                        row_field_coders[i])
+                    for i in range(row_field_count)])
+        row.set_field_names(row_field_names)
+        row_kind_value = 0
+        for i in range(ROW_KIND_BIT_SIZE):
+            row_kind_value += mask[i] * 2 ** i
+        row.set_row_kind(RowKind(row_kind_value))
+        free(mask)
+        return row
 
     cdef unsigned char _decode_byte(self) except? -1:
         self._input_pos += 1
@@ -896,6 +947,7 @@ cdef class RowCoderImpl(FieldCoder):
     def __cinit__(self, field_coders, field_names):
         self.field_coders = field_coders
         self.field_names = field_names
+        self.field_count = len(self.field_coders)
 
     cpdef CoderType coder_type(self):
         return COMPLEX


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Introduce `InternalRow` to optimize `Row` used in Python UDAF*


## Brief change log

  - *Introduce `InternalRow`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Original Tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

class MeanAggregateFunction(AggregateFunction):

    def get_value(self, accumulator: ACC) -> T:
        if accumulator[1] == 0:
            return None
        else:
            return accumulator[0] / accumulator[1]

    def create_accumulator(self) -> ACC:
        return [0, 0]

    def accumulate(self, accumulator: ACC, *args):
        accumulator[0] += args[0]
        accumulator[1] += 1

    def retract(self, accumulator: ACC, *args):
        accumulator[0] -= args[0]
        accumulator[1] -= 1

    def merge(self, accumulator: ACC, accumulators):
        for other_acc in accumulators:
            accumulator[0] += other_acc[0]
            accumulator[1] += other_acc[1]

    def get_accumulator_type(self) -> DataType:
        return DataTypes.ARRAY(DataTypes.BIGINT())

    def get_result_type(self) -> DataType:
        return DataTypes.FLOAT()

### Test Code
    env = StreamExecutionEnvironment.get_execution_environment()
    env.set_parallelism(1)
    env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
    environment_settings = EnvironmentSettings.new_instance().use_blink_planner().build()
    t_env = StreamTableEnvironment.create(env, environment_settings=environment_settings)
    t_env.get_config().get_configuration().set_integer("python.fn-execution.bundle.time", 1000) 
     t_env.get_config().get_configuration().set_boolean("pipeline.object-reuse", True)

    t_env.create_temporary_function("python_avg", MeanAggregateFunction())
    t_env.create_java_temporary_system_function("java_avg", "com.alibaba.flink.function.JavaAvg")

    num_rows = 10000000

    t_env.execute_sql(f"""
        CREATE TABLE source (
            id INT,
            num INT,
            rowtime TIMESTAMP(3),
            WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
        ) WITH (
          'connector' = 'Range',
          'start' = '1',
          'end' = '{num_rows}',
          'step' = '1',
          'partition' = '200'
        )
    """)
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["value"],
            [DataTypes.FLOAT(False)], 1000000))
    result = t_env.from_path("source") \
        .select("python_avg(id)")
    result.insert_into("sink")
    beg_time = time.time()
    t_env.execute("Python UDF")
    print("PyFlink stream group agg consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
1000w,3                      |     180.50s                          |    95.40s

