### PR TITLE
[FLINK-20681][yarn] Support remote path for shipping archives and files

### DIFF
--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -156,13 +156,13 @@
             <td><h5>yarn.ship-archives</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip".</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and remote file system, They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip".</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster.</td>
+            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local client and remote file system.</td>
         </tr>
         <tr>
             <td><h5>yarn.staging-directory</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -156,13 +156,13 @@
             <td><h5>yarn.ship-archives</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and remote file system, They will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip".</td>
+            <td>A semicolon-separated list of archives to be shipped to the YARN cluster. These archives can come from the local client and remote file system, they will be un-packed when localizing and they can be any of the following types: ".tar.gz", ".tar", ".tgz", ".dst", ".jar", ".zip". For example, yarn.ship-archives=/opt/path/conf.zip;hdfs://$namenode_address/path/jars.tar</td>
         </tr>
         <tr>
             <td><h5>yarn.ship-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local client and remote file system.</td>
+            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files and/or directories can come from the local client and remote file system. For example, yarn.ship-files=/opt/path/conf;hdfs://$namenode_address/path/jars;hdfs://$namenode_address/path/extra.jar</td>
         </tr>
         <tr>
             <td><h5>yarn.staging-directory</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -162,7 +162,7 @@
             <td><h5>yarn.ship-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files and/or directories can come from the local client and remote file system. For example, yarn.ship-files=/opt/path/conf;hdfs://$namenode_address/path/jars;hdfs://$namenode_address/path/extra.jar</td>
+            <td>A semicolon-separated list of files and/or directories to be shipped to the YARN cluster. These files/directories can come from the local client and remote file system. For example, yarn.ship-files=/opt/path/conf;hdfs://$namenode_address/path/jars;hdfs://$namenode_address/path/extra.jar</td>
         </tr>
         <tr>
             <td><h5>yarn.staging-directory</h5></td>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
@@ -43,7 +43,9 @@ import org.junit.Test;
 import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
 import static org.hamcrest.Matchers.is;
@@ -83,7 +85,11 @@ public class YARNFileReplicationITCase extends YarnTestBase {
                 createYarnClusterDescriptor(configuration)) {
 
             yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-            yarnClusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+            List<Path> paths = Arrays.asList(flinkLibFolder.listFiles()).stream()
+                .map(File::toURI)
+                .map(Path::new)
+                .collect(Collectors.toList());
+            yarnClusterDescriptor.addShipFiles(paths);
 
             final int masterMemory =
                     yarnClusterDescriptor

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
@@ -85,10 +85,11 @@ public class YARNFileReplicationITCase extends YarnTestBase {
                 createYarnClusterDescriptor(configuration)) {
 
             yarnClusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-            List<Path> paths = Arrays.asList(flinkLibFolder.listFiles()).stream()
-                .map(File::toURI)
-                .map(Path::new)
-                .collect(Collectors.toList());
+            List<Path> paths =
+                    Arrays.asList(flinkLibFolder.listFiles()).stream()
+                            .map(File::toURI)
+                            .map(Path::new)
+                            .collect(Collectors.toList());
             yarnClusterDescriptor.addShipFiles(paths);
 
             final int masterMemory =

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.yarn.util.TestUtils.getTestJarPath;
 import static org.hamcrest.Matchers.closeTo;
@@ -100,7 +101,11 @@ public class YarnConfigurationITCase extends YarnTestBase {
                                     true);
 
                     clusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-                    clusterDescriptor.addShipFiles(Arrays.asList(flinkLibFolder.listFiles()));
+                    List<Path> paths = Arrays.asList(flinkLibFolder.listFiles()).stream()
+                        .map(File::toURI)
+                        .map(Path::new)
+                        .collect(Collectors.toList());
+                    clusterDescriptor.addShipFiles(paths);
 
                     final File streamingWordCountFile = getTestJarPath("WindowJoin.jar");
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -101,10 +101,11 @@ public class YarnConfigurationITCase extends YarnTestBase {
                                     true);
 
                     clusterDescriptor.setLocalJarPath(new Path(flinkUberjar.getAbsolutePath()));
-                    List<Path> paths = Arrays.asList(flinkLibFolder.listFiles()).stream()
-                        .map(File::toURI)
-                        .map(Path::new)
-                        .collect(Collectors.toList());
+                    List<Path> paths =
+                            Arrays.asList(flinkLibFolder.listFiles()).stream()
+                                    .map(File::toURI)
+                                    .map(Path::new)
+                                    .collect(Collectors.toList());
                     clusterDescriptor.addShipFiles(paths);
 
                     final File streamingWordCountFile = getTestJarPath("WindowJoin.jar");

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -387,7 +387,7 @@ public abstract class YarnTestBase extends TestLogger {
             org.apache.flink.configuration.Configuration flinkConfiguration) {
         final YarnClusterDescriptor yarnClusterDescriptor =
                 createYarnClusterDescriptorWithoutLibDir(flinkConfiguration);
-        yarnClusterDescriptor.addShipFiles(Collections.singletonList(flinkLibFolder));
+        yarnClusterDescriptor.addShipFiles(Collections.singletonList(new Path(flinkLibFolder.toURI())));
         return yarnClusterDescriptor;
     }
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -387,7 +387,8 @@ public abstract class YarnTestBase extends TestLogger {
             org.apache.flink.configuration.Configuration flinkConfiguration) {
         final YarnClusterDescriptor yarnClusterDescriptor =
                 createYarnClusterDescriptorWithoutLibDir(flinkConfiguration);
-        yarnClusterDescriptor.addShipFiles(Collections.singletonList(new Path(flinkLibFolder.toURI())));
+        yarnClusterDescriptor.addShipFiles(
+                Collections.singletonList(new Path(flinkLibFolder.toURI())));
         return yarnClusterDescriptor;
     }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -200,22 +200,26 @@ class YarnApplicationFileUploader implements AutoCloseable {
     }
 
     Tuple2<Path, Long> uploadLocalFileToRemote(
-            final Path localSrcPath, final String relativeDstPath, final boolean isLocal) throws IOException {
+            final Path localSrcPath, final String relativeDstPath, final boolean isLocal)
+            throws IOException {
 
         final Long lastModified;
         if (isLocal) {
             final File localFile = new File(localSrcPath.toUri().getPath());
             checkArgument(
-                !localFile.isDirectory(), "File to copy cannot be a directory: " + localSrcPath);
+                    !localFile.isDirectory(),
+                    "File to copy cannot be a directory: " + localSrcPath);
             lastModified = localFile.lastModified();
         } else {
             final FileSystem srcFs = localSrcPath.getFileSystem(fileSystem.getConf());
             checkArgument(
-                !srcFs.isDirectory(localSrcPath), "File to copy cannot be a directory: " + localSrcPath);
+                    !srcFs.isDirectory(localSrcPath),
+                    "File to copy cannot be a directory: " + localSrcPath);
             lastModified = srcFs.getFileStatus(localSrcPath).getModificationTime();
         }
 
-        final Path dst = copyToRemoteApplicationDir(localSrcPath, relativeDstPath, isLocal, fileReplication);
+        final Path dst =
+                copyToRemoteApplicationDir(localSrcPath, relativeDstPath, isLocal, fileReplication);
 
         // Note: If we directly used registerLocalResource(FileSystem, Path) here, we would access
         // the remote
@@ -401,7 +405,10 @@ class YarnApplicationFileUploader implements AutoCloseable {
     }
 
     private Path copyToRemoteApplicationDir(
-            final Path localSrcPath, final String relativeDstPath, final boolean isLocal, final int replicationFactor)
+            final Path localSrcPath,
+            final String relativeDstPath,
+            final boolean isLocal,
+            final int replicationFactor)
             throws IOException {
 
         final Path applicationDir = getApplicationDirPath(homeDir, applicationId);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -251,7 +251,9 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDeprecatedKeys("yarn.ship-directories")
                     .withDescription(
-                            "A semicolon-separated list of files and/or directories to be shipped to the YARN cluster.");
+                            "A semicolon-separated list of files and/or directories to be shipped to the YARN cluster."
+                                    + " These files/directories can come from the local client and remote file system."
+                                    + " For example, yarn.ship-files=/opt/path/conf;hdfs://$namenode_address/path/jars;hdfs://$namenode_address/path/extra.jar");
 
     public static final ConfigOption<List<String>> SHIP_ARCHIVES =
             key("yarn.ship-archives")
