### PR TITLE
[FLINK-20769][python] Support minibatch to optimize Python UDAF

### DIFF
--- a/flink-python/pyflink/fn_execution/aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/aggregate_fast.pxd
@@ -81,10 +81,12 @@ cdef class GroupAggFunctionBase:
     cdef object state_value_coder
     cdef object state_backend
     cdef RecordCounter record_counter
+    cdef dict buffer
 
     cpdef void open(self, function_context)
     cpdef void close(self)
-    cpdef list process_element(self, InternalRow input_data)
+    cpdef void process_element(self, InternalRow input_data)
+    cpdef list finish_bundle(self)
     cpdef void on_timer(self, InternalRow key)
     cdef bint is_retract_msg(self, InternalRowKind row_kind)
     cdef bint is_accumulate_msg(self, InternalRowKind row_kind)

--- a/flink-python/pyflink/fn_execution/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/aggregate_fast.pyx
@@ -593,14 +593,13 @@ cdef class GroupTableAggFunction(GroupAggFunctionBase):
         cdef size_t start_index, i, input_rows_num
         cdef object state_backend, accumulator_state
         results = []
-        # input_value = input_data.values
-        # input_row_kind = input_data.row_kind
         aggs_handle = <SimpleTableAggsHandleFunction> self.aggs_handle
         state_backend = self.state_backend
         for current_key in self.buffer:
             input_rows = self.buffer[current_key]
             input_rows_num = len(input_rows)
             key = list(current_key)
+            first_row = False
             state_backend.set_current_key(key)
             state_backend.clear_cached_iterators()
             accumulator_state = state_backend.get_value_state(

--- a/flink-python/pyflink/fn_execution/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/aggregate_fast.pyx
@@ -429,6 +429,7 @@ cdef class GroupAggFunctionBase:
         self.state_value_coder = state_value_coder
         self.state_backend = state_backend
         self.record_counter = RecordCounter.of(index_of_count_star)
+        self.buffer = {}
 
     cpdef void open(self, object function_context):
         self.aggs_handle.open(StateDataViewStore(function_context, self.state_backend))
@@ -450,7 +451,16 @@ cdef class GroupAggFunctionBase:
     cdef bint is_accumulate_msg(self, InternalRowKind row_kind):
         return row_kind == InternalRowKind.UPDATE_AFTER or row_kind == InternalRowKind.INSERT
 
-    cpdef list process_element(self, InternalRow input_data):
+    cpdef void process_element(self, InternalRow input_data):
+        cdef list input_value, key
+        input_value = input_data.values
+        key = self.key_selector.get_key(input_value)
+        try:
+            self.buffer[tuple(key)].append(input_data)
+        except KeyError:
+            self.buffer[tuple(key)] = [input_data]
+
+    cpdef list finish_bundle(self):
         pass
 
 cdef class GroupAggFunction(GroupAggFunctionBase):
@@ -466,89 +476,98 @@ cdef class GroupAggFunction(GroupAggFunctionBase):
             aggs_handle, key_selector, state_backend, state_value_coder, generate_update_before,
             state_cleaning_enabled, index_of_count_star)
 
-    cpdef list process_element(self, InternalRow input_data):
+    cpdef list finish_bundle(self):
         cdef list results = []
         cdef bint first_row
-        cdef list key, pre_agg_value, new_agg_value, accumulators, input_value
+        cdef list key, pre_agg_value, new_agg_value, accumulators, input_value, input_rows
         cdef InternalRow retract_row, result_row
         cdef SimpleAggsHandleFunction aggs_handle
         cdef InternalRowKind input_row_kind
-        input_row_kind = input_data.row_kind
-        input_value = input_data.values
+        cdef tuple current_key
+        cdef size_t input_rows_num, start_index, i
+        cdef InternalRow input_data
+        cdef object accumulator_state, state_backend
         aggs_handle = <SimpleAggsHandleFunction> self.aggs_handle
-        key = self.key_selector.get_key(input_value)
-        self.state_backend.set_current_key(key)
-        self.state_backend.clear_cached_iterators()
-        accumulator_state = self.state_backend.get_value_state(
-            "accumulators", self.state_value_coder)
-        accumulators = accumulator_state.value()
-        if accumulators is None:
-            if self.is_retract_msg(input_row_kind):
-                # Don't create a new accumulator for a retraction message. This might happen if the
-                # retraction message is the first message for the key or after a state clean up.
-                return
-            first_row = True
-            accumulators = aggs_handle.create_accumulators()
-        else:
+        state_backend = self.state_backend
+        for current_key in self.buffer:
+            input_rows = self.buffer[current_key]
+            input_rows_num = len(input_rows)
+            key = list(current_key)
             first_row = False
