### PR TITLE
[FLINK-14814][WebUI] Highlight back pressured and busy nodes in the WebUI

### DIFF
--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -1250,7 +1250,12 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td>idleTimeMsPerSecond</td>
-      <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
+      <td>The time (in milliseconds) this task is idle (has no data to process) per second. Idle time excludes back pressured time, so if the task is back pressured it is not idle.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>backPressuredTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is back pressured per second.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -1259,6 +1259,11 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Meter</td>
     </tr>
     <tr>
+      <td>busyTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is busy (neither idle nor back pressured) per second. Can be NaN, if the value could not be calculated.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -1250,7 +1250,12 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
     </tr>
     <tr>
       <td>idleTimeMsPerSecond</td>
-      <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
+      <td>The time (in milliseconds) this task is idle (has no data to process) per second. Idle time excludes back pressured time, so if the task is back pressured it is not idle.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>backPressuredTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is back pressured per second.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -1259,6 +1259,11 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Meter</td>
     </tr>
     <tr>
+      <td>busyTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is busy (neither idle nor back pressured) per second. Can be NaN, if the value could not be calculated.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
+++ b/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -125,8 +126,9 @@ public class Slf4jReporterTest extends TestLogger {
     public void testAddGauge() throws Exception {
         String gaugeName = "gauge";
 
+        int gaugesBefore = reporter.getGauges().size();
         taskMetricGroup.gauge(gaugeName, null);
-        assertTrue(reporter.getGauges().isEmpty());
+        assertThat(reporter.getGauges().size(), is(gaugesBefore));
 
         Gauge<Long> gauge = () -> null;
         taskMetricGroup.gauge(gaugeName, gauge);

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -130,6 +130,8 @@ export interface NodesItemInterface {
 export interface NodesItemCorrectInterface extends NodesItemInterface {
   detail: VerticesItemInterface | undefined;
   lowWatermark?: number;
+  backPressuredPercentage?: number;
+  busyPercentage?: number;
 }
 
 export interface NodesItemLinkInterface {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/job-overview.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/job-overview.component.ts
@@ -62,6 +62,22 @@ export class JobOverviewComponent implements OnInit, OnDestroy {
     }
   }
 
+  mergeWithBackPressure(nodes: NodesItemCorrectInterface[]): Observable<NodesItemCorrectInterface[]> {
+      return forkJoin(
+        nodes.map(node => {
+          return this.metricService.getAggregatedMetrics(this.jobId, node.id, ["backPressuredTimeMsPerSecond", "busyTimeMsPerSecond"]).pipe(
+            map(result => {
+              return {
+                ...node,
+                backPressuredPercentage: Math.min(Math.round(result.backPressuredTimeMsPerSecond / 10), 100),
+                busyPercentage: Math.min(Math.round(result.busyTimeMsPerSecond / 10), 100),
+              };
+            })
+          );
+        })
+      ).pipe(catchError(() => of(nodes)));
+    }
+
   mergeWithWatermarks(nodes: NodesItemCorrectInterface[]): Observable<NodesItemCorrectInterface[]> {
     return forkJoin(
       nodes.map(node => {
@@ -74,10 +90,12 @@ export class JobOverviewComponent implements OnInit, OnDestroy {
     ).pipe(catchError(() => of(nodes)));
   }
 
-  refreshNodesWithWatermarks() {
-    this.mergeWithWatermarks(this.nodes).subscribe(nodes => {
-      nodes.forEach(node => {
-        this.dagreComponent.updateNode(node.id, node);
+  refreshNodesWithMetrics() {
+    this.mergeWithBackPressure(this.nodes).subscribe(nodes => {
+      this.mergeWithWatermarks(nodes).subscribe(nodes2 => {
+        nodes2.forEach(node => {
+          this.dagreComponent.updateNode(node.id, node);
+        });
       });
     });
   }
@@ -103,10 +121,10 @@ export class JobOverviewComponent implements OnInit, OnDestroy {
           this.links = data.plan.links;
           this.jobId = data.plan.jid;
           this.dagreComponent.flush(this.nodes, this.links, true).then();
-          this.refreshNodesWithWatermarks();
+          this.refreshNodesWithMetrics();
         } else {
           this.nodes = data.plan.nodes;
-          this.refreshNodesWithWatermarks();
+          this.refreshNodesWithMetrics();
         }
         this.cdr.markForCheck();
       });

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -79,6 +79,44 @@ export class MetricsService {
   }
 
   /**
+   * Get aggregated metric data from all subtasks of the given vertexId
+   * @param jobId
+   * @param vertexId
+   * @param listOfMetricName
+   */
+  getAggregatedMetrics(jobId: string, vertexId: string, listOfMetricName: string[], aggregate: string = "max") {
+    const metricName = listOfMetricName.join(',');
+    return this.httpClient
+      .get<Array<{ id: string; min: number; max: number; avg: number; sum: number }>>(
+        `${BASE_URL}/jobs/${jobId}/vertices/${vertexId}/subtasks/metrics?get=${metricName}`
+      )
+      .pipe(
+        map(arr => {
+          const result: { [id: string]: number } = {};
+          arr.forEach(item => {
+            switch (aggregate) {
+              case "min":
+                result[item.id] = +item.min;
+                break;
+              case "max":
+                result[item.id] = +item.max;
+                break;
+              case "avg":
+                result[item.id] = +item.avg;
+                break;
+              case "sum":
+                result[item.id] = +item.sum;
+                break;
+              default:
+                throw new Error("Unsupported aggregate: " + aggregate);
+            }
+          });
+          return result;
+        })
+      );
+  }
+
+  /**
    * Gets the watermarks for a given vertex id.
    * @param jobId
    * @param vertexId

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.html
@@ -17,15 +17,26 @@
   -->
 
 <svg:g class="node node-rect">
-  <svg:foreignObject class="node-labels-container" [attr.y]="height ? -height / 2 : 0" [attr.width]="200" [attr.height]="height">
-    <xhtml:div class="node-label-wrapper">
-      <h4 class="content-wrap">
-        <xhtml:div class="detail">{{operator}}</xhtml:div>
-        <xhtml:div class="detail description">{{description}}</xhtml:div>
-        <xhtml:div class="node-label">Parallelism: {{parallelism}}</xhtml:div>
-        <xhtml:div class="node-label watermark" *ngIf="lowWatermark">Low Watermark <xhtml:br/> {{lowWatermark}}</xhtml:div>
-        <xhtml:div class="detail last" *ngIf="operatorStrategy">Operation: {{operatorStrategy}}</xhtml:div>
-      </h4>
-    </xhtml:div>
-  </svg:foreignObject>
+    <svg:foreignObject class="node-labels-container" [attr.y]="height ? -height / 2 : 0"
+                       [attr.width]="205" [attr.height]="height">
+        <xhtml:div class="node-label-wrapper">
+            <h4 class="content-wrap">
+                <xhtml:div class="detail">{{operator}}</xhtml:div>
+                <xhtml:div class="detail description">{{description}}</xhtml:div>
+                <xhtml:div class="node-label">Parallelism: {{parallelism}}</xhtml:div>
+                <xhtml:div class="node-label metric" title="Maximum back pressured percentage across all subtasks">
+                    Backpressured (max): {{prettyPrint(backPressuredPercentage)}}
+                </xhtml:div>
+                <xhtml:div class="node-label metric" title="Maximum busy percentage across all subtasks">
+                    Busy (max): {{prettyPrint(busyPercentage)}}
+                </xhtml:div>
+                <xhtml:div class="node-label metric" *ngIf="lowWatermark">
+                    Low Watermark: {{lowWatermark}}
+                </xhtml:div>
+                <xhtml:div class="detail last" *ngIf="operatorStrategy">
+                    Operation: {{operatorStrategy}}
+                </xhtml:div>
+            </h4>
+        </xhtml:div>
+    </svg:foreignObject>
 </svg:g>

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.html
@@ -19,7 +19,8 @@
 <svg:g class="node node-rect">
     <svg:foreignObject class="node-labels-container" [attr.y]="height ? -height / 2 : 0"
                        [attr.width]="205" [attr.height]="height">
-        <xhtml:div class="node-label-wrapper">
+        <xhtml:div class="node-label-wrapper" [style.border-color]="borderColor"
+                   [style.background-color]="backgroundColor">
             <h4 class="content-wrap">
                 <xhtml:div class="detail">{{operator}}</xhtml:div>
                 <xhtml:div class="detail description">{{description}}</xhtml:div>

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.less
@@ -51,15 +51,16 @@
         margin-top: 24px;
       }
 
-      &.watermark {
+      &.metric {
         font-weight: normal;;
         font-weight: 12px;
+        margin-bottom: 2px;
         color: @text-color-secondary;
       }
     }
 
     .detail {
-      margin-bottom: 12px;
+      margin-bottom: 2px;
       color: @text-color;
       &.description {
         color: @heading-color;

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.less
@@ -32,10 +32,10 @@
     border-radius: 0;
     padding: 15px;
     color: @text-color;
-    background: lighten(@primary-color, 30%);
     text-align: left;
     word-break: break-all;
-    border: 1px solid @primary-color;
+    border-width: 1px;
+    border-style: solid;
 
     .content-wrap {
       font-size: 12px;

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
@@ -31,6 +31,8 @@ export class NodeComponent {
   operatorStrategy: string | null;
   parallelism: number | null;
   lowWatermark: number | null | undefined;
+  backPressuredPercentage: number | undefined = NaN;
+  busyPercentage: number | undefined = NaN;
   height = 0;
   id: string;
 
@@ -47,6 +49,13 @@ export class NodeComponent {
     this.operatorStrategy = this.decodeHTML(value.operator_strategy);
     this.parallelism = value.parallelism;
     this.lowWatermark = value.lowWatermark;
+    if (this.isValid(value.backPressuredPercentage)) {
+        console.log(value.backPressuredPercentage)
+        this.backPressuredPercentage = value.backPressuredPercentage
+    }
+    if (this.isValid(value.busyPercentage)) {
+        this.busyPercentage = value.busyPercentage;
+    }
     this.height = value.height || 0;
     this.id = value.id;
     if (description && description.length > 300) {
@@ -54,6 +63,10 @@ export class NodeComponent {
     } else {
       this.description = description;
     }
+  }
+
+  isValid = (value?: number) => {
+    return value || value === 0 || value === NaN;
   }
 
   constructor(protected cd: ChangeDetectorRef) {}
@@ -65,5 +78,14 @@ export class NodeComponent {
   update(node: NodesItemCorrectInterface): void {
     this.node = node;
     this.cd.markForCheck();
+  }
+
+  prettyPrint(value: number | undefined): string {
+    if (value === undefined || isNaN(value)) {
+      return "N/A"
+    }
+    else {
+      return value + "%";
+    }
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
@@ -33,8 +33,16 @@ export class NodeComponent {
   lowWatermark: number | null | undefined;
   backPressuredPercentage: number | undefined = NaN;
   busyPercentage: number | undefined = NaN;
+  backgroundColor: string | undefined;
+  borderColor: string | undefined;
   height = 0;
   id: string;
+  backgroundBusyColor = '#ee6464';
+  backgroundDefaultColor = '#5db1ff';
+  backgroundBackPressuredColor = '#888888';
+  borderBusyColor = '#ee2222';
+  borderDefaultColor = '#1890ff';
+  borderBackPressuredColor = '#000000';
 
   decodeHTML(value: string): string | null {
     const parser = new DOMParser();
@@ -69,6 +77,48 @@ export class NodeComponent {
     return value || value === 0 || value === NaN;
   }
 
+  toRGBA = (d: string) => {
+    const l = d.length;
+    const rgba = [];
+    const hex = parseInt(d.slice(1), 16);
+    rgba[0] = (hex >> 16) & 255;
+    rgba[1] = (hex >> 8) & 255;
+    rgba[2] = hex & 255;
+    rgba[3] = l === 9 || l === 5 ? Math.round((((hex >> 24) & 255) / 255) * 10000) / 10000 : -1;
+    return rgba;
+  };
+
+  blend = (from: string, to: string, p = 0.5) => {
+    from = from.trim();
+    to = to.trim();
+    const b = p < 0;
+    p = b ? p * -1 : p;
+    const f = this.toRGBA(from);
+    const t = this.toRGBA(to);
+    if (to[0] === 'r') {
+      return 'rgb' + (to[3] === 'a' ? 'a(' : '(') +
+        Math.round(((t[0] - f[0]) * p) + f[0]) + ',' +
+        Math.round(((t[1] - f[1]) * p) + f[1]) + ',' +
+        Math.round(((t[2] - f[2]) * p) + f[2]) + (
+          f[3] < 0 && t[3] < 0 ? '' : ',' + (
+            f[3] > -1 && t[3] > -1
+              ? Math.round((((t[3] - f[3]) * p) + f[3]) * 10000) / 10000
+              : t[3] < 0 ? f[3] : t[3]
+          )
+        ) + ')';
+    }
+
+    return '#' + (0x100000000 + ((
+        f[3] > -1 && t[3] > -1
+          ? Math.round((((t[3] - f[3]) * p) + f[3]) * 255)
+          : t[3] > -1 ? Math.round(t[3] * 255) : f[3] > -1 ? Math.round(f[3] * 255) : 255
+      ) * 0x1000000) +
+      (Math.round(((t[0] - f[0]) * p) + f[0]) * 0x10000) +
+      (Math.round(((t[1] - f[1]) * p) + f[1]) * 0x100) +
+      Math.round(((t[2] - f[2]) * p) + f[2])
+    ).toString(16).slice(f[3] > -1 || t[3] > -1 ? 1 : 3);
+  };
+
   constructor(protected cd: ChangeDetectorRef) {}
 
   /**
@@ -77,6 +127,16 @@ export class NodeComponent {
    */
   update(node: NodesItemCorrectInterface): void {
     this.node = node;
+    this.backgroundColor = this.backgroundDefaultColor;
+    this.borderColor = this.borderDefaultColor;
+    if (node.busyPercentage) {
+      this.backgroundColor = this.blend(this.backgroundColor, this.backgroundBusyColor, node.busyPercentage / 100.0 );
+      this.borderColor = this.blend(this.borderColor, this.borderBusyColor, node.busyPercentage / 100.0);
+    }
+    if (node.backPressuredPercentage) {
+      this.backgroundColor = this.blend(this.backgroundColor, this.backgroundBackPressuredColor, node.backPressuredPercentage / 100.0);
+      this.borderColor = this.blend(this.borderColor, this.borderBackPressuredColor, node.backPressuredPercentage / 100.0);
+    }
     this.cd.markForCheck();
   }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -67,5 +67,6 @@ public class MetricNames {
     }
 
     public static final String TASK_IDLE_TIME = "idleTimeMs" + SUFFIX_RATE;
+    public static final String TASK_BUSY_TIME = "busyTimeMs" + SUFFIX_RATE;
     public static final String TASK_BACK_PRESSURED_TIME = "backPressuredTimeMs" + SUFFIX_RATE;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -67,4 +67,5 @@ public class MetricNames {
     }
 
     public static final String TASK_IDLE_TIME = "idleTimeMs" + SUFFIX_RATE;
+    public static final String TASK_BACK_PRESSURED_TIME = "backPressuredTimeMs" + SUFFIX_RATE;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -57,7 +57,7 @@ public class MetricNames {
     public static final String MEMORY_COMMITTED = "Committed";
     public static final String MEMORY_MAX = "Max";
 
-    public static final String IS_BACKPRESSURED = "isBackPressured";
+    public static final String IS_BACK_PRESSURED = "isBackPressured";
 
     public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
     public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.View;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+/**
+ * {@link TimerGauge} measures how much time is spent in a given state, with entry into that state
+ * being signaled by {@link #markStart()}. Measuring is stopped by {@link #markEnd()}. This class in
+ * particularly takes care of the case, when {@link #update()} is called when some measurement
+ * started but has not yet finished. For example even if next {@link #markEnd()} call is expected to
+ * happen in a couple of hours, the returned value will account for this ongoing measurement.
+ */
+public class TimerGauge implements Gauge<Long>, View {
+    private final Clock clock;
+
+    private long previousCount;
+    private long currentCount;
+    private long currentMeasurementStart;
+
+    public TimerGauge() {
+        this(SystemClock.getInstance());
+    }
+
+    public TimerGauge(Clock clock) {
+        this.clock = clock;
+    }
+
+    public synchronized void markStart() {
+        if (currentMeasurementStart == 0) {
+            currentMeasurementStart = clock.absoluteTimeMillis();
+        }
+    }
+
+    public synchronized void markEnd() {
+        if (currentMeasurementStart != 0) {
+            currentCount += clock.absoluteTimeMillis() - currentMeasurementStart;
+            currentMeasurementStart = 0;
+        }
+    }
+
+    @Override
+    public synchronized void update() {
+        if (currentMeasurementStart != 0) {
+            long now = clock.absoluteTimeMillis();
+            currentCount += now - currentMeasurementStart;
+            currentMeasurementStart = now;
+        }
+        previousCount = Math.max(Math.min(currentCount / UPDATE_INTERVAL_SECONDS, 1000), 0);
+        currentCount = 0;
+    }
+
+    @Override
+    public synchronized Long getValue() {
+        return previousCount;
+    }
+
+    @VisibleForTesting
+    public synchronized long getCount() {
+        return currentCount;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -46,6 +46,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private final Meter numRecordsOutRate;
     private final Meter numBuffersOutRate;
     private final Meter idleTimePerSecond;
+    private final Meter backPressuredTimePerSecond;
 
     public TaskIOMetricGroup(TaskMetricGroup parent) {
         super(parent);
@@ -68,6 +69,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
         this.idleTimePerSecond =
                 meter(MetricNames.TASK_IDLE_TIME, new MeterView(new SimpleCounter()));
+        this.backPressuredTimePerSecond =
+                meter(MetricNames.TASK_BACK_PRESSURED_TIME, new MeterView(new SimpleCounter()));
     }
 
     public IOMetrics createSnapshot() {
@@ -100,6 +103,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
     public Meter getIdleTimeMsPerSecond() {
         return idleTimePerSecond;
+    }
+
+    public Meter getBackPressuredTimePerSecond() {
+        return backPressuredTimePerSecond;
     }
 
     // ============================================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -696,7 +696,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             partitionStateChecker,
                             getRpcService().getExecutor());
 
-            taskMetricGroup.gauge(MetricNames.IS_BACKPRESSURED, task::isBackPressured);
+            taskMetricGroup.gauge(MetricNames.IS_BACK_PRESSURED, task::isBackPressured);
 
             log.info(
                     "Received task {} ({}), deploy into slot with allocation id {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -511,12 +511,12 @@ public class Task
         if (invokable == null || consumableNotifyingPartitionWriters.length == 0 || !isRunning()) {
             return false;
         }
-        final CompletableFuture<?>[] outputFutures =
-                new CompletableFuture[consumableNotifyingPartitionWriters.length];
-        for (int i = 0; i < outputFutures.length; ++i) {
-            outputFutures[i] = consumableNotifyingPartitionWriters[i].getAvailableFuture();
+        for (int i = 0; i < consumableNotifyingPartitionWriters.length; ++i) {
+            if (!consumableNotifyingPartitionWriters[i].isAvailable()) {
+                return true;
+            }
         }
-        return !CompletableFuture.allOf(outputFutures).isDone();
+        return false;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -50,6 +50,7 @@ import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.c
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.verifyCreateSubpartitionViewThrowsException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -510,7 +511,7 @@ public class ResultPartitionTest {
         assertNotNull(buffer);
 
         // back-pressured time is zero when there is buffer available.
-        assertEquals(0, resultPartition.getBackPressuredTimeMsPerSecond().getCount());
+        assertThat(resultPartition.getBackPressuredTimeMsPerSecond().getValue(), equalTo(0L));
 
         CountDownLatch syncLock = new CountDownLatch(1);
         final Thread requestThread =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -493,7 +493,7 @@ public class ResultPartitionTest {
     }
 
     @Test
-    public void testIdleTime() throws IOException, InterruptedException {
+    public void testIdleAndBackPressuredTime() throws IOException, InterruptedException {
         // setup
         int bufferSize = 1024;
         NetworkBufferPool globalPool = new NetworkBufferPool(10, bufferSize);
@@ -509,8 +509,8 @@ public class ResultPartitionTest {
         Buffer buffer = readView.getNextBuffer().buffer();
         assertNotNull(buffer);
 
-        // idle time is zero when there is buffer available.
-        assertEquals(0, resultPartition.getIdleTimeMsPerSecond().getCount());
+        // back-pressured time is zero when there is buffer available.
+        assertEquals(0, resultPartition.getBackPressuredTimeMsPerSecond().getCount());
 
         CountDownLatch syncLock = new CountDownLatch(1);
         final Thread requestThread =
@@ -536,7 +536,8 @@ public class ResultPartitionTest {
         requestThread.join();
 
         Assert.assertThat(
-                resultPartition.getIdleTimeMsPerSecond().getCount(), Matchers.greaterThan(0L));
+                resultPartition.getBackPressuredTimeMsPerSecond().getCount(),
+                Matchers.greaterThan(0L));
         assertNotNull(readView.getNextBuffer().buffer());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TimerGaugeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TimerGaugeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+//  This class is largely adapted from "com.google.common.base.Preconditions",
+//  which is part of the "Guava" library.
+//
+//  Because of frequent issues with dependency conflicts, this class was
+//  added to the Flink code base to reduce dependency on Guava.
+// ----------------------------------------------------------------------------
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.View;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link TimerGauge}. */
+public class TimerGaugeTest {
+    private static final long SLEEP = 10;
+
+    @Test
+    public void testBasicUsage() {
+        ManualClock clock = new ManualClock(42_000_000);
+        TimerGauge gauge = new TimerGauge(clock);
+
+        gauge.update();
+        assertThat(gauge.getValue(), is(0L));
+
+        gauge.markStart();
+        clock.advanceTime(SLEEP, TimeUnit.MILLISECONDS);
+        gauge.markEnd();
+        gauge.update();
+
+        assertThat(gauge.getValue(), greaterThanOrEqualTo(SLEEP / View.UPDATE_INTERVAL_SECONDS));
+    }
+
+    @Test
+    public void testUpdateWithoutMarkingEnd() {
+        ManualClock clock = new ManualClock(42_000_000);
+        TimerGauge gauge = new TimerGauge(clock);
+
+        gauge.markStart();
+        clock.advanceTime(SLEEP, TimeUnit.MILLISECONDS);
+        gauge.update();
+
+        assertThat(gauge.getValue(), greaterThanOrEqualTo(SLEEP / View.UPDATE_INTERVAL_SECONDS));
+    }
+
+    @Test
+    public void testGetWithoutUpdate() {
+        ManualClock clock = new ManualClock(42_000_000);
+        TimerGauge gauge = new TimerGauge(clock);
+
+        gauge.markStart();
+        clock.advanceTime(SLEEP, TimeUnit.MILLISECONDS);
+
+        assertThat(gauge.getValue(), is(0L));
+
+        gauge.markEnd();
+
+        assertThat(gauge.getValue(), is(0L));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
@@ -24,13 +24,15 @@ import org.apache.flink.runtime.executiongraph.IOMetrics;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link TaskIOMetricGroup}. */
 public class TaskIOMetricGroupTest {
     @Test
-    public void testTaskIOMetricGroup() {
+    public void testTaskIOMetricGroup() throws InterruptedException {
         TaskMetricGroup task = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
         TaskIOMetricGroup taskIO = task.getIOMetricGroup();
 
@@ -52,7 +54,12 @@ public class TaskIOMetricGroupTest {
         taskIO.getNumBytesInCounter().inc(100L);
         taskIO.getNumBytesOutCounter().inc(250L);
         taskIO.getNumBuffersOutCounter().inc(3L);
-        taskIO.getIdleTimeMsPerSecond().markEvent(2L);
+        taskIO.getIdleTimeMsPerSecond().markStart();
+        taskIO.getBackPressuredTimePerSecond().markStart();
+        long sleepTime = 2L;
+        Thread.sleep(sleepTime);
+        taskIO.getIdleTimeMsPerSecond().markEnd();
+        taskIO.getBackPressuredTimePerSecond().markEnd();
 
         IOMetrics io = taskIO.createSnapshot();
         assertEquals(32L, io.getNumRecordsIn());
@@ -60,6 +67,8 @@ public class TaskIOMetricGroupTest {
         assertEquals(100L, io.getNumBytesIn());
         assertEquals(250L, io.getNumBytesOut());
         assertEquals(3L, taskIO.getNumBuffersOutCounter().getCount());
-        assertEquals(2L, taskIO.getIdleTimeMsPerSecond().getCount());
+        assertThat(taskIO.getIdleTimeMsPerSecond().getCount(), greaterThanOrEqualTo(sleepTime));
+        assertThat(
+                taskIO.getBackPressuredTimePerSecond().getCount(), greaterThanOrEqualTo(sleepTime));
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -80,6 +80,8 @@ public class SourceStreamTask<
                 StreamTaskActionExecutor.synchronizedExecutor(lock));
         this.lock = Preconditions.checkNotNull(lock);
         this.sourceThread = new LegacySourceFunctionThread();
+
+        getEnvironment().getMetricGroup().getIOMetricGroup().setEnableBusyTime(false);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -343,6 +343,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                         new ExecutorThreadFactory("channel-state-unspilling"));
 
         injectChannelStateWriterIntoChannels();
+
+        environment.getMetricGroup().getIOMetricGroup().setEnableBusyTime(true);
     }
 
     private void injectChannelStateWriterIntoChannels() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
@@ -47,6 +48,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
@@ -72,6 +74,7 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction.Suspension;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorFactory;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
@@ -304,7 +307,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         this.recordWriter = createRecordWriterDelegate(configuration, environment);
         this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
         this.mailboxProcessor = new MailboxProcessor(this::processInput, mailbox, actionExecutor);
-        this.mailboxProcessor.initMetric(environment.getMetricGroup());
         this.mainMailboxExecutor = mailboxProcessor.getMainMailboxExecutor();
         this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
         this.asyncOperationsThreadPool =
@@ -400,25 +402,20 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             controller.allActionsCompleted();
             return;
         }
-        CompletableFuture<?> jointFuture = getInputOutputJointFuture(status);
-        MailboxDefaultAction.Suspension suspendedDefaultAction = controller.suspendDefaultAction();
-        assertNoException(jointFuture.thenRun(suspendedDefaultAction::resume));
-    }
 
-    /**
-     * Considers three scenarios to combine input and output futures: 1. Both input and output are
-     * unavailable. 2. Only input is unavailable. 3. Only output is unavailable.
-     */
-    @VisibleForTesting
-    CompletableFuture<?> getInputOutputJointFuture(InputStatus status) {
-        if (status == InputStatus.NOTHING_AVAILABLE && !recordWriter.isAvailable()) {
-            return CompletableFuture.allOf(
-                    inputProcessor.getAvailableFuture(), recordWriter.getAvailableFuture());
-        } else if (status == InputStatus.NOTHING_AVAILABLE) {
-            return inputProcessor.getAvailableFuture();
+        TaskIOMetricGroup ioMetrics = getEnvironment().getMetricGroup().getIOMetricGroup();
+        final long startTime = System.currentTimeMillis();
+        Meter timer;
+        CompletableFuture<?> resumeFuture;
+        if (!recordWriter.isAvailable()) {
+            timer = ioMetrics.getBackPressuredTimePerSecond();
+            resumeFuture = recordWriter.getAvailableFuture();
         } else {
-            return recordWriter.getAvailableFuture();
+            timer = ioMetrics.getIdleTimeMsPerSecond();
+            resumeFuture = inputProcessor.getAvailableFuture();
         }
+        assertNoException(
+                resumeFuture.thenRun(new ResumeWrapper(controller.suspendDefaultAction(), timer, startTime)));
     }
 
     private void resetSynchronousSavepointId() {
@@ -1320,5 +1317,23 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
     protected long getAsyncCheckpointStartDelayNanos() {
         return latestAsyncCheckpointStartDelayNanos;
+    }
+
+    private static class ResumeWrapper implements Runnable {
+        private final Suspension suspendedDefaultAction;
+        private final Meter timer;
+        private final long startTime;
+
+        public ResumeWrapper(Suspension suspendedDefaultAction, Meter timer, long startTime) {
+            this.suspendedDefaultAction = suspendedDefaultAction;
+            this.timer = timer;
+            this.startTime = startTime;
+        }
+
+        @Override
+        public void run() {
+            timer.markEvent(System.currentTimeMillis() - startTime);
+            suspendedDefaultAction.resume();
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -19,10 +19,6 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.metrics.Meter;
-import org.apache.flink.metrics.MeterView;
-import org.apache.flink.metrics.SimpleCounter;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MailboxClosedException;
@@ -91,8 +87,6 @@ public class MailboxProcessor implements Closeable {
 
     private final StreamTaskActionExecutor actionExecutor;
 
-    private Meter idleTime = new MeterView(new SimpleCounter());
-
     @VisibleForTesting
     public MailboxProcessor() {
         this(MailboxDefaultAction.Controller::suspendDefaultAction);
@@ -129,10 +123,6 @@ public class MailboxProcessor implements Closeable {
      */
     public MailboxExecutor getMailboxExecutor(int priority) {
         return new MailboxExecutorImpl(mailbox, priority, actionExecutor, this);
-    }
-
-    public void initMetric(TaskMetricGroup metricGroup) {
-        idleTime = metricGroup.getIOMetricGroup().getIdleTimeMsPerSecond();
     }
 
     /** Lifecycle method to close the mailbox for action submission. */
@@ -315,9 +305,7 @@ public class MailboxProcessor implements Closeable {
         while (isDefaultActionUnavailable() && isMailboxLoopRunning()) {
             maybeMail = mailbox.tryTake(MIN_PRIORITY);
             if (!maybeMail.isPresent()) {
-                long start = System.currentTimeMillis();
                 maybeMail = Optional.of(mailbox.take(MIN_PRIORITY));
-                idleTime.markEvent(System.currentTimeMillis() - start);
             }
             maybeMail.get().run();
             processed = true;
@@ -352,11 +340,6 @@ public class MailboxProcessor implements Closeable {
     @VisibleForTesting
     public boolean isMailboxLoopRunning() {
         return mailboxLoopRunning;
-    }
-
-    @VisibleForTesting
-    public Meter getIdleTime() {
-        return idleTime;
     }
 
     @VisibleForTesting

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -110,7 +110,7 @@ public class SourceStreamTaskTest {
     }
 
     @Test(timeout = 60_000)
-    public void testStartDelayMetric() throws Exception {
+    public void testMetrics() throws Exception {
         long sleepTime = 42;
         StreamTaskMailboxTestHarnessBuilder<String> builder =
                 new StreamTaskMailboxTestHarnessBuilder<>(
@@ -145,6 +145,8 @@ public class SourceStreamTaskTest {
                 (Gauge<Long>) metrics.get(MetricNames.CHECKPOINT_START_DELAY_TIME);
         assertThat(
                 checkpointStartDelayGauge.getValue(), greaterThanOrEqualTo(sleepTime * 1_000_000));
+        Gauge<Double> busyTimeGauge = (Gauge<Double>) metrics.get(MetricNames.TASK_BUSY_TIME);
+        assertTrue(Double.isNaN(busyTimeGauge.getValue()));
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -23,13 +23,11 @@ import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.function.RunnableWithException;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -252,71 +250,6 @@ public class TaskMailboxProcessorTest {
         MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
         mailboxProcessor.close();
         mailboxProcessor.allActionsCompleted();
-    }
-
-    @Test
-    public void testNoIdleTimeWhenBusy() throws InterruptedException {
-        final AtomicReference<MailboxDefaultAction.Suspension> suspendedActionRef =
-                new AtomicReference<>();
-        final int totalSwitches = 10;
-
-        AtomicInteger count = new AtomicInteger();
-        MailboxThread mailboxThread =
-                new MailboxThread() {
-                    @Override
-                    public void runDefaultAction(Controller controller) {
-                        int currentCount = count.incrementAndGet();
-                        if (currentCount == totalSwitches) {
-                            controller.allActionsCompleted();
-                        }
-                    }
-                };
-        mailboxThread.start();
-        final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
-
-        mailboxThread.signalStart();
-        mailboxThread.join();
-
-        Assert.assertEquals(0, mailboxProcessor.getIdleTime().getCount());
-        Assert.assertEquals(totalSwitches, count.get());
-    }
-
-    @Test
-    public void testIdleTime() throws InterruptedException {
-        final AtomicReference<MailboxDefaultAction.Suspension> suspendedActionRef =
-                new AtomicReference<>();
-        final int totalSwitches = 2;
-
-        CountDownLatch syncLock = new CountDownLatch(1);
-        MailboxThread mailboxThread =
-                new MailboxThread() {
-                    int count = 0;
-
-                    @Override
-                    public void runDefaultAction(Controller controller) {
-                        // If this is violated, it means that the default action was invoked while
-                        // we assumed suspension
-                        Assert.assertTrue(
-                                suspendedActionRef.compareAndSet(
-                                        null, controller.suspendDefaultAction()));
-                        ++count;
-                        if (count == totalSwitches) {
-                            controller.allActionsCompleted();
-                        }
-                        syncLock.countDown();
-                    }
-                };
-        mailboxThread.start();
-        final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
-        mailboxThread.signalStart();
-
-        syncLock.await();
-        Thread.sleep(10);
-        mailboxProcessor
-                .getMailboxExecutor(DEFAULT_PRIORITY)
-                .execute(suspendedActionRef.get()::resume, "resume");
-        mailboxThread.join();
-        Assert.assertThat(mailboxProcessor.getIdleTime().getCount(), Matchers.greaterThan(0L));
     }
 
     private static MailboxProcessor start(MailboxThread mailboxThread) {


### PR DESCRIPTION
This PR adds coloring nodes in the webUI based on newly defined `backPressuredTimeMsPerSecond` and `busyTimeMsPerSecond` metrics.

## Brief change log

Please check the individual commits.

## Verifying this change

This is a webui change without test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
