### PR TITLE
[FLINK-20632] Use Docker image published to apache/flink by default

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -36,7 +36,7 @@
             <td><h5>kubernetes.container.image</h5></td>
             <td style="word-wrap: break-word;">The default value depends on the actually running version. In general it looks like "flink:&lt;FLINK_VERSION&gt;-scala_&lt;SCALA_VERSION&gt;"</td>
             <td>String</td>
-            <td>Image to use for Flink containers. The specified image must be based upon the same Apache Flink and Scala versions as used by the application. Visit https://hub.docker.com/_/flink?tab=tags for the images provided by the Flink project.</td>
+            <td>Image to use for Flink containers. The specified image must be based upon the same Apache Flink and Scala versions as used by the application. Visit https://hub.docker.com/_/flink?tab=tags for the official docker images provided by the Flink project. The Flink project also publishes docker images here: https://hub.docker.com/r/apache/flink</td>
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-policy</h5></td>

--- a/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/deployment/resource-providers/standalone/docker.md
@@ -34,7 +34,7 @@ This *Getting Started* section guides you through the local setup (on one machin
 ### Introduction
 
 [Docker](https://www.docker.com) is a popular container runtime.
-There are Docker images for Apache Flink available [on Docker Hub](https://hub.docker.com/_/flink).
+There are official Docker images for Apache Flink available [on Docker Hub](https://hub.docker.com/_/flink).
 You can use the Docker images to deploy a *Session* or *Application cluster* on Docker. This page focuses on the setup of Flink on Docker, Docker Swarm and Docker Compose.
 
 Deployment into managed containerized environments, such as [standalone Kubernetes]({% link deployment/resource-providers/standalone/kubernetes.md %}) or [native Kubernetes]({% link deployment/resource-providers/native_kubernetes.md %}), are described on separate pages.
@@ -209,6 +209,16 @@ Local deployment in the Session Mode has already been described in the [Getting 
 {% top %}
 
 ## Flink on Docker Reference
+
+### Image hosting
+
+There are two distribution channels for the Flink Docker images:
+1. [Official Flink images on Docker Hub (reviewed and build by Docker)](https://hub.docker.com/_/flink/)
+2. [Flink images on Docker Hub `apache/flink` (managed by the Flink developers)](https://hub.docker.com/r/apache/flink)
+
+We recommend using the official images on Docker Hub, as they are reviewed by Docker. The images on `apache/flink` are provided in case of delays in the review process by Docker.
+
+Launching an image named `flink:latest` will pull the latest image from Docker Hub. In order to use the images hosted in `apache/flink`, replace `flink` by `apache/flink`. Any of the image tags (starting from Flink 1.11.3) are avaialble on `apache/flink` as well.
 
 ### Image tags
 

--- a/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -372,7 +372,7 @@ spec:
     spec:
       containers:
       - name: jobmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
+        image: apache/flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["jobmanager"]
         ports:
         - containerPort: 6123
@@ -422,7 +422,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
+        image: apache/flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["taskmanager"]
         ports:
         - containerPort: 6122
@@ -468,7 +468,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: jobmanager
-          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
+          image: apache/flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
           env:
           args: ["standalone-job", "--job-classname", "com.job.ClassName", <optional arguments>, <job arguments>] # optional arguments: ["--job-id", "<job id>", "--fromSavepoint", "/path/to/savepoint", "--allowNonRestoredState"]
           ports:
@@ -524,7 +524,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
+        image: apache/flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         env:
         args: ["taskmanager"]
         ports:

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -197,7 +197,7 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "Image to use for Flink containers. "
                                     + "The specified image must be based upon the same Apache Flink and Scala versions as used by the application. "
-                                    + "Visit https://hub.docker.com/_/flink?tab=tags for the images provided by the Flink project.");
+                                    + "Visit https://hub.docker.com/_/flink?tab=tags for the official docker images provided by the Flink project. The Flink project also publishes docker images here: https://hub.docker.com/r/apache/flink");
 
     /** The following config options need to be set according to the image. */
     public static final ConfigOption<String> KUBERNETES_ENTRY_PATH =
@@ -352,7 +352,7 @@ public class KubernetesConfigOptions {
                         : EnvironmentInformation.getVersion()
                                 + "-scala_"
                                 + EnvironmentInformation.getScalaVersion();
-        return "flink:" + tag;
+        return "apache/flink:" + tag;
     }
 
     /** The flink rest service exposed type. */


### PR DESCRIPTION

## What is the purpose of the change

Add second docker image distribution channel to docs. Use `apache/flink` images by default in the docs and in the code (for K8s).

## Verifying this change

Manually tested.


