### PR TITLE
[FLINK-18778][table-planner] Support the SupportsProjectionPushDown i…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoTemporalTableSourceRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoTemporalTableSourceRule.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSnapshot;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.Snapshot;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Planner rule that pushes a {@link FlinkLogicalCalc} into a {@link FlinkLogicalTableSourceScan}
+ * which wraps a {@link SupportsProjectionPushDown} temporal tableSource.
+ */
+public class PushCalcIntoTemporalTableSourceRule extends PushProjectIntoTableSourceRuleBase {
+    public static final PushCalcIntoTemporalTableSourceRule INSTANCE =
+            new PushCalcIntoTemporalTableSourceRule();
+
+    public PushCalcIntoTemporalTableSourceRule() {
+        super(
+                operand(
+                        FlinkLogicalSnapshot.class,
+                        operand(
+                                FlinkLogicalCalc.class,
+                                operand(FlinkLogicalTableSourceScan.class, none()))),
+                "PushCalcIntoTemporalTableSourceRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        TableScan scan = call.rel(2);
+        TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+        if (tableSourceTable == null
+                || !(tableSourceTable.tableSource() instanceof SupportsProjectionPushDown)) {
+            return false;
+        }
+        // Can not push calc into tableSource once watermarkAssigner has be pushed.
+        // This is a case of temporal join with eventTime.
+        // Because the input reference index of watermarkAssigner can not be adjusted.
+        // So we can support pushing calc into tableSource across watermarkAssigner for temporal
+        // tableSource.
+        return Arrays.stream(tableSourceTable.extraDigests())
+                .noneMatch(
+                        digest -> digest.contains("project=[") || digest.contains("watermark=["));
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final FlinkLogicalSnapshot snapshot = call.rel(0);
+        final FlinkLogicalCalc calc = call.rel(1);
+
+        final FlinkLogicalTableSourceScan scan = call.rel(2);
+        RexProgram oldRexProgram = calc.getProgram();
+        List<RexNode> newProjectExps = new ArrayList<>();
+        List<RexNode> oldProjectExps =
+                oldRexProgram.getProjectList().stream()
+                        .map(ref -> oldRexProgram.expandLocalRef(ref))
+                        .collect(Collectors.toList());
+        RexLocalRef oldCondition = oldRexProgram.getCondition();
+
+        if (oldCondition != null) {
+            oldProjectExps.add(oldRexProgram.expandLocalRef(oldCondition));
+        }
+        TableSourceTable newTableSourceTable =
+                applyPushIntoTableSource(scan, oldProjectExps, newProjectExps, call);
+        // no need to transform
+        if (newTableSourceTable == null) {
+            return;
+        }
+        // new scan
+        FlinkLogicalTableSourceScan newScan =
+                new FlinkLogicalTableSourceScan(
+                        scan.getCluster(), scan.getTraitSet(), newTableSourceTable);
+
+        List<RexNode> projectExprs =
+                oldCondition != null
+                        ? newProjectExps.subList(0, newProjectExps.size() - 1)
+                        : newProjectExps;
+        RexNode newCondition =
+                oldCondition != null ? newProjectExps.get(newProjectExps.size() - 1) : null;
+        // new Calc
+        RexProgram newRexProgram =
+                RexProgram.create(
+                        newScan.getRowType(),
+                        projectExprs,
+                        newCondition,
+                        calc.getRowType(),
+                        calc.getCluster().getRexBuilder());
+        Calc newCalc =
+                new FlinkLogicalCalc(calc.getCluster(), calc.getTraitSet(), newScan, newRexProgram);
+        // new snapshot
+        Snapshot newSnapshot;
+        if (newRexProgram.isTrivial()) {
+            newSnapshot = snapshot.copy(snapshot.getTraitSet(), newScan, snapshot.getPeriod());
+        } else {
+            newSnapshot = snapshot.copy(snapshot.getTraitSet(), newCalc, snapshot.getPeriod());
+        }
+        call.transformTo(newSnapshot);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceRuleBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceRuleBase.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.utils.NestedColumn;
+import org.apache.flink.table.planner.plan.utils.NestedProjectionUtil;
+import org.apache.flink.table.planner.plan.utils.NestedSchema;
+import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
+import org.apache.flink.table.planner.sources.DynamicSourceUtils;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Base planner rule for push projects into tableSource which implements {@link
+ * SupportsProjectionPushDown}.
+ */
+abstract class PushProjectIntoTableSourceRuleBase extends RelOptRule {
+
+    public PushProjectIntoTableSourceRuleBase(RelOptRuleOperand operand, String description) {
+        super(operand, description);
+    }
+
+    protected static TableSourceTable applyPushIntoTableSource(
+            TableScan oldTableScan,
+            List<RexNode> oldProjectExps,
+            List<RexNode> newProjectExps,
+            RelOptRuleCall call) {
+        final int[] refFields = RexNodeExtractor.extractRefInputFields(oldProjectExps);
+        TableSourceTable oldTableSourceTable =
+                oldTableScan.getTable().unwrap(TableSourceTable.class);
+        final TableSchema oldSchema = oldTableSourceTable.catalogTable().getSchema();
+        final DynamicTableSource oldSource = oldTableSourceTable.tableSource();
+
+        final boolean supportsNestedProjection =
+                ((SupportsProjectionPushDown) oldTableSourceTable.tableSource())
+                        .supportsNestedProjection();
+        List<String> fieldNames = oldTableScan.getRowType().getFieldNames();
+
+        final TableConfig config =
+                ShortcutUtils.unwrapContext(call.getPlanner().getContext()).getTableConfig();
+
+        if (!supportsNestedProjection && refFields.length == fieldNames.size()) {
+            return null;
+        }
+
+        List<RexNode> oldProjectsWithPK = new ArrayList<>(oldProjectExps);
+        FlinkTypeFactory flinkTypeFactory =
+                (FlinkTypeFactory) oldTableSourceTable.getRelOptSchema().getTypeFactory();
+        if (isPrimaryKeyFieldsRequired(oldTableSourceTable, config)) {
+            // add pk into projects for upsert source
+            oldSchema
+                    .getPrimaryKey()
+                    .ifPresent(
+                            pks -> {
+                                for (String name : pks.getColumns()) {
+                                    int index = fieldNames.indexOf(name);
+                                    TableColumn col = oldSchema.getTableColumn(index).get();
+                                    oldProjectsWithPK.add(
+                                            new RexInputRef(
+                                                    index,
+                                                    flinkTypeFactory.createFieldTypeFromLogicalType(
+                                                            col.getType().getLogicalType())));
+                                }
+                            });
+        }
+        // build used schema tree
+        RowType originType = DynamicSourceUtils.createProducedType(oldSchema, oldSource);
+        NestedSchema nestedSchema =
+                NestedProjectionUtil.build(
+                        oldProjectsWithPK, flinkTypeFactory.buildRelNodeRowType(originType));
+        if (!supportsNestedProjection) {
+            // mark the fields in the top level as leaf
+            for (NestedColumn column : nestedSchema.columns().values()) {
+                column.markLeaf();
+            }
+        }
+        DynamicTableSource newSource = oldSource.copy();
+        DataType producedDataType = TypeConversions.fromLogicalToDataType(originType);
+
+        DataType newProducedDataType = null;
+        if (oldSource instanceof SupportsReadingMetadata) {
+            List<String> metadataKeys =
+                    DynamicSourceUtils.createRequiredMetadataKeys(oldSchema, oldSource);
+            newProducedDataType =
+                    applyPhysicalAndMetadataPushDown(
+                            nestedSchema, metadataKeys, originType, newSource);
+        } else {
+            int[][] projectedFields = NestedProjectionUtil.convertToIndexArray(nestedSchema);
+            ((SupportsProjectionPushDown) newSource).applyProjection(projectedFields);
+            newProducedDataType = DataTypeUtils.projectRow(producedDataType, projectedFields);
+        }
+
+        RelDataType newRowType =
+                flinkTypeFactory.buildRelNodeRowType(
+                        (RowType) newProducedDataType.getLogicalType());
+
+        // project push down does not change the statistic, we can reuse origin statistic
+        TableSourceTable newTableSourceTable =
+                oldTableSourceTable.copy(
+                        newSource,
+                        newRowType,
+                        new String[] {
+                            ("project=[" + String.join(", ", newRowType.getFieldNames()) + "]")
+                        });
+        // rewrite the input field in projections
+        // the origin projections are enough. Because the upsert source only uses pk info
+        // normalization node.
+        List<RexNode> newProjects =
+                NestedProjectionUtil.rewrite(
+                        oldProjectExps, nestedSchema, call.builder().getRexBuilder());
+        newProjectExps.addAll(newProjects);
+
+        return newTableSourceTable;
+    }
+
+    /** Returns true if the primary key is required and should be retained. */
+    private static boolean isPrimaryKeyFieldsRequired(TableSourceTable table, TableConfig config) {
+        return DynamicSourceUtils.isUpsertSource(table.catalogTable(), table.tableSource())
+                || DynamicSourceUtils.isSourceChangeEventsDuplicate(
+                        table.catalogTable(), table.tableSource(), config);
+    }
+
+    /**
+     * Push the used physical column and metadata into table source. The returned value is used to
+     * build new table schema.
+     */
+    private static DataType applyPhysicalAndMetadataPushDown(
+            NestedSchema nestedSchema,
+            List<String> metadataKeys,
+            RowType originType,
+            DynamicTableSource newSource) {
+        // TODO: supports nested projection for metadata
+        List<NestedColumn> usedMetaDataFields = new LinkedList<>();
+        int physicalCount = originType.getFieldCount() - metadataKeys.size();
+        List<String> fieldNames = originType.getFieldNames();
+
+        // rm metadata in the tree
+        for (int i = 0; i < metadataKeys.size(); i++) {
+            NestedColumn usedMetadata =
+                    nestedSchema.columns().remove(fieldNames.get(i + physicalCount));
+            if (usedMetadata != null) {
+                usedMetaDataFields.add(usedMetadata);
+            }
+        }
+
+        // get path of the used fields
+        int[][] projectedPhysicalFields = NestedProjectionUtil.convertToIndexArray(nestedSchema);
+        ((SupportsProjectionPushDown) newSource).applyProjection(projectedPhysicalFields);
+
+        // push the metadata back for later rewrite and extract the location in the origin row
+        int newIndex = projectedPhysicalFields.length;
+        List<String> usedMetadataNames = new LinkedList<>();
+        for (NestedColumn metadata : usedMetaDataFields) {
+            metadata.setIndexOfLeafInNewSchema(newIndex++);
+            nestedSchema.columns().put(metadata.name(), metadata);
+            usedMetadataNames.add(metadataKeys.get(metadata.indexInOriginSchema() - physicalCount));
+        }
+
+        // apply metadata push down
+        int[][] projectedFields =
+                Stream.concat(
+                                Stream.of(projectedPhysicalFields),
+                                usedMetaDataFields.stream()
+                                        .map(field -> new int[] {field.indexInOriginSchema()}))
+                        .toArray(int[][]::new);
+        DataType newProducedDataType =
+                DataTypeUtils.projectRow(
+                        TypeConversions.fromLogicalToDataType(originType), projectedFields);
+        ((SupportsReadingMetadata) newSource)
+                .applyReadableMetadata(usedMetadataNames, newProducedDataType);
+
+        return newProducedDataType;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -18,45 +18,25 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
-import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
-import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
-import org.apache.flink.table.planner.plan.utils.NestedColumn;
-import org.apache.flink.table.planner.plan.utils.NestedProjectionUtil;
-import org.apache.flink.table.planner.plan.utils.NestedSchema;
-import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
-import org.apache.flink.table.planner.sources.DynamicSourceUtils;
-import org.apache.flink.table.planner.utils.ShortcutUtils;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.utils.DataTypeUtils;
-import org.apache.flink.table.types.utils.TypeConversions;
 
-import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Planner rule that pushes a {@link LogicalProject} into a {@link LogicalTableScan} which wraps a
- * {@link SupportsProjectionPushDown} dynamic table source.
+ * {@link SupportsProjectionPushDown} dynamic tableSource.
  */
-public class PushProjectIntoTableSourceScanRule extends RelOptRule {
+public class PushProjectIntoTableSourceScanRule extends PushProjectIntoTableSourceRuleBase {
     public static final PushProjectIntoTableSourceScanRule INSTANCE =
             new PushProjectIntoTableSourceScanRule();
 
@@ -68,7 +48,7 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
 
     @Override
     public boolean matches(RelOptRuleCall call) {
-        LogicalTableScan scan = call.rel(1);
+        TableScan scan = call.rel(1);
         TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
         if (tableSourceTable == null
                 || !(tableSourceTable.tableSource() instanceof SupportsProjectionPushDown)) {
@@ -83,98 +63,23 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
         final LogicalProject project = call.rel(0);
         final LogicalTableScan scan = call.rel(1);
 
-        final int[] refFields = RexNodeExtractor.extractRefInputFields(project.getProjects());
-        TableSourceTable oldTableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
-        final TableSchema oldSchema = oldTableSourceTable.catalogTable().getSchema();
-        final DynamicTableSource oldSource = oldTableSourceTable.tableSource();
-        final TableConfig config =
-                ShortcutUtils.unwrapContext(call.getPlanner().getContext()).getTableConfig();
-
-        final boolean supportsNestedProjection =
-                ((SupportsProjectionPushDown) oldTableSourceTable.tableSource())
-                        .supportsNestedProjection();
-        List<String> fieldNames = scan.getRowType().getFieldNames();
-
-        if (!supportsNestedProjection && refFields.length == fieldNames.size()) {
-            // just keep as same as the old plan
-            // TODO: refactor the affected plan
+        List<RexNode> newProjectExps = new ArrayList<>();
+        TableSourceTable newTableSourceTable =
+                applyPushIntoTableSource(scan, project.getProjects(), newProjectExps, call);
+        // no need to transform
+        if (newTableSourceTable == null) {
             return;
         }
 
-        List<RexNode> oldProjectsWithPK = new ArrayList<>(project.getProjects());
-        FlinkTypeFactory flinkTypeFactory =
-                (FlinkTypeFactory) oldTableSourceTable.getRelOptSchema().getTypeFactory();
-        if (isPrimaryKeyFieldsRequired(oldTableSourceTable, config)) {
-            // add pk into projects for upsert source
-            oldSchema
-                    .getPrimaryKey()
-                    .ifPresent(
-                            pks -> {
-                                for (String name : pks.getColumns()) {
-                                    int index = fieldNames.indexOf(name);
-                                    TableColumn col = oldSchema.getTableColumn(index).get();
-                                    oldProjectsWithPK.add(
-                                            new RexInputRef(
-                                                    index,
-                                                    flinkTypeFactory.createFieldTypeFromLogicalType(
-                                                            col.getType().getLogicalType())));
-                                }
-                            });
-        }
-        // build used schema tree
-        RowType originType = DynamicSourceUtils.createProducedType(oldSchema, oldSource);
-        NestedSchema nestedSchema =
-                NestedProjectionUtil.build(
-                        oldProjectsWithPK, flinkTypeFactory.buildRelNodeRowType(originType));
-        if (!supportsNestedProjection) {
-            // mark the fields in the top level as leaf
-            for (NestedColumn column : nestedSchema.columns().values()) {
-                column.markLeaf();
-            }
-        }
-        DynamicTableSource newSource = oldSource.copy();
-        DataType producedDataType = TypeConversions.fromLogicalToDataType(originType);
-
-        DataType newProducedDataType;
-        if (oldSource instanceof SupportsReadingMetadata) {
-            List<String> metadataKeys =
-                    DynamicSourceUtils.createRequiredMetadataKeys(oldSchema, oldSource);
-            newProducedDataType =
-                    applyPhysicalAndMetadataPushDown(
-                            nestedSchema, metadataKeys, originType, newSource);
-        } else {
-            int[][] projectedFields = NestedProjectionUtil.convertToIndexArray(nestedSchema);
-            ((SupportsProjectionPushDown) newSource).applyProjection(projectedFields);
-            newProducedDataType = DataTypeUtils.projectRow(producedDataType, projectedFields);
-        }
-
-        RelDataType newRowType =
-                flinkTypeFactory.buildRelNodeRowType(
-                        (RowType) newProducedDataType.getLogicalType());
-
-        // project push down does not change the statistic, we can reuse origin statistic
-        TableSourceTable newTableSourceTable =
-                oldTableSourceTable.copy(
-                        newSource,
-                        newRowType,
-                        new String[] {
-                            ("project=[" + String.join(", ", newRowType.getFieldNames()) + "]")
-                        });
         LogicalTableScan newScan =
                 new LogicalTableScan(
                         scan.getCluster(),
                         scan.getTraitSet(),
                         scan.getHints(),
                         newTableSourceTable);
-        // rewrite the input field in projections
-        // the origin projections are enough. Because the upsert source only uses pk info
-        // normalization node.
-        List<RexNode> newProjects =
-                NestedProjectionUtil.rewrite(
-                        project.getProjects(), nestedSchema, call.builder().getRexBuilder());
         // rewrite new source
         LogicalProject newProject =
-                project.copy(project.getTraitSet(), newScan, newProjects, project.getRowType());
+                project.copy(project.getTraitSet(), newScan, newProjectExps, project.getRowType());
 
         if (ProjectRemoveRule.isTrivial(newProject)) {
             // drop project if the transformed program merely returns its input
@@ -182,63 +87,5 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
         } else {
             call.transformTo(newProject);
         }
-    }
-
-    /** Returns true if the primary key is required and should be retained. */
-    private static boolean isPrimaryKeyFieldsRequired(TableSourceTable table, TableConfig config) {
-        return DynamicSourceUtils.isUpsertSource(table.catalogTable(), table.tableSource())
-                || DynamicSourceUtils.isSourceChangeEventsDuplicate(
-                        table.catalogTable(), table.tableSource(), config);
-    }
-
-    /**
-     * Push the used physical column and metadata into table source. The returned value is used to
-     * build new table schema.
-     */
-    private static DataType applyPhysicalAndMetadataPushDown(
-            NestedSchema nestedSchema,
-            List<String> metadataKeys,
-            RowType originType,
-            DynamicTableSource newSource) {
-        // TODO: supports nested projection for metadata
-        List<NestedColumn> usedMetaDataFields = new LinkedList<>();
-        int physicalCount = originType.getFieldCount() - metadataKeys.size();
-        List<String> fieldNames = originType.getFieldNames();
-
-        // rm metadata in the tree
-        for (int i = 0; i < metadataKeys.size(); i++) {
-            NestedColumn usedMetadata =
-                    nestedSchema.columns().remove(fieldNames.get(i + physicalCount));
-            if (usedMetadata != null) {
-                usedMetaDataFields.add(usedMetadata);
-            }
-        }
-
-        // get path of the used fields
-        int[][] projectedPhysicalFields = NestedProjectionUtil.convertToIndexArray(nestedSchema);
-        ((SupportsProjectionPushDown) newSource).applyProjection(projectedPhysicalFields);
-
-        // push the metadata back for later rewrite and extract the location in the origin row
-        int newIndex = projectedPhysicalFields.length;
-        List<String> usedMetadataNames = new LinkedList<>();
-        for (NestedColumn metadata : usedMetaDataFields) {
-            metadata.setIndexOfLeafInNewSchema(newIndex++);
-            nestedSchema.columns().put(metadata.name(), metadata);
-            usedMetadataNames.add(metadataKeys.get(metadata.indexInOriginSchema() - physicalCount));
-        }
-
-        // apply metadata push down
-        int[][] projectedFields =
-                Stream.concat(
-                                Stream.of(projectedPhysicalFields),
-                                usedMetaDataFields.stream()
-                                        .map(field -> new int[] {field.indexInOriginSchema()}))
-                        .toArray(int[][]::new);
-        DataType newProducedDataType =
-                DataTypeUtils.projectRow(
-                        TypeConversions.fromLogicalToDataType(originType), projectedFields);
-        ((SupportsReadingMetadata) newSource)
-                .applyReadableMetadata(usedMetadataNames, newProducedDataType);
-        return newProducedDataType;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonLookupJoin.scala
@@ -235,6 +235,7 @@ abstract class CommonLookupJoin(
 
     super.explainTerms(pw)
       .item("table", tableIdentifier.asSummaryString())
+      .item("tableFieldNames", tableFieldNames.asScala.mkString(", "))
       .item("joinType", JoinTypeUtil.getFlinkJoinType(joinType))
       .item("async", isAsyncEnabled)
       .item("lookup", lookupKeys)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -376,6 +376,8 @@ object FlinkBatchRuleSets {
     PythonCorrelateSplitRule.INSTANCE,
     // merge calc after calc transpose
     FlinkCalcMergeRule.INSTANCE,
+    // Rule that push down calc into lookup tableSource
+    PushCalcIntoTemporalTableSourceRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
     PythonCalcSplitRule.SPLIT_CONDITION_REX_FIELD,
     PythonCalcSplitRule.SPLIT_PROJECTION_REX_FIELD,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -378,6 +378,8 @@ object FlinkStreamRuleSets {
     // because [[PushWatermarkIntoTableSourceScanAcrossCalcRule]] will push the rowtime computed
     // column into the source. After FlinkCalcMergeRule applies, it may produces a trivial calc.
     FlinkLogicalCalcRemoveRule.INSTANCE,
+    // Rule that push calc into lookup tableSource
+    PushCalcIntoTemporalTableSourceRule.INSTANCE,
     //Rule that rewrites temporal join with extracted primary key
     TemporalJoinRewriteWithUniqueKeyRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -800,7 +800,7 @@ public final class TestValuesTableFactory
             return result;
         }
 
-        private Row projectRow(Row row) {
+        protected Row projectRow(Row row) {
             if (projectedPhysicalFields == null) {
                 return row;
             }
@@ -1043,17 +1043,18 @@ public final class TestValuesTableFactory
             }
             rows.forEach(
                     record -> {
+                        Row projectRow = projectRow(record);
                         Row key =
                                 Row.of(
                                         Arrays.stream(lookupIndices)
-                                                .mapToObj(record::getField)
+                                                .mapToObj(projectRow::getField)
                                                 .toArray());
                         List<Row> list = mapping.get(key);
                         if (list != null) {
-                            list.add(record);
+                            list.add(projectRow);
                         } else {
                             list = new ArrayList<>();
-                            list.add(record);
+                            list.add(projectRow);
                             mapping.put(key, list);
                         }
                     });
@@ -1062,6 +1063,26 @@ public final class TestValuesTableFactory
             } else {
                 return TableFunctionProvider.of(new TestValuesLookupFunction(mapping));
             }
+        }
+
+        @Override
+        public DynamicTableSource copy() {
+            return new TestValuesScanLookupTableSource(
+                    producedDataType,
+                    changelogMode,
+                    bounded,
+                    runtimeSource,
+                    data,
+                    isAsync,
+                    lookupFunctionClass,
+                    nestedProjectionSupported,
+                    projectedPhysicalFields,
+                    filterPredicates,
+                    filterableFields,
+                    limit,
+                    allPartitions,
+                    readableMetadata,
+                    projectedMetadataFields);
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoTemporalTableSourceRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoTemporalTableSourceRuleTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSnapshot;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkVolcanoProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
+import org.apache.flink.table.planner.plan.rules.FlinkStreamRuleSets;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.PushProjector;
+import org.apache.calcite.tools.RuleSets;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test for {@link PushCalcIntoTemporalTableSourceRule}. */
+public class PushCalcIntoTemporalTableSourceRuleTest extends TableTestBase {
+    private StreamTableTestUtil util = streamTestUtil(new TableConfig());
+
+    @Before
+    public void setup() {
+        FlinkChainedProgram<StreamOptimizeContext> program = new FlinkChainedProgram<>();
+        program.addLast(
+                "Transforms",
+                FlinkHepRuleSetProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE())
+                        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                        .add(FlinkStreamRuleSets.EXPAND_PLAN_RULES())
+                        .add(RuleSets.ofList(CoreRules.FILTER_INTO_JOIN))
+                        .build());
+        program.addLast(
+                "Converters",
+                FlinkVolcanoProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .add(
+                                RuleSets.ofList(
+                                        CoreRules.PROJECT_TO_CALC,
+                                        CoreRules.FILTER_TO_CALC,
+                                        FlinkLogicalCalc.CONVERTER(),
+                                        FlinkLogicalTableSourceScan.CONVERTER(),
+                                        FlinkLogicalSnapshot.CONVERTER(),
+                                        FlinkLogicalJoin.CONVERTER(),
+                                        new FlinkProjectJoinTransposeRule(
+                                                PushProjector.ExprCondition.FALSE,
+                                                RelFactories.LOGICAL_BUILDER)))
+                        .setRequiredOutputTraits(new Convention[] {FlinkConventions.LOGICAL()})
+                        .build());
+        program.addLast(
+                "Logical rewrite",
+                FlinkHepRuleSetProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE())
+                        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                        .add(
+                                RuleSets.ofList(
+                                        CalcSnapshotTransposeRule.INSTANCE(),
+                                        FlinkCalcMergeRule.INSTANCE()))
+                        .build());
+        program.addLast(
+                "PushCalcIntoTemporalTableSourceRule",
+                FlinkHepRuleSetProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE())
+                        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                        .add(RuleSets.ofList(PushCalcIntoTemporalTableSourceRule.INSTANCE))
+                        .build());
+        util.replaceStreamProgram(program);
+
+        String ddl1 =
+                "CREATE TABLE table1 (\n"
+                        + "  `a` bigint,\n"
+                        + "  `b` bigint,\n"
+                        + "  `c` string,\n"
+                        + "  `proctime` as proctime()\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl1);
+
+        String lookupDDL1 =
+                "CREATE TABLE LookupTable (\n"
+                        + "  `id` bigint,\n"
+                        + "  `name` string,\n"
+                        + "  `age` int\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(lookupDDL1);
+
+        String lookupDDL2 =
+                "CREATE TABLE LookupTableWithComputedColumn (\n"
+                        + "  `id` bigint,\n"
+                        + "  `name` string,\n"
+                        + "  `age` int,\n"
+                        + "  `computed_age` as age + 1\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(lookupDDL2);
+    }
+
+    @Test
+    public void testLookupWithCalcPushIntoLookupTableSource() {
+        String sqlQuery =
+                "SELECT T.a, D.id FROM table1 AS T JOIN LookupTable "
+                        + "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id";
+
+        util.verifyRelPlan(sqlQuery);
+    }
+
+    @Test
+    public void testLookupWithConditionAndCalcPushIntoLookupTableSource() {
+        String sqlQuery =
+                "SELECT T.a, D.id FROM table1 AS T JOIN LookupTable "
+                        + "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id WHERE D.age + 1 > 60";
+
+        util.verifyRelPlan(sqlQuery);
+    }
+
+    @Test
+    public void testLookupWithComputedColumnAndCalcPushIntoLookupTableSource() {
+        String sqlQuery =
+                "SELECT T.a, D.id FROM table1 AS T JOIN LookupTableWithComputedColumn "
+                        + "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id WHERE D.computed_age + 1 > 60";
+
+        util.verifyRelPlan(sqlQuery);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.xml
@@ -53,7 +53,7 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
 +- Exchange(distribution=[hash[b]])
    +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0, Partial_SUM(c) AS sum$1, Partial_SUM(d) AS sum$2])
       +- Calc(select=[b, a, c, d])
-         +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+         +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
             +- Calc(select=[b, a, c, d])
                +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_SUM(sum$0) AS c, Final_SUM(sum$1) AS d])
                   +- Exchange(distribution=[hash[a, b]])
@@ -99,7 +99,7 @@ HashAggregate(isMerge=[true], groupBy=[b], select=[b, Final_COUNT(count$0) AS EX
 +- Exchange(distribution=[hash[b]])
    +- LocalHashAggregate(groupBy=[b], select=[b, Partial_COUNT(a) AS count$0, Partial_SUM(c) AS sum$1, Partial_SUM(d) AS sum$2])
       +- Calc(select=[b, a, c, d])
-         +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+         +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
             +- Calc(select=[b, a, c, d])
                +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_SUM(sum$0) AS c, Final_SUM(sum$1) AS d])
                   +- Exchange(distribution=[hash[a, b]])
@@ -125,7 +125,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -148,7 +148,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -179,7 +179,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$5], age=[$6], nominal_age=[$7])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -209,10 +209,40 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$5], age=[$6], nominal_age=[$7])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
+  ON T.a = D.id and D.nominal_age > 12
+]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], age=[$6], nominal_age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($3, 12))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, b, c, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, age, (age + 1) AS nominal_age])
+   +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
   </TestCase>
   <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false]">
     <Resource name="sql">
