### PR TITLE
[FLINK-20860][core][config] Separate managed memory consumer `DATAPROC` into `OPERATOR` and `STATE_BACKEND`

### DIFF
--- a/docs/_includes/generated/common_memory_section.html
+++ b/docs/_includes/generated/common_memory_section.html
@@ -106,9 +106,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.consumer-weights</h5></td>
-            <td style="word-wrap: break-word;">DATAPROC:70,PYTHON:30</td>
+            <td style="word-wrap: break-word;">OPERATOR:70,STATE_BACKEND:70,PYTHON:30</td>
             <td>Map</td>
-            <td>Managed memory weights for different kinds of consumers. A slot’s managed memory is shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless of the number of consumers from each kind. Currently supported kinds of consumers are DATAPROC (for RocksDB state backend in streaming and built-in algorithms in batch) and PYTHON (for Python processes).</td>
+            <td>Managed memory weights for different kinds of consumers. A slot’s managed memory is shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless of the number of consumers from each kind. Currently supported kinds of consumers are OPERATOR (for built-in algorithms), STATE_BACKEND (for RocksDB state backend) and PYTHON (for Python processes).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.fraction</h5></td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -52,9 +52,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.consumer-weights</h5></td>
-            <td style="word-wrap: break-word;">DATAPROC:70,PYTHON:30</td>
+            <td style="word-wrap: break-word;">OPERATOR:70,STATE_BACKEND:70,PYTHON:30</td>
             <td>Map</td>
