### PR TITLE
[FLINK-20781] Avoid NPE after SourceOperator is closed.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -126,6 +126,9 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
      */
     private TimestampsAndWatermarks<OUT> eventTimeLogic;
 
+    /** Indicating whether the source operator has been closed. */
+    private boolean closed;
+
     public SourceOperator(
             FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception>
                     readerFactory,
@@ -247,9 +250,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         }
         if (sourceReader != null) {
             sourceReader.close();
-            // Set the field to null so the reader won't be closed again in dispose().
-            sourceReader = null;
         }
+        closed = true;
         super.close();
     }
 
@@ -257,7 +259,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     public void dispose() throws Exception {
         // We also need to close the source reader to make sure the resources
         // are released if the task does not finish normally.
-        if (sourceReader != null) {
+        if (!closed && sourceReader != null) {
             sourceReader.close();
         }
     }


### PR DESCRIPTION
## What is the purpose of the change
This patch is a band-aid patch that prevent NPE thrown from SourceOperator after it is closed. 

The root cause of the NPE is in the out of order mailbox task shutdown sequence which may result in method invocation on `SourceOperator` after it is closed. A proper fix would be fix the the mailbox shutdown sequence.

## Brief change log
- Avoid NPE after SourceOperator is closed.

## Verifying this change
Ran `UnalignedCheckpointITCase` for over 1500 times in IDE without failure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
