### PR TITLE
[FLINK-20718][FLINK-20717][metrics] Add isCausingBackPressureRatio and isBackPressuredRatio metrics

### DIFF
--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -1254,6 +1254,16 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>isCausingBackPressure</td>
+      <td>Whether the task is currently causing back-pressure.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>isCausingBackPressureRatio</td>
+      <td>Ratio how often this task is causing back-pressure. Can have values between 0.0 and 1.0, where value 1.0 means the task is constantly causing back-pressure. It is created by sampling isCausingBackPressure and averaging the sampled value using the exponential moving average algorithm.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>idleTimeMsPerSecond</td>
       <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
       <td>Meter</td>

--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -1245,7 +1245,12 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td>isBackPressured</td>
-      <td>Whether the task is back-pressured.</td>
+      <td>Whether the task is currently back-pressured.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>isBackPressuredRatio</td>
+      <td>Ratio how often this task is back-pressured. Can have values between 0.0 and 1.0, where value 1.0 means the task is constantly back-pressured. It is created by sampling isBackPressured and averaging the sampled value using the exponential moving average algorithm.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -1254,6 +1254,16 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>isCausingBackPressure</td>
+      <td>Whether the task is currently causing back-pressure.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>isCausingBackPressureRatio</td>
+      <td>Ratio how often this task is causing back-pressure. Can have values between 0.0 and 1.0, where value 1.0 means the task is constantly causing back-pressure. It is created by sampling isCausingBackPressure and averaging the sampled value using the exponential moving average algorithm.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>idleTimeMsPerSecond</td>
       <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
       <td>Meter</td>

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -1245,7 +1245,12 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td>isBackPressured</td>
-      <td>Whether the task is back-pressured.</td>
+      <td>Whether the task is currently back-pressured.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>isBackPressuredRatio</td>
+      <td>Ratio how often this task is back-pressured. Can have values between 0.0 and 1.0, where value 1.0 means the task is constantly back-pressured. It is created by sampling isBackPressured and averaging the sampled value using the exponential moving average algorithm.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/EMAGaugeSampler.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/EMAGaugeSampler.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import javax.annotation.Nullable;
+
+/**
+ * A {@link EMAGaugeSampler} provides an exponential moving average view over a {@link Gauge}.
+ *
+ * <p>As other {@link View}s, advantage of this class is that it is updated in regular intervals by
+ * a background thread.
+ */
+public class EMAGaugeSampler<T extends Number> implements Gauge<Double>, View {
+
+    /** The underlying sampled metric. */
+    private final Gauge<T> source;
+    /** Alpha parameter of the exponential moving average. */
+    private final double alpha;
+    /** The index in the array for the current time. */
+    @Nullable private double currentAverage;
+
+    public EMAGaugeSampler(Gauge<T> source, double alpha) {
+        this.source = source;
+        this.alpha = alpha;
+    }
+
+    @Override
+    public void update() {
+        currentAverage = currentAverage * alpha + source.getValue().doubleValue() * (1.0 - alpha);
+    }
+
+    @Override
+    public Double getValue() {
+        return currentAverage;
+    }
+}

--- a/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/EMAGaugeSamplerTest.java
+++ b/flink-metrics/flink-metrics-core/src/test/java/org/apache/flink/metrics/EMAGaugeSamplerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for the {@link EMAGaugeSamplerTest}. */
+public class EMAGaugeSamplerTest extends TestLogger {
+    @Test
+    public void testUpdates() {
+        double sample = 100.0;
+        double alpha = 0.4;
+        EMAGaugeSampler<Double> emaGaugeSampler = new EMAGaugeSampler<>(() -> sample, alpha);
+
+        for (int i = 1; i <= 5; i++) {
+            emaGaugeSampler.update();
+            double expected = sample - Math.pow(alpha, i) * sample;
+            assertEquals(expected, emaGaugeSampler.getValue(), 0.01);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -57,7 +57,7 @@ public class MetricNames {
     public static final String MEMORY_COMMITTED = "Committed";
     public static final String MEMORY_MAX = "Max";
 
-    public static final String IS_BACKPRESSURED = "isBackPressured";
+    public static final String IS_BACK_PRESSURED = "isBackPressured";
 
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -60,6 +60,9 @@ public class MetricNames {
     public static final String IS_BACK_PRESSURED = "isBackPressured";
     public static final String IS_BACK_PRESSURED_RATIO = "isBackPressuredRatio";
 
+    public static final String IS_CAUSING_BACK_PRESSURE = "isCausingBackPressure";
+    public static final String IS_CAUSING_BACK_PRESSURE_RATIO = "isCausingBackPressureRatio";
+
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -58,6 +58,7 @@ public class MetricNames {
     public static final String MEMORY_MAX = "Max";
 
     public static final String IS_BACK_PRESSURED = "isBackPressured";
+    public static final String IS_BACK_PRESSURED_RATIO = "isBackPressuredRatio";
 
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -696,7 +696,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             partitionStateChecker,
                             getRpcService().getExecutor());
 
-            taskMetricGroup.gauge(MetricNames.IS_BACKPRESSURED, task::isBackPressured);
+            taskMetricGroup.gauge(MetricNames.IS_BACK_PRESSURED, task::isBackPressured);
 
             log.info(
                     "Received task {} ({}), deploy into slot with allocation id {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -709,6 +709,13 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     MetricNames.IS_BACK_PRESSURED_RATIO,
                     new EMAGaugeSampler<>(() -> task.isBackPressured() ? 1.0 : 0.0, emaAlpha));
 
+            taskMetricGroup.gauge(
+                    MetricNames.IS_CAUSING_BACK_PRESSURE, task::isCausingBackPressure);
+            taskMetricGroup.gauge(
+                    MetricNames.IS_CAUSING_BACK_PRESSURE_RATIO,
+                    new EMAGaugeSampler<>(
+                            () -> task.isCausingBackPressure() ? 1.0 : 0.0, emaAlpha));
+
             log.info(
                     "Received task {} ({}), deploy into slot with allocation id {}.",
                     task.getTaskInfo().getTaskNameWithSubtasks(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -519,6 +519,11 @@ public class Task
         return !CompletableFuture.allOf(outputFutures).isDone();
     }
 
+    public boolean isCausingBackPressure() {
+        return !isBackPressured()
+                && metrics.getIOMetricGroup().getIdleTimeMsPerSecond().getRate() < 1.0;
+    }
+
     // ------------------------------------------------------------------------
     //  Task Execution
     // ------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds three new metrics:

- `isCausingBackPressure`
- `isCausingBackPressureRatio`
- `isBackPressuredRatio`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