+            state_backend.set_current_key(key)
+            state_backend.clear_cached_iterators()
+            accumulator_state = state_backend.get_value_state(
+                "accumulators", self.state_value_coder)
+            accumulators = accumulator_state.value()
+            start_index = 0
+            if accumulators is None:
+                for i in range(input_rows_num):
+                    input_data = input_rows[i]
+                    if self.is_retract_msg(input_data.row_kind):
+                        start_index += 1
+                    else:
+                        break
+                if start_index == input_rows_num:
+                    continue
+                accumulators = aggs_handle.create_accumulators()
+                first_row = True
 
-        # set accumulators to handler first
-        aggs_handle.set_accumulators(accumulators)
-        # get previous aggregate result
-        pre_agg_value = aggs_handle.get_value()
+            # set accumulators to handler first
+            aggs_handle.set_accumulators(accumulators)
+            # get previous aggregate result
+            pre_agg_value = aggs_handle.get_value()
 
-        # update aggregate result and set to the newRow
-        if self.is_accumulate_msg(input_row_kind):
-            # accumulate input
-            aggs_handle.accumulate(input_value)
-        else:
-            # retract input
-            aggs_handle.retract(input_value)
-
-        # get current aggregate result
-        new_agg_value = aggs_handle.get_value()
-
-        # get accumulator
-        accumulators = aggs_handle.get_accumulators()
-
-        if not self.record_counter.record_count_is_zero(accumulators):
-            # we aggregated at least one record for this key
-
-            # update the state
-            accumulator_state.update(accumulators)
-
-            # if this was not the first row and we have to emit retractions
-            if not first_row:
-                if not self.state_cleaning_enabled and pre_agg_value == new_agg_value:
-                    # newRow is the same as before and state cleaning is not enabled.
-                    # We do not emit retraction and acc message.
-                    # If state cleaning is enabled, we have to emit messages to prevent too early
-                    # state eviction of downstream operators.
-                    return
+            for i in range(start_index, input_rows_num):
+                input_data = input_rows[i]
+                # update aggregate result and set to the newRow
+                if self.is_accumulate_msg(input_data.row_kind):
+                    # accumulate input
+                    aggs_handle.accumulate(input_data.values)
                 else:
-                    # retract previous result
-                    if self.generate_update_before:
-                        # prepare UPDATE_BEFORE message for previous row
-                        retract_row = join_row(key, pre_agg_value, InternalRowKind.UPDATE_BEFORE)
-                        results.append(retract_row)
-                    # prepare UPDATE_AFTER message for new row
-                    result_row = join_row(key, new_agg_value, InternalRowKind.UPDATE_AFTER)
+                    # retract input
+                    aggs_handle.retract(input_data.values)
+
+            # get current aggregate result
+            new_agg_value = aggs_handle.get_value()
+
+            # get accumulator
+            accumulators = aggs_handle.get_accumulators()
+
+            if not self.record_counter.record_count_is_zero(accumulators):
+                # we aggregated at least one record for this key
+
+                # update the state
+                accumulator_state.update(accumulators)
+
+                # if this was not the first row and we have to emit retractions
+                if not first_row:
+                    if pre_agg_value != new_agg_value:
+                        # retract previous result
+                        if self.generate_update_before:
+                            # prepare UPDATE_BEFORE message for previous row
+                            retract_row = join_row(key, pre_agg_value,
+                                                   InternalRowKind.UPDATE_BEFORE)
+                            results.append(retract_row)
+                        # prepare UPDATE_AFTER message for new row
+                        result_row = join_row(key, new_agg_value, InternalRowKind.UPDATE_AFTER)
+                        results.append(result_row)
+                else:
+                    # this is the first, output new result
+                    # prepare INSERT message for new row
+                    result_row = join_row(key, new_agg_value, InternalRowKind.INSERT)
+                    results.append(result_row)
             else:
-                # this is the first, output new result
-                # prepare INSERT message for new row
-                result_row = join_row(key, new_agg_value, InternalRowKind.INSERT)
-            results.append(result_row)
-        else:
-            # we retracted the last record for this key
-            # sent out a delete message
-            if not first_row:
-                # prepare delete message for previous row
-                result_row = join_row(key, pre_agg_value, InternalRowKind.DELETE)
-                results.append(result_row)
-            # and clear all state
-            accumulator_state.clear()
-            # cleanup dataview under current key
-            aggs_handle.cleanup()
+                # we retracted the last record for this key
+                # sent out a delete message
+                if not first_row:
+                    # prepare delete message for previous row
+                    result_row = join_row(key, pre_agg_value, InternalRowKind.DELETE)
+                    results.append(result_row)
+                # and clear all state
+                accumulator_state.clear()
+                # cleanup dataview under current key
+                aggs_handle.cleanup()
+        self.buffer = {}
         return results
 
 cdef class GroupTableAggFunction(GroupAggFunctionBase):