@@ -238,7 +268,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, proctime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -268,7 +298,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, proctime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, id, name])
    +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
       +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -293,7 +323,7 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
 +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -318,7 +348,7 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
 +- Calc(select=[a, b, PROCTIME() AS proctime], where=[(c > 1000)])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -346,7 +376,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -369,7 +399,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -397,7 +427,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -425,7 +455,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -448,7 +478,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
@@ -521,11 +551,94 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], id=[$4], name=[$5], age=[$
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, id, name, age])
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, id, name, age])
 +- Calc(select=[a, b, c, PROCTIME() AS proctime], where=[(c > 1000)])
    +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
 ]]>
     </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[SELECT T.a, D.id, D.age FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], id=[$4], age=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, id, age])
++- Calc(select=[a])
+   +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCallAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT T.a, T.c, D.age FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id + 1 AND T.b = concat( Cast(D.age as varchar), '!')
+WHERE T.c > 1000
+      ]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], c=[$2], age=[$6])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT(CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'!')))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, c, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[age, id], joinType=[InnerJoin], async=[false], lookup=[], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, age, (id + 1) AS $f3, CONCAT(CAST(age), _UTF-16LE'!') AS $f4])
+   +- Calc(select=[a, b, c], where=[(c > 1000)])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithConditionAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT T.a, T.c, D.age FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age + 1 > 1000
+      ]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], c=[$2], age=[$6])
++- LogicalFilter(condition=[>(+($6, 1), 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, T0]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, c, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 1000)], select=[a, c, id, age])
+   +- Calc(select=[a, c])
+      +- BoundedStreamScan(table=[[default_catalog, default_database, T0]], fields=[a, b, c])
+]]>
+	</Resource>
   </TestCase>
   <TestCase name="testReusing[LegacyTableSource=true]">
     <Resource name="sql">
