### PR TITLE
[FLINK-20868][task][metrics] Pause the idle/back pressure timers during processing mailbox actions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -416,7 +416,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             resumeFuture = inputProcessor.getAvailableFuture();
         }
         assertNoException(
-                resumeFuture.thenRun(new ResumeWrapper(controller.suspendDefaultAction(), timer)));
+                resumeFuture.thenRun(
+                        new ResumeWrapper(controller.suspendDefaultAction(timer), timer)));
     }
 
     private void resetSynchronousSavepointId() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxDefaultAction.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.metrics.TimerGauge;
 
 /** Interface for the default action that is repeatedly invoked in the mailbox-loop. */
 @Internal
@@ -59,6 +60,16 @@ public interface MailboxDefaultAction {
          * Calling this method signals that the mailbox-thread should (temporarily) stop invoking
          * the default action, e.g. because there is currently no input available. This method must
          * be invoked from the mailbox-thread only!
+         *
+         * @param suspensionIdleTimer started (ticking) {@link TimerGauge} that measures how long
+         *     the default action was suspended/idling. If mailbox loop is busy processing mails,
+         *     this timer should be paused for the time required to process the mails.
+         */
+        Suspension suspendDefaultAction(TimerGauge suspensionIdleTimer);
+
+        /**
+         * Same as {@link #suspendDefaultAction(TimerGauge)} but without any associated timer
+         * measuring the idle time.
          */
         Suspension suspendDefaultAction();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.metrics.TimerGauge;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MailboxClosedException;
@@ -30,11 +31,14 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MIN_PRIORITY;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * This class encapsulates the logic of the mailbox-based execution model. At the core of this model
@@ -83,7 +87,7 @@ public class MailboxProcessor implements Closeable {
      * suspended default action (suspended if not-null) and to reuse the object as return value in
      * consecutive suspend attempts. Must only be accessed from mailbox thread.
      */
-    private MailboxDefaultAction.Suspension suspendedDefaultAction;
+    private DefaultActionSuspension suspendedDefaultAction;
 
     private final StreamTaskActionExecutor actionExecutor;
 
@@ -171,7 +175,7 @@ public class MailboxProcessor implements Closeable {
 
         final TaskMailbox localMailbox = mailbox;
 
-        Preconditions.checkState(
+        checkState(
                 localMailbox.isMailboxThread(),
                 "Method must be executed by declared mailbox thread!");
 
@@ -285,47 +289,82 @@ public class MailboxProcessor implements Closeable {
             return false;
         }
 
-        boolean processed = false;
         // Take mails in a non-blockingly and execute them.
-        Optional<Mail> maybeMail;
-        while (isMailboxLoopRunning() && (maybeMail = mailbox.tryTakeFromBatch()).isPresent()) {
-            maybeMail.get().run();
-            processed = true;
-            if (singleStep) {
-                break;
-            }
-        }
+        boolean processed = processMailsNonBlocking(singleStep);
         if (singleStep) {
             return processed;
         }
 
         // If the default action is currently not available, we can run a blocking mailbox execution
-        // until the default
-        // action becomes available again.
+        // until the default action becomes available again.
+        processed |= processMailsWhenDefaultActionUnavailable();
+
+        return processed;
+    }
+
+    private boolean processMailsWhenDefaultActionUnavailable() throws Exception {
+        boolean processedSomething = false;
+        Optional<Mail> maybeMail;
         while (isDefaultActionUnavailable() && isMailboxLoopRunning()) {
             maybeMail = mailbox.tryTake(MIN_PRIORITY);
             if (!maybeMail.isPresent()) {
                 maybeMail = Optional.of(mailbox.take(MIN_PRIORITY));
             }
+            maybePauseIdleTimer();
             maybeMail.get().run();
-            processed = true;
+            maybeRestartIdleTimer();
+            processedSomething = true;
         }
+        return processedSomething;
+    }
 
-        return processed;
+    private boolean processMailsNonBlocking(boolean singleStep) throws Exception {
+        long processedMails = 0;
+        Optional<Mail> maybeMail;
+
+        while (isMailboxLoopRunning() && (maybeMail = mailbox.tryTakeFromBatch()).isPresent()) {
+            if (processedMails++ == 0) {
+                maybePauseIdleTimer();
+            }
+            maybeMail.get().run();
+            if (singleStep) {
+                break;
+            }
+        }
+        if (processedMails > 0) {
+            maybeRestartIdleTimer();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void maybePauseIdleTimer() {
+        if (suspendedDefaultAction != null && suspendedDefaultAction.suspensionTimer != null) {
+            suspendedDefaultAction.suspensionTimer.markEnd();
+        }
+    }
+
+    private void maybeRestartIdleTimer() {
+        if (suspendedDefaultAction != null && suspendedDefaultAction.suspensionTimer != null) {
+            suspendedDefaultAction.suspensionTimer.markStart();
+        }
     }
 
     /**
      * Calling this method signals that the mailbox-thread should (temporarily) stop invoking the
      * default action, e.g. because there is currently no input available.
      */
-    private MailboxDefaultAction.Suspension suspendDefaultAction() {
+    private MailboxDefaultAction.Suspension suspendDefaultAction(
+            @Nullable TimerGauge suspensionTimer) {
 
-        Preconditions.checkState(
+        checkState(
                 mailbox.isMailboxThread(),
                 "Suspending must only be called from the mailbox thread!");
 
+        checkState(suspendedDefaultAction == null, "Default action has already been suspended");
         if (suspendedDefaultAction == null) {
-            suspendedDefaultAction = new DefaultActionSuspension();
+            suspendedDefaultAction = new DefaultActionSuspension(suspensionTimer);
             ensureControlFlowSignalCheck();
         }
 
@@ -377,8 +416,14 @@ public class MailboxProcessor implements Closeable {
         }
 
         @Override
+        public MailboxDefaultAction.Suspension suspendDefaultAction(
+                TimerGauge suspensionIdleTimer) {
+            return mailboxProcessor.suspendDefaultAction(suspensionIdleTimer);
+        }
+
+        @Override
         public MailboxDefaultAction.Suspension suspendDefaultAction() {
-            return mailboxProcessor.suspendDefaultAction();
+            return mailboxProcessor.suspendDefaultAction(null);
         }
     }
 
@@ -387,6 +432,11 @@ public class MailboxProcessor implements Closeable {
      * resume execution.
      */
     private final class DefaultActionSuspension implements MailboxDefaultAction.Suspension {
+        @Nullable private final TimerGauge suspensionTimer;
+
+        public DefaultActionSuspension(@Nullable TimerGauge suspensionTimer) {
+            this.suspensionTimer = suspensionTimer;
+        }
 
         @Override
         public void resume() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImplTest.java
@@ -82,8 +82,7 @@ public class MailboxExecutorImplTest {
 
     @Test
     public void testIsIdle() throws Exception {
-        MailboxProcessor processor =
-                new MailboxProcessor(MailboxDefaultAction.Controller::suspendDefaultAction);
+        MailboxProcessor processor = new MailboxProcessor();
         MailboxExecutorImpl executor =
                 (MailboxExecutorImpl) processor.getMailboxExecutor(DEFAULT_PRIORITY);
 


### PR DESCRIPTION
FLINK-20717 introduced a bug, where any time spent on processing mails, when task is idle or
back pressured, will be accounted to idle or back pressured time instead of the busy time.

The fix is to assign idle or back pressure timer to the suspenssion marker and pause this
timer when MailboxProcessor is running mails.

## Verifying this change

This PR expand existing tests to cover for the fixed bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
