### PR TITLE
[FLINK-20778] the comment for the type of kafka consumer  is wrong at KafkaPartitionSplit

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -31,13 +31,13 @@ import java.util.Set;
 
 /** A {@link SourceSplit} for a Kafka partition. */
 public class KafkaPartitionSplit implements SourceSplit {
-    public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
-    // Indicating the split should consume from the earliest.
-    public static final long LATEST_OFFSET = -1;
-    // Indicating the split should consume from the latest.
-    public static final long EARLIEST_OFFSET = -2;
-    // Indicating the split should consume from the last committed offset.
-    public static final long COMMITTED_OFFSET = -3;
+	public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
+	// Indicating the split should consume from the latest.
+	public static final long LATEST_OFFSET = -1;
+	// Indicating the split should consume from the earliest.
+	public static final long EARLIEST_OFFSET = -2;
+	// Indicating the split should consume from the last committed offset.
+	public static final long COMMITTED_OFFSET = -3;
 
     // Valid special starting offsets
     public static final Set<Long> VALID_STARTING_OFFSET_MARKERS =

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -31,13 +31,13 @@ import java.util.Set;
 
 /** A {@link SourceSplit} for a Kafka partition. */
 public class KafkaPartitionSplit implements SourceSplit {
-	public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
-	// Indicating the split should consume from the latest.
-	public static final long LATEST_OFFSET = -1;
-	// Indicating the split should consume from the earliest.
-	public static final long EARLIEST_OFFSET = -2;
-	// Indicating the split should consume from the last committed offset.
-	public static final long COMMITTED_OFFSET = -3;
+    public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
+    // Indicating the split should consume from the latest.
+    public static final long LATEST_OFFSET = -1;
+    // Indicating the split should consume from the earliest.
+    public static final long EARLIEST_OFFSET = -2;
+    // Indicating the split should consume from the last committed offset.
+    public static final long COMMITTED_OFFSET = -3;
 
     // Valid special starting offsets
     public static final Set<Long> VALID_STARTING_OFFSET_MARKERS =


### PR DESCRIPTION
## What is the purpose of the change
fix comment for tyhe type of kafka consumer  at  ```KafkaPartitionSplit```.

## Brief change log
switch the comment to related type of kafka consume at ```KafkaPartitionSplit```.

## Verifying this change
This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