@@ -591,7 +704,7 @@ Calc(select=[EXPR$0, EXPR$1, EXPR$2])
       +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
          +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
             :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
-            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
             :     +- Calc(select=[b, a])
             :        +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
             :           +- Exchange(distribution=[hash[a, b]])
@@ -644,7 +757,7 @@ FlinkLogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=
       :     +- FlinkLogicalDataStreamTableScan(table=[[default_catalog, default_database, T1]])
       +- FlinkLogicalSnapshot(period=[$cor0.proctime])
          +- FlinkLogicalCalc(select=[id], where=[>(age, 10)])
-            +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable]], fields=[id, name, age])
+            +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable, project=[id, age]]], fields=[id, age])
 ]]>
     </Resource>
   </TestCase>
@@ -712,7 +825,7 @@ Calc(select=[EXPR$0, EXPR$1, EXPR$2])
       +- LocalHashAggregate(groupBy=[b, b0], select=[b, b0, Partial_COUNT(a) AS count$0, Partial_COUNT(id) AS count$1, Partial_SUM(a0) AS sum$2])
          +- HashJoin(joinType=[InnerJoin], where=[(a = a0)], select=[b, a, id, a0, b0], build=[right])
             :- Exchange(distribution=[hash[a]], shuffle_mode=[BATCH])