-            <td>Managed memory weights for different kinds of consumers. A slot’s managed memory is shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless of the number of consumers from each kind. Currently supported kinds of consumers are DATAPROC (for RocksDB state backend in streaming and built-in algorithms in batch) and PYTHON (for Python processes).</td>
+            <td>Managed memory weights for different kinds of consumers. A slot’s managed memory is shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless of the number of consumers from each kind. Currently supported kinds of consumers are OPERATOR (for built-in algorithms), STATE_BACKEND (for RocksDB state backend) and PYTHON (for Python processes).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.managed.fraction</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -37,7 +37,14 @@ import static org.apache.flink.configuration.description.TextElement.text;
 @ConfigGroups(groups = @ConfigGroup(name = "TaskManagerMemory", keyPrefix = "taskmanager.memory"))
 public class TaskManagerOptions {
 
-    public static final String MANAGED_MEMORY_CONSUMER_NAME_DATAPROC = "DATAPROC";
+    /**
+     * @deprecated use {@link #MANAGED_MEMORY_CONSUMER_NAME_OPERATOR} and {@link
+     *     #MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND} instead
+     */
+    @Deprecated public static final String MANAGED_MEMORY_CONSUMER_NAME_DATAPROC = "DATAPROC";
+
+    public static final String MANAGED_MEMORY_CONSUMER_NAME_OPERATOR = "OPERATOR";
+    public static final String MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND = "STATE_BACKEND";
     public static final String MANAGED_MEMORY_CONSUMER_NAME_PYTHON = "PYTHON";
 
     // ------------------------------------------------------------------------
@@ -433,17 +440,21 @@ public class TaskManagerOptions {
                     .defaultValue(
                             new HashMap<String, String>() {
                                 {
-                                    put(MANAGED_MEMORY_CONSUMER_NAME_DATAPROC, "70");
+                                    put(MANAGED_MEMORY_CONSUMER_NAME_OPERATOR, "70");
+                                    put(MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND, "70");
                                     put(MANAGED_MEMORY_CONSUMER_NAME_PYTHON, "30");
                                 }
                             })
                     .withDescription(
-                            "Managed memory weights for different kinds of consumers. A slot’s managed memory is"
-                                    + " shared by all kinds of consumers it contains, proportionally to the kinds’ weights and regardless"
-                                    + " of the number of consumers from each kind. Currently supported kinds of consumers are "
-                                    + MANAGED_MEMORY_CONSUMER_NAME_DATAPROC
-                                    + " (for RocksDB state backend in streaming and built-in"
-                                    + " algorithms in batch) and "
+                            "Managed memory weights for different kinds of consumers. A slot’s"
+                                    + " managed memory is shared by all kinds of consumers it"
+                                    + " contains, proportionally to the kinds’ weights and"
+                                    + " regardless of the number of consumers from each kind."
+                                    + " Currently supported kinds of consumers are "
+                                    + MANAGED_MEMORY_CONSUMER_NAME_OPERATOR
+                                    + " (for built-in algorithms), "
+                                    + MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND
+                                    + " (for RocksDB state backend) and "
                                     + MANAGED_MEMORY_CONSUMER_NAME_PYTHON
                                     + " (for Python processes).");
 

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ManagedMemoryUseCase.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.Preconditions;
 /** Use cases of managed memory. */
 @Internal
 public enum ManagedMemoryUseCase {
-    BATCH_OP(Scope.OPERATOR),
+    OPERATOR(Scope.OPERATOR),
     STATE_BACKEND(Scope.SLOT),
     PYTHON(Scope.SLOT);
 

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -45,12 +45,12 @@ public class TransformationTest extends TestLogger {
     @Test
     public void testDeclareManagedMemoryUseCase() {
         transformation.declareManagedMemoryUseCaseAtOperatorScope(
-                ManagedMemoryUseCase.BATCH_OP, 123);
+                ManagedMemoryUseCase.OPERATOR, 123);
         transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.STATE_BACKEND);
         assertThat(
                 transformation
                         .getManagedMemoryOperatorScopeUseCaseWeights()
-                        .get(ManagedMemoryUseCase.BATCH_OP),
+                        .get(ManagedMemoryUseCase.OPERATOR),
                 is(123));
         assertThat(
                 transformation.getManagedMemorySlotScopeUseCases(),
@@ -64,18 +64,18 @@ public class TransformationTest extends TestLogger {
 
     @Test(expected = IllegalArgumentException.class)
     public void testDeclareManagedMemoryOperatorScopeUseCaseFailZeroWeight() {
-        transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 0);
+        transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDeclareManagedMemoryOperatorScopeUseCaseFailNegativeWeight() {
         transformation.declareManagedMemoryUseCaseAtOperatorScope(
-                ManagedMemoryUseCase.BATCH_OP, -1);
+                ManagedMemoryUseCase.OPERATOR, -1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDeclareManagedMemorySlotScopeUseCaseFailWrongScope() {
-        transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.BATCH_OP);
+        transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.OPERATOR);
     }
 
     /** A test implementation of {@link Transformation}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
@@ -121,7 +121,7 @@ public enum ManagedMemoryUtils {
                             switch (consumer) {
                                 case TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC:
                                     return Stream.of(
-                                            Tuple2.of(ManagedMemoryUseCase.BATCH_OP, weight),
+                                            Tuple2.of(ManagedMemoryUseCase.OPERATOR, weight),
                                             Tuple2.of(ManagedMemoryUseCase.STATE_BACKEND, weight));
                                 case TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_PYTHON:
                                     return Stream.of(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
@@ -19,22 +19,25 @@
 package org.apache.flink.runtime.util.config.memory;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.state.StateBackendLoader;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /** Utils for configuration and calculations related to managed memory and its various use cases. */
 public enum ManagedMemoryUtils {
@@ -44,11 +47,20 @@ public enum ManagedMemoryUtils {
 
     private static final int MANAGED_MEMORY_FRACTION_SCALE = 16;
 
-    /** Valid names of managed memory consumers. */
-    private static final String[] MANAGED_MEMORY_CONSUMER_VALID_NAMES = {
-        TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC,
-        TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_PYTHON
-    };
+    /** Names of managed memory use cases, in the fallback order. */
+    @SuppressWarnings("deprecation")
+    private static final Map<ManagedMemoryUseCase, List<String>> USE_CASE_CONSUMER_NAMES =
+            ImmutableMap.of(
+                    ManagedMemoryUseCase.OPERATOR,
+                    ImmutableList.of(
+                            TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_OPERATOR,
+                            TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC),
+                    ManagedMemoryUseCase.STATE_BACKEND,
+                    ImmutableList.of(
+                            TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND,
+                            TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC),
+                    ManagedMemoryUseCase.PYTHON,
+                    ImmutableList.of(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_PYTHON));
 
     public static double convertToFractionOfSlot(
             ManagedMemoryUseCase useCase,
@@ -86,52 +98,53 @@ public enum ManagedMemoryUtils {
     @VisibleForTesting
     static Map<ManagedMemoryUseCase, Integer> getManagedMemoryUseCaseWeightsFromConfig(
             Configuration config) {
-        final Map<String, String> consumerWeights =
+        final Map<String, String> configuredWeights =
                 config.get(TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS);
+        final Map<ManagedMemoryUseCase, Integer> effectiveWeights = new HashMap<>();
 
-        for (String consumer : MANAGED_MEMORY_CONSUMER_VALID_NAMES) {
-            if (!consumerWeights.containsKey(consumer)) {
+        for (Map.Entry<ManagedMemoryUseCase, List<String>> entry :
+                USE_CASE_CONSUMER_NAMES.entrySet()) {
+            final ManagedMemoryUseCase useCase = entry.getKey();
+            final Iterator<String> nameIter = entry.getValue().iterator();
+
+            boolean findWeight = false;
+            while (!findWeight && nameIter.hasNext()) {
+                final String name = nameIter.next();
+                final String weightStr = configuredWeights.get(name);
+                if (weightStr != null) {
+                    final int weight = Integer.parseInt(weightStr);
+                    findWeight = true;
+
+                    if (weight < 0) {
+                        throw new IllegalConfigurationException(
+                                String.format(
+                                        "Managed memory weight should not be negative. Configured "
+                                                + "weight for %s is %d.",
+                                        useCase, weight));
+                    }
+
+                    if (weight == 0) {
+                        LOG.debug(
+                                "Managed memory consumer weight for {} is configured to 0. Jobs "
+                                        + "containing this type of managed memory consumers may "
+                                        + "fail due to not being able to allocate managed memory.",
+                                useCase);
+                    }
+
+                    effectiveWeights.put(useCase, weight);
+                }
+            }
+
+            if (!findWeight) {
                 LOG.debug(
-                        "Managed memory consumer weight for {} is not configured. Jobs containing this type of "
-                                + "managed memory consumers may fail due to not being able to allocate managed memory.",
-                        consumer);
+                        "Managed memory consumer weight for {} is not configured. Jobs containing "
+                                + "this type of managed memory consumers may fail due to not being "
+                                + "able to allocate managed memory.",
+                        useCase);
             }
         }
 
-        return consumerWeights.entrySet().stream()
-                .flatMap(
-                        (entry) -> {
-                            final String consumer = entry.getKey();
-                            final int weight = Integer.parseInt(entry.getValue());
-
-                            if (weight < 0) {
-                                throw new IllegalConfigurationException(
-                                        String.format(
-                                                "Managed memory weight should not be negative. Configured weight for %s is %d.",
-                                                consumer, weight));
-                            }
-
-                            if (weight == 0) {
-                                LOG.debug(
-                                        "Managed memory consumer weight for {} is configured to 0. Jobs containing this type of "
-                                                + "managed memory consumers may fail due to not being able to allocate managed memory.",
-                                        consumer);
-                            }
-
-                            switch (consumer) {
-                                case TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC:
-                                    return Stream.of(
-                                            Tuple2.of(ManagedMemoryUseCase.OPERATOR, weight),
-                                            Tuple2.of(ManagedMemoryUseCase.STATE_BACKEND, weight));
-                                case TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_PYTHON:
-                                    return Stream.of(
-                                            Tuple2.of(ManagedMemoryUseCase.PYTHON, weight));
-                                default:
-                                    throw new IllegalConfigurationException(
-                                            "Unknown managed memory consumer: " + consumer);
-                            }
-                        })
-                .collect(Collectors.toMap((tuple2) -> tuple2.f0, (tuple2) -> tuple2.f1));
+        return effectiveWeights;
     }
 
     public static double getFractionRoundedDown(final long dividend, final long divisor) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -73,7 +73,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                 new HashMap<ManagedMemoryUseCase, Integer>() {
                     {
                         put(ManagedMemoryUseCase.STATE_BACKEND, DATA_PROC_WEIGHT);
-                        put(ManagedMemoryUseCase.BATCH_OP, DATA_PROC_WEIGHT);
+                        put(ManagedMemoryUseCase.OPERATOR, DATA_PROC_WEIGHT);
                         put(ManagedMemoryUseCase.PYTHON, PYTHON_WEIGHT);
                     }
                 };
@@ -117,7 +117,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 
     @Test
     public void testConvertToFractionOfSlot() {
-        final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.BATCH_OP;
+        final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.OPERATOR;
         final double fractionOfUseCase = 0.3;
 
         final double fractionOfSlot =
@@ -126,7 +126,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         fractionOfUseCase,
                         new HashSet<ManagedMemoryUseCase>() {
                             {
-                                add(ManagedMemoryUseCase.BATCH_OP);
+                                add(ManagedMemoryUseCase.OPERATOR);
                                 add(ManagedMemoryUseCase.PYTHON);
                             }
                         },
@@ -139,7 +139,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 
     @Test
     public void testConvertToFractionOfSlotWeightNotConfigured() {
-        final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.BATCH_OP;
+        final ManagedMemoryUseCase useCase = ManagedMemoryUseCase.OPERATOR;
         final double fractionOfUseCase = 0.3;
 
         final Configuration config =
@@ -157,7 +157,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         fractionOfUseCase,
                         new HashSet<ManagedMemoryUseCase>() {
                             {
-                                add(ManagedMemoryUseCase.BATCH_OP);
+                                add(ManagedMemoryUseCase.OPERATOR);
                                 add(ManagedMemoryUseCase.PYTHON);
                             }
                         },

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -45,8 +45,40 @@ public class ManagedMemoryUtilsTest extends TestLogger {
 
     private static final int DATA_PROC_WEIGHT = 111;
     private static final int PYTHON_WEIGHT = 222;
+    private static final int OPERATOR_WEIGHT = 333;
+    private static final int STATE_BACKEND_WEIGHT = 444;
+    private static final int TOTAL_WEIGHT = PYTHON_WEIGHT + OPERATOR_WEIGHT + STATE_BACKEND_WEIGHT;
 
     private static final UnmodifiableConfiguration CONFIG_WITH_ALL_USE_CASES =
+            new UnmodifiableConfiguration(
+                    new Configuration() {
+                        {
+                            set(
+                                    TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
+                                    new HashMap<String, String>() {
+                                        {
+                                            put(
+                                                    TaskManagerOptions
+                                                            .MANAGED_MEMORY_CONSUMER_NAME_DATAPROC,
+                                                    String.valueOf(DATA_PROC_WEIGHT));
+                                            put(
+                                                    TaskManagerOptions
+                                                            .MANAGED_MEMORY_CONSUMER_NAME_PYTHON,
+                                                    String.valueOf(PYTHON_WEIGHT));
+                                            put(
+                                                    TaskManagerOptions
+                                                            .MANAGED_MEMORY_CONSUMER_NAME_OPERATOR,
+                                                    String.valueOf(OPERATOR_WEIGHT));
+                                            put(
+                                                    TaskManagerOptions
+                                                            .MANAGED_MEMORY_CONSUMER_NAME_STATE_BACKEND,
+                                                    String.valueOf(STATE_BACKEND_WEIGHT));
+                                        }
+                                    });
+                        }
+                    });
+
+    private static final UnmodifiableConfiguration CONFIG_WITH_LEGACY_USE_CASES =
             new UnmodifiableConfiguration(
                     new Configuration() {
                         {
@@ -72,8 +104,8 @@ public class ManagedMemoryUtilsTest extends TestLogger {
         final Map<ManagedMemoryUseCase, Integer> expectedWeights =
                 new HashMap<ManagedMemoryUseCase, Integer>() {
                     {
-                        put(ManagedMemoryUseCase.STATE_BACKEND, DATA_PROC_WEIGHT);
-                        put(ManagedMemoryUseCase.OPERATOR, DATA_PROC_WEIGHT);
+                        put(ManagedMemoryUseCase.OPERATOR, OPERATOR_WEIGHT);
+                        put(ManagedMemoryUseCase.STATE_BACKEND, STATE_BACKEND_WEIGHT);
                         put(ManagedMemoryUseCase.PYTHON, PYTHON_WEIGHT);
                     }
                 };
@@ -85,18 +117,22 @@ public class ManagedMemoryUtilsTest extends TestLogger {
         assertThat(configuredWeights, is(expectedWeights));
     }
 
-    @Test(expected = IllegalConfigurationException.class)
-    public void testGetWeightsFromConfigFailUnknownUseCase() {
-        final Configuration config =
-                new Configuration() {
+    @Test
+    public void testGetWeightsFromConfigLegacy() {
+        final Map<ManagedMemoryUseCase, Integer> expectedWeights =
+                new HashMap<ManagedMemoryUseCase, Integer>() {
                     {
-                        set(
-                                TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
-                                Collections.singletonMap("UNKNOWN_KEY", "123"));
+                        put(ManagedMemoryUseCase.OPERATOR, DATA_PROC_WEIGHT);
+                        put(ManagedMemoryUseCase.STATE_BACKEND, DATA_PROC_WEIGHT);
+                        put(ManagedMemoryUseCase.PYTHON, PYTHON_WEIGHT);
                     }
                 };
 
-        ManagedMemoryUtils.getManagedMemoryUseCaseWeightsFromConfig(config);
+        final Map<ManagedMemoryUseCase, Integer> configuredWeights =
+                ManagedMemoryUtils.getManagedMemoryUseCaseWeightsFromConfig(
+                        CONFIG_WITH_LEGACY_USE_CASES);
+
+        assertThat(configuredWeights, is(expectedWeights));
     }
 
     @Test(expected = IllegalConfigurationException.class)
@@ -107,7 +143,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         set(
                                 TaskManagerOptions.MANAGED_MEMORY_CONSUMER_WEIGHTS,
                                 Collections.singletonMap(
-                                        TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_DATAPROC,
+                                        TaskManagerOptions.MANAGED_MEMORY_CONSUMER_NAME_OPERATOR,
                                         "-123"));
                     }
                 };
@@ -127,14 +163,15 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         new HashSet<ManagedMemoryUseCase>() {
                             {
                                 add(ManagedMemoryUseCase.OPERATOR);
+                                add(ManagedMemoryUseCase.STATE_BACKEND);
                                 add(ManagedMemoryUseCase.PYTHON);
                             }
                         },
                         CONFIG_WITH_ALL_USE_CASES,
-                        Optional.empty(),
+                        Optional.of(true),
                         ClassLoader.getSystemClassLoader());
 
-        assertEquals(fractionOfUseCase / 3, fractionOfSlot, DELTA);
+        assertEquals(fractionOfUseCase * OPERATOR_WEIGHT / TOTAL_WEIGHT, fractionOfSlot, DELTA);
     }
 
     @Test
@@ -158,11 +195,12 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         new HashSet<ManagedMemoryUseCase>() {
                             {
                                 add(ManagedMemoryUseCase.OPERATOR);
+                                add(ManagedMemoryUseCase.STATE_BACKEND);
                                 add(ManagedMemoryUseCase.PYTHON);
                             }
                         },
                         config,
-                        Optional.empty(),
+                        Optional.of(true),
                         ClassLoader.getSystemClassLoader());
 
         assertEquals(0.0, fractionOfSlot, DELTA);
@@ -171,27 +209,42 @@ public class ManagedMemoryUtilsTest extends TestLogger {
     @Test
     public void testConvertToFractionOfSlotStateBackendUseManagedMemory() {
         testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
-                true, 1.0 / 3, 1.0 * 2 / 3);
+                true,
+                1.0 * OPERATOR_WEIGHT / TOTAL_WEIGHT,
+                1.0 * STATE_BACKEND_WEIGHT / TOTAL_WEIGHT,
+                1.0 * PYTHON_WEIGHT / TOTAL_WEIGHT);
     }
 
     @Test
     public void testConvertToFractionOfSlotStateBackendNotUserManagedMemory() {
-        testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(false, 0.0, 1.0);
+        final int totalWeight = OPERATOR_WEIGHT + PYTHON_WEIGHT;
+        testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
+                false, 1.0 * OPERATOR_WEIGHT / totalWeight, 0.0, 1.0 * PYTHON_WEIGHT / totalWeight);
     }
 
     private void testConvertToFractionOfSlotGivenWhetherStateBackendUsesManagedMemory(
             boolean stateBackendUsesManagedMemory,
+            double expectedOperatorFractionOfSlot,
             double expectedStateFractionOfSlot,
             double expectedPythonFractionOfSlot) {
 
         final Set<ManagedMemoryUseCase> allUseCases =
                 new HashSet<ManagedMemoryUseCase>() {
                     {
+                        add(ManagedMemoryUseCase.OPERATOR);
                         add(ManagedMemoryUseCase.STATE_BACKEND);
                         add(ManagedMemoryUseCase.PYTHON);
                     }
                 };
 
+        final double opFractionOfSlot =
+                ManagedMemoryUtils.convertToFractionOfSlot(
+                        ManagedMemoryUseCase.OPERATOR,
+                        1.0,
+                        allUseCases,
+                        CONFIG_WITH_ALL_USE_CASES,
+                        Optional.of(stateBackendUsesManagedMemory),
+                        ClassLoader.getSystemClassLoader());
         final double stateFractionOfSlot =
                 ManagedMemoryUtils.convertToFractionOfSlot(
                         ManagedMemoryUseCase.STATE_BACKEND,
@@ -209,6 +262,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                         Optional.of(stateBackendUsesManagedMemory),
                         ClassLoader.getSystemClassLoader());
 
+        assertEquals(expectedOperatorFractionOfSlot, opFractionOfSlot, DELTA);
         assertEquals(expectedStateFractionOfSlot, stateFractionOfSlot, DELTA);
         assertEquals(expectedPythonFractionOfSlot, pythonFractionOfSlot, DELTA);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -165,7 +165,7 @@ public class StreamMultipleInputProcessorFactory {
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
                             streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                    ManagedMemoryUseCase.BATCH_OP,
+                                    ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
                             jobConfig);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -139,7 +139,7 @@ public class StreamTwoInputProcessorFactory {
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
                             streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                    ManagedMemoryUseCase.BATCH_OP,
+                                    ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
                             jobConfig);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -128,7 +128,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                 getEnvironment().getIOManager(),
                 getExecutionConfig().isObjectReuseEnabled(),
                 configuration.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                        ManagedMemoryUseCase.BATCH_OP, getTaskConfiguration(), userCodeClassLoader),
+                        ManagedMemoryUseCase.OPERATOR, getTaskConfiguration(), userCodeClassLoader),
                 getJobConfiguration(),
                 this);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -61,7 +61,7 @@ class BatchExecutionUtils {
                 node.addInputRequirement(i, inputRequirements[i]);
             }
             Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights = new HashMap<>();
-            operatorScopeUseCaseWeights.put(ManagedMemoryUseCase.BATCH_OP, 1);
+            operatorScopeUseCaseWeights.put(ManagedMemoryUseCase.OPERATOR, 1);
             node.setManagedMemoryUseCaseWeights(
                     operatorScopeUseCaseWeights, Collections.emptySet());
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -508,7 +508,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
         source.getTransformation()
-                .declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, weight);
+                .declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, weight);
         source.print().name("sink");
 
         final StreamGraph streamGraph = env.getStreamGraph();
@@ -517,7 +517,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
                 assertThat(
                         streamNode
                                 .getManagedMemoryOperatorScopeUseCaseWeights()
-                                .get(ManagedMemoryUseCase.BATCH_OP),
+                                .get(ManagedMemoryUseCase.OPERATOR),
                         is(weight));
             } else {
                 assertThat(streamNode.getManagedMemoryOperatorScopeUseCaseWeights().size(), is(0));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -982,12 +982,12 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
         // source: batch
         operatorScopeManagedMemoryUseCaseWeights.add(
-                Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+                Collections.singletonMap(ManagedMemoryUseCase.OPERATOR, 1));
         slotScopeManagedMemoryUseCases.add(Collections.emptySet());
 
         // map1: batch, python
         operatorScopeManagedMemoryUseCaseWeights.add(
-                Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+                Collections.singletonMap(ManagedMemoryUseCase.OPERATOR, 1));
         slotScopeManagedMemoryUseCases.add(Collections.singleton(ManagedMemoryUseCase.PYTHON));
 
         // map3: python
@@ -996,7 +996,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
         // map3: batch
         operatorScopeManagedMemoryUseCaseWeights.add(
-                Collections.singletonMap(ManagedMemoryUseCase.BATCH_OP, 1));
+                Collections.singletonMap(ManagedMemoryUseCase.OPERATOR, 1));
         slotScopeManagedMemoryUseCases.add(Collections.emptySet());
 
         // slotSharingGroup1 contains batch and python use cases: v1(source[batch]) -> map1[batch,
@@ -1121,7 +1121,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         assertEquals(
                 expectedBatchFrac,
                 streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                        ManagedMemoryUseCase.BATCH_OP,
+                        ManagedMemoryUseCase.OPERATOR,
                         tmConfig,
                         ClassLoader.getSystemClassLoader()),
                 delta);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
@@ -60,7 +60,7 @@ public class ExecNodeUtil {
             int memoryKibiBytes = (int) Math.max(1, (memoryBytes >> 10));
             Optional<Integer> previousWeight =
                     transformation.declareManagedMemoryUseCaseAtOperatorScope(
-                            ManagedMemoryUseCase.BATCH_OP, memoryKibiBytes);
+                            ManagedMemoryUseCase.OPERATOR, memoryKibiBytes);
             if (previousWeight.isPresent()) {
                 throw new TableException(
                         "Managed memory weight has been set, this should not happen.");

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -75,7 +75,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
     val streamConfig = testHarness.getStreamConfig
     streamConfig.setStreamOperatorFactory(args._1)
     streamConfig.setOperatorID(new OperatorID)
-    streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, .99)
+    streamConfig.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, .99)
 
     testHarness.invoke()
     testHarness.waitForTaskRunning()

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -54,7 +54,7 @@ public class TableStreamOperator<OUT> extends AbstractStreamOperator<OUT> {
                 .computeMemorySize(
                         getOperatorConfig()
                                 .getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                        ManagedMemoryUseCase.BATCH_OP,
+                                        ManagedMemoryUseCase.OPERATOR,
                                         environment.getTaskManagerInfo().getConfiguration(),
                                         environment.getUserCodeClassLoader().asClassLoader()));
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/BatchMultipleInputStreamOperator.java
@@ -73,12 +73,12 @@ public class BatchMultipleInputStreamOperator extends MultipleInputStreamOperato
                 multipleInputOperatorParameters
                                 .getStreamConfig()
                                 .getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                        ManagedMemoryUseCase.BATCH_OP,
+                                        ManagedMemoryUseCase.OPERATOR,
                                         taskManagerConfig,
                                         getRuntimeContext().getUserCodeClassLoader())
                         * wrapper.getManagedMemoryFraction();
         streamConfig.setManagedMemoryFractionOperatorOfUseCase(
-                ManagedMemoryUseCase.BATCH_OP, managedMemoryFraction);
+                ManagedMemoryUseCase.OPERATOR, managedMemoryFraction);
         return streamConfig;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGenerator.java
@@ -175,14 +175,14 @@ public class TableOperatorWrapperGenerator {
             managedMemoryWeight =
                     transform
                             .getManagedMemoryOperatorScopeUseCaseWeights()
-                            .getOrDefault(ManagedMemoryUseCase.BATCH_OP, 0);
+                            .getOrDefault(ManagedMemoryUseCase.OPERATOR, 0);
         } else {
             minResources = minResources.merge(transform.getMinResources());
             preferredResources = preferredResources.merge(transform.getPreferredResources());
             managedMemoryWeight +=
                     transform
                             .getManagedMemoryOperatorScopeUseCaseWeights()
-                            .getOrDefault(ManagedMemoryUseCase.BATCH_OP, 0);
+                            .getOrDefault(ManagedMemoryUseCase.OPERATOR, 0);
         }
     }
 
@@ -310,7 +310,7 @@ public class TableOperatorWrapperGenerator {
                 fraction =
                         entry.getKey()
                                         .getManagedMemoryOperatorScopeUseCaseWeights()
-                                        .getOrDefault(ManagedMemoryUseCase.BATCH_OP, 0)
+                                        .getOrDefault(ManagedMemoryUseCase.OPERATOR, 0)
                                 * 1.0
                                 / this.managedMemoryWeight;
             }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/Int2HashJoinOperatorTest.java
@@ -348,7 +348,7 @@ public class Int2HashJoinOperatorTest implements Serializable {
         testHarness.getStreamConfig().setOperatorID(new OperatorID());
         testHarness
                 .getStreamConfig()
-                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
+                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, 0.99);
 
         testHarness.invoke();
         testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RandomSortMergeInnerJoinTest.java
@@ -290,7 +290,7 @@ public class RandomSortMergeInnerJoinTest {
         testHarness.getStreamConfig().setOperatorID(new OperatorID());
         testHarness
                 .getStreamConfig()
-                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
+                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, 0.99);
 
         long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2HashJoinOperatorTest.java
@@ -101,7 +101,7 @@ public class String2HashJoinOperatorTest implements Serializable {
         testHarness.getStreamConfig().setOperatorID(new OperatorID());
         testHarness
                 .getStreamConfig()
-                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
+                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, 0.99);
 
         testHarness.invoke();
         testHarness.waitForTaskRunning();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/String2SortMergeJoinOperatorTest.java
@@ -167,7 +167,7 @@ public class String2SortMergeJoinOperatorTest {
         testHarness.getStreamConfig().setOperatorID(new OperatorID());
         testHarness
                 .getStreamConfig()
-                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.BATCH_OP, 0.99);
+                .setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, 0.99);
 
         long initialTime = 0L;
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
@@ -69,13 +69,13 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source1,
                         "agg1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
         OneInputTransformation<RowData, RowData> agg2 =
                 createOneInputTransform(
                         source2,
                         "agg2",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        agg2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 2);
