### PR TITLE
[hotfix][typo]Fix typo in StreamingJobGraphGenerator.areOperatorsChainable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -834,7 +834,7 @@ public class StreamingJobGraphGenerator {
 				isChainable &= (upStreamOperator instanceof SourceOperatorFactory);
 				break;
 			default:
-				throw new RuntimeException("Unknown chaining strategy: " + upStreamOperator.getChainingStrategy());
+				throw new RuntimeException("Unknown chaining strategy: " + downStreamOperator.getChainingStrategy());
 		}
 
 		return isChainable;


### PR DESCRIPTION

What is the purpose of the change
Fix typo in StreamingJobGraphGenerator.areOperatorsChainable.
There are two separate switch to determine whether the ChainingStrategy isChainable for the upstream and downstream operators. In the second switch statement's default condition, there appears to be a Typo.

Brief change log
upStreamOperator -> downStreamOperator

Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
The S3 file system connector: (no)
