### PR TITLE
[FLINK-20348][kafka] Make "schema-registry.subject" optional for Kafka sink with avro-confluent format

### DIFF
--- a/docs/dev/table/connectors/formats/avro-confluent.md
+++ b/docs/dev/table/connectors/formats/avro-confluent.md
@@ -97,14 +97,14 @@ Format Options
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The URL of the Confluent Schema Registry to fetch/register schemas</td>
+      <td>The URL of the Confluent Schema Registry to fetch/register schemas.</td>
     </tr>
     <tr>
       <td><h5>avro-confluent.schema-registry.subject</h5></td>
-      <td>required by sink</td>
+      <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The Confluent Schema Registry subject under which to register the schema used by this format during serialization</td>
+      <td>The Confluent Schema Registry subject under which to register the schema used by this format during serialization. By default, kafka and upsert-kafka connectors use "&lt;topic_name&gt;-value" or "&lt;topic_name&gt;-key" as the default subject name if avro-confluent is used as the value or key format. But for other connectors (e.g. filesystem), the subject option is required when used as sink.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/avro-confluent.zh.md
+++ b/docs/dev/table/connectors/formats/avro-confluent.zh.md
@@ -90,21 +90,21 @@ Format 参数
       <td>必选</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>指定要使用的格式，这里应该是 <code>'avro-confluent'</code>.</td>
+      <td>指定要使用的格式，这里应该是 <code>'avro-confluent'</code>。</td>
     </tr>
     <tr>
       <td><h5>avro-confluent.schema-registry.url</h5></td>
       <td>必选</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>用于获取/注册 schemas 的 Confluent Schema Registry 的URL </td>
+      <td>用于获取/注册 schemas 的 Confluent Schema Registry 的URL。</td>
     </tr>
     <tr>
       <td><h5>avro-confluent.schema-registry.subject</h5></td>
-      <td>sink 必选</td>
+      <td>可选</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Confluent Schema Registry主题，用于在序列化期间注册此格式使用的 schema </td>
+      <td>Confluent Schema Registry 主题，用于在序列化期间注册此格式使用的 schema。默认 kafka 和 upsert-kafka 连接器会使用 "&lt;topic_name&gt;-value" 或者 "&lt;topic_name&gt;-key" 作为 subject 名字。但是对于其他连接器（如 filesystem）则在当做 sink 使用时需要显式指定 subject 名字。</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/debezium.md
+++ b/docs/dev/table/connectors/formats/debezium.md
@@ -285,10 +285,10 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
     </tr>
     <tr>
       <td><h5>debezium-avro-confluent.schema-registry.subject</h5></td>
-      <td>required by sink</td>
+      <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>The Confluent Schema Registry subject under which to register the schema used by this format during serialization.</td>
+      <td>The Confluent Schema Registry subject under which to register the schema used by this format during serialization. By default, kafka connector use "&lt;topic_name&gt;-value" as the default subject name when debezium-avro-confluent is used as the value format. But for other connectors (e.g. filesystem), the subject option is required when used as sink.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/debezium.zh.md
+++ b/docs/dev/table/connectors/formats/debezium.zh.md
@@ -285,10 +285,10 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
     </tr>
     <tr>
       <td><h5>debezium-avro-confluent.schema-registry.subject</h5></td>
-      <td>sink 必选</td>
+      <td>可选</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Confluent Schema Registry主题，用于在序列化期间注册此格式使用的 schema。</td>
+      <td>Confluent Schema Registry主题，用于在序列化期间注册此格式使用的 schema。默认 kafka 连接器会使用 "&lt;topic_name&gt;-value" 作为默认的 subject 名字，但是对于其他连接器（如 filesystem）则在当做 sink 使用时需要显式指定 subject 名字。</td>
     </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -199,11 +199,17 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro-confluent-registry</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-csv</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-    </dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -74,6 +74,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOP
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOPIC_PATTERN;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FIELDS_INCLUDE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.autoCompleteSchemaRegistrySubject;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getFlinkKafkaPartitioner;
@@ -186,7 +187,9 @@ public class KafkaDynamicTableFactory
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
-        final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        final TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
 
         final ReadableConfig tableOptions = helper.getOptions();
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -57,6 +57,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.PRO
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.TOPIC;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FIELDS_INCLUDE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VALUE_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.autoCompleteSchemaRegistrySubject;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getKafkaProperties;
@@ -131,9 +132,11 @@ public class UpsertKafkaDynamicTableFactory
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
-        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        this, autoCompleteSchemaRegistrySubject(context));
 
-        ReadableConfig tableOptions = helper.getOptions();
+        final ReadableConfig tableOptions = helper.getOptions();
 
         EncodingFormat<SerializationSchema<RowData>> keyEncodingFormat =
                 helper.discoverEncodingFormat(SerializationFormatFactory.class, KEY_FORMAT);

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -133,9 +133,7 @@ public class SQLClientSchemaRegistryITCase {
                         " 'format' = 'avro-confluent',",
                         " 'avro-confluent.schema-registry.url' = 'http://"
                                 + INTER_CONTAINER_REGISTRY_ALIAS
-                                + ":8082"
-                                + "',",
-                        " 'avro-confluent.schema-registry.subject' = '" + categorySubject + "'",
+                                + ":8082'",
                         ");",
                         "",
                         "CREATE TABLE results (",
@@ -167,7 +165,7 @@ public class SQLClientSchemaRegistryITCase {
         // Create topic test-avro
         kafkaClient.createTopic(1, 1, testUserBehaviorTopic);
 
-        String behaviourSubject = "user_behavior";
+        String behaviourSubject = testUserBehaviorTopic + "-value";
         List<String> sqlLines =
                 Arrays.asList(
                         "CREATE TABLE user_behavior (",
@@ -186,8 +184,7 @@ public class SQLClientSchemaRegistryITCase {
                         " 'avro-confluent.schema-registry.url' = 'http://"
                                 + INTER_CONTAINER_REGISTRY_ALIAS
                                 + ":8082"
-                                + "',",
-                        " 'avro-confluent.schema-registry.subject' = '" + behaviourSubject + "'",
+                                + "'",
                         ");",
                         "",
                         "INSERT INTO user_behavior VALUES (1, 1, 1, 'buy', CAST (1234 AS TIMESTAMP(3)));");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -626,7 +626,8 @@ public final class FactoryUtil {
         }
     }
 
-    private static class DefaultDynamicTableContext implements DynamicTableFactory.Context {
+    /** Default implemention of {@link DynamicTableFactory.Context}. */
+    public static class DefaultDynamicTableContext implements DynamicTableFactory.Context {
 
         private final ObjectIdentifier objectIdentifier;
         private final CatalogTable catalogTable;
@@ -634,7 +635,7 @@ public final class FactoryUtil {
         private final ClassLoader classLoader;
         private final boolean isTemporary;
 
-        DefaultDynamicTableContext(
+        public DefaultDynamicTableContext(
                 ObjectIdentifier objectIdentifier,
                 CatalogTable catalogTable,
                 ReadableConfig configuration,


### PR DESCRIPTION
…tional for Kafka sink with avro-confluent format


## What is the purpose of the change

*Autocomplete the schema-registry.subject by '<topic-name>-value' if not set by user in kafka/upsert-kafka connector when use avro-confluent format*


## Brief change log

*(for example:)*
  - *Autocomplete the schema-registry.subject by '<topic-name>-value' if not set by user in kafka/upsert-kafka connector when use avro-confluent format*
 


## Verifying this change


This change added tests and can be verified as follows:

*(example:)*
  - testCompleteAvroConfluentSubject

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)no
