### PR TITLE
[FLINK-20841][tests] Removed obsolete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ tmp
 *.pyc
 .DS_Store
 build-target
-flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/avro/
-flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/generated/
-flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/generated/
 flink-runtime-web/web-dashboard/node/
 flink-runtime-web/web-dashboard/node_modules/
 flink-runtime-web/web-dashboard/web/

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/.gitignore
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/.gitignore
@@ -1,1 +1,0 @@
-src/main/java/example/avro


### PR DESCRIPTION
## What is the purpose of the change

The `.gitignore` file is not needed anymore since we're creating the generated source in the `target/` subfolder now.

## Brief change log

Removed `.gitignore`.

## Verifying this change

I ran `mvn package` on the `flink-confluent-schema-registry` module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
