### PR TITLE
[FLINK-20848][connector/kafka] Fix Kafka consumer client ID with subtask ID suffix

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -77,6 +77,7 @@ public class KafkaPartitionSplitReader<T>
 
     public KafkaPartitionSplitReader(
             Properties props, KafkaRecordDeserializer<T> deserializationSchema, int subtaskId) {
+        this.subtaskId = subtaskId;
         Properties consumerProps = new Properties();
         consumerProps.putAll(props);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
@@ -85,7 +86,6 @@ public class KafkaPartitionSplitReader<T>
         this.deserializationSchema = deserializationSchema;
         this.collector = new SimpleCollector<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
-        this.subtaskId = subtaskId;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug of assigning subtask ID after creating Kafka consumer client ID, which will lead to all consumer client ID used uninitialized subtask ID 0 as suffix. 

## Brief change log

  - Move subtask ID assignment above creating Kafka consumer client ID

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
