### PR TITLE
[hotfix][docs]fix typo in Create statements page

### DIFF
--- a/docs/dev/table/sql/create.md
+++ b/docs/dev/table/sql/create.md
@@ -486,9 +486,9 @@ CREATE TABLE Orders_in_file (
     order_time AS to_timestamp(order_time)
     
 )
-PARTITIONED BY `user` 
+PARTITIONED BY (`user`) 
 WITH ( 
-    'connector' = 'filesystem'
+    'connector' = 'filesystem',
     'path' = '...'
 );
 
@@ -497,7 +497,7 @@ CREATE TABLE Orders_in_kafka (
     -- Add watermark definition
     WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND 
 ) WITH (
-    'connector': 'kafka'
+    'connector' = 'kafka',
     ...
 )
 LIKE Orders_in_file (

--- a/docs/dev/table/sql/create.zh.md
+++ b/docs/dev/table/sql/create.zh.md
@@ -482,9 +482,9 @@ CREATE TABLE Orders_in_file (
     order_time AS to_timestamp(order_time)
     
 )
-PARTITIONED BY `user` 
+PARTITIONED BY (`user`) 
 WITH ( 
-    'connector' = 'filesystem'
+    'connector' = 'filesystem',
     'path' = '...'
 );
 
@@ -493,7 +493,7 @@ CREATE TABLE Orders_in_kafka (
     -- 添加 watermark 定义
     WATERMARK FOR order_time AS order_time - INTERVAL '5' SECOND 
 ) WITH (
-    'connector': 'kafka'
+    'connector' = 'kafka',
     ...
 )
 LIKE Orders_in_file (


### PR DESCRIPTION

## What is the purpose of the change

*fix typo in Create statements page*


## Brief change log

fix typo in Create statements page


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)no