@@ -260,8 +262,10 @@ public class YarnConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "A semicolon-separated list of archives to be shipped to the YARN cluster."
-                                    + " These archives will be un-packed when localizing and they can be any of the following types: "
-                                    + "\".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\".");
+                                    + " These archives can come from the local client and remote file system,"
+                                    + " they will be un-packed when localizing and they can be any of the following types: "
+                                    + "\".tar.gz\", \".tar\", \".tgz\", \".dst\", \".jar\", \".zip\"."
+                                    + " For example, yarn.ship-archives=/opt/path/conf.zip;hdfs://$namenode_address/path/jars.tar");
 
     public static final ConfigOption<String> FLINK_DIST_JAR =
             key("yarn.flink-dist-jar")

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -49,6 +49,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.junit.Rule;
 import org.junit.Test;
@@ -559,7 +560,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
         YarnClusterDescriptor flinkYarnDescriptor =
                 (YarnClusterDescriptor) clientFactory.createClusterDescriptor(executorConfig);
 
-        assertEquals(Lists.newArrayList(tmpFile), flinkYarnDescriptor.getShipFiles());
+        assertEquals(
+                Lists.newArrayList(new Path(tmpFile.toString())),
+                flinkYarnDescriptor.getShipFiles());
     }
 
     @Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -725,7 +725,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
         final Configuration flinkConfig = new Configuration();
         flinkConfig.set(
                 YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR,
-                YarnConfigOptions.UserJarInclusion.DISABLED.name());
+                YarnConfigOptions.UserJarInclusion.DISABLED);
 
         final YarnClusterDescriptor yarnClusterDescriptor =
                 createYarnClusterDescriptor(flinkConfig);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -144,6 +144,10 @@ public class YarnFileStageTest extends TestLogger {
                 targetFileSystem, targetDir, LOCAL_RESOURCE_DIRECTORY, tempFolder);
     }
 
+    /**
+     * Verifies that nested directories are properly copied with a <tt>hdfs://</tt> file system
+     * (from a <tt>hdfs://</tt> source remote path).
+     */
     @Test
     public void testRegisterMultipleLocalResourcesWithRemoteFiles() throws Exception {
         final FileSystem targetFileSystem = hdfsRootPath.getFileSystem(hadoopConfig);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR can support config options 'yarn.ship-archives' and 'yarn.ship-files' specify remote resources on distributed files ystem (such as hdfs) to be shipped to the YARN cluster, which could get the following benefits: 

- client will exclude the local resource uploading to accelerate the job submission process
- yarn will cache them on the nodes so that they doesn't need to be downloaded for application

**NOTE**: before that, above two options only supported local resources on client.


## Brief change log

  - The ship Archives and Files changed from File to Path in YarnClusterDescriptor
  - Archives and Files belongs to remote resource are copied to Hadoop filesystem in YarnApplicationFileUploader


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