@@ -564,50 +583,68 @@ cdef class GroupTableAggFunction(GroupAggFunctionBase):
             aggs_handle, key_selector, state_backend, state_value_coder, generate_update_before,
             state_cleaning_enabled, index_of_count_star)
 
-    cpdef list process_element(self, InternalRow input_data):
+    cpdef list finish_bundle(self):
         cdef bint first_row
         cdef list key, accumulators, input_value, results
         cdef SimpleTableAggsHandleFunction aggs_handle
         cdef InternalRowKind input_row_kind
+        cdef tuple current_key
+        cdef InternalRow input_data
+        cdef size_t start_index, i, input_rows_num
+        cdef object state_backend, accumulator_state
         results = []
-        input_value = input_data.values
-        input_row_kind = input_data.row_kind
+        # input_value = input_data.values
+        # input_row_kind = input_data.row_kind
         aggs_handle = <SimpleTableAggsHandleFunction> self.aggs_handle
-        key = self.key_selector.get_key(input_value)
-        self.state_backend.set_current_key(key)
-        self.state_backend.clear_cached_iterators()
-        accumulator_state = self.state_backend.get_value_state(
-            "accumulators", self.state_value_coder)
-        accumulators = accumulator_state.value()
-        if accumulators is None:
-            first_row = True
-            accumulators = aggs_handle.create_accumulators()
-        else:
-            first_row = False
+        state_backend = self.state_backend
+        for current_key in self.buffer:
+            input_rows = self.buffer[current_key]
+            input_rows_num = len(input_rows)
+            key = list(current_key)
+            state_backend.set_current_key(key)
+            state_backend.clear_cached_iterators()
+            accumulator_state = state_backend.get_value_state(
+                "accumulators", self.state_value_coder)
+            accumulators = accumulator_state.value()
+            start_index = 0
+            if accumulators is None:
+                for i in range(input_rows_num):
+                    input_data = input_rows[i]
+                    if self.is_retract_msg(input_data.row_kind):
+                        start_index += 1
+                    else:
+                        break
+                if start_index == input_rows_num:
+                    continue
+                accumulators = aggs_handle.create_accumulators()
+                first_row = True
 
-        # set accumulators to handler first
-        aggs_handle.set_accumulators(accumulators)
+            # set accumulators to handler first
+            aggs_handle.set_accumulators(accumulators)
 
-        if not first_row and self.generate_update_before:
-            results.append(aggs_handle.emit_value(key, True))
+            if not first_row and self.generate_update_before:
+                results.append(aggs_handle.emit_value(key, True))
 
-        # update aggregate result and set to the newRow
-        if self.is_accumulate_msg(input_row_kind):
-            # accumulate input
-            aggs_handle.accumulate(input_value)
-        else:
-            # retract input
-            aggs_handle.retract(input_value)
+            for i in range(start_index, input_rows_num):
+                input_data = input_rows[i]
+                # update aggregate result and set to the newRow
+                if self.is_accumulate_msg(input_data.row_kind):
+                    # accumulate input
+                    aggs_handle.accumulate(input_data.values)
+                else:
+                    # retract input
+                    aggs_handle.retract(input_data.values)
 
-        # get accumulator
-        accumulators = aggs_handle.get_accumulators()
+            # get accumulator
+            accumulators = aggs_handle.get_accumulators()
 
-        if not self.record_counter.record_count_is_zero(accumulators):
-            results.append(aggs_handle.emit_value(key, False))
-            accumulator_state.update(accumulators)
-        else:
-            # and clear all state
-            accumulator_state.clear()
-            # cleanup dataview under current key
-            aggs_handle.cleanup()
+            if not self.record_counter.record_count_is_zero(accumulators):
+                results.append(aggs_handle.emit_value(key, False))
+                accumulator_state.update(accumulators)
+            else:
+                # and clear all state
+                accumulator_state.clear()
+                # cleanup dataview under current key
+                aggs_handle.cleanup()
+        self.buffer = {}
         return results

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -220,7 +220,7 @@ class AggregateFunctionRowCoderImpl(StreamCoderImpl):
             data_out_stream._clear()
 
     def decode_from_stream(self, in_stream, nested):
-        return self._flatten_row_coder.decode_from_stream(in_stream, nested)
+        return [[item for item in self._flatten_row_coder.decode_from_stream(in_stream, nested)]]
 
     def __repr__(self):
         return 'AggregateFunctionRowCoderImpl[%s]' % repr(self._flatten_row_coder)

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -85,6 +85,14 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
     cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
         self._encode_list_value(iter_value, output_stream)
 
