### PR TITLE
[FLINK-20782][table-planner-blink] Separate implementation of BatchExecRank

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.stream.IntStream;
 
 /**
- * Batch physical ExecNode for Rank.
+ * {@link BatchExecNode} for Rank.
  *
  * <p>This node supports two-stage(local and global) rank to reduce data-shuffling.
  */
@@ -56,7 +56,7 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
             long rankEnd,
             boolean outputRankNumber,
             ExecEdge inputEdge,
-            LogicalType outputType,
+            RowType outputType,
             String description) {
         super(Collections.singletonList(inputEdge), outputType, description);
         this.partitionFields = partitionFields;
@@ -73,7 +73,6 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
         Transformation<RowData> input =
                 (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
 
-        RowType outputType = (RowType) getOutputType();
         RowType inputType = (RowType) getInputNodes().get(0).getOutputType();
 
         LogicalType[] partitionTypes =
@@ -106,6 +105,7 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
                         rankEnd,
                         outputRankNumber);
 
+        RowType outputType = (RowType) getOutputType();
         OneInputTransformation<RowData, RowData> ret =
                 ExecNodeUtil.createOneInputTransformation(
                         input,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
-import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.sort.RankOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -107,13 +106,12 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
 
         RowType outputType = (RowType) getOutputType();
         OneInputTransformation<RowData, RowData> ret =
-                ExecNodeUtil.createOneInputTransformation(
+                new OneInputTransformation<>(
                         input,
                         getDesc(),
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(outputType),
-                        input.getParallelism(),
-                        0);
+                        input.getParallelism());
         if (inputsContainSingleton()) {
             ret.setParallelism(1);
             ret.setMaxParallelism(1);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.runtime.operators.sort.RankOperator;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Collections;
+import java.util.stream.IntStream;
+
+/**
+ * Batch physical ExecNode for Rank.
+ *
+ * <p>This node supports two-stage(local and global) rank to reduce data-shuffling.
+ */
+public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
+
+    private final int[] partitionFields;
+    private final int[] sortFields;
+    private final long rankStart;
+    private final long rankEnd;
+    private final boolean outputRankNumber;
+
+    public BatchExecRank(
+            int[] partitionFields,
+            int[] sortFields,
+            long rankStart,
+            long rankEnd,
+            boolean outputRankNumber,
+            ExecEdge inputEdge,
+            LogicalType outputType,
+            String description) {
+        super(Collections.singletonList(inputEdge), outputType, description);
+        this.partitionFields = partitionFields;
+        this.sortFields = sortFields;
+        this.rankStart = rankStart;
+        this.rankEnd = rankEnd;
+        this.outputRankNumber = outputRankNumber;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+
+        Transformation<RowData> input =
+                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+
+        RowType outputType = (RowType) getOutputType();
+        RowType inputType = (RowType) getInputNodes().get(0).getOutputType();
+
+        LogicalType[] partitionTypes =
+                IntStream.of(partitionFields)
+                        .mapToObj(inputType::getTypeAt)
+                        .toArray(LogicalType[]::new);
+        LogicalType[] sortTypes =
+                IntStream.of(sortFields).mapToObj(inputType::getTypeAt).toArray(LogicalType[]::new);
+
+        // operator needn't cache data
+        // The collation for the partition-by and order-by fields is inessential here,
+        // we only use the comparator to distinguish fields change.
+        RankOperator operator =
+                new RankOperator(
+                        ComparatorCodeGenerator.gen(
+                                planner.getTableConfig(),
+                                "PartitionByComparator",
+                                partitionFields,
+                                partitionTypes,
+                                new boolean[partitionFields.length],
+                                new boolean[partitionFields.length]),
+                        ComparatorCodeGenerator.gen(
+                                planner.getTableConfig(),
+                                "OrderByComparator",
+                                sortFields,
+                                sortTypes,
+                                new boolean[sortFields.length],
+                                new boolean[sortFields.length]),
+                        rankStart,
+                        rankEnd,
+                        outputRankNumber);
+
+        OneInputTransformation<RowData, RowData> ret =
+                ExecNodeUtil.createOneInputTransformation(
+                        input,
+                        getDesc(),
+                        SimpleOperatorFactory.of(operator),
+                        InternalTypeInfo.of(outputType),
+                        input.getParallelism(),
+                        0);
+        if (inputsContainSingleton()) {
+            ret.setParallelism(1);
+            ret.setMaxParallelism(1);
+        }
+        return ret;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
@@ -18,23 +18,16 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
-import org.apache.flink.api.dag.Transformation
-import org.apache.flink.streaming.api.operators.SimpleOperatorFactory
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator
-import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef}
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
 import org.apache.flink.table.planner.plan.nodes.calcite.Rank
-import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil
-import org.apache.flink.table.planner.plan.nodes.exec.{LegacyBatchExecNode, ExecEdge}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecRank
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecJoinRuleBase
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, RelExplainUtil}
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankRange, RankType}
-import org.apache.flink.table.runtime.operators.sort.RankOperator
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelDistribution.Type
@@ -53,7 +46,7 @@ import scala.collection.JavaConversions._
   *
   * This node supports two-stage(local and global) rank to reduce data-shuffling.
   */
-class BatchExecRank(
+class BatchPhysicalRank(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
@@ -74,8 +67,7 @@ class BatchExecRank(
     rankRange,
     rankNumberType,
     outputRankNumber)
-  with BatchPhysicalRel
-  with LegacyBatchExecNode[RowData] {
+  with BatchPhysicalRel {
 
   require(rankType == RankType.RANK, "Only RANK is supported now")
   val (rankStart, rankEnd) = rankRange match {
@@ -84,7 +76,7 @@ class BatchExecRank(
   }
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new BatchExecRank(
+    new BatchPhysicalRank(
       cluster,
       traitSet,
       inputs.get(0),
@@ -237,52 +229,16 @@ class BatchExecRank(
 
   //~ ExecNode methods -----------------------------------------------------------
 
-  override def getInputEdges: util.List[ExecEdge] = List(ExecEdge.DEFAULT)
-
-  override protected def translateToPlanInternal(
-      planner: BatchPlanner): Transformation[RowData] = {
-    val input = getInputNodes.get(0).translateToPlan(planner)
-        .asInstanceOf[Transformation[RowData]]
-    val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
-    val partitionBySortingKeys = partitionKey.toArray
-    // The collation for the partition-by fields is inessential here, we only use the
-    // comparator to distinguish different groups.
-    // (order[is_asc], null_is_last)
-    val partitionBySortCollation = partitionBySortingKeys.map(_ => (true, true))
-
-    // The collation for the order-by fields is inessential here, we only use the
-    // comparator to distinguish order-by fields change.
-    // (order[is_asc], null_is_last)
-    val orderByCollation = orderKey.getFieldCollations.map(_ => (true, true)).toArray
-    val orderByKeys = orderKey.getFieldCollations.map(_.getFieldIndex).toArray
-
-    val inputType = FlinkTypeFactory.toLogicalRowType(getInput.getRowType)
-    //operator needn't cache data
-    val operator = new RankOperator(
-      ComparatorCodeGenerator.gen(
-        planner.getTableConfig,
-        "PartitionByComparator",
-        partitionBySortingKeys,
-        partitionBySortingKeys.map(inputType.getTypeAt),
-        partitionBySortCollation.map(_._1),
-        partitionBySortCollation.map(_._2)),
-      ComparatorCodeGenerator.gen(
-        planner.getTableConfig,
-        "OrderByComparator",
-        orderByKeys,
-        orderByKeys.map(inputType.getTypeAt),
-        orderByCollation.map(_._1),
-        orderByCollation.map(_._2)),
+  override def translateToExecNode(): ExecNode[_] = {
+    new BatchExecRank(
+      partitionKey.toArray,
+      orderKey.getFieldCollations.map(_.getFieldIndex).toArray,
       rankStart,
       rankEnd,
-      outputRankNumber)
-
-    ExecNodeUtil.createOneInputTransformation(
-      input,
-      getRelDetailedDescription,
-      SimpleOperatorFactory.of(operator),
-      InternalTypeInfo.of(outputType),
-      input.getParallelism,
-      0)
+      outputRankNumber,
+      ExecEdge.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription
+    )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalRank.scala
@@ -227,8 +227,6 @@ class BatchPhysicalRank(
     }
   }
 
-  //~ ExecNode methods -----------------------------------------------------------
-
   override def translateToExecNode(): ExecNode[_] = {
     new BatchExecRank(
       partitionKey.toArray,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecRankRule.scala
@@ -22,7 +22,7 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalRank
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 
@@ -72,7 +72,7 @@ class BatchExecRankRule
 
     // create local BatchExecRank
     val localRankRange = new ConstantRankRange(1, rankEnd) // local rank always start from 1
-    val localRank = new BatchExecRank(
+    val localRank = new BatchPhysicalRank(
       cluster,
       emptyTraits,
       newLocalInput,
@@ -98,7 +98,7 @@ class BatchExecRankRule
 
     // require SINGLETON or HASH exchange
     val newGlobalInput = RelOptRule.convert(localRank, globalRequiredTraitSet)
-    val globalRank = new BatchExecRank(
+    val globalRank = new BatchPhysicalRank(
       cluster,
       emptyTraits,
       newGlobalInput,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveRedundantLocalRankRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveRedundantLocalRankRule.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 
 import org.apache.calcite.plan.RelOptRule._
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -28,18 +28,18 @@ import org.apache.calcite.rel.RelNode
 import scala.collection.JavaConversions._
 
 /**
-  * Planner rule that matches a global [[BatchExecRank]] on a local [[BatchExecRank]],
-  * and merge them into a global [[BatchExecRank]].
+  * Planner rule that matches a global [[BatchPhysicalRank]] on a local [[BatchPhysicalRank]],
+  * and merge them into a global [[BatchPhysicalRank]].
   */
 class RemoveRedundantLocalRankRule extends RelOptRule(
-  operand(classOf[BatchExecRank],
-    operand(classOf[BatchExecRank],
+  operand(classOf[BatchPhysicalRank],
+    operand(classOf[BatchPhysicalRank],
       operand(classOf[RelNode], FlinkConventions.BATCH_PHYSICAL, any))),
   "RemoveRedundantLocalRankRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val globalRank: BatchExecRank = call.rel(0)
-    val localRank: BatchExecRank = call.rel(1)
+    val globalRank: BatchPhysicalRank = call.rel(0)
+    val localRank: BatchPhysicalRank = call.rel(1)
     globalRank.isGlobal && !localRank.isGlobal &&
       globalRank.rankType == localRank.rankType &&
       globalRank.partitionKey == localRank.partitionKey &&
@@ -48,7 +48,7 @@ class RemoveRedundantLocalRankRule extends RelOptRule(
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
-    val globalRank: BatchExecRank = call.rel(0)
+    val globalRank: BatchPhysicalRank = call.rel(0)
     val inputOfLocalRank: RelNode = call.rel(2)
     val newGlobalRank = globalRank.copy(globalRank.getTraitSet, List(inputOfLocalRank))
     call.transformTo(newGlobalRank)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnIntervalTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 import org.apache.flink.table.planner.plan.stats._
 import org.apache.flink.table.planner.plan.utils.ColumnIntervalUtil
 import org.apache.flink.table.planner.{JBoolean, JDouble}
@@ -331,7 +331,8 @@ class FlinkRelMdColumnIntervalTest extends FlinkRelMdHandlerTestBase {
         assertNull(mq.getColumnInterval(rank, 5))
         assertNull(mq.getColumnInterval(rank, 6))
         rank match {
-          case r: BatchExecRank if !r.isGlobal => // local batch rank does not output rank function
+          case r: BatchPhysicalRank if !r.isGlobal =>
+              // local batch rank does not output rank function
           case _ => assertEquals(ValueInterval(bd(1), bd(5)), mq.getColumnInterval(rank, 7))
         }
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 import org.apache.flink.table.planner.plan.utils.FlinkRelMdUtil
 
 import org.apache.calcite.rel.metadata.RelMdUtil
@@ -307,7 +307,7 @@ class FlinkRelMdDistinctRowCountTest extends FlinkRelMdHandlerTestBase {
         assertEquals(2.0, mq.getDistinctRowCount(rank, ImmutableBitSet.of(5), null))
         assertEquals(null, mq.getDistinctRowCount(rank, ImmutableBitSet.of(6), null))
         rank match {
-          case r: BatchExecRank if !r.isGlobal => // local rank does not output rank func
+          case r: BatchPhysicalRank if !r.isGlobal => // local rank does not output rank func
           case _ =>
             assertEquals(5.0, mq.getDistinctRowCount(rank, ImmutableBitSet.of(7), null))
         }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -449,7 +449,7 @@ class FlinkRelMdHandlerTestBase {
       outputRankNumber = true
     )
 
-    val batchLocalRank = new BatchExecRank(
+    val batchLocalRank = new BatchPhysicalRank(
       cluster,
       batchPhysicalTraits,
       studentBatchScan,
@@ -465,7 +465,7 @@ class FlinkRelMdHandlerTestBase {
     val hash6 = FlinkRelDistribution.hash(Array(6), requireStrict = true)
     val batchExchange = new BatchPhysicalExchange(
       cluster, batchLocalRank.getTraitSet.replace(hash6), batchLocalRank, hash6)
-    val batchGlobalRank = new BatchExecRank(
+    val batchGlobalRank = new BatchPhysicalRank(
       cluster,
       batchPhysicalTraits,
       batchExchange,
@@ -531,7 +531,7 @@ class FlinkRelMdHandlerTestBase {
       outputRankNumber = true
     )
 
-    val batchLocalRank = new BatchExecRank(
+    val batchLocalRank = new BatchPhysicalRank(
       cluster,
       batchPhysicalTraits,
       studentBatchScan,
@@ -547,7 +547,7 @@ class FlinkRelMdHandlerTestBase {
     val hash6 = FlinkRelDistribution.hash(Array(6), requireStrict = true)
     val batchExchange = new BatchPhysicalExchange(
       cluster, batchLocalRank.getTraitSet.replace(hash6), batchLocalRank, hash6)
-    val batchGlobalRank = new BatchExecRank(
+    val batchGlobalRank = new BatchPhysicalRank(
       cluster,
       batchPhysicalTraits,
       batchExchange,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSizeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdPopulationSizeTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecRank
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.ImmutableBitSet
@@ -179,7 +179,7 @@ class FlinkRelMdPopulationSizeTest extends FlinkRelMdHandlerTestBase {
         assertNull(mq.getPopulationSize(rank, ImmutableBitSet.of(6)))
         assertEquals(50.0, mq.getPopulationSize(rank, ImmutableBitSet.of(0, 2)))
         rank match {
-          case r: BatchExecRank =>
+          case r: BatchPhysicalRank =>
             // local batch rank does not output rank func
             // TODO re-check this
             if (r.isGlobal) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.metadata
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalExpand
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalDataStreamTableScan, FlinkLogicalExpand, FlinkLogicalOverAggregate}
-import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchExecRank, BatchPhysicalCalc}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalRank, BatchPhysicalCalc}
 import org.apache.flink.table.planner.plan.utils.ExpandUtil
 
 import com.google.common.collect.{ImmutableList, Lists}
@@ -196,7 +196,7 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
         assertEquals(1.0 / 7.0, mq.getSelectivity(rank, condition1))
 
         rank match {
-          case r: BatchExecRank if !r.isGlobal => // batch local rank does not output rank fun
+          case r: BatchPhysicalRank if !r.isGlobal => // batch local rank does not output rank fun
           case _ =>
             // rk > 2
             val condition2 =


### PR DESCRIPTION
## What is the purpose of the change
Separate the implementations of BatchExecRank

## Brief change log
Introduce BatchPhysicalRank, and make BatchExecRank only extended from ExecNode

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
