### PR TITLE
[FLINK-20828][python] Fix some aggregate and flat_aggregate tests failed in py35

### DIFF
--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -237,7 +237,8 @@ class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkStreamT
             .aggregate(agg.alias("c", "d")) \
             .select("a, c, d") \
             .to_pandas()
-        assert_frame_equal(result, pd.DataFrame([[1, 3, 15], [2, 2, 4]], columns=['a', 'c', 'd']))
+        assert_frame_equal(result.sort_values('a').reset_index(drop=True),
+                           pd.DataFrame([[1, 3, 15], [2, 2, 4]], columns=['a', 'c', 'd']))
 
     def test_flat_aggregate(self):
         import pandas as pd
@@ -279,11 +280,11 @@ class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkStreamT
             .flat_aggregate(my_concat(t.b, ',').alias("b")) \
             .select(t.b, t.c) \
             .alias("a, c")
-        assert_frame_equal(result.to_pandas(),
-                           pd.DataFrame([["Hi,Hi2,Hi,Hi3,Hi3", "hi"],
-                                         ["Hi,Hi2,Hi,Hi3,Hi3", "hi"],
+        assert_frame_equal(result.to_pandas().sort_values('c').reset_index(drop=True),
+                           pd.DataFrame([["Hi,Hi,Hi2,Hi2,Hi3", "Hello"],
                                          ["Hi,Hi,Hi2,Hi2,Hi3", "Hello"],
-                                         ["Hi,Hi,Hi2,Hi2,Hi3", "Hello"]],
+                                         ["Hi,Hi2,Hi,Hi3,Hi3", "hi"],
+                                         ["Hi,Hi2,Hi,Hi3,Hi3", "hi"]],
                                         columns=['a', 'c']))
 
 

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -371,9 +371,9 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
                                       (3, 'Hi3', 'hi'),
                                       (2, 'Hi3', 'Hello')], ['a', 'b', 'c'])
         result = t.group_by(t.c).select(my_concat(t.b, ',').alias("a"), t.c)
-        assert_frame_equal(result.to_pandas(),
-                           pd.DataFrame([["Hi,Hi2,Hi,Hi3,Hi3", "hi"],
-                                         ["Hi,Hi,Hi2,Hi2,Hi3", "Hello"]], columns=['a', 'c']))
+        assert_frame_equal(result.to_pandas().sort_values('c').reset_index(drop=True),
+                           pd.DataFrame([["Hi,Hi,Hi2,Hi2,Hi3", "Hello"],
+                                         ["Hi,Hi2,Hi,Hi3,Hi3", "hi"]], columns=['a', 'c']))
 
     def test_map_view(self):
         my_count = udaf(CountDistinctAggregateFunction())
@@ -465,10 +465,10 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
                     col("a").get(3).alias("d"),
                     t.c.alias("e"))
         assert_frame_equal(
-            result.to_pandas(),
+            result.to_pandas().sort_values('c').reset_index(drop=True),
             pd.DataFrame([
-                ["hello,hello2", "1,3", 'hello:3,hello2:1', 2, "hello"],
-                ["Hi,Hi2,Hi3", "1,2,3", "Hi:3,Hi2:2,Hi3:1", 3, "hi"]],
+                ["Hi,Hi2,Hi3", "1,2,3", "Hi:3,Hi2:2,Hi3:1", 3, "hi"],
+                ["hello,hello2", "1,3", 'hello:3,hello2:1', 2, "hello"]],
                 columns=['a', 'b', 'c', 'd', 'e']))
 
     def test_distinct_and_filter(self):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix some aggregate and flat_aggregate tests failed in py35*


## Brief change log

  - *fix some aggregate and flat_aggregate tests failed in py35*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