+    cpdef decode_from_stream(self, LengthPrefixInputStream input_stream):
+        cdef list result
+        result = []
+        while input_stream.available():
+            self._decode_next_row(input_stream)
+            result.append(self.row[:])
+        return result
+
     cdef void _encode_list_value(self, list results, LengthPrefixOutputStream output_stream):
         cdef list result
         cdef InternalRow value

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -305,7 +305,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         expected = Row('Hi,Hi,hello,hello2', 'Hi', 'hello', 4, 5, 'Hi,Hi,hello2,hello',
                        'Hi|Hi|hello2|hello', 10, 11.0, 2, Decimal(3.0), 24, 28.0, 6, 7.0,
                        3.1622777, 3.6514838, 10.0, 13.333333)
-        expected.set_row_kind(RowKind.UPDATE_AFTER)
+        expected.set_row_kind(RowKind.INSERT)
         self.assertEqual(result[len(result) - 1], expected)
 
     def test_mixed_with_built_in_functions_without_retract(self):
@@ -338,7 +338,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         result = [i for i in result_table.execute().collect()]
         expected = Row('Hi,Hi,hello,hello2', 'Hi', 'hello', 4, 5, 'Hi,Hi,hello2,hello',
                        'Hi|Hi|hello2|hello', 10, 11.0, 2, Decimal(3.0), 24, 28.0)
-        expected.set_row_kind(RowKind.UPDATE_AFTER)
+        expected.set_row_kind(RowKind.INSERT)
         self.assertEqual(result[len(result) - 1], expected)
 
     def test_using_decorator(self):
@@ -405,7 +405,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         table_with_retract_message = self.t_env.sql_query(
             "select LAST_VALUE(b) as b, LAST_VALUE(c) as c from source group by a")
         result = table_with_retract_message.group_by(t.c).select(my_count(t.b).alias("a"), t.c)
-        assert_frame_equal(result.to_pandas(),
+        assert_frame_equal(result.to_pandas().sort_values('c').reset_index(drop=True),
                            pd.DataFrame([[2, "hello"],
                                          [3, "hi"]], columns=['a', 'c']))
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Support minibatch to optimize Python UDAF*


## Brief change log

  - *Support minibatch to optimize Python UDAF*

## Verifying this change

This change added tests and can be verified as follows:

  - *original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

class MeanAggregateFunction(AggregateFunction):

    def get_value(self, accumulator: ACC) -> T:
        if accumulator[1] == 0:
            return None
        else:
            return accumulator[0] / accumulator[1]

    def create_accumulator(self) -> ACC:
        return [0, 0]

    def accumulate(self, accumulator: ACC, *args):
        accumulator[0] += args[0]
        accumulator[1] += 1

    def retract(self, accumulator: ACC, *args):
        accumulator[0] -= args[0]
        accumulator[1] -= 1

    def merge(self, accumulator: ACC, accumulators):
        for other_acc in accumulators:
            accumulator[0] += other_acc[0]
            accumulator[1] += other_acc[1]

    def get_accumulator_type(self) -> DataType:
        return DataTypes.ARRAY(DataTypes.BIGINT())

    def get_result_type(self) -> DataType:
        return DataTypes.FLOAT()

### Test Code
    env = StreamExecutionEnvironment.get_execution_environment()
    env.set_parallelism(1)
    env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
    environment_settings = EnvironmentSettings.new_instance().use_blink_planner().build()
    t_env = StreamTableEnvironment.create(env, environment_settings=environment_settings)
    t_env.get_config().get_configuration().set_integer("python.fn-execution.bundle.time", 1000) 
     t_env.get_config().get_configuration().set_boolean("pipeline.object-reuse", True)

    t_env.create_temporary_function("python_avg", MeanAggregateFunction())
    t_env.create_java_temporary_system_function("java_avg", "com.alibaba.flink.function.JavaAvg")

    num_rows = 10000000

    t_env.execute_sql(f"""
        CREATE TABLE source (
            id INT,
            num INT,
            rowtime TIMESTAMP(3),
            WATERMARK FOR rowtime AS rowtime - INTERVAL '60' MINUTE
        ) WITH (
          'connector' = 'Range',
          'start' = '1',
          'end' = '{num_rows}',
          'step' = '1',
          'partition' = '200'
        )
    """)
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["value"],
            [DataTypes.FLOAT(False)], 1000000))
    result = t_env.from_path("source") \
        .select("python_avg(id)")
    result.insert_into("sink")
    beg_time = time.time()
    t_env.execute("Python UDF")
    print("PyFlink stream group agg consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
1000w,3                      |     95.40s                         |    54.85s

