### PR TITLE
[FLINK-20783][table-planner-blink] Separate implementation of ExecNode and PhysicalNode in batch join

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.LongHashJoinGenerator;
+import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.utils.JoinUtil;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.generated.GeneratedProjection;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.HashJoinOperator;
+import org.apache.flink.table.runtime.operators.join.HashJoinType;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/** {@link BatchExecNode} for Hash Join. */
+public class BatchExecHashJoin extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
+
+    private final FlinkJoinType joinType;
+    private final int[] leftKeys;
+    private final int[] rightKeys;
+    private final boolean[] filterNulls;
+    private final @Nullable RexNode nonEquiConditions;
+    private final boolean leftIsBuild;
+    private final int estimatedLeftAvgRowSize;
+    private final int estimatedRightAvgRowSize;
+    private final long estimatedLeftRowCount;
+    private final long estimatedRightRowCount;
+    private final boolean tryDistinctBuildRow;
+
+    public BatchExecHashJoin(
+            FlinkJoinType joinType,
+            int[] leftKeys,
+            int[] rightKeys,
+            boolean[] filterNulls,
+            @Nullable RexNode nonEquiConditions,
+            int estimatedLeftAvgRowSize,
+            int estimatedRightAvgRowSize,
+            long estimatedLeftRowCount,
+            long estimatedRightRowCount,
+            boolean leftIsBuild,
+            boolean tryDistinctBuildRow,
+            List<ExecEdge> inputEdges,
+            RowType outputType,
+            String description) {
+        super(inputEdges, outputType, description);
+        this.joinType = joinType;
+
+        Preconditions.checkNotNull(leftKeys);
+        Preconditions.checkNotNull(rightKeys);
+        Preconditions.checkNotNull(filterNulls);
+        Preconditions.checkArgument(leftKeys.length == rightKeys.length);
+        Preconditions.checkArgument(leftKeys.length == filterNulls.length);
+
+        this.leftKeys = leftKeys;
+        this.rightKeys = rightKeys;
+        this.filterNulls = filterNulls;
+        this.nonEquiConditions = nonEquiConditions;
+        this.leftIsBuild = leftIsBuild;
+        this.estimatedLeftAvgRowSize = estimatedLeftAvgRowSize;
+        this.estimatedRightAvgRowSize = estimatedRightAvgRowSize;
+        this.estimatedLeftRowCount = estimatedLeftRowCount;
+        this.estimatedRightRowCount = estimatedRightRowCount;
+        this.tryDistinctBuildRow = tryDistinctBuildRow;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+        ExecNode<RowData> leftInputNode = (ExecNode<RowData>) getInputNodes().get(0);
+        ExecNode<RowData> rightInputNode = (ExecNode<RowData>) getInputNodes().get(1);
+
+        Transformation<RowData> lInput = leftInputNode.translateToPlan(planner);
+        Transformation<RowData> rInput = rightInputNode.translateToPlan(planner);
+        // get type
+        RowType lType = (RowType) leftInputNode.getOutputType();
+        RowType rType = (RowType) rightInputNode.getOutputType();
+
+        LogicalType[] keyFieldTypes =
+                IntStream.of(leftKeys).mapToObj(lType::getTypeAt).toArray(LogicalType[]::new);
+        RowType keyType = RowType.of(keyFieldTypes);
+
+        TableConfig config = planner.getTableConfig();
+        GeneratedJoinCondition condFunc =
+                JoinUtil.generateConditionFunction(config, nonEquiConditions, lType, rType);
+
+        // projection for equals
+        GeneratedProjection lProj =
+                ProjectionCodeGenerator.generateProjection(
+                        new CodeGeneratorContext(config),
+                        "HashJoinLeftProjection",
+                        lType,
+                        keyType,
+                        leftKeys);
+        GeneratedProjection rProj =
+                ProjectionCodeGenerator.generateProjection(
+                        new CodeGeneratorContext(config),
+                        "HashJoinRightProjection",
+                        rType,
+                        keyType,
+                        rightKeys);
+
+        Transformation<RowData> build;
+        Transformation<RowData> probe;
+        GeneratedProjection bProj;
+        GeneratedProjection pProj;
+        int[] bKeys;
+        int[] pKeys;
+        RowType bType;
+        RowType pType;
+        int bRowSize;
+        long bRowCount;
+        long pRowCount;
+        boolean reverseJoin = !leftIsBuild;
+        if (leftIsBuild) {
+            build = lInput;
+            bProj = lProj;
+            bType = lType;
+            bRowSize = estimatedLeftAvgRowSize;
+            bRowCount = estimatedLeftRowCount;
+            bKeys = leftKeys;
+
+            probe = rInput;
+            pProj = rProj;
+            pType = rType;
+            pRowCount = estimatedLeftRowCount;
+            pKeys = rightKeys;
+        } else {
+            build = rInput;
+            bProj = rProj;
+            bType = rType;
+            bRowSize = estimatedRightAvgRowSize;
+            bRowCount = estimatedRightRowCount;
+            bKeys = rightKeys;
+
+            probe = lInput;
+            pProj = lProj;
+            pType = lType;
+            pRowCount = estimatedLeftRowCount;
+            pKeys = leftKeys;
+        }
+
+        // operator
+        StreamOperatorFactory<RowData> operator;
+        HashJoinType hashJoinType =
+                HashJoinType.of(
+                        leftIsBuild,
+                        joinType.isLeftOuter(),
+                        joinType.isRightOuter(),
+                        joinType == FlinkJoinType.SEMI,
+                        joinType == FlinkJoinType.ANTI);
+        if (LongHashJoinGenerator.support(hashJoinType, keyType, filterNulls)) {
+            operator =
+                    LongHashJoinGenerator.gen(
+                            config,
+                            hashJoinType,
+                            keyType,
+                            bType,
+                            pType,
+                            bKeys,
+                            pKeys,
+                            bRowSize,
+                            bRowCount,
+                            reverseJoin,
+                            condFunc);
+        } else {
+            operator =
+                    SimpleOperatorFactory.of(
+                            HashJoinOperator.newHashJoinOperator(
+                                    hashJoinType,
+                                    condFunc,
+                                    reverseJoin,
+                                    filterNulls,
+                                    bProj,
+                                    pProj,
+                                    tryDistinctBuildRow,
+                                    bRowSize,
+                                    bRowCount,
+                                    pRowCount,
+                                    keyType));
+        }
+
+        long managedMemory =
+                ExecNodeUtil.getMemorySize(
+                        config, ExecutionConfigOptions.TABLE_EXEC_RESOURCE_HASH_JOIN_MEMORY);
+
+        TwoInputTransformation<RowData, RowData, RowData> ret =
+                ExecNodeUtil.createTwoInputTransformation(
+                        build,
+                        probe,
+                        getDesc(),
+                        operator,
+                        InternalTypeInfo.of(getOutputType()),
+                        probe.getParallelism(),
+                        managedMemory);
+
+        if (inputsContainSingleton()) {
+            ret.setParallelism(1);
+            ret.setMaxParallelism(1);
+        }
+        return ret;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.NestedLoopJoinCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.calcite.rex.RexNode;
+
+import java.util.List;
+
+/** {@link BatchExecNode} for Nested-loop Join. */
+public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
+        implements BatchExecNode<RowData> {
+
+    private final FlinkJoinType joinType;
+    private final RexNode condition;
+    private final boolean leftIsBuild;
+    private final boolean singleRowJoin;
+
+    public BatchExecNestedLoopJoin(
+            FlinkJoinType joinType,
+            RexNode condition,
+            boolean leftIsBuild,
+            boolean singleRowJoin,
+            List<ExecEdge> inputEdges,
+            RowType outputType,
+            String description) {
+        super(inputEdges, outputType, description);
+        this.joinType = joinType;
+        this.condition = condition;
+        this.leftIsBuild = leftIsBuild;
+        this.singleRowJoin = singleRowJoin;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+        ExecNode<RowData> leftInputNode = (ExecNode<RowData>) getInputNodes().get(0);
+        ExecNode<RowData> rightInputNode = (ExecNode<RowData>) getInputNodes().get(1);
+
+        Transformation<RowData> lInput = leftInputNode.translateToPlan(planner);
+        Transformation<RowData> rInput = rightInputNode.translateToPlan(planner);
+
+        // get type
+        RowType lType = (RowType) leftInputNode.getOutputType();
+        RowType rType = (RowType) rightInputNode.getOutputType();
+
+        TableConfig config = planner.getTableConfig();
+        CodeGenOperatorFactory<RowData> op =
+                new NestedLoopJoinCodeGenerator(
+                                new CodeGeneratorContext(config),
+                                singleRowJoin,
+                                leftIsBuild,
+                                lType,
+                                rType,
+                                (RowType) getOutputType(),
+                                joinType,
+                                condition)
+                        .gen();
+
+        int parallelism = lInput.getParallelism();
+        if (leftIsBuild) {
+            parallelism = rInput.getParallelism();
+        }
+        long manageMem = 0;
+        if (!singleRowJoin) {
+            manageMem =
+                    ExecNodeUtil.getMemorySize(
+                            config,
+                            ExecutionConfigOptions.TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY);
+        }
+
+        TwoInputTransformation<RowData, RowData, RowData> ret =
+                ExecNodeUtil.createTwoInputTransformation(
+                        lInput,
+                        rInput,
+                        getDesc(),
+                        op,
+                        InternalTypeInfo.of(getOutputType()),
+                        parallelism,
+                        manageMem);
+
+        if (inputsContainSingleton()) {
+            ret.setParallelism(1);
+            ret.setMaxParallelism(1);
+        }
+        return ret;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -60,13 +60,7 @@ public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNod
 
         TableConfig config = planner.getTableConfig();
         RowType inputType = (RowType) inputNode.getOutputType();
-        SortCodeGenerator codeGen =
-                new SortCodeGenerator(
-                        config,
-                        sortSpec.getFieldIndices(),
-                        sortSpec.getFieldTypes(inputType),
-                        sortSpec.getAscendingOrders(),
-                        sortSpec.getNullsIsLast());
+        SortCodeGenerator codeGen = new SortCodeGenerator(config, inputType, sortSpec);
 
         SortOperator operator =
                 new SortOperator(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.api.TableConfig;
@@ -75,12 +74,8 @@ public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNod
                         codeGen.generateRecordComparator("BatchExecSortComparator"));
 
         long sortMemory =
-                MemorySize.parse(
-                                config.getConfiguration()
-                                        .getString(
-                                                ExecutionConfigOptions
-                                                        .TABLE_EXEC_RESOURCE_SORT_MEMORY))
-                        .getBytes();
+                ExecNodeUtil.getMemorySize(
+                        config, ExecutionConfigOptions.TABLE_EXEC_RESOURCE_SORT_MEMORY);
 
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
@@ -77,12 +77,7 @@ public class BatchExecSortLimit extends ExecNodeBase<RowData> implements BatchEx
         // generate comparator
         GeneratedRecordComparator genComparator =
                 ComparatorCodeGenerator.gen(
-                        planner.getTableConfig(),
-                        "SortLimitComparator",
-                        sortSpec.getFieldIndices(),
-                        sortSpec.getFieldTypes(inputType),
-                        sortSpec.getAscendingOrders(),
-                        sortSpec.getNullsIsLast());
+                        planner.getTableConfig(), "SortLimitComparator", inputType, sortSpec);
 
         // TODO If input is ordered, there is no need to use the heap.
         SortLimitOperator operator =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
+import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.utils.JoinUtil;
+import org.apache.flink.table.planner.plan.utils.SortUtil;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.SortMergeJoinOperator;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import scala.Tuple3;
+
+/** {@link BatchExecNode} for Sort Merge Join. */
+public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
+        implements BatchExecNode<RowData> {
+
+    private final FlinkJoinType joinType;
+    private final int[] leftKeys;
+    private final int[] rightKeys;
+    private final boolean[] filterNulls;
+    private final @Nullable RexNode nonEquiConditions;
+    private final boolean leftIsSmaller;
+
+    public BatchExecSortMergeJoin(
+            FlinkJoinType joinType,
+            int[] leftKeys,
+            int[] rightKeys,
+            boolean[] filterNulls,
+            @Nullable RexNode nonEquiConditions,
+            boolean leftIsSmaller,
+            List<ExecEdge> inputEdges,
+            RowType outputType,
+            String description) {
+        super(inputEdges, outputType, description);
+        this.joinType = joinType;
+
+        Preconditions.checkNotNull(leftKeys);
+        Preconditions.checkNotNull(rightKeys);
+        Preconditions.checkNotNull(filterNulls);
+        Preconditions.checkArgument(leftKeys.length == rightKeys.length);
+        Preconditions.checkArgument(leftKeys.length == filterNulls.length);
+        this.leftKeys = leftKeys;
+        this.rightKeys = rightKeys;
+        this.filterNulls = filterNulls;
+        this.nonEquiConditions = nonEquiConditions;
+        this.leftIsSmaller = leftIsSmaller;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+        ExecNode<RowData> leftInputNode = (ExecNode<RowData>) getInputNodes().get(0);
+        ExecNode<RowData> rightInputNode = (ExecNode<RowData>) getInputNodes().get(1);
+
+        // get type
+        RowType lType = (RowType) leftInputNode.getOutputType();
+        RowType rType = (RowType) rightInputNode.getOutputType();
+
+        LogicalType[] keyFieldTypes =
+                IntStream.of(leftKeys).mapToObj(lType::getTypeAt).toArray(LogicalType[]::new);
+        RowType keyType = RowType.of(keyFieldTypes);
+
+        TableConfig config = planner.getTableConfig();
+        GeneratedJoinCondition condFunc =
+                JoinUtil.generateConditionFunction(config, nonEquiConditions, lType, rType);
+
+        long externalBufferMemory =
+                ExecNodeUtil.getMemorySize(
+                        config, ExecutionConfigOptions.TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY);
+        long sortMemory =
+                ExecNodeUtil.getMemorySize(
+                        config, ExecutionConfigOptions.TABLE_EXEC_RESOURCE_SORT_MEMORY);
+        int externalBufferNum = 1;
+        if (joinType == FlinkJoinType.FULL) {
+            externalBufferNum = 2;
+        }
+
+        long managedMemory = externalBufferMemory * externalBufferNum + sortMemory * 2;
+
+        SortCodeGenerator leftSortGen = newSortGen(config, leftKeys, lType);
+        SortCodeGenerator rightSortGen = newSortGen(config, rightKeys, rType);
+
+        int[] keyPositions = IntStream.range(0, leftKeys.length).toArray();
+        SortMergeJoinOperator operator =
+                new SortMergeJoinOperator(
+                        1.0 * externalBufferMemory / managedMemory,
+                        joinType,
+                        leftIsSmaller,
+                        condFunc,
+                        ProjectionCodeGenerator.generateProjection(
+                                new CodeGeneratorContext(config),
+                                "SMJProjection",
+                                lType,
+                                keyType,
+                                leftKeys),
+                        ProjectionCodeGenerator.generateProjection(
+                                new CodeGeneratorContext(config),
+                                "SMJProjection",
+                                rType,
+                                keyType,
+                                rightKeys),
+                        leftSortGen.generateNormalizedKeyComputer("LeftComputer"),
+                        leftSortGen.generateRecordComparator("LeftComparator"),
+                        rightSortGen.generateNormalizedKeyComputer("RightComputer"),
+                        rightSortGen.generateRecordComparator("RightComparator"),
+                        newSortGen(config, keyPositions, keyType)
+                                .generateRecordComparator("KeyComparator"),
+                        filterNulls);
+
+        Transformation<RowData> lInput = leftInputNode.translateToPlan(planner);
+        Transformation<RowData> rInput = rightInputNode.translateToPlan(planner);
+        TwoInputTransformation<RowData, RowData, RowData> ret =
+                ExecNodeUtil.createTwoInputTransformation(
+                        lInput,
+                        rInput,
+                        getDesc(),
+                        SimpleOperatorFactory.of(operator),
+                        InternalTypeInfo.of(getOutputType()),
+                        rInput.getParallelism(),
+                        managedMemory);
+
+        if (inputsContainSingleton()) {
+            ret.setParallelism(1);
+            ret.setMaxParallelism(1);
+        }
+        return ret;
+    }
+
+    private SortCodeGenerator newSortGen(TableConfig config, int[] originalKeys, RowType type) {
+        boolean[] originalOrders = new boolean[originalKeys.length];
+        Arrays.fill(originalOrders, true);
+        boolean[] nullsIsLast = SortUtil.getNullDefaultOrders(originalOrders);
+
+        // deduplicated sort field infos: <fieldIndices, ascendingOrders, nullsIslast>
+        Tuple3<int[], boolean[], boolean[]> ret =
+                SortUtil.deduplicateSortKeys(originalKeys, originalOrders, nullsIsLast);
+        LogicalType[] types =
+                IntStream.of(ret._1()).mapToObj(type::getTypeAt).toArray(LogicalType[]::new);
+        return new SortCodeGenerator(config, ret._1(), types, ret._2(), ret._3());
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
@@ -77,12 +77,7 @@ public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecN
         // sort code gen
         GeneratedRecordComparator rowComparator =
                 ComparatorCodeGenerator.gen(
-                        config,
-                        "StreamExecSortComparator",
-                        sortSpec.getFieldIndices(),
-                        sortSpec.getFieldTypes(inputType),
-                        sortSpec.getAscendingOrders(),
-                        sortSpec.getNullsIsLast());
+                        config, "StreamExecSortComparator", inputType, sortSpec);
         StreamSortOperator sortOperator =
                 new StreamSortOperator(InternalTypeInfo.of(inputType), rowComparator);
         Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -94,12 +94,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
 
             GeneratedRecordComparator rowComparator =
                     ComparatorCodeGenerator.gen(
-                            tableConfig,
-                            "ProcTimeSortComparator",
-                            specExcludeTime.getFieldIndices(),
-                            specExcludeTime.getFieldTypes(inputType),
-                            specExcludeTime.getAscendingOrders(),
-                            specExcludeTime.getNullsIsLast());
+                            tableConfig, "ProcTimeSortComparator", inputType, specExcludeTime);
             ProcTimeSortOperator sortOperator =
                     new ProcTimeSortOperator(InternalTypeInfo.of(inputType), rowComparator);
 
@@ -136,12 +131,7 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
             SortSpec specExcludeTime = sortSpec.createSubSortSpec(1);
             rowComparator =
                     ComparatorCodeGenerator.gen(
-                            tableConfig,
-                            "RowTimeSortComparator",
-                            specExcludeTime.getFieldIndices(),
-                            specExcludeTime.getFieldTypes(inputType),
-                            specExcludeTime.getAscendingOrders(),
-                            specExcludeTime.getNullsIsLast());
+                            tableConfig, "RowTimeSortComparator", inputType, specExcludeTime);
         }
         RowTimeSortOperator sortOperator =
                 new RowTimeSortOperator(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 
 /** An Utility class that helps translating {@link ExecNode} to {@link Transformation}. */
 public class ExecNodeUtil {
-
     /**
      * Return bytes size for given option in {@link TableConfig}.
      *

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/SortSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/SortSpec.java
@@ -69,6 +69,11 @@ public class SortSpec {
         return nullIsLasts;
     }
 
+    /** Gets all {@link SortFieldSpec} in the SortSpec. */
+    public SortFieldSpec[] getFieldSpecs() {
+        return fieldSpecs;
+    }
+
     /** Gets {@link SortFieldSpec} of field at given index. */
     public SortFieldSpec getFieldSpec(int index) {
         return fieldSpecs[index];

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -813,13 +813,10 @@ object HashAggCodeGenHelper {
       keyComputerTerm: String,
       recordComparatorTerm: String,
       aggMapKeyType: RowType) : String = {
-    val keyFieldTypes = aggMapKeyType.getChildren.toArray(Array[LogicalType]())
-    val keys = keyFieldTypes.indices.toArray
-    val orders = keys.map(_ => true)
-    val nullsIsLast = SortUtil.getNullDefaultOrders(orders)
-
     val sortCodeGenerator = new SortCodeGenerator(
-      ctx.tableConfig, keys, keyFieldTypes, orders, nullsIsLast)
+        ctx.tableConfig,
+        aggMapKeyType,
+        SortUtil.getAscendingSortSpec(Array.range(0, aggMapKeyType.getFieldCount)))
     val computer = sortCodeGenerator.generateNormalizedKeyComputer("AggMapKeyComputer")
     val comparator = sortCodeGenerator.generateRecordComparator("AggMapValueComparator")
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/ComparatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/ComparatorCodeGenerator.scala
@@ -22,8 +22,9 @@ import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{ROW_DATA, newName}
 import org.apache.flink.table.planner.codegen.Indenter.toISC
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GenerateUtils}
+import org.apache.flink.table.planner.plan.nodes.exec.utils.SortSpec
 import org.apache.flink.table.runtime.generated.{GeneratedRecordComparator, RecordComparator}
-import org.apache.flink.table.types.logical.LogicalType
+import org.apache.flink.table.types.logical.{LogicalType, RowType}
 
 /**
   * A code generator for generating [[RecordComparator]].
@@ -36,25 +37,25 @@ object ComparatorCodeGenerator {
     * @param conf        Table config.
     * @param name        Class name of the function.
     *                    Does not need to be unique but has to be a valid Java class identifier.
-    * @param keys        key positions describe which fields are keys in what order.
-    * @param keyTypes    types for the key fields, in the same order as the key fields.
-    * @param orders      sorting orders for the key fields.
-    * @param nullsIsLast Ordering of nulls.
+    * @param input        input type.
+    * @param sortSpec     sort specification.
     * @return A GeneratedRecordComparator
     */
   def gen(
       conf: TableConfig,
       name: String,
-      keys: Array[Int],
-      keyTypes: Array[LogicalType],
-      orders: Array[Boolean],
-      nullsIsLast: Array[Boolean]): GeneratedRecordComparator = {
+      input: RowType,
+      sortSpec: SortSpec): GeneratedRecordComparator = {
     val className = newName(name)
     val baseClass = classOf[RecordComparator]
 
     val ctx = new CodeGeneratorContext(conf)
     val compareCode = GenerateUtils.generateRowCompare(
-      ctx, keys, keyTypes, orders, nullsIsLast, "o1", "o2")
+        ctx,
+        input,
+        sortSpec,
+        "o1",
+        "o2")
 
     val code =
       j"""

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/sort/SortCodeGenerator.scala
@@ -23,28 +23,26 @@ import org.apache.flink.table.data.{DecimalData, TimestampData}
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{ROW_DATA, SEGMENT, newName}
 import org.apache.flink.table.planner.codegen.Indenter.toISC
+import org.apache.flink.table.planner.plan.nodes.exec.utils.SortSpec
 import org.apache.flink.table.runtime.generated.{GeneratedNormalizedKeyComputer, GeneratedRecordComparator, NormalizedKeyComputer, RecordComparator}
 import org.apache.flink.table.runtime.operators.sort.SortUtil
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
-import org.apache.flink.table.types.logical.{DecimalType, LogicalType, TimestampType}
+import org.apache.flink.table.types.logical.{DecimalType, LogicalType, RowType, TimestampType}
 
 import scala.collection.mutable
 
 /**
   * A code generator for generating [[NormalizedKeyComputer]] and [[RecordComparator]].
   *
-  * @param keys        key positions describe which fields are keys in what order.
-  * @param keyTypes       types for the key fields, in the same order as the key fields.
-  * @param orders      sorting orders for the key fields.
-  * @param nullsIsLast      Ordering of nulls.
+  * @param conf         config of the planner.
+  * @param input        input type.
+  * @param sortSpec     sort specification.
   */
 class SortCodeGenerator(
     conf: TableConfig,
-    val keys: Array[Int],
-    val keyTypes: Array[LogicalType],
-    val orders: Array[Boolean],
-    val nullsIsLast: Array[Boolean]) {
+    val input: RowType,
+    val sortSpec: SortSpec) {
 
   private val MAX_NORMALIZED_KEY_LEN = 16
 
@@ -70,10 +68,11 @@ class SortCodeGenerator(
     val keyLengths = new mutable.ArrayBuffer[Int]
     var break = false
     var i = 0
-    while (i < keys.length && !break) {
-      val t = keyTypes(i)
+    while (i < sortSpec.getFieldSize && !break) {
+      val fieldSpec = sortSpec.getFieldSpec(i)
+      val t = input.getTypeAt(fieldSpec.getFieldIndex)
       if (supportNormalizedKey(t)) {
-        val invert = !orders(i)
+        val invert = !fieldSpec.getIsAscendingOrder
 
         if (i == 0) {
           // the first comparator decides whether we need to invert the key direction
@@ -113,7 +112,7 @@ class SortCodeGenerator(
       // Anyway, we can't fit it, so align the most efficient 8 bytes.
       (false, Math.min(MAX_NORMALIZED_KEY_LEN, 8 * normalizedKeyNum))
     } else {
-      (normalizedKeyNum == keys.length, nullAwareNormalizedKeyLen)
+      (normalizedKeyNum == sortSpec.getFieldSize, nullAwareNormalizedKeyLen)
     }
   }
 
@@ -203,10 +202,11 @@ class SortCodeGenerator(
     var keyIndex = 0
     while (bytesLeft > 0 && keyIndex < normalizedKeyNum) {
       var len = normalizedKeyLengths(keyIndex)
-      val index = keys(keyIndex)
-      val nullIsMaxValue = orders(keyIndex) == nullsIsLast(keyIndex)
+      val fieldSpec = sortSpec.getFieldSpec(keyIndex)
+      val index = fieldSpec.getFieldIndex
+      val nullIsMaxValue = fieldSpec.getIsAscendingOrder == fieldSpec.getNullIsLast
       len = if (bytesLeft >= len) len else bytesLeft
-      val t = keyTypes(keyIndex)
+      val t = input.getTypeAt(fieldSpec.getFieldIndex)
       val prefix = prefixGetFromBinaryRow(t)
       val putCode = t match {
         case _ if getNormalizeKeyLen(t) != Int.MaxValue =>
@@ -382,7 +382,11 @@ class SortCodeGenerator(
     * @return A GeneratedRecordComparator
     */
   def generateRecordComparator(name: String): GeneratedRecordComparator = {
-    ComparatorCodeGenerator.gen(conf, name, keys, keyTypes, orders, nullsIsLast)
+    ComparatorCodeGenerator.gen(
+        conf,
+        name,
+        input,
+        sortSpec)
   }
 
   def getter(t: LogicalType, index: Int): String = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecNestedLoopJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecNestedLoopJoin.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, NestedLoopJoinCodeGenerator}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, LegacyBatchExecNode}
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil
 import org.apache.flink.table.runtime.typeutils.{BinaryRowDataSerializer, InternalTypeInfo}
 
@@ -54,7 +54,8 @@ class BatchExecNestedLoopJoin(
     val leftIsBuild: Boolean,
     // true if one side returns single row, else false
     val singleRowJoin: Boolean)
-  extends BatchExecJoinBase(cluster, traitSet, leftRel, rightRel, condition, joinType) {
+  extends BatchPhysicalJoinBase(cluster, traitSet, leftRel, rightRel, condition, joinType)
+  with LegacyBatchExecNode[RowData] {
 
   override def copy(
       traitSet: RelTraitSet,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSortMergeJoin.scala
@@ -30,7 +30,7 @@ import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.cost.{FlinkCost, FlinkCostFactory}
-import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecEdge, LegacyBatchExecNode}
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil
 import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, FlinkRelOptUtil, JoinUtil, SortUtil}
 import org.apache.flink.table.runtime.operators.join.{FlinkJoinType, SortMergeJoinOperator}
@@ -61,7 +61,8 @@ class BatchExecSortMergeJoin(
     val leftSorted: Boolean,
     // true if RHS is sorted by right join key, else false
     val rightSorted: Boolean)
-  extends BatchExecJoinBase(cluster, traitSet, leftRel, rightRel, condition, joinType) {
+  extends BatchPhysicalJoinBase(cluster, traitSet, leftRel, rightRel, condition, joinType)
+  with LegacyBatchExecNode[RowData] {
 
   protected lazy val (leftAllKey, rightAllKey) =
     JoinUtil.checkAndGetJoinKeys(keyPairs, getLeft, getRight)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalJoinBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalJoinBase.scala
@@ -39,7 +39,7 @@ import scala.collection.mutable
 /**
   * Batch physical RelNode for [[Join]]
   */
-abstract class BatchExecJoinBase(
+abstract class BatchPhysicalJoinBase(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     leftRel: RelNode,
@@ -47,8 +47,7 @@ abstract class BatchExecJoinBase(
     condition: RexNode,
     joinType: JoinRelType)
   extends CommonPhysicalJoin(cluster, traitSet, leftRel, rightRel, condition, joinType)
-  with BatchPhysicalRel
-  with LegacyBatchExecNode[RowData] {
+  with BatchPhysicalRel {
 
   private[flink] def generateCondition(
       config: TableConfig,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
@@ -249,15 +249,13 @@ class StreamExecMatch(
 
     val eventComparator = if (orderKeys.getFieldCollations.size() > 1) {
       val inputType = FlinkTypeFactory.toLogicalRowType(getInput.getRowType)
-      val (keys, orders, nullsIsLast) = SortUtil.getKeysAndOrders(orderKeys.getFieldCollations)
-      val keyTypes = keys.map(inputType.getTypeAt)
+      val sortSpec = SortUtil.getSortSpec(orderKeys.getFieldCollations)
+      val keyTypes = sortSpec.getFieldTypes(inputType)
       val rowComparator = ComparatorCodeGenerator.gen(
         config,
         "RowDataComparator",
-        keys,
-        keyTypes,
-        orders,
-        nullsIsLast)
+        inputType,
+        sortSpec)
       new RowDataEventComparator(rowComparator)
     } else {
       null

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -428,7 +428,7 @@ object FlinkBatchRuleSets {
     // join
     BatchPhysicalHashJoinRule.INSTANCE,
     BatchExecSortMergeJoinRule.INSTANCE,
-    BatchExecNestedLoopJoinRule.INSTANCE,
+    BatchPhysicalNestedLoopJoinRule.INSTANCE,
     BatchExecSingleRowJoinRule.INSTANCE,
     BatchExecLookupJoinRule.SNAPSHOT_ON_TABLESCAN,
     BatchExecLookupJoinRule.SNAPSHOT_ON_CALC_TABLESCAN,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -427,7 +427,7 @@ object FlinkBatchRuleSets {
     BatchExecPythonWindowAggregateRule.INSTANCE,
     // join
     BatchPhysicalHashJoinRule.INSTANCE,
-    BatchExecSortMergeJoinRule.INSTANCE,
+    BatchPhysicalSortMergeJoinRule.INSTANCE,
     BatchPhysicalNestedLoopJoinRule.INSTANCE,
     BatchExecSingleRowJoinRule.INSTANCE,
     BatchExecLookupJoinRule.SNAPSHOT_ON_TABLESCAN,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -426,7 +426,7 @@ object FlinkBatchRuleSets {
     BatchExecWindowAggregateRule.INSTANCE,
     BatchExecPythonWindowAggregateRule.INSTANCE,
     // join
-    BatchExecHashJoinRule.INSTANCE,
+    BatchPhysicalHashJoinRule.INSTANCE,
     BatchExecSortMergeJoinRule.INSTANCE,
     BatchExecNestedLoopJoinRule.INSTANCE,
     BatchExecSingleRowJoinRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecNestedLoopJoinRuleBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecNestedLoopJoinRuleBase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution.BROADCAST_DISTRIBUTED
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions.BATCH_PHYSICAL
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalNestedLoopJoin
 
 import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.RelNode
@@ -52,7 +52,7 @@ trait BatchExecNestedLoopJoinRuleBase {
     val newRight = RelOptRule.convert(right, rightRequiredTrait)
     val providedTraitSet = join.getTraitSet.replace(BATCH_PHYSICAL)
 
-    new BatchExecNestedLoopJoin(
+    new BatchPhysicalNestedLoopJoin(
       join.getCluster,
       providedTraitSet,
       newLeft,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecOverAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecOverAggregateRule.scala
@@ -70,8 +70,7 @@ class BatchExecOverAggregateRule
 
     def generatorOverAggregate(): Unit = {
       val groupSet: Array[Int] = lastGroup.keys.toArray
-      val (orderKeyIndexes, orders, nullIsLasts) = SortUtil.getKeysAndOrders(
-        lastGroup.orderKeys.getFieldCollations)
+      val sortSpec = SortUtil.getSortSpec(lastGroup.orderKeys.getFieldCollations)
 
       val requiredDistribution = if (groupSet.nonEmpty) {
         FlinkRelDistribution.hash(groupSet.map(Integer.valueOf).toList, requireStrict = false)
@@ -96,7 +95,7 @@ class BatchExecOverAggregateRule
         val (_, _, aggregates) = AggregateUtil.transformToBatchAggregateFunctions(
           FlinkTypeFactory.toLogicalRowType(inputTypeWithConstants),
           aggregateCalls,
-          orderKeyIndexes)
+          sortSpec.getFieldIndices)
         val aggCallToAggFunction = aggregateCalls.zip(aggregates)
         (group, aggCallToAggFunction)
       }
@@ -132,9 +131,9 @@ class BatchExecOverAggregateRule
           outputRowType,
           newInput.getRowType,
           groupSet,
-          orderKeyIndexes,
-          orders,
-          nullIsLasts,
+          sortSpec.getFieldIndices,
+          sortSpec.getAscendingOrders,
+          sortSpec.getNullsIsLast,
           groupToAggCallToAggFunction,
           logicWindow)
       } else {
@@ -146,9 +145,9 @@ class BatchExecOverAggregateRule
           outputRowType,
           newInput.getRowType,
           groupSet,
-          orderKeyIndexes,
-          orders,
-          nullIsLasts,
+          sortSpec.getFieldIndices,
+          sortSpec.getAscendingOrders,
+          sortSpec.getNullsIsLast,
           groupToAggCallToAggFunction,
           logicWindow)
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSingleRowJoinRule.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalNestedLoopJoin
 
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
@@ -29,7 +29,7 @@ import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core._
 
 /**
-  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecNestedLoopJoin]]
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchPhysicalNestedLoopJoin]]
   * if one of join input sides returns at most a single row.
   */
 class BatchExecSingleRowJoinRule

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecHashJoin
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalHashJoin
 import org.apache.flink.table.planner.plan.utils.OperatorType
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
@@ -40,15 +40,15 @@ import java.util
 import scala.collection.JavaConversions._
 
 /**
-  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecHashJoin]]
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchPhysicalHashJoin]]
   * if there exists at least one equal-join condition and
   * ShuffleHashJoin or BroadcastHashJoin are enabled.
   */
-class BatchExecHashJoinRule
+class BatchPhysicalHashJoinRule
   extends RelOptRule(
     operand(classOf[FlinkLogicalJoin],
       operand(classOf[RelNode], any)),
-    "BatchExecHashJoinRule")
+    "BatchPhysicalHashJoinRule")
   with BatchExecJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
@@ -112,7 +112,7 @@ class BatchExecHashJoinRule
       val newRight = RelOptRule.convert(right, rightRequiredTrait)
       val providedTraitSet = join.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
 
-      val newJoin = new BatchExecHashJoin(
+      val newJoin = new BatchPhysicalHashJoin(
         join.getCluster,
         providedTraitSet,
         newLeft,
@@ -191,6 +191,6 @@ class BatchExecHashJoinRule
   }
 }
 
-object BatchExecHashJoinRule {
-  val INSTANCE = new BatchExecHashJoinRule
+object BatchPhysicalHashJoinRule {
+  val INSTANCE = new BatchPhysicalHashJoinRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalNestedLoopJoinRule.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecNestedLoopJoin
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalNestedLoopJoin
 import org.apache.flink.table.planner.plan.utils.OperatorType
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
@@ -29,14 +29,14 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Join, JoinRelType}
 
 /**
-  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecNestedLoopJoin]]
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchPhysicalNestedLoopJoin]]
   * if NestedLoopJoin is enabled.
   */
-class BatchExecNestedLoopJoinRule
+class BatchPhysicalNestedLoopJoinRule
   extends RelOptRule(
     operand(classOf[FlinkLogicalJoin],
       operand(classOf[RelNode], any)),
-    "BatchExecNestedLoopJoinRule")
+    "BatchPhysicalNestedLoopJoinRule")
   with BatchExecJoinRuleBase
   with BatchExecNestedLoopJoinRuleBase {
 
@@ -83,6 +83,6 @@ class BatchExecNestedLoopJoinRule
   }
 }
 
-object BatchExecNestedLoopJoinRule {
-  val INSTANCE: RelOptRule = new BatchExecNestedLoopJoinRule
+object BatchPhysicalNestedLoopJoinRule {
+  val INSTANCE: RelOptRule = new BatchPhysicalNestedLoopJoinRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.calcite.FlinkContext
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecSortMergeJoin
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSortMergeJoin
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, OperatorType}
 import org.apache.flink.table.planner.utils.TableConfigUtils.isOperatorDisabled
 
@@ -40,14 +40,14 @@ import java.lang.{Boolean => JBoolean}
 import scala.collection.JavaConversions._
 
 /**
-  * Rule that converts [[FlinkLogicalJoin]] to [[BatchExecSortMergeJoin]]
+  * Rule that converts [[FlinkLogicalJoin]] to [[BatchPhysicalSortMergeJoin]]
   * if there exists at least one equal-join condition and SortMergeJoin is enabled.
   */
-class BatchExecSortMergeJoinRule
+class BatchPhysicalSortMergeJoinRule
   extends RelOptRule(
     operand(classOf[FlinkLogicalJoin],
       operand(classOf[RelNode], any)),
-    "BatchExecSortMergeJoinRule")
+    "BatchPhysicalSortMergeJoinRule")
   with BatchExecJoinRuleBase {
 
   override def matches(call: RelOptRuleCall): Boolean = {
@@ -96,7 +96,7 @@ class BatchExecSortMergeJoinRule
       val providedTraitSet = call.getPlanner
         .emptyTraitSet()
         .replace(FlinkConventions.BATCH_PHYSICAL)
-      val newJoin = new BatchExecSortMergeJoin(
+      val newJoin = new BatchPhysicalSortMergeJoin(
         join.getCluster,
         providedTraitSet,
         newLeft,
@@ -110,7 +110,7 @@ class BatchExecSortMergeJoinRule
 
     val tableConfig = call.getPlanner.getContext.unwrap(classOf[FlinkContext]).getTableConfig
     val candidates = if (tableConfig.getConfiguration.getBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED)) {
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED)) {
       // add more possibility to remove redundant sort, and longer optimization time
       Array((false, false), (true, false), (false, true), (true, true))
     } else {
@@ -143,8 +143,8 @@ class BatchExecSortMergeJoinRule
   }
 }
 
-object BatchExecSortMergeJoinRule {
-  val INSTANCE: RelOptRule = new BatchExecSortMergeJoinRule
+object BatchPhysicalSortMergeJoinRule {
+  val INSTANCE: RelOptRule = new BatchPhysicalSortMergeJoinRule
 
   // It is a experimental config, will may be removed later.
   @Experimental

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -115,18 +115,29 @@ object JoinUtil {
       joinInfo: JoinInfo,
       leftType: LogicalType,
       rightType: LogicalType): GeneratedJoinCondition = {
+    generateConditionFunction(
+        config,
+        joinInfo.getRemaining(rexBuilder),
+        leftType,
+        rightType)
+  }
+
+  def generateConditionFunction(
+        config: TableConfig,
+        joinCondition: RexNode,
+        leftType: LogicalType,
+        rightType: LogicalType): GeneratedJoinCondition = {
     val ctx = CodeGeneratorContext(config)
     // should consider null fields
     val exprGenerator = new ExprCodeGenerator(ctx, false)
-      .bindInput(leftType)
-      .bindSecondInput(rightType)
+        .bindInput(leftType)
+        .bindSecondInput(rightType)
 
-    val body = if (joinInfo.isEqui) {
+    val body = if (joinCondition == null) {
       // only equality condition
       "return true;"
     } else {
-      val nonEquiPredicates = joinInfo.getRemaining(rexBuilder)
-      val condition = exprGenerator.generateExpression(nonEquiPredicates)
+      val condition = exprGenerator.generateExpression(joinCondition)
       s"""
          |${condition.code}
          |return ${condition.resultTerm};

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/OverAggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/OverAggregateUtil.scala
@@ -68,7 +68,7 @@ object OverAggregateUtil {
   def createCollation(group: Group): RelCollation = {
     val groupSet: Array[Int] = group.keys.toArray
     val collations = group.orderKeys.getFieldCollations
-    val (orderKeyIndexes, _, _) = SortUtil.getKeysAndOrders(collations)
+    val orderKeyIndexes = SortUtil.getSortSpec(collations).getFieldIndices
     if (groupSet.nonEmpty || orderKeyIndexes.nonEmpty) {
       val collectionIndexes = collations.map(_.getFieldIndex)
       val intersectIds = orderKeyIndexes.intersect(groupSet)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.data.util.DataFormatTestUtil;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.SortSpec;
 import org.apache.flink.table.planner.plan.utils.SortUtil;
 import org.apache.flink.table.runtime.generated.GeneratedNormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
@@ -116,10 +117,8 @@ public class SortCodeGeneratorTest {
                 new TimestampType(9)
             };
 
-    private int[] fields;
-    private int[] keys;
-    private boolean[] orders;
-    private boolean[] nullsIsLast;
+    private RowType inputType;
+    private SortSpec sortSpec;
 
     private static final DataType INT_ROW_TYPE =
             DataTypes.ROW(DataTypes.FIELD("f0", DataTypes.INT())).bridgedTo(Row.class);
@@ -149,37 +148,42 @@ public class SortCodeGeneratorTest {
     public void testOneKey() throws Exception {
         for (int time = 0; time < 100; time++) {
             Random rnd = new Random();
-            fields = new int[rnd.nextInt(9) + 1];
+            LogicalType[] fields = new LogicalType[rnd.nextInt(9) + 1];
             for (int i = 0; i < fields.length; i++) {
-                fields[i] = rnd.nextInt(types.length);
+                fields[i] = types[rnd.nextInt(types.length)];
             }
+            inputType = RowType.of(fields);
 
-            keys = new int[] {0};
-            orders = new boolean[] {rnd.nextBoolean()};
-            nullsIsLast = SortUtil.getNullDefaultOrders(orders);
+            SortSpec.SortSpecBuilder builder = SortSpec.builder();
+            boolean order = rnd.nextBoolean();
+            builder.addField(0, order, SortUtil.getNullDefaultOrder(order));
+            sortSpec = builder.build();
+
             testInner();
         }
     }
 
     private void randomKeysAndOrders() {
         Random rnd = new Random();
-        fields = new int[rnd.nextInt(9) + 1];
+        LogicalType[] fields = new LogicalType[rnd.nextInt(9) + 1];
         for (int i = 0; i < fields.length; i++) {
-            fields[i] = rnd.nextInt(types.length);
+            fields[i] = types[rnd.nextInt(types.length)];
         }
+        inputType = RowType.of(fields);
 
-        keys = new int[rnd.nextInt(fields.length) + 1];
+        int keyCount = rnd.nextInt(fields.length) + 1;
         LinkedList<Integer> indexQueue = new LinkedList<>();
-        for (int i = 0; i < fields.length; i++) {
+        for (int i = 0; i < keyCount; i++) {
             indexQueue.add(i);
         }
         Collections.shuffle(indexQueue);
-        orders = new boolean[keys.length];
-        for (int i = 0; i < keys.length; i++) {
-            keys[i] = indexQueue.poll();
-            orders[i] = rnd.nextBoolean();
+
+        SortSpec.SortSpecBuilder builder = SortSpec.builder();
+        for (int i = 0; i < keyCount; i++) {
+            boolean order = rnd.nextBoolean();
+            builder.addField(indexQueue.poll(), order, SortUtil.getNullDefaultOrder(order));
         }
-        nullsIsLast = SortUtil.getNullDefaultOrders(orders);
+        sortSpec = builder.build();
     }
 
     private Object[] shuffle(Object[] objects) {
@@ -188,9 +192,9 @@ public class SortCodeGeneratorTest {
     }
 
     private BinaryRowData row(int i, Object[][] values) {
-        BinaryRowData row = new BinaryRowData(fields.length);
+        BinaryRowData row = new BinaryRowData(inputType.getFieldCount());
         BinaryRowWriter writer = new BinaryRowWriter(row);
-        for (int j = 0; j < fields.length; j++) {
+        for (int j = 0; j < inputType.getFieldCount(); j++) {
             Object value = values[j][i];
             if (value == null) {
                 writer.setNullAt(j);
@@ -199,8 +203,8 @@ public class SortCodeGeneratorTest {
                         writer,
                         j,
                         value,
-                        types[fields[j]],
-                        InternalSerializers.create(types[fields[j]]));
+                        inputType.getTypeAt(j),
+                        InternalSerializers.create(inputType.getTypeAt(j)));
             }
         }
 
@@ -210,9 +214,9 @@ public class SortCodeGeneratorTest {
 
     private BinaryRowData[] getTestData() {
         BinaryRowData[] result = new BinaryRowData[RECORD_NUM];
-        Object[][] values = new Object[fields.length][];
-        for (int i = 0; i < fields.length; i++) {
-            values[i] = shuffle(generateValues(types[fields[i]]));
+        Object[][] values = new Object[inputType.getFieldCount()][];
+        for (int i = 0; i < inputType.getFieldCount(); i++) {
+            values[i] = shuffle(generateValues(inputType.getTypeAt(i)));
         }
         for (int i = 0; i < RECORD_NUM; i++) {
             result[i] = row(i, values);
@@ -450,36 +454,16 @@ public class SortCodeGeneratorTest {
         }
     }
 
-    private LogicalType[] getFieldTypes() {
-        LogicalType[] result = new LogicalType[fields.length];
-        for (int i = 0; i < fields.length; i++) {
-            result[i] = types[fields[i]];
-        }
-        return result;
-    }
-
-    private LogicalType[] getKeyTypes() {
-        LogicalType[] result = new LogicalType[keys.length];
-        for (int i = 0; i < keys.length; i++) {
-            result[i] = types[fields[keys[i]]];
-        }
-        return result;
-    }
-
     private void testInner() throws Exception {
         List<MemorySegment> segments = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             segments.add(MemorySegmentFactory.wrap(new byte[32768]));
         }
 
-        LogicalType[] fieldTypes = getFieldTypes();
-        LogicalType[] keyTypes = getKeyTypes();
-
         Tuple2<NormalizedKeyComputer, RecordComparator> tuple2 =
-                getSortBaseWithNulls(
-                        this.getClass().getSimpleName(), keyTypes, keys, orders, nullsIsLast);
+                getSortBaseWithNulls(this.getClass().getSimpleName(), inputType, sortSpec);
 
-        BinaryRowDataSerializer serializer = new BinaryRowDataSerializer(fieldTypes.length);
+        BinaryRowDataSerializer serializer = new BinaryRowDataSerializer(inputType.getFieldCount());
 
         BinaryInMemorySortBuffer sortBuffer =
                 BinaryInMemorySortBuffer.createBuffer(
@@ -510,10 +494,13 @@ public class SortCodeGeneratorTest {
             result.add(row.copy());
         }
 
+        int[] keys = sortSpec.getFieldIndices();
+        LogicalType[] keyTypes = sortSpec.getFieldTypes(inputType);
+        boolean[] orders = sortSpec.getAscendingOrders();
         data.sort(
                 (o1, o2) -> {
                     for (int i = 0; i < keys.length; i++) {
-                        LogicalType t = types[fields[keys[i]]];
+                        LogicalType t = inputType.getTypeAt(keys[i]);
                         boolean order = orders[i];
                         Object first = null;
                         Object second = null;
@@ -613,11 +600,11 @@ public class SortCodeGeneratorTest {
         for (int i = 0; i < data.size(); i++) {
             builder.append("\n")
                     .append("expect: ")
-                    .append(DataFormatTestUtil.rowDataToString(data.get(i), fieldTypes))
+                    .append(DataFormatTestUtil.rowDataToString(data.get(i), inputType))
                     .append("; actual: ")
-                    .append(DataFormatTestUtil.rowDataToString(result.get(i), fieldTypes));
+                    .append(DataFormatTestUtil.rowDataToString(result.get(i), inputType));
         }
-        builder.append("\n").append("types: ").append(Arrays.asList(fieldTypes));
+        builder.append("\n").append("types: ").append(Arrays.asList(inputType.getChildren()));
         builder.append("\n").append("keys: ").append(Arrays.toString(keys));
         String msg = builder.toString();
         for (int i = 0; i < data.size(); i++) {
@@ -648,14 +635,8 @@ public class SortCodeGeneratorTest {
     }
 
     public static Tuple2<NormalizedKeyComputer, RecordComparator> getSortBaseWithNulls(
-            String namePrefix,
-            LogicalType[] keyTypes,
-            int[] keys,
-            boolean[] orders,
-            boolean[] nullsIsLast)
-            throws IllegalAccessException, InstantiationException {
-        SortCodeGenerator generator =
-                new SortCodeGenerator(new TableConfig(), keys, keyTypes, orders, nullsIsLast);
+            String namePrefix, RowType inputType, SortSpec sortSpec) {
+        SortCodeGenerator generator = new SortCodeGenerator(new TableConfig(), inputType, sortSpec);
         GeneratedNormalizedKeyComputer computer =
                 generator.generateNormalizedKeyComputer(namePrefix + "Computer");
         GeneratedRecordComparator comparator =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RemoveCollationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RemoveCollationTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.plan.stats.TableStats
-import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecSortMergeJoinRule
+import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortMergeJoinRule
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.StringSplit
@@ -60,7 +60,7 @@ class RemoveCollationTest extends TableTestBase {
     )
 
     util.tableEnv.getConfig.getConfiguration.setBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RemoveShuffleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RemoveShuffleTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.plan.stats.TableStats
-import org.apache.flink.table.planner.plan.rules.physical.batch.{BatchExecJoinRuleBase, BatchExecSortMergeJoinRule}
+import org.apache.flink.table.planner.plan.rules.physical.batch.{BatchExecJoinRuleBase, BatchPhysicalSortMergeJoinRule}
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.utils.{TableFunc1, TableTestBase}
 
@@ -213,7 +213,7 @@ class RemoveShuffleTest extends TableTestBase {
     util.tableEnv.getConfig.getConfiguration.setString(
       ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "HashJoin,NestedLoopJoin")
     util.tableEnv.getConfig.getConfiguration.setBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
     val sqlQuery =
       """
         |WITH r AS (SELECT * FROM x, y WHERE a = d AND c LIKE 'He%')
@@ -227,7 +227,7 @@ class RemoveShuffleTest extends TableTestBase {
     util.tableEnv.getConfig.getConfiguration.setString(
       ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "HashJoin,NestedLoopJoin")
     util.tableEnv.getConfig.getConfiguration.setBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
     val sqlQuery =
       """
         |WITH r AS (SELECT * FROM x left join (SELECT * FROM y WHERE e = 2) r on a = d)
@@ -241,7 +241,7 @@ class RemoveShuffleTest extends TableTestBase {
     util.tableEnv.getConfig.getConfiguration.setString(
       ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "HashJoin,NestedLoopJoin")
     util.tableEnv.getConfig.getConfiguration.setBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
     val sqlQuery =
       """
         |WITH r AS (SELECT * FROM x right join (SELECT * FROM y WHERE e = 2) r on a = d)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/SubplanReuseTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.functions.aggfunctions.FirstValueAggFunction
-import org.apache.flink.table.planner.plan.rules.physical.batch.BatchExecSortMergeJoinRule
+import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortMergeJoinRule
 import org.apache.flink.table.planner.plan.rules.physical.batch.BatchPhysicalSortRule.TABLE_EXEC_RANGE_SORT_ENABLED
 import org.apache.flink.table.planner.plan.utils.OperatorType
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.NonDeterministicUdf
@@ -279,7 +279,7 @@ class SubplanReuseTest extends TableTestBase {
     util.tableEnv.getConfig.getConfiguration.setString(
       ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "HashJoin,NestedLoopJoin")
     util.tableEnv.getConfig.getConfiguration.setBoolean(
-      BatchExecSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
+      BatchPhysicalSortMergeJoinRule.TABLE_OPTIMIZER_SMJ_REMOVE_SORT_ENABLED, true)
     val sqlQuery =
       """
         |WITH r AS (SELECT * FROM x, y WHERE a = d AND c LIKE 'He%')

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/util/DataFormatTestUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/util/DataFormatTestUtil.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.writer.BinaryRowWriter;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
@@ -34,8 +34,8 @@ import static org.junit.Assert.assertEquals;
 public class DataFormatTestUtil {
 
     /** Stringify the given {@link RowData}. */
-    public static String rowDataToString(RowData row, LogicalType[] types) {
-        checkArgument(types.length == row.getArity());
+    public static String rowDataToString(RowData row, RowType type) {
+        checkArgument(type.getFieldCount() == row.getArity());
         StringBuilder build = new StringBuilder();
         build.append(row.getRowKind().shortString()).append("(");
         for (int i = 0; i < row.getArity(); i++) {
@@ -43,7 +43,7 @@ public class DataFormatTestUtil {
             if (row.isNullAt(i)) {
                 build.append("null");
             } else {
-                RowData.FieldGetter fieldGetter = RowData.createFieldGetter(types[i], i);
+                RowData.FieldGetter fieldGetter = RowData.createFieldGetter(type.getTypeAt(i), i);
                 build.append(fieldGetter.getFieldOrNull(row));
             }
         }


### PR DESCRIPTION
## What is the purpose of the change
Separate implementation of HashJoin/NestedLoopJoin/SortMergeJoin in batch

## Brief change log
1. Introduce BatchPhysicalHashJoin, and make BatchExecHashJoin only extended from ExecNode
2. Introduce BatchPhysicalNestedLoopJoin, and make BatchExecNestedLoopJoin only extended from ExecNode
3. Introduce BatchPhysicalSortMergeJoin, and make BatchExecSortMergeJoin only extended from ExecNode

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)