-            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
+            :  +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, id])(reuse_id=[1])
             :     +- Calc(select=[b, a])
             :        +- HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b])
             :           +- Exchange(distribution=[hash[a, b]])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoLookupTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushCalcIntoLookupTableSourceRuleTest.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testLookupWithCalcPushIntoLookupTableSource">
+    <Resource name="sql">
+      <![CDATA[SELECT T.a, D.id FROM table1 AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], id=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, table1]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalJoin(condition=[=($0, $1)], joinType=[inner])
+:- FlinkLogicalCalc(select=[a])
+:  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, table1]], fields=[a, b, c])
++- FlinkLogicalSnapshot(period=[$cor0.proctime])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable, project=[id]]], fields=[id])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLookupWithConditionAndCalcPushIntoLookupTableSource">
+	<Resource name="sql">
+	  <![CDATA[SELECT T.a, D.id FROM table1 AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id WHERE D.age + 1 > 60]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], id=[$4])
++- LogicalFilter(condition=[>(+($6, 1), 60)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, table1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+	  <![CDATA[
+FlinkLogicalJoin(condition=[=($0, $1)], joinType=[inner])
+:- FlinkLogicalCalc(select=[a])
+:  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, table1]], fields=[a, b, c])
++- FlinkLogicalSnapshot(period=[$cor0.proctime])
+   +- FlinkLogicalCalc(select=[id], where=[>(+(age, 1), 60)])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTable, project=[id, age]]], fields=[id, age])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testLookupWithComputedColumnAndCalcPushIntoLookupTableSource">
+	<Resource name="sql">
+	  <![CDATA[SELECT T.a, D.id FROM table1 AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id WHERE D.computed_age + 1 > 60]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], id=[$4])
++- LogicalFilter(condition=[>(+($7, 1), 60)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, table1]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalProject(id=[$0], name=[$1], age=[$2], computed_age=[+($2, 1)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+	  <![CDATA[
+FlinkLogicalJoin(condition=[=($0, $1)], joinType=[inner])
+:- FlinkLogicalCalc(select=[a])
+:  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, table1]], fields=[a, b, c])
++- FlinkLogicalSnapshot(period=[$cor0.proctime])
+   +- FlinkLogicalCalc(select=[id], where=[>(+(+(age, 1), 1), 60)])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn, project=[id, age]]], fields=[id, age])
+]]>
+	</Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -52,7 +52,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
 GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
 +- Exchange(distribution=[hash[b]])
    +- Calc(select=[b, a, c, d])
