### PR TITLE
[FLINK-20768][Connectors/ElasticSearch] Support routing field for Elasticsearch connector

### DIFF
--- a/docs/dev/table/connectors/elasticsearch.md
+++ b/docs/dev/table/connectors/elasticsearch.md
@@ -125,6 +125,13 @@ Connector Options
       <td>Delimiter for composite keys ("_" by default), e.g., "$" would result in IDs "KEY1$KEY2$KEY3"."</td>
     </tr>
     <tr>
+      <td><h5>routing.filed-name</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Using field value in the record to dynamically generate routing filed.</td>
+    </tr>
+    <tr>
       <td><h5>username</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/dev/table/connectors/elasticsearch.zh.md
+++ b/docs/dev/table/connectors/elasticsearch.zh.md
@@ -125,6 +125,13 @@ Connector Options
       <td>Delimiter for composite keys ("_" by default), e.g., "$" would result in IDs "KEY1$KEY2$KEY3"."</td>
     </tr>
     <tr>
+      <td><h5>routing.filed-name</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Using field value in the record to dynamically generate routing filed.</td>
+    </tr>
+    <tr>
       <td><h5>username</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchConfiguration.java
@@ -145,6 +145,10 @@ class ElasticsearchConfiguration {
         return config.get(ElasticsearchOptions.KEY_DELIMITER_OPTION);
     }
 
+    public Optional<String> getRoutingField() {
+        return config.getOptional(ElasticsearchOptions.ROUTING_FILED_NAME);
+    }
+
     public Optional<String> getPathPrefix() {
         return config.getOptional(ElasticsearchOptions.CONNECTION_PATH_PREFIX);
     }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/ElasticsearchOptions.java
@@ -75,6 +75,11 @@ public class ElasticsearchOptions {
                     .defaultValue("_")
                     .withDescription(
                             "Delimiter for composite keys e.g., \"$\" would result in IDs \"KEY1$KEY2$KEY3\".");
+    public static final ConfigOption<String> ROUTING_FILED_NAME =
+            ConfigOptions.key("routing.filed-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Elasticsearch routing filed.");
     public static final ConfigOption<String> FAILURE_HANDLER_OPTION =
             ConfigOptions.key("failure-handler")
                     .stringType()

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RoutingExtractor.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/RoutingExtractor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * An extractor for a Elasticsearch routing from a {@link RowData}.
+ */
+@Internal
+public class RoutingExtractor {
+	private RoutingExtractor() {
+	}
+
+	public static Function<RowData, String> createRoutingExtractor(
+		TableSchema schema,
+		@Nullable String filedName) {
+		if (filedName == null) {
+			return null;
+		}
+		List<TableColumn> tableColumns = schema.getTableColumns();
+		for (int i = 0; i < schema.getFieldCount(); i++) {
+			TableColumn column = tableColumns.get(i);
+			if (column.getName().equals(filedName)) {
+				RowData.FieldGetter fieldGetter = RowData.createFieldGetter(
+					column.getType().getLogicalType(),
+					i);
+				return (Function<RowData, String> & Serializable) (row) -> {
+					Object fieldOrNull = fieldGetter.getFieldOrNull(row);
+					if (fieldOrNull != null) {
+						return fieldOrNull.toString();
+					} else {
+						return null;
+					}
+				};
+			}
+		}
+		throw new IllegalArgumentException("Filed " + filedName + " not exist in table schema.");
+	}
+}

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -86,7 +86,7 @@ under the License.
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSink.java
@@ -125,7 +125,9 @@ final class Elasticsearch6DynamicSink implements DynamicTableSink {
                             format,
                             XContentType.JSON,
                             REQUEST_FACTORY,
-                            KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()));
+                            KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()),
+                            RoutingExtractor.createRoutingExtractor(
+                                    schema, config.getRoutingField().orElse(null)));
 
             final ElasticsearchSink.Builder<RowData> builder =
                     builderProvider.createBuilder(config.getHosts(), upsertFunction);

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactory.java
@@ -54,6 +54,7 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.INDEX_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.ROUTING_FILED_NAME;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /** A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch6DynamicSink}. */
@@ -64,6 +65,7 @@ public class Elasticsearch6DynamicSinkFactory implements DynamicTableSinkFactory
     private static final Set<ConfigOption<?>> optionalOptions =
             Stream.of(
                             KEY_DELIMITER_OPTION,
+                            ROUTING_FILED_NAME,
                             FAILURE_HANDLER_OPTION,
                             FLUSH_ON_CHECKPOINT_OPTION,
                             BULK_FLASH_MAX_SIZE_OPTION,

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -86,7 +86,7 @@ under the License.
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>1.15.0</version>
+			<version>1.15.1</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSink.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSink.java
@@ -126,7 +126,9 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
                             format,
                             XContentType.JSON,
                             REQUEST_FACTORY,
-                            KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()));
+                            KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()),
+                            RoutingExtractor.createRoutingExtractor(
+                                    schema, config.getRoutingField().orElse(null)));
 
             final ElasticsearchSink.Builder<RowData> builder =
                     builderProvider.createBuilder(config.getHosts(), upsertFunction);

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkFactory.java
@@ -53,6 +53,7 @@ import static org.apache.flink.streaming.connectors.elasticsearch.table.Elastics
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.INDEX_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
+import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.ROUTING_FILED_NAME;
 import static org.apache.flink.streaming.connectors.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /** A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch7DynamicSink}. */
