### PR TITLE
[FLINK-20882][checkstyle] Improve error messages for illegal imports

### DIFF
--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -210,7 +210,23 @@ This file is based on the checkstyle file of Apache Beam.
 
 		<module name="IllegalImport">
 			<property name="illegalPkgs"
-					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged, org.codehaus.jackson, io.netty, org.objectweb.asm, com.google.common"/>
+					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.codehaus.jackson"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-jackson instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.objectweb.asm"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-asm instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="io.netty"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-netty instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-guava instead."/>
 		</module>
 
 		<module name="RedundantModifier">


### PR DESCRIPTION
Enhances the checkstyle error messages for illegal imports.

Example output:
```
[INFO] --- maven-checkstyle-plugin:2.17:check (default-cli) @ flink-core ---
[INFO] There are 2 errors reported by Checkstyle 8.14 with /tools/maven/checkstyle.xml ruleset.
[ERROR] src\main\java\org\apache\flink\configuration\AlgorithmOptions.java:[21,1] (imports) IllegalImport: com.google.common.collect.ImmutableList; Use flink-shaded-guava instead
[ERROR] src\main\java\org\apache\flink\configuration\AlgorithmOptions.java:[22,1] (imports) IllegalImport: com.google.common.collect.ImmutableMap; Use flink-shaded-guava instead
```