-      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
          +- Calc(select=[b, a, c, d])
             +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
                +- Exchange(distribution=[hash[a, b]])
@@ -83,7 +83,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name) > 1000))], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name) > 1000))], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -124,7 +124,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
 GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
 +- Exchange(distribution=[hash[b]])
    +- Calc(select=[b, a, c, d])
-      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
          +- Calc(select=[b, a, c, d])
             +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
                +- Exchange(distribution=[hash[a, b]])
@@ -149,7 +149,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -171,7 +171,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -199,7 +199,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name) > 1000))], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name) > 1000))], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -228,7 +228,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6], age=[$7], nominal_age=[$8])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -258,11 +258,41 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6], age=[$7], nominal_age=[$8])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name, age, nominal_age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, name, age, (age + 1) AS nominal_age])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithComputedColumnAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT
+  T.a, T.b, T.c, D.age, D.nominal_age
+FROM
+  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
+  ON T.a = D.id and D.nominal_age > 12
+]]>
+    </Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], age=[$7], nominal_age=[$8])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($3, 12))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalProject(id=[$0], name=[$1], age=[$2], nominal_age=[+($2, 1)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTableWithComputedColumn]])
+]]>
+    </Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, b, c, age, nominal_age])
++- LookupJoin(table=[default_catalog.default_database.LookupTableWithComputedColumn], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 12)], select=[a, b, c, id, age, (age + 1) AS nominal_age])
+   +- Calc(select=[a, b, c])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
   </TestCase>
   <TestCase name="testJoinTemporalTableWithFilterPushDown[LegacyTableSource=false]">
     <Resource name="sql">
