### PR TITLE
[FLINK-18685] [runtime] Make MiniClusterJobClient#getAccumulators non-blocking in Streaming mode

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -38,6 +38,7 @@ import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniClusterJobClient;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -153,24 +154,10 @@ public class AccumulatorLiveITCase extends TestLogger {
         try {
             NotifyingMapper.notifyLatch.await();
 
-            FutureUtils.retrySuccessfulWithDelay(
-                            () -> {
-                                try {
-                                    return CompletableFuture.completedFuture(
-                                            client.getAccumulators(jobGraph.getJobID()).get());
-                                } catch (Exception e) {
-                                    return FutureUtils.completedExceptionally(e);
-                                }
-                            },
-                            Time.milliseconds(20),
-                            deadline,
-                            accumulators ->
-                                    accumulators.size() == 1
-                                            && accumulators.containsKey(ACCUMULATOR_NAME)
-                                            && (int) accumulators.get(ACCUMULATOR_NAME)
-                                                    == NUM_ITERATIONS,
-                            TestingUtils.defaultScheduledExecutor())
-                    .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+            // verify using the ClusterClient
+            verifyResults(jobGraph, deadline, client);
+            // verify using the MiniClusterJobClient
+            verifyResults(jobGraph, deadline, null);
 
             NotifyingMapper.shutdownLatch.trigger();
         } finally {
@@ -179,6 +166,41 @@ public class AccumulatorLiveITCase extends TestLogger {
             // wait for the job to have terminated
             submissionThread.sync();
         }
+    }
+
+    private static void verifyResults(JobGraph jobGraph, Deadline deadline, ClusterClient<?> client)
+            throws InterruptedException, java.util.concurrent.ExecutionException,
+                    java.util.concurrent.TimeoutException {
+        FutureUtils.retrySuccessfulWithDelay(
+                        () -> {
+                            try {
+                                if (client != null) {
+                                    return CompletableFuture.completedFuture(
+                                            client.getAccumulators(jobGraph.getJobID()).get());
+                                } else {
+                                    final MiniClusterJobClient miniClusterJobClient =
+                                            new MiniClusterJobClient(
+                                                    jobGraph.getJobID(),
+                                                    MINI_CLUSTER_RESOURCE.getMiniCluster(),
+                                                    ClassLoader.getSystemClassLoader(),
+                                                    MiniClusterJobClient.JobFinalizationBehavior
+                                                            .NOTHING);
+                                    return CompletableFuture.completedFuture(
+                                            miniClusterJobClient.getAccumulators().get());
+                                }
+                            } catch (Exception e) {
+                                return FutureUtils.completedExceptionally(e);
+                            }
+                        },
+                        Time.milliseconds(20),
+                        deadline,
+                        accumulators ->
+                                accumulators.size() == 1
+                                        && accumulators.containsKey(ACCUMULATOR_NAME)
+                                        && (int) accumulators.get(ACCUMULATOR_NAME)
+                                                == NUM_ITERATIONS,
+                        TestingUtils.defaultScheduledExecutor())
+                .get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
     }
 
     /** UDF that notifies when it changes the accumulator values. */

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointCompatibilityITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -146,7 +147,10 @@ public class UnalignedCheckpointCompatibilityITCase extends TestLogger {
                 () -> miniCluster.getMiniCluster().getExecutionGraph(jobClient.getJobID()).get());
         Thread.sleep(FIRST_RUN_BACKPRESSURE_MS); // wait for some backpressure from sink
 
-        Future<Map<String, Object>> accFuture = jobClient.getAccumulators();
+        Future<Map<String, Object>> accFuture =
+                jobClient
+                        .getJobExecutionResult()
+                        .thenApply(JobExecutionResult::getAllAccumulatorResults);
         Future<String> savepointFuture =
                 jobClient.stopWithSavepoint(false, tempFolder().toURI().toString());
         return new Tuple2<>(savepointFuture.get(), accFuture.get());


### PR DESCRIPTION
## What is the purpose of the change

Make _MiniClusterJobClient#getAccumulators()_ non-blocking in Streaming mode

## Brief change log

Get the serialized accumulators from the execution graph rather than getting the accumulators from the _JobExecutionResult_.

## Verifying this change

Changed _AccumulatorLiveITCase_ so that the verification of the accumulators is done by calling _getAccumulators()_ with both _ClusterClient_ (as it was in previous test version) and _MiniClusterJobClient_  

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? it was a bug that was not compliant with the javadocs. Now it is, so javadoc is untouched by this PR.