+        agg2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 2);
         TwoInputTransformation<RowData, RowData, RowData> join =
                 createTwoInputTransform(
                         agg1,
@@ -85,7 +85,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                                 RowType.of(
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType())));
-        join.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 3);
+        join.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 3);
 
         TableOperatorWrapperGenerator generator =
                 new TableOperatorWrapperGenerator(
@@ -141,14 +141,14 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source1,
                         "agg1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
 
         OneInputTransformation<RowData, RowData> agg2 =
                 createOneInputTransform(
                         source2,
                         "agg2",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        agg2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 2);
+        agg2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 2);
 
         TwoInputTransformation<RowData, RowData, RowData> join1 =
                 createTwoInputTransform(
@@ -159,7 +159,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                                 RowType.of(
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType())));
-        join1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 3);
+        join1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 3);
 
         TwoInputTransformation<RowData, RowData, RowData> join2 =
                 createTwoInputTransform(
@@ -171,7 +171,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType())));
-        join2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 4);
+        join2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 4);
 
         TwoInputTransformation<RowData, RowData, RowData> join3 =
                 createTwoInputTransform(
@@ -182,7 +182,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                                 RowType.of(
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType())));
-        join3.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 5);
+        join3.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 5);
 
         TwoInputTransformation<RowData, RowData, RowData> join4 =
                 createTwoInputTransform(
@@ -196,7 +196,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType(),
                                         DataTypes.STRING().getLogicalType())));
