### PR TITLE
[FLINK-20770][k8s] Correct the description of kubernetes config option 'kubernetes.rest-service.exposed.type'

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -138,7 +138,7 @@
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">LoadBalancer</td>
             <td><p>Enum</p>Possible values: [ClusterIP, NodePort, LoadBalancer]</td>
-            <td>The type of the rest service (ClusterIP or NodePort or LoadBalancer). When set to ClusterIP, the rest service will not be created.</td>
+            <td>The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.secrets</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -52,8 +52,8 @@ public class KubernetesConfigOptions {
                     .enumType(ServiceExposedType.class)
                     .defaultValue(ServiceExposedType.LoadBalancer)
                     .withDescription(
-                            "The type of the rest service (ClusterIP or NodePort or LoadBalancer). "
-                                    + "When set to ClusterIP, the rest service will not be created.");
+                            "The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). "
+                                    + "The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.");
 
     public static final ConfigOption<String> JOB_MANAGER_SERVICE_ACCOUNT =
             key("kubernetes.jobmanager.service-account")


### PR DESCRIPTION
```
public static final ConfigOption<ServiceExposedType> REST_SERVICE_EXPOSED_TYPE =
   key("kubernetes.rest-service.exposed.type")
   .enumType(ServiceExposedType.class)
   .defaultValue(ServiceExposedType.LoadBalancer)
   .withDescription("The type of the rest service (ClusterIP or NodePort or LoadBalancer). " +
      "When set to ClusterIP, the rest service will not be created.");
```

The description of the config option is not correct. We will always create the rest service after refactoring the Kubernetes decorators in FLINK-16194. 