### PR TITLE
[FLINK-20841][build][avro/parquet] Removed packages with auto-generated sources from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ tmp
 *.pyc
 .DS_Store
 build-target
-flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/avro/
-flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/generated/
-flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/generated/
 flink-runtime-web/web-dashboard/node/
 flink-runtime-web/web-dashboard/node_modules/
 flink-runtime-web/web-dashboard/web/


### PR DESCRIPTION
## What is the purpose of the change

We ran into compilation failures because of duplicated classes in the classpath after changes were introduced by [FLINK-20790](https://issues.apache.org/jira/browse/FLINK-20790). The packages containing generated source still appeared in .gitignore which caused those packages to not being deleted.


## Brief change log

* `.gitignore` got cleaned up.

## Verifying this change

`mvn test-compile` was executed on all three packages with the generated-sources packages being removed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