-        join4.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 6);
+        join4.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 6);
 
         TableOperatorWrapperGenerator generator =
                 new TableOperatorWrapperGenerator(
@@ -269,7 +269,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source4,
                         "agg1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        agg1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
 
         TwoInputTransformation<RowData, RowData, RowData> join1 =
                 createTwoInputTransform(
@@ -277,7 +277,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         union2,
                         "join1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        join1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 2);
+        join1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 2);
 
         UnionTransformation<RowData> union3 = createUnionInputTransform("union3", source5, join1);
 
@@ -343,7 +343,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source1,
                         "calc1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        calc1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        calc1.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
         calc1.setParallelism(100);
 
         OneInputTransformation<RowData, RowData> calc2 =
@@ -351,7 +351,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source2,
                         "calc2",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        calc2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        calc2.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
         calc2.setParallelism(50);
 
         UnionTransformation<RowData> union = createUnionInputTransform("union1", calc1, calc2);
@@ -362,7 +362,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
                         source3,
                         "join1",
                         InternalTypeInfo.of(RowType.of(DataTypes.STRING().getLogicalType())));
-        join.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.BATCH_OP, 1);
+        join.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 1);
         join.setParallelism(200);
 
         TableOperatorWrapperGenerator generator =

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -234,7 +234,7 @@ public class BufferDataOverWindowOperatorTest {
                         when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
                                 .thenReturn(inputSer);
                         when(conf.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                        eq(ManagedMemoryUseCase.BATCH_OP),
+                                        eq(ManagedMemoryUseCase.OPERATOR),
                                         any(Configuration.class),
                                         any(ClassLoader.class)))
                                 .thenReturn(0.99);


### PR DESCRIPTION
## What is the purpose of the change

Previously, `DATAPROC` represents both operators (batch) and state backends, assuming they never coexist in the same job.
To allow streaming operators to use managed memory, we break that assumption, thus need to separate `DATAPROC` into `OPERATOR` and `STATE_BACKEND`.

## Brief change log

- Rename `ManagedMemoryUseCase#BATCH_OP` to `OPERATOR`.
- Separate consumer name `DATAPROC` into `OPERATOR` and `STATE_BACKEND`

## Verifying this change

Update existing tests.
