### PR TITLE
[FLINK-20792][build] Allow shorthand calls to spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1827,9 +1827,6 @@ under the License.
 					</configuration>
 				</plugin>
 
-				<!-- Due to the Flink build setup, "mvn spotless:apply" and "mvn spotless:check"
-				don't work. You have to use the fully qualified name, i.e.
-				"mvn com.diffplug.spotless:spotless-maven-plugin:apply" -->
 				<plugin>
 					<groupId>com.diffplug.spotless</groupId>
 					<artifactId>spotless-maven-plugin</artifactId>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -43,6 +43,21 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- This only exists to allow shorthand invocations on the command-line
+						i.e., 'mvn spotless:check'
+						This is necessary because this module does not declare the flink-parent pom as its parent -->
+					<groupId>com.diffplug.spotless</groupId>
+					<artifactId>spotless-maven-plugin</artifactId>
+					<version>2.4.2</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 	<profiles>
 		<profile>
 			<id>release</id>


### PR DESCRIPTION
It was not possible to just run 'mvn spotless:check', but instead one needed to use the fully qualified name of the plugin, i.e., 'mvn com.diffplug.spotless:spotless-maven-plugin:check'.

This is due to 'force-shading'; this module is declared as a child of the flink-parent pom (i.e., the root pom of the project), but is not actually declaring that very module as it's parent.
This seems to throw of maven, which fails to retrieve the plugin information from the parent.

Note that this is just a band-aid; a proper fix would declare flink-parent as the parent of force-shading, but this is the easier fix.
We could also think of finally migrating to flink-shaded-force-shading, or before that, verify whether the original issue that causes us to introduce force-shading actually still exists.
