### PR TITLE
[FLINK-20837] Refactor dynamic SlotID

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotID.java
@@ -90,8 +90,8 @@ public class SlotID implements ResourceIDRetrievable, Serializable {
         return resourceId + "_" + (slotNumber >= 0 ? slotNumber : "dynamic");
     }
 
-    /** Generate a SlotID without actual slot index for dynamic slot allocation. */
-    public static SlotID generateDynamicSlotID(ResourceID resourceID) {
+    /** Get a SlotID without actual slot index for dynamic slot allocation. */
+    public static SlotID getDynamicSlotID(ResourceID resourceID) {
         return new SlotID(resourceID);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2075,7 +2075,7 @@ public class TaskExecutorTest extends TestLogger {
                     .taskExecutor
                     .getSelfGateway(TaskExecutorGateway.class)
                     .requestSlot(
-                            SlotID.generateDynamicSlotID(ResourceID.generate()),
+                            SlotID.getDynamicSlotID(ResourceID.generate()),
                             jobId,
                             allocationId,
                             resourceProfile,
@@ -2092,7 +2092,7 @@ public class TaskExecutorTest extends TestLogger {
                             new SlotStatus(new SlotID(resourceId, 0), DEFAULT_RESOURCE_PROFILE),
                             new SlotStatus(new SlotID(resourceId, 1), DEFAULT_RESOURCE_PROFILE),
                             new SlotStatus(
-                                    SlotID.generateDynamicSlotID(resourceId),
+                                    new SlotID(resourceId, 2),
                                     resourceProfile,
                                     jobId,
                                     allocationId)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -158,7 +158,7 @@ public class TaskSlotTableImplTest extends TestLogger {
             assertThat(
                     taskSlotTable.allocateSlot(-1, jobId2, allocationId, SLOT_TIMEOUT), is(false));
 
-            assertThat(taskSlotTable.isAllocated(-1, jobId1, allocationId), is(true));
+            assertThat(taskSlotTable.isAllocated(1, jobId1, allocationId), is(true));
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId1);
@@ -201,7 +201,7 @@ public class TaskSlotTableImplTest extends TestLogger {
             allocatedSlots = taskSlotTable.getAllocatedSlots(jobId);
             TaskSlot<TaskSlotPayload> taskSlot2 = allocatedSlots.next();
 
-            assertThat(taskSlotTable.isAllocated(-1, jobId, allocationId), is(true));
+            assertThat(taskSlotTable.isAllocated(1, jobId, allocationId), is(true));
             assertEquals(taskSlot1, taskSlot2);
             assertThat(allocatedSlots.hasNext(), is(false));
         }
@@ -239,9 +239,9 @@ public class TaskSlotTableImplTest extends TestLogger {
 
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
-            assertThat(allocatedSlots.next().getIndex(), is(-1));
+            assertThat(allocatedSlots.next().getIndex(), is(2));
             assertThat(allocatedSlots.hasNext(), is(false));
-            assertThat(taskSlotTable.isAllocated(-1, jobId, allocationId), is(true));
+            assertThat(taskSlotTable.isAllocated(2, jobId, allocationId), is(true));
         }
     }
 
@@ -262,7 +262,7 @@ public class TaskSlotTableImplTest extends TestLogger {
             Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
                     taskSlotTable.getAllocatedSlots(jobId);
             TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
-            assertThat(allocatedSlot.getIndex(), is(-1));
+            assertThat(allocatedSlot.getIndex(), is(2));
             assertThat(allocatedSlot.getResourceProfile(), is(resourceProfile));
             assertThat(allocatedSlots.hasNext(), is(false));
         }
@@ -305,7 +305,7 @@ public class TaskSlotTableImplTest extends TestLogger {
                     taskSlotTable.allocateSlot(-1, jobId, allocationId3, SLOT_TIMEOUT),
                     is(true)); // index 4
 
-            assertThat(taskSlotTable.freeSlot(allocationId2), is(-1));
+            assertThat(taskSlotTable.freeSlot(allocationId2), is(3));
 
             ResourceID resourceId = ResourceID.generate();
             SlotReport slotReport = taskSlotTable.createSlotReport(resourceId);
@@ -336,7 +336,7 @@ public class TaskSlotTableImplTest extends TestLogger {
                                             null)),
                             is(
                                     new SlotStatus(
-                                            SlotID.generateDynamicSlotID(resourceId),
+                                            new SlotID(resourceId, 4),
                                             TaskSlotUtils.DEFAULT_RESOURCE_PROFILE,
                                             jobId,
                                             allocationId3))));


### PR DESCRIPTION

## What is the purpose of the change

Refactor dynamic SlotID.
In FLINK-14189, we specified that the SlotID whose slot number is -1 represents the dynamic slot. However, the SlotID with a negative slot number will be treated as invalid in other components, e.g. SlotPool and SlotManager. We have to remove a lot of sanity checks with this change, which is error-prone. The evidence is that there are still some sanity checks that have not been removed, e.g. sanity checks in AllocatedSlotInfo.

In this PR, we refactor the dynamic SlotID:
- In SlotManager, it still uses -1 as slot number when allocating dynamic slot.
- In TM, when allocating dynamic slots, it will asssign an increasing number larger than the numberSlots as the slot number.




## Verifying this change

This change is already covered by existing tests:
- TaskExecutorTest
- TaskSlotTableImplTest
