### PR TITLE
(backport to 1.12) [FLINK-20654][checkpointing] Decline checkpoints until restored channel state is consumed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -21,6 +21,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_TASK_NOT_READY;
+
 /** An {@link InputGate} with a specific index. */
 public abstract class IndexedInputGate extends InputGate implements CheckpointableInput {
     /** Returns the index of this input gate. Only supported on */
@@ -28,6 +30,9 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
 
     @Override
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
+        if (!getStateConsumedFuture().isDone()) {
+            throw new CheckpointException(CHECKPOINT_DECLINED_TASK_NOT_READY);
+        }
         for (int index = 0, numChannels = getNumberOfInputChannels();
                 index < numChannels;
                 index++) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -32,6 +34,7 @@ import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
@@ -70,11 +73,14 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createLocalInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.apache.flink.runtime.io.network.partition.InputGateFairnessTest.setupInputGate;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder.createRemoteWithIdAndLocation;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -87,6 +93,14 @@ import static org.junit.Assert.fail;
 
 /** Tests for {@link SingleInputGate}. */
 public class SingleInputGateTest extends InputGateTestBase {
+
+    @Test(expected = CheckpointException.class)
+    public void testCheckpointsDeclinedUnlessStateConsumed() throws CheckpointException {
+        SingleInputGate gate = createInputGate(createNettyShuffleEnvironment());
+        checkState(!gate.getStateConsumedFuture().isDone());
+        gate.checkpointStarted(
+                new CheckpointBarrier(1L, 1L, new CheckpointOptions(CHECKPOINT, getDefault())));
+    }
 
     /**
      * Tests {@link InputGate#setup()} should create the respective {@link BufferPool} and assign

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
-import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -40,16 +39,17 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
-
-import javax.annotation.Nonnull;
+import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -73,21 +73,20 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
     private final DeserializationDelegate<StreamElement> deserializationDelegate;
 
-    private final RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers;
+    private final Map<InputChannelInfo, RecordDeserializer<DeserializationDelegate<StreamElement>>>
+            recordDeserializers;
+    private final Map<InputChannelInfo, Integer> flattenedChannelIndices;
 
     /** Valve that controls how watermarks and stream statuses are forwarded. */
     private final StatusWatermarkValve statusWatermarkValve;
 
     private final int inputIndex;
 
-    private final Map<InputChannelInfo, Integer> channelIndexes;
-
-    private int lastChannel = UNSPECIFIED;
+    private InputChannelInfo lastChannel = null;
 
     private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer =
             null;
 
-    @SuppressWarnings("unchecked")
     public StreamTaskNetworkInput(
             CheckpointedInputGate checkpointedInputGate,
             TypeSerializer<?> inputSerializer,
@@ -101,29 +100,21 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
         // Initialize one deserializer per input channel
         this.recordDeserializers =
-                new SpillingAdaptiveSpanningRecordDeserializer
-                        [checkpointedInputGate.getNumberOfInputChannels()];
-        for (int i = 0; i < recordDeserializers.length; i++) {
-            recordDeserializers[i] =
-                    new SpillingAdaptiveSpanningRecordDeserializer<>(
-                            ioManager.getSpillingDirectoriesPaths());
+                checkpointedInputGate.getChannelInfos().stream()
+                        .collect(
+                                toMap(
+                                        identity(),
+                                        unused ->
+                                                new SpillingAdaptiveSpanningRecordDeserializer<>(
+                                                        ioManager.getSpillingDirectoriesPaths())));
+
+        this.flattenedChannelIndices = new HashMap<>();
+        for (InputChannelInfo i : checkpointedInputGate.getChannelInfos()) {
+            flattenedChannelIndices.put(i, flattenedChannelIndices.size());
         }
 
         this.statusWatermarkValve = checkNotNull(statusWatermarkValve);
         this.inputIndex = inputIndex;
-        this.channelIndexes = getChannelIndexes(checkpointedInputGate);
-    }
-
-    @Nonnull
-    private static Map<InputChannelInfo, Integer> getChannelIndexes(
-            CheckpointedInputGate checkpointedInputGate) {
-        int index = 0;
-        List<InputChannelInfo> channelInfos = checkpointedInputGate.getChannelInfos();
-        Map<InputChannelInfo, Integer> channelIndexes = new HashMap<>(channelInfos.size());
-        for (InputChannelInfo channelInfo : channelInfos) {
-            channelIndexes.put(channelInfo, index++);
-        }
-        return channelIndexes;
     }
 
     @VisibleForTesting
@@ -133,15 +124,32 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
             StatusWatermarkValve statusWatermarkValve,
             int inputIndex,
             RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers) {
+        Preconditions.checkArgument(
+                checkpointedInputGate.getChannelInfos().stream()
+                                .map(InputChannelInfo::getGateIdx)
+                                .distinct()
+                                .count()
+                        <= 1);
+        Preconditions.checkArgument(
+                checkpointedInputGate.getNumberOfInputChannels() == recordDeserializers.length);
 
         this.checkpointedInputGate = checkpointedInputGate;
         this.deserializationDelegate =
                 new NonReusingDeserializationDelegate<>(
                         new StreamElementSerializer<>(inputSerializer));
-        this.recordDeserializers = recordDeserializers;
+        this.recordDeserializers =
+                checkpointedInputGate.getChannelInfos().stream()
+                        .collect(
+                                toMap(
+                                        identity(),
+                                        info -> recordDeserializers[info.getInputChannelIdx()]));
+        this.flattenedChannelIndices = new HashMap<>();
+        for (InputChannelInfo i : checkpointedInputGate.getChannelInfos()) {
+            flattenedChannelIndices.put(i, flattenedChannelIndices.size());
+        }
+
         this.statusWatermarkValve = statusWatermarkValve;
         this.inputIndex = inputIndex;
-        this.channelIndexes = getChannelIndexes(checkpointedInputGate);
     }
 
     @Override
@@ -150,8 +158,13 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
         while (true) {
             // get the stream element from the deserializer
             if (currentRecordDeserializer != null) {
-                DeserializationResult result =
-                        currentRecordDeserializer.getNextRecord(deserializationDelegate);
+                DeserializationResult result;
+                try {
+                    result = currentRecordDeserializer.getNextRecord(deserializationDelegate);
+                } catch (IOException e) {
+                    throw new IOException(
+                            String.format("Can't get next record for channel %s", lastChannel), e);
+                }
                 if (result.isBufferConsumed()) {
                     currentRecordDeserializer.getCurrentBuffer().recycleBuffer();
                     currentRecordDeserializer = null;
@@ -190,12 +203,15 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
         if (recordOrMark.isRecord()) {
             output.emitRecord(recordOrMark.asRecord());
         } else if (recordOrMark.isWatermark()) {
-            statusWatermarkValve.inputWatermark(recordOrMark.asWatermark(), lastChannel, output);
+            statusWatermarkValve.inputWatermark(
+                    recordOrMark.asWatermark(), flattenedChannelIndices.get(lastChannel), output);
         } else if (recordOrMark.isLatencyMarker()) {
             output.emitLatencyMarker(recordOrMark.asLatencyMarker());
         } else if (recordOrMark.isStreamStatus()) {
             statusWatermarkValve.inputStreamStatus(
-                    recordOrMark.asStreamStatus(), lastChannel, output);
+                    recordOrMark.asStreamStatus(),
+                    flattenedChannelIndices.get(lastChannel),
+                    output);
         } else {
             throw new UnsupportedOperationException("Unknown type of StreamElement");
         }
@@ -209,14 +225,14 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
         if (event.getClass() == EndOfPartitionEvent.class) {
             // release the record deserializer immediately,
             // which is very valuable in case of bounded stream
-            releaseDeserializer(channelIndexes.get(bufferOrEvent.getChannelInfo()));
+            releaseDeserializer(bufferOrEvent.getChannelInfo());
         }
     }
 
     private void processBuffer(BufferOrEvent bufferOrEvent) throws IOException {
-        lastChannel = channelIndexes.get(bufferOrEvent.getChannelInfo());
-        checkState(lastChannel != StreamTaskInput.UNSPECIFIED);
-        currentRecordDeserializer = recordDeserializers[lastChannel];
+        lastChannel = bufferOrEvent.getChannelInfo();
+        checkState(lastChannel != null);
+        currentRecordDeserializer = recordDeserializers.get(lastChannel);
         checkState(
                 currentRecordDeserializer != null,
                 "currentRecordDeserializer has already been released");
@@ -240,17 +256,14 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
     @Override
     public CompletableFuture<Void> prepareSnapshot(
             ChannelStateWriter channelStateWriter, long checkpointId) throws IOException {
-        for (int channelIndex = 0; channelIndex < recordDeserializers.length; channelIndex++) {
-            RecordDeserializer<?> deserializer = recordDeserializers[channelIndex];
-            if (deserializer != null) {
-                final InputChannel channel = checkpointedInputGate.getChannel(channelIndex);
+        for (Map.Entry<InputChannelInfo, RecordDeserializer<DeserializationDelegate<StreamElement>>>
+                e : recordDeserializers.entrySet()) {
 
-                channelStateWriter.addInputData(
-                        checkpointId,
-                        channel.getChannelInfo(),
-                        ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
-                        deserializer.getUnconsumedBuffer());
-            }
+            channelStateWriter.addInputData(
+                    checkpointId,
+                    e.getKey(),
+                    ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
+                    e.getValue().getUnconsumedBuffer());
         }
         return checkpointedInputGate.getAllBarriersReceivedFuture(checkpointId);
     }
@@ -258,16 +271,16 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
     @Override
     public void close() throws IOException {
         // release the deserializers . this part should not ever fail
-        for (int channelIndex = 0; channelIndex < recordDeserializers.length; channelIndex++) {
-            releaseDeserializer(channelIndex);
+        for (InputChannelInfo channelInfo : new HashSet<>(recordDeserializers.keySet())) {
+            releaseDeserializer(channelInfo);
         }
 
         // cleanup the resources of the checkpointed input gate
         checkpointedInputGate.close();
     }
 
-    private void releaseDeserializer(int channelIndex) {
-        RecordDeserializer<?> deserializer = recordDeserializers[channelIndex];
+    private void releaseDeserializer(InputChannelInfo channelInfo) {
+        RecordDeserializer<?> deserializer = recordDeserializers.get(channelInfo);
         if (deserializer != null) {
             // recycle buffers and clear the deserializer.
             Buffer buffer = deserializer.getCurrentBuffer();
@@ -276,7 +289,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
             }
             deserializer.clear();
 
-            recordDeserializers[channelIndex] = null;
+            recordDeserializers.remove(channelInfo);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -65,7 +65,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -162,7 +161,6 @@ public class StreamTaskNetworkInputTest {
         // send EndOfPartitionEvent and ensure that deserializer has been released
         inputGate.sendEvent(EndOfPartitionEvent.INSTANCE, channelId);
         input.emitNext(output);
-        assertNull(deserializers[channelId]);
 
         // now snapshot all inflight buffers
         CompletableFuture<Void> completableFuture =
@@ -201,7 +199,6 @@ public class StreamTaskNetworkInputTest {
             assertNotNull(deserializers[i]);
             inputGate.sendEvent(EndOfPartitionEvent.INSTANCE, i);
             input.emitNext(output);
-            assertNull(deserializers[i]);
             assertTrue(copiedDeserializers[i].isCleared());
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -38,7 +38,6 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoFlatMapFunction;
 import org.apache.flink.util.Collector;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -121,8 +120,9 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
             },
             new Object[] {"Parallel cogroup, p = 5", createCogroupSettings(5)},
             new Object[] {"Parallel cogroup, p = 10", createCogroupSettings(10)},
-            new Object[] {"Parallel union, p = 5", createUnionSettings(5)},
-            new Object[] {"Parallel union, p = 10", createUnionSettings(10)},
+            // todo: enable after completely  fixing FLINK-20654
+            //            new Object[] {"Parallel union, p = 5", createUnionSettings(5)},
+            //            new Object[] {"Parallel union, p = 10", createUnionSettings(10)},
         };
     }
 
@@ -179,7 +179,6 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
     }
 
     @Test
-    @Ignore
     public void execute() throws Exception {
         execute(settings);
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -236,7 +236,6 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                 if (split == null) {
                     return Collections.emptyList();
                 }
-                throttle = split.numCompletedCheckpoints >= minCheckpoints;
                 LOG.info(
                         "Snapshotted {} @ {} subtask ({} attempt)",
                         split,
@@ -255,6 +254,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                             numRestarts);
                     split.numCompletedCheckpoints++;
                     numAbortedCheckpoints = 0;
+                    throttle = split.numCompletedCheckpoints >= minCheckpoints;
                 }
             }
 


### PR DESCRIPTION
This is a backport of #14509 to 1.12 fixing several issues with Unaligned Checkpoints.