@@ -63,6 +64,7 @@ public class Elasticsearch7DynamicSinkFactory implements DynamicTableSinkFactory
     private static final Set<ConfigOption<?>> optionalOptions =
             Stream.of(
                             KEY_DELIMITER_OPTION,
+                            ROUTING_FILED_NAME,
                             FAILURE_HANDLER_OPTION,
                             FLUSH_ON_CHECKPOINT_OPTION,
                             BULK_FLASH_MAX_SIZE_OPTION,

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.RowKind;
 
 import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -344,6 +345,79 @@ public class Elasticsearch7DynamicSinkITCase {
         expectedMap.put("a", 1);
         expectedMap.put("b", "2012-12-12 12:12:12");
         assertThat(response, equalTo(expectedMap));
+    }
+
+    @Test
+    public void testWritingDocumentsWithRouting() throws Exception {
+        TableSchema schema =
+                TableSchema.builder()
+                        .field("a", DataTypes.BIGINT().notNull())
+                        .field("b", DataTypes.TIME())
+                        .field("c", DataTypes.STRING().notNull())
+                        .field("d", DataTypes.FLOAT())
+                        .field("e", DataTypes.TINYINT().notNull())
+                        .field("f", DataTypes.DATE())
+                        .field("g", DataTypes.TIMESTAMP().notNull())
+                        .primaryKey("a", "g")
+                        .build();
+        GenericRowData rowData =
+                GenericRowData.of(
+                        1L,
+                        12345,
+                        StringData.fromString("ABCDE"),
+                        12.12f,
+                        (byte) 2,
+                        12345,
+                        TimestampData.fromLocalDateTime(
+                                LocalDateTime.parse("2012-12-12T12:12:12")));
+
+        String index = "writing-documents";
+        Elasticsearch7DynamicSinkFactory sinkFactory = new Elasticsearch7DynamicSinkFactory();
+
+        SinkFunctionProvider sinkRuntimeProvider =
+                (SinkFunctionProvider)
+                        sinkFactory
+                                .createDynamicTableSink(
+                                        context()
+                                                .withSchema(schema)
+                                                .withOption(
+                                                        ElasticsearchOptions.INDEX_OPTION.key(),
+                                                        index)
+                                                .withOption(
+                                                        ElasticsearchOptions.ROUTING_FILED_NAME
+                                                                .key(),
+                                                        "c")
+                                                .withOption(
+                                                        ElasticsearchOptions.HOSTS_OPTION.key(),
+                                                        elasticsearchContainer.getHttpHostAddress())
+                                                .withOption(
+                                                        ElasticsearchOptions
+                                                                .FLUSH_ON_CHECKPOINT_OPTION
+                                                                .key(),
+                                                        "false")
+                                                .build())
+                                .getSinkRuntimeProvider(new MockContext());
+
+        SinkFunction<RowData> sinkFunction = sinkRuntimeProvider.createSinkFunction();
+        StreamExecutionEnvironment environment =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        rowData.setRowKind(RowKind.UPDATE_AFTER);
+        environment.<RowData>fromElements(rowData).addSink(sinkFunction);
+        environment.execute();
+
+        Client client = getClient();
+        GetResponse response =
+                client.get(new GetRequest(index, "1_2012-12-12T12:12:12").routing("ABCDE"))
+                        .actionGet();
+        Map<Object, Object> expectedMap = new HashMap<>();
+        expectedMap.put("a", 1);
+        expectedMap.put("b", "00:00:12");
+        expectedMap.put("c", "ABCDE");
+        expectedMap.put("d", 12.12d);
+        expectedMap.put("e", 2);
+        expectedMap.put("f", "2003-10-20");
+        expectedMap.put("g", "2012-12-12 12:12:12");
+        assertThat(response.getSource(), equalTo(expectedMap));
     }
 
     private static class MockContext implements DynamicTableSink.Context {


### PR DESCRIPTION
## What is the purpose of the change

This pull request add support for routing field in ElasticSearch connector.


## Brief change log
  -  Add `routing.filed-name` option to ES DynamicTableSink
  -  If `routing.filed-name` is set, will generate routing field for each `IndexRequest`, `UpdateRequest` and `DeleteRequest`.


## Verifying this change

This change added tests in `Elasticsearch7DynamicSinkITCase` and  `Elasticsearch6DynamicSinkITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