@@ -287,7 +317,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -316,7 +346,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[(age = 10)], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -343,7 +373,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, CONCAT(name, _UTF-16LE'!') AS $f3])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, CONCAT(name, _UTF-16LE'!') AS $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -367,7 +397,7 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
    +- Calc(select=[a, b, proctime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -394,7 +424,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, CONCAT(name, _UTF-16LE'!') AS $f3])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, CONCAT(name, _UTF-16LE'!') AS $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -422,7 +452,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, _UTF-16LE'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, _UTF-16LE'!') AS $f3])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, _UTF-16LE'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, _UTF-16LE'!') AS $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -450,7 +480,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, _UTF-16LE'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, _UTF-16LE'!') AS $f3])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[LIKE(name, _UTF-16LE'Jack%')], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, age, CONCAT(name, _UTF-16LE'!') AS $f3])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -476,7 +506,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, (id + 1) AS $f3, CONCAT(name, _UTF-16LE'!') AS $f4])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, (id + 1) AS $f3, CONCAT(name, _UTF-16LE'!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -502,7 +532,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, (id + 1) AS $f3, CONCAT(name, _UTF-16LE'!') AS $f4])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, proctime, rowtime, id, name, CAST(11) AS age, (id + 1) AS $f3, CONCAT(name, _UTF-16LE'!') AS $f4])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -530,7 +560,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST(_UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = _UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = _UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -559,7 +589,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, CAST(_UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(10) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = _UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[age=10, name=_UTF-16LE'AAA', id=a], where=[((age = 10) AND (name = _UTF-16LE'AAA':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -584,7 +614,7 @@ LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
    +- Calc(select=[a, b, proctime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -612,7 +642,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -634,7 +664,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -661,7 +691,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
@@ -688,7 +718,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -716,7 +746,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[], select=[a, b, c, proctime, rowtime, id, name, age])
    +- Calc(select=[a, b, c, proctime, rowtime], where=[(c > 1000)])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -746,7 +776,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT(_UTF-16LE'Hello-', name) = _UTF-16LE'Hello-Jark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], select=[a, b, c, id, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT(_UTF-16LE'Hello-', name) = _UTF-16LE'Hello-Jark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], select=[a, b, c, id, name])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
@@ -776,11 +806,91 @@ LogicalProject(a=[$0], b=[$1], c=[$2], name=[$6])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, name])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT(_UTF-16LE'Hello-', name) = _UTF-16LE'Hello-Jark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], select=[a, b, c, id, name])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(CONCAT(_UTF-16LE'Hello-', name) = _UTF-16LE'Hello-Jark':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], select=[a, b, c, id, name])
    +- Calc(select=[a, b, c])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[SELECT T.a, D.id, D.age FROM MyTable AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], id=[$5], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, id, age])
