### PR TITLE
[FLINK-20899][table-planner-blink] Fix ClassCastException when calculating cost in HepPlanner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkHepProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkHepProgram.scala
@@ -54,7 +54,8 @@ class FlinkHepProgram[OC <: FlinkOptimizeContext] extends FlinkOptimizeProgram[O
     }
 
     try {
-      val planner = new HepPlanner(hepProgram.get, context)
+      val planner = new HepPlanner(
+        hepProgram.get, context, false, null, root.getCluster.getPlanner.getCostFactory)
       FlinkRelMdNonCumulativeCost.THREAD_PLANNER.set(planner)
 
       planner.setRoot(root)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkHepProgramTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkHepProgramTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize.program
+
+import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
+
+import org.apache.calcite.plan.RelOptPlanner
+import org.apache.log4j.{Level, LogManager}
+import org.junit.Test
+
+class FlinkHepProgramTest {
+
+  @Test
+  def testEnableTrace(): Unit = {
+    val tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().inBatchMode().build())
+    val before = LogManager.getLogger(RelOptPlanner.LOGGER.getName).getLevel
+    try {
+      LogManager.getLogger(RelOptPlanner.LOGGER.getName).setLevel(Level.TRACE)
+      tEnv.explainSql("SELECT COUNT(*) FROM (VALUES (1), (2), (3)) AS T(a)")
+    } finally {
+      LogManager.getLogger(RelOptPlanner.LOGGER.getName).setLevel(before)
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*After TREACE level is enabled for Logger, we will encounter ClassCastException when executing the following query: 
SELECT COUNT(1) FROM MyTable. 
The reason is the HepPlanner will calculate the cost of the optimized plan when TRACE is enabled, while the cost factory in hep planner is RelOptCostImpl.Factory, not the sub-class of FlinkCostFactory.
The solution is we should create HepPlanner with the cost factory in the RelOptCluster.*


## Brief change log

  - *Fix ClassCastException when calculating cost in HepPlanner*


## Verifying this change



This change added tests and can be verified as follows:

  - *Added FlinkHepProgramTest to verify the bug*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
