### PR TITLE
[FLINK-19656] [metrics] filter delimiter in metrics components

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/CharacterFilter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/CharacterFilter.java
@@ -23,6 +23,7 @@ package org.apache.flink.metrics;
  * can transform. The returned string is the transformation result.
  */
 public interface CharacterFilter {
+    CharacterFilter NO_OP_FILTER = input -> input;
 
     /**
      * Filter the given string and generate a resulting string from it.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -30,6 +30,7 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -268,7 +269,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
      */
     @Override
     public String getMetricIdentifier(String metricName) {
-        return getMetricIdentifier(metricName, null);
+        return getMetricIdentifier(metricName, CharacterFilter.NO_OP_FILTER);
     }
 
     /**
@@ -297,27 +298,16 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
      */
     public String getMetricIdentifier(
             String metricName, CharacterFilter filter, int reporterIndex, char delimiter) {
+        Preconditions.checkNotNull(filter);
+
+        metricName = filter.filterCharacters(metricName);
         if (scopeStrings.length == 0
                 || (reporterIndex < 0 || reporterIndex >= scopeStrings.length)) {
-            String newScopeString;
-            if (filter != null) {
-                newScopeString = ScopeFormat.concat(filter, delimiter, scopeComponents);
-                metricName = filter.filterCharacters(metricName);
-            } else {
-                newScopeString = ScopeFormat.concat(delimiter, scopeComponents);
-            }
-            return newScopeString + delimiter + metricName;
+            return ScopeFormat.concat(filter, delimiter, scopeComponents) + delimiter + metricName;
         } else {
             if (scopeStrings[reporterIndex] == null) {
-                if (filter != null) {
-                    scopeStrings[reporterIndex] =
-                            ScopeFormat.concat(filter, delimiter, scopeComponents);
-                } else {
-                    scopeStrings[reporterIndex] = ScopeFormat.concat(delimiter, scopeComponents);
-                }
-            }
-            if (filter != null) {
-                metricName = filter.filterCharacters(metricName);
+                scopeStrings[reporterIndex] =
+                        ScopeFormat.concat(filter, delimiter, scopeComponents);
             }
             return scopeStrings[reporterIndex] + delimiter + metricName;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -43,7 +43,10 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
     @Override
     public String getMetricIdentifier(String metricName) {
         return parentMetricGroup.getMetricIdentifier(
-                metricName, null, this.settings.getReporterIndex(), this.settings.getDelimiter());
+                metricName,
+                CharacterFilter.NO_OP_FILTER,
+                this.settings.getReporterIndex(),
+                this.settings.getDelimiter());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.metrics.groups;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.CharacterFilter;
 
 import java.util.Map;
@@ -33,6 +34,9 @@ import java.util.Map;
  */
 public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMetricGroup<P> {
 
+    @VisibleForTesting static final char DEFAULT_REPLACEMENT = '_';
+    @VisibleForTesting static final char DEFAULT_REPLACEMENT_ALTERNATIVE = '-';
+
     private final ReporterScopedSettings settings;
 
     public FrontMetricGroup(ReporterScopedSettings settings, P reference) {
@@ -44,7 +48,7 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
     public String getMetricIdentifier(String metricName) {
         return parentMetricGroup.getMetricIdentifier(
                 metricName,
-                CharacterFilter.NO_OP_FILTER,
+                getDelimiterFilter(this.settings, CharacterFilter.NO_OP_FILTER),
                 this.settings.getReporterIndex(),
                 this.settings.getDelimiter());
     }
@@ -52,7 +56,10 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
     @Override
     public String getMetricIdentifier(String metricName, CharacterFilter filter) {
         return parentMetricGroup.getMetricIdentifier(
-                metricName, filter, this.settings.getReporterIndex(), this.settings.getDelimiter());
+                metricName,
+                getDelimiterFilter(this.settings, filter),
+                this.settings.getReporterIndex(),
+                this.settings.getDelimiter());
     }
 
     @Override
@@ -62,11 +69,31 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
     }
 
     public String getLogicalScope(CharacterFilter filter) {
-        return parentMetricGroup.getLogicalScope(filter, this.settings.getDelimiter());
+        return parentMetricGroup.getLogicalScope(
+                getDelimiterFilter(this.settings, filter), this.settings.getDelimiter());
     }
 
     public String getLogicalScope(CharacterFilter filter, char delimiter) {
         return parentMetricGroup.getLogicalScope(
-                filter, delimiter, this.settings.getReporterIndex());
+                getDelimiterFilter(this.settings, filter),
+                delimiter,
+                this.settings.getReporterIndex());
+    }
+
+    private static CharacterFilter getDelimiterFilter(
+            ReporterScopedSettings reporterScopedSettings, CharacterFilter generalCharacterFilter) {
+
+        if (reporterScopedSettings.getDelimiter() != DEFAULT_REPLACEMENT) {
+            return input ->
+                    generalCharacterFilter.filterCharacters(
+                            input.replace(
+                                    reporterScopedSettings.getDelimiter(), DEFAULT_REPLACEMENT));
+        } else {
+            return input ->
+                    generalCharacterFilter.filterCharacters(
+                            input.replace(
+                                    reporterScopedSettings.getDelimiter(),
+                                    DEFAULT_REPLACEMENT_ALTERNATIVE));
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -38,14 +38,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public abstract class ScopeFormat {
 
-    private static CharacterFilter defaultFilter =
-            new CharacterFilter() {
-                @Override
-                public String filterCharacters(String input) {
-                    return input;
-                }
-            };
-
     // ------------------------------------------------------------------------
     //  Scope Format Special Characters
     // ------------------------------------------------------------------------
@@ -206,18 +198,6 @@ public abstract class ScopeFormat {
      */
     public static String asVariable(String scope) {
         return SCOPE_VARIABLE_PREFIX + scope + SCOPE_VARIABLE_SUFFIX;
-    }
-
-    public static String concat(String... components) {
-        return concat(defaultFilter, '.', components);
-    }
-
-    public static String concat(CharacterFilter filter, String... components) {
-        return concat(filter, '.', components);
-    }
-
-    public static String concat(Character delimiter, String... components) {
-        return concat(defaultFilter, delimiter, components);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroupTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link FrontMetricGroup}. */
+public class FrontMetricGroupTest {
+
+    @Test
+    public void testDelimiterReplacement() {
+        final char delimiter = '*';
+        final String hostName = "some" + delimiter + "host";
+        final String metricName = "hello" + delimiter + "world";
+
+        final Configuration config = new Configuration();
+        config.set(MetricOptions.SCOPE_NAMING_JM, ScopeFormat.SCOPE_HOST);
+
+        final FrontMetricGroup<?> frontMetricGroup =
+                new FrontMetricGroup<>(
+                        new ReporterScopedSettings(0, delimiter, Collections.emptySet()),
+                        new ProcessMetricGroup(
+                                TestingMetricRegistry.builder()
+                                        .setScopeFormats(ScopeFormats.fromConfig(config))
+                                        .build(),
+                                hostName));
+
+        assertThat(
+                frontMetricGroup.getMetricIdentifier(metricName),
+                is(
+                        hostName.replace(delimiter, FrontMetricGroup.DEFAULT_REPLACEMENT)
+                                + delimiter
+                                + metricName.replace(
+                                        delimiter, FrontMetricGroup.DEFAULT_REPLACEMENT)));
+        // delimiters in variables should not be filtered, because they are usually not used in a
+        // context where the delimiter matters
+        assertThat(frontMetricGroup.getAllVariables(), hasEntry(ScopeFormat.SCOPE_HOST, hostName));
+    }
+
+    @Test
+    public void testDelimiterReplacementWithAlternative() {
+        final char delimiter = FrontMetricGroup.DEFAULT_REPLACEMENT;
+        final String hostName = "some" + delimiter + "host";
+        final String metricName = "hello" + delimiter + "world";
+
+        final Configuration config = new Configuration();
+        config.set(MetricOptions.SCOPE_NAMING_JM, ScopeFormat.SCOPE_HOST);
+
+        final FrontMetricGroup<?> frontMetricGroup =
+                new FrontMetricGroup<>(
+                        new ReporterScopedSettings(0, delimiter, Collections.emptySet()),
+                        new ProcessMetricGroup(
+                                TestingMetricRegistry.builder()
+                                        .setScopeFormats(ScopeFormats.fromConfig(config))
+                                        .build(),
+                                hostName));
+
+        assertThat(
+                frontMetricGroup.getMetricIdentifier(metricName),
+                is(
+                        hostName.replace(
+                                        delimiter, FrontMetricGroup.DEFAULT_REPLACEMENT_ALTERNATIVE)
+                                + delimiter
+                                + metricName.replace(
+                                        delimiter,
+                                        FrontMetricGroup.DEFAULT_REPLACEMENT_ALTERNATIVE)));
+        // delimiters in variables should not be filtered, because they are usually not used in a
+        // context where the delimiter matters
+        assertThat(frontMetricGroup.getAllVariables(), hasEntry(ScopeFormat.SCOPE_HOST, hostName));
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
@@ -127,7 +128,8 @@ public class SystemResourcesMetricsITCase extends TestLogger {
 
         @Override
         public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
-            final String metricIdentifier = group.getMetricIdentifier(metricName, name -> name);
+            final String metricIdentifier =
+                    group.getMetricIdentifier(metricName, CharacterFilter.NO_OP_FILTER);
             for (final String expectedPattern : patternFutures.keySet()) {
                 if (metricIdentifier.matches(expectedPattern)) {
                     patternFutures.get(expectedPattern).complete(null);


### PR DESCRIPTION
## What is the purpose of the change
This PR makes sure the configured per-reporter delimiter is filtered out of the metrics components names.


## Brief change log

- I made the configured reporter delimiter come through to the reporter instance itself. For this I made a default impl in AbstractReporter.open() that loads the configured delimiter and I made all the reporters extend AbstractReporter and I made open() overrides call the default impl. But for configuration name, I chose to copy the conf string "scope.delimiter" which was already defined twice in flink-core/ConfigConstants and flink-core/MetricsOptions rather than making flink-metrics depend on flink-core. Is that correct ?
- In MetricsOptions, the deprecated "metrics.scope.delimiter" conf name was in use. I replaced with the new name "scope.delimiter" in a separate commit. But I find it weird that this conf name is duplicated between MetricsOptions and ConfigConstants
- I made a default impl in AbstractReporter.filterCharacter() that filters out the configured delimiter. I made sure all AbstractReporter subclasses (all the reporters) and overrides call this default impl.

## Verifying this change
Added AbstractReporterITCase test


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no unless MetricOptions is used publicly (I have fixed a deprecation in this file)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Added javadocs on AbstractReporter#open and AbstractReporter#filterCharacters to document the default impl and recall users to call super when they override.