++- Calc(select=[a])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCallAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT T.a, T.c, D.age FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id + 1 AND T.b = concat( Cast(D.age as varchar), '!')
+WHERE T.c > 1000
+      ]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], c=[$2], age=[$7])
++- LogicalFilter(condition=[>($2, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, +($0, 1)), =($cor0.b, CONCAT(CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'!')))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, c, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[age, id], joinType=[InnerJoin], async=[false], lookup=[], joinCondition=[((a = $f3) AND (b = $f4))], select=[a, b, c, age, (id + 1) AS $f3, CONCAT(CAST(age), _UTF-16LE'!') AS $f4])
+   +- Calc(select=[a, b, c], where=[(c > 1000)])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithConditionAndCalcPushIntoLookupTableSource[LegacyTableSource=false]">
+	<Resource name="sql">
+	  <![CDATA[
+SELECT T.a, T.c, D.age FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+WHERE D.age + 1 > 1000
+      ]]>
+	</Resource>
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(a=[$0], c=[$2], age=[$7])
++- LogicalFilter(condition=[>(+($7, 1), 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[a, c, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, age], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[((age + 1) > 1000)], select=[a, c, id, age])
+   +- Calc(select=[a, c])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+	</Resource>
   </TestCase>
   <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=false]">
     <Resource name="sql">
@@ -799,7 +909,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], tableFieldNames=[id, name, age], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -429,7 +429,7 @@ Calc(select=[currency, currency0, rate1])
    :           +- TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[amount, currency, rowtime])
    +- Exchange(distribution=[hash[currency]])
       +- Calc(select=[currency, (rate + 1) AS rate1], where=[(rate < 100)])
-         +- TableSourceScan(table=[[default_catalog, default_database, RatesBinlogWithoutWatermark]], fields=[currency, rate, rowtime])
+         +- TableSourceScan(table=[[default_catalog, default_database, RatesBinlogWithoutWatermark, project=[currency, rate]]], fields=[currency, rate])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -292,6 +292,46 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
   }
 
   @Test
