### PR TITLE
[FLINK-20756][python] Add PythonCalcSplitConditionRexFieldRule

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -377,7 +377,8 @@ object FlinkBatchRuleSets {
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
-    PythonCalcSplitRule.SPLIT_REX_FIELD,
+    PythonCalcSplitRule.SPLIT_CONDITION_REX_FIELD,
+    PythonCalcSplitRule.SPLIT_PROJECTION_REX_FIELD,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -380,7 +380,8 @@ object FlinkStreamRuleSets {
     //Rule that rewrites temporal join with extracted primary key
     TemporalJoinRewriteWithUniqueKeyRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.
-    PythonCalcSplitRule.SPLIT_REX_FIELD,
+    PythonCalcSplitRule.SPLIT_CONDITION_REX_FIELD,
+    PythonCalcSplitRule.SPLIT_PROJECTION_REX_FIELD,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
@@ -174,7 +174,7 @@ abstract class PythonCalcSplitRexFieldRuleBase(description: String)
   override def needConvert(program: RexProgram, node: RexNode): Boolean = {
     node match {
       case x: RexFieldAccess => x.getReferenceExpr match {
-        case y: RexLocalRef if isPythonCall(program.expandLocalRef(y)) => true
+        case y: RexLocalRef if containsPythonCall(program.expandLocalRef(y)) => true
         case _ => false
       }
       case _ => false
@@ -184,7 +184,7 @@ abstract class PythonCalcSplitRexFieldRuleBase(description: String)
   protected def containsFieldAccessAfterPythonCall(node: RexNode): Boolean = {
     node match {
       case call: RexCall => call.getOperands.exists(containsFieldAccessAfterPythonCall)
-      case x: RexFieldAccess => isPythonCall(x.getReferenceExpr)
+      case x: RexFieldAccess => containsPythonCall(x.getReferenceExpr)
       case _ => false
     }
   }
@@ -393,7 +393,7 @@ private class ScalarFunctionSplitter(
     if (needConvert(fieldAccess)) {
       val expr = fieldAccess.getReferenceExpr
       expr match {
-        case localRef: RexLocalRef if isPythonCall(program.expandLocalRef(localRef))
+        case localRef: RexLocalRef if containsPythonCall(program.expandLocalRef(localRef))
           => getExtractedRexFieldAccess(fieldAccess, localRef.getIndex)
         case _ => getExtractedRexNode(fieldAccess)
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.calcite.rel.core.AggregateCall
-import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexNode}
 import org.apache.flink.table.functions.FunctionDefinition
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionKind}
 import org.apache.flink.table.planner.functions.aggfunctions.{DeclarativeAggregateFunction, InternalAggregateFunction}
@@ -149,6 +149,10 @@ object PythonUtil {
     override def visitCall(call: RexCall): Boolean = {
       findPythonFunction == isPythonRexCall(call) ||
         (recursive && call.getOperands.exists(_.accept(this)))
+    }
+
+    override def visitFieldAccess(fieldAccess: RexFieldAccess): Boolean = {
+      fieldAccess.getReferenceExpr.accept(this)
     }
 
     override def visitNode(rexNode: RexNode): Boolean = false

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -279,6 +279,32 @@ public class JavaUserDefinedScalarFunctions {
 	}
 
 	/**
+	 * Test for Python Scalar Function.
+	 */
+	public static class RowJavaScalarFunction extends ScalarFunction {
+
+		private final String name;
+
+		public RowJavaScalarFunction(String name) {
+			this.name = name;
+		}
+
+		public Row eval(Object... a) {
+			return Row.of(1, 2);
+		}
+
+		@Override
+		public TypeInformation<?> getResultType(Class<?>[] signature) {
+			return Types.ROW(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+	}
+
+	/**
 	 * Test for Pandas Python Scalar Function.
 	 */
 	public static class PandasScalarFunction extends PythonScalarFunction {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -427,6 +427,25 @@ FlinkLogicalCalc(select=[f0.f0 AS f0, f0.f1 AS f1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPythonFunctionWithCompositeWhereClause">
+	<Resource name="sql">
+	  <![CDATA[SELECT a + 1 FROM MyTable where pyFunc5(a).f0 is NULL and b > 0]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(EXPR$0=[+($0, 1)])
++- LogicalFilter(condition=[AND(IS NULL(pyFunc5($0).f0), >($1, 0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+	  <![CDATA[
+FlinkLogicalCalc(select=[+(a, 1) AS EXPR$0], where=[AND(IS NULL(f0.f0), >(b, 0))])
++- FlinkLogicalCalc(select=[a, b, pyFunc5(a) AS f0])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+	</Resource>
+  </TestCase>
   <TestCase name="testPythonFunctionWithCompositeInputsAndWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT a, pyFunc1(b, d._1) FROM MyTable WHERE a + 1 > 0]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -429,20 +429,21 @@ FlinkLogicalCalc(select=[f0.f0 AS f0, f0.f1 AS f1])
   </TestCase>
   <TestCase name="testPythonFunctionWithCompositeWhereClause">
 	<Resource name="sql">
-	  <![CDATA[SELECT a + 1 FROM MyTable where pyFunc5(a).f0 is NULL and b > 0]]>
+	  <![CDATA[SELECT a + 1 FROM MyTable where RowJavaFunc(pyFunc5(a).f0).f0 is NULL and b > 0]]>
 	</Resource>
 	<Resource name="ast">
 	  <![CDATA[
 LogicalProject(EXPR$0=[+($0, 1)])
-+- LogicalFilter(condition=[AND(IS NULL(pyFunc5($0).f0), >($1, 0))])
++- LogicalFilter(condition=[AND(IS NULL(RowJavaFunc(pyFunc5($0).f0).f0), >($1, 0))])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
 	</Resource>
 	<Resource name="optimized rel plan">
 	  <![CDATA[
 FlinkLogicalCalc(select=[+(a, 1) AS EXPR$0], where=[AND(IS NULL(f0.f0), >(b, 0))])
-+- FlinkLogicalCalc(select=[a, b, pyFunc5(a) AS f0])
-   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
++- FlinkLogicalCalc(select=[a, b, RowJavaFunc(f0.f0) AS f0])
+   +- FlinkLogicalCalc(select=[a, b, pyFunc5(a) AS f0])
+      +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
 	</Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.optimize.program._
 import org.apache.flink.table.planner.plan.rules.{FlinkBatchRuleSets, FlinkStreamRuleSets}
-import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.{BooleanPandasScalarFunction, BooleanPythonScalarFunction, PandasScalarFunction, PythonScalarFunction, RowPythonScalarFunction}
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.{BooleanPandasScalarFunction, BooleanPythonScalarFunction, PandasScalarFunction, PythonScalarFunction, RowJavaScalarFunction, RowPythonScalarFunction}
 import org.apache.flink.table.planner.utils.TableTestBase
 
 import org.apache.calcite.plan.hep.HepMatchOrder
@@ -60,6 +60,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
     util.addFunction("pyFunc3", new PythonScalarFunction("pyFunc3"))
     util.addFunction("pyFunc4", new BooleanPythonScalarFunction("pyFunc4"))
     util.addFunction("pyFunc5", new RowPythonScalarFunction("pyFunc5"))
+    util.addFunction("RowJavaFunc", new RowJavaScalarFunction("RowJavaFunc"))
     util.addFunction("pandasFunc1", new PandasScalarFunction("pandasFunc1"))
     util.addFunction("pandasFunc2", new PandasScalarFunction("pandasFunc2"))
     util.addFunction("pandasFunc3", new PandasScalarFunction("pandasFunc3"))
@@ -226,7 +227,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
   @Test
   def testPythonFunctionWithCompositeWhereClause(): Unit = {
-    val sqlQuery = "SELECT a + 1 FROM MyTable where pyFunc5(a).f0 is NULL and b > 0"
+    val sqlQuery = "SELECT a + 1 FROM MyTable where RowJavaFunc(pyFunc5(a).f0).f0 is NULL and b > 0"
     util.verifyRelPlan(sqlQuery)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -223,4 +223,10 @@ class PythonCalcSplitRuleTest extends TableTestBase {
     val sqlQuery = "SELECT e.* FROM (SELECT pyFunc5(d._1) as e FROM MyTable) AS T"
     util.verifyRelPlan(sqlQuery)
   }
+
+  @Test
+  def testPythonFunctionWithCompositeWhereClause(): Unit = {
+    val sqlQuery = "SELECT a + 1 FROM MyTable where pyFunc5(a).f0 is NULL and b > 0"
+    util.verifyRelPlan(sqlQuery)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add `PythonCalcSplitConditionRexFieldRule`*


## Brief change log

  - *Add `PythonCalcSplitConditionRexFieldRule`*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT in `testPythonFunctionWithCompositeWhereClause`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
