### PR TITLE
FLINK-20359 Added Owner Reference to Job Manager in native kubernetes

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -89,6 +89,17 @@ public class KubernetesConfigOptions {
                                     + TASK_MANAGER_SERVICE_ACCOUNT.key()
                                     + "' for jobmanager and taskmanager respectively.");
 
+    public static final ConfigOption<List<Map<String, String>>> JOB_MANAGER_OWNER_REFERENCE =
+            key("kubernetes.jobmanager.owner.reference")
+                    .mapType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The user-specified owner reference to be set to the JobManager Deployment. "
+                                    + "The owner reference is used to delete deployment (and the actual cluster) when controlling resource is deleted. "
+                                    + "The value should be in the form of key:value,where keys define owner reference parameters: apiVersion, "
+                                    + "blockOwnerDeletion, controller, kind, name, uid");
+
     public static final ConfigOption<Double> JOB_MANAGER_CPU =
             key("kubernetes.jobmanager.cpu")
                     .doubleType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for constructing all the Kubernetes components on the client-side. This can include
@@ -101,6 +103,10 @@ public class KubernetesJobManagerFactory {
                         KubernetesUtils.getDeploymentName(
                                 kubernetesJobManagerParameters.getClusterId()))
                 .withLabels(kubernetesJobManagerParameters.getLabels())
+                .withOwnerReferences(
+                        kubernetesJobManagerParameters.getOwnerReference().stream()
+                                .map(e -> KubernetesOwnerReference.fromMap(e).getInternalResource())
+                                .collect(Collectors.toList()))
                 .endMetadata()
                 .editOrNewSpec()
                 .withReplicas(1)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -95,6 +95,12 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
                 .orElse(Collections.emptyList());
     }
 
+    public List<Map<String, String>> getOwnerReference() {
+        return flinkConfig
+                .getOptional(KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE)
+                .orElse(Collections.emptyList());
+    }
+
     public Map<String, String> getRestServiceAnnotations() {
         return flinkConfig
                 .getOptional(KubernetesConfigOptions.REST_SERVICE_ANNOTATIONS)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesOwnerReference.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesOwnerReference.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/** Represent Owner reference resource in kubernetes. */
+public class KubernetesOwnerReference extends KubernetesResource<OwnerReference> {
+
+    private static final String API_VERSION = "apiversion";
+    private static final String DELETION = "blockownerdeletion";
+    private static final String CONTROLLER = "controller";
+    private static final String KIND = "kind";
+    private static final String NAME = "name";
+    private static final String UUID = "uid";
+
+    private static final Logger LOG = LoggerFactory.getLogger(KubernetesOwnerReference.class);
+
+    private KubernetesOwnerReference(OwnerReference ownerReference) {
+        super(ownerReference);
+    }
+
+    public static KubernetesOwnerReference fromMap(Map<String, String> stringMap) {
+        final OwnerReferenceBuilder ownerReferenceBuilder = new OwnerReferenceBuilder();
+        stringMap.forEach(
+                (k, v) -> {
+                    switch (k.toLowerCase()) {
+                        case API_VERSION:
+                            ownerReferenceBuilder.withApiVersion(v);
+                            break;
+                        case DELETION:
+                            ownerReferenceBuilder.withBlockOwnerDeletion(Boolean.valueOf(v));
+                            break;
+                        case CONTROLLER:
+                            ownerReferenceBuilder.withController(Boolean.valueOf(v));
+                            break;
+                        case KIND:
+                            ownerReferenceBuilder.withKind(v);
+                            break;
+                        case NAME:
+                            ownerReferenceBuilder.withName(v);
+                            break;
+                        case UUID:
+                            ownerReferenceBuilder.withUid(v);
+                            break;
+                        default:
+                            LOG.warn("Unrecognized key({}) of toleration, will ignore.", k);
+                            break;
+                    }
+                });
+        return new KubernetesOwnerReference(ownerReferenceBuilder.build());
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Flink implementation is often a part of the larger application. As a result a synchronized management - clean up of Flink resources, when a main application is deleted is important. In Kubernetes, a common approach for such clean up is usage of the owner's reference (https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/)

This PR allows adding owner reference support to Flink Job manager deployment

## Brief change log

*(for example:)*

- Add configuration for owner reference
- Add Owner manager resource
- Add Owner manager support to KubernetesJobManagerParameters
- Updated Job Manager factory to process owner's reference and add it to deployment
- Updated Job Manager factory unit test

## Verifying this change

This change added tests and can be verified as follows:

Extended KubernetesJobManagerFactoryTest to validate owner reference support

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) yes
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) java doc