+  def testJoinTemporalTableWithCalcPushIntoLookupTableSource(): Unit = {
+    // Calc does not support push into legacyTableSource.
+    Assume.assumeFalse(legacyTableSource)
+    val sql = "SELECT T.a, D.id, D.age FROM MyTable AS T JOIN LookupTable " +
+      "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id"
+
+    testUtil.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testJoinTemporalTableWithCallAndCalcPushIntoLookupTableSource(): Unit = {
+    // Calc does not support push into legacyTableSource.
+    Assume.assumeFalse(legacyTableSource)
+    val sql =
+      """
+        |SELECT T.a, T.c, D.age FROM MyTable AS T
+        |JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.a = D.id + 1 AND T.b = concat( Cast(D.age as varchar), '!')
+        |WHERE T.c > 1000
+      """.stripMargin
+
+    testUtil.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testJoinTemporalTableWithConditionAndCalcPushIntoLookupTableSource(): Unit = {
+    // Calc does not support push into legacyTableSource.
+    Assume.assumeFalse(legacyTableSource)
+    val sql =
+      """
+        |SELECT T.a, T.c, D.age FROM MyTable AS T
+        |JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.a = D.id
+        |WHERE D.age + 1 > 1000
+      """.stripMargin
+
+    testUtil.verifyExecPlan(sql)
+  }
+
+  @Test
   def testJoinTemporalTableWithComputedColumn(): Unit = {
     //Computed column do not support in legacyTableSource.
     Assume.assumeFalse(legacyTableSource)
@@ -318,6 +358,21 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
         |  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
         |  ON T.a = D.id and D.nominal_age > 12
       """.stripMargin
+    testUtil.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testJoinTemporalTableWithComputedColumnAndCalcPushIntoLookupTableSource(): Unit = {
+    // Calc does not support push into legacyTableSource.
+    Assume.assumeFalse(legacyTableSource)
+    val sql =
+      """
+        |SELECT
+        |  T.a, T.b, T.c, D.age, D.nominal_age
+        |FROM
+        |  MyTable AS T JOIN LookupTableWithComputedColumn FOR SYSTEM_TIME AS OF T.proctime AS D
+        |  ON T.a = D.id and D.nominal_age > 12
+        |""".stripMargin
     testUtil.verifyExecPlan(sql)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/LookupJoinITCase.scala
@@ -208,6 +208,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
 
   @Test
   def testJoinTemporalTableOnMultiFieldsWithUdf(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON mod(T.id, 4) = D.id AND T.content = D.name"
 
@@ -219,6 +220,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
 
   @Test
   def testJoinTemporalTableOnMultiKeyFields(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = s"SELECT T.id, T.len, D.name FROM T JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
@@ -230,6 +232,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
 
   @Test
   def testLeftJoinTemporalTable(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = s"SELECT T.id, T.len, D.name, D.age FROM T LEFT JOIN userTable " +
       "for system_time as of T.proctime AS D ON T.id = D.id"
 
@@ -244,6 +247,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
 
   @Test
   def testJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = s"SELECT T.id, T.len, D.name FROM nullableT T JOIN userTableWithNull " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
@@ -254,6 +258,7 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
 
   @Test
   def testLeftJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = s"SELECT D.id, T.len, D.name FROM nullableT T LEFT JOIN userTableWithNull " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
     val expected = Seq(
@@ -300,14 +305,14 @@ class LookupJoinITCase(legacyTableSource: Boolean, isAsyncMode: Boolean) extends
   def testJoinTemporalTableWithComputedColumnAndPushDown(): Unit = {
     //Computed column do not support in legacyTableSource.
     Assume.assumeFalse(legacyTableSource)
-
-    val sql = s"SELECT T.id, T.len, T.content, D.name, D.age, D.nominal_age " +
+    // push [id, age] into lookup tableSource
+    val sql = s"SELECT T.id, T.len, T.content, D.age, D.nominal_age " +
       "FROM T JOIN userTableWithComputedColumn " +
       "for system_time as of T.proctime AS D ON T.id = D.id and D.nominal_age > 12"
 
     val expected = Seq(
-      BatchTestBase.row(2, 15, "Hello", "Jark", 22, 23),
-      BatchTestBase.row(3, 15, "Fabian", "Fabian", 33, 34))
+      BatchTestBase.row(2, 15, "Hello", 22, 23),
+      BatchTestBase.row(3, 15, "Fabian", 33, 34))
     checkResult(sql, expected)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -272,6 +272,7 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
 
   @Test
   def testJoinTemporalTableOnMultiKeyFields(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = "SELECT T.id, T.len, D.name FROM src AS T JOIN user_table " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
@@ -305,6 +306,7 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
 
   @Test
   def testJoinTemporalTableOnMultiKeyFieldsWithConstantKey(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = "SELECT T.id, T.len, D.name FROM src AS T JOIN user_table " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND 3 = D.id"
 
@@ -318,6 +320,7 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
 
   @Test
   def testJoinTemporalTableOnMultiKeyFieldsWithStringConstantKey(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = "SELECT T.id, T.len, D.name FROM src AS T JOIN user_table " +
       "for system_time as of T.proctime AS D ON D.name = 'Fabian' AND T.id = D.id"
 
@@ -403,6 +406,7 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
 
   @Test
   def testJoinTemporalTableOnMultiKeyFieldsWithNullData(): Unit = {
+    // push [id, name] into lookup tableSource
     val sql = "SELECT T.id, T.len, D.name FROM nullable_src AS T JOIN nullable_user_table " +
       "for system_time as of T.proctime AS D ON T.content = D.name AND T.id = D.id"
 
@@ -498,7 +502,8 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
       //Computed column do not support in legacyTableSource.
       return
     }
-    val sql = s"SELECT T.id, T.len, T.content, D.name, D.age, D.nominal_age " +
+    // push [id, age] into lookup tableSource
+    val sql = s"SELECT T.id, T.len, T.content, D.age, D.nominal_age " +
       "FROM src AS T JOIN userTableWithComputedColumn " +
       "for system_time as of T.proctime AS D ON T.id = D.id and D.nominal_age > 12"
 
@@ -507,8 +512,8 @@ class LookupJoinITCase(legacyTableSource: Boolean) extends StreamingTestBase {
     env.execute()
 
     val expected = Seq(
-      "2,15,Hello,Jark,22,23",
-      "3,15,Fabian,Fabian,33,34")
+      "2,15,Hello,22,23",
+      "3,15,Fabian,33,34")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 }


### PR DESCRIPTION
…nterface for LookupTableSource

## What is the purpose of the change

LookupTableSource supports projection pushing down when implements SupportsProjectionPushDown interface.

## Brief change log

Add rule `PushCalcIntoTemporalTableSourceRule ` to support projection push into temporal tableSource.
And add some tests to verify this.

## Verifying this change

This change added tests and can be verified as follows:
1. Add PushCalcIntoTemporalTableSourceRuleTest class.
2. Add some test method to LookupJoinTest, and some tests in LookupJoinTest also verify this.
3. Some tests in LookupJoinITCase already verify this. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
