### PR TITLE
[FLINK-20903] Remove unnecessary methods from SchedulerNG

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -354,7 +354,8 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         shuffleMaster,
                         partitionTracker,
                         executionDeploymentTracker,
-                        initializationTimestamp);
+                        initializationTimestamp,
+                        getMainThreadExecutor());
 
         scheduler.initialize(getMainThreadExecutor());
         scheduler.registerJobStatusListener(jobStatusListener);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -355,9 +355,8 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         partitionTracker,
                         executionDeploymentTracker,
                         initializationTimestamp,
-                        getMainThreadExecutor());
-
-        scheduler.registerJobStatusListener(jobStatusListener);
+                        getMainThreadExecutor(),
+                        jobStatusListener);
 
         return scheduler;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -357,7 +357,6 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         initializationTimestamp,
                         getMainThreadExecutor());
 
-        scheduler.initialize(getMainThreadExecutor());
         scheduler.registerJobStatusListener(jobStatusListener);
 
         return scheduler;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
@@ -122,7 +123,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
             final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory,
             final ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            final ComponentMainThreadExecutor mainThreadExecutor)
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final JobStatusListener jobStatusListener)
             throws Exception {
 
         super(
@@ -141,7 +143,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 executionVertexVersioner,
                 executionDeploymentTracker,
                 initializationTimestamp,
-                mainThreadExecutor);
+                mainThreadExecutor,
+                jobStatusListener);
 
         this.log = log;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -99,8 +99,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
     private final Set<ExecutionVertexID> verticesWaitingForRestart;
 
-    private final Consumer<ComponentMainThreadExecutor> startUpAction;
-
     DefaultScheduler(
             final Logger log,
             final JobGraph jobGraph,
@@ -171,18 +169,12 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                         .createInstance(new DefaultExecutionSlotAllocationContext());
 
         this.verticesWaitingForRestart = new HashSet<>();
-        this.startUpAction = startUpAction;
+        startUpAction.accept(mainThreadExecutor);
     }
 
     // ------------------------------------------------------------------------
     // SchedulerNG
     // ------------------------------------------------------------------------
-
-    @Override
-    public void initialize(ComponentMainThreadExecutor mainThreadExecutor) {
-        super.initialize(mainThreadExecutor);
-        startUpAction.accept(mainThreadExecutor);
-    }
 
     @Override
     protected long getNumberOfRestarts() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -123,7 +123,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
             final ExecutionVertexVersioner executionVertexVersioner,
             final ExecutionSlotAllocatorFactory executionSlotAllocatorFactory,
             final ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            final ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
 
         super(
@@ -141,7 +142,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 partitionTracker,
                 executionVertexVersioner,
                 executionDeploymentTracker,
-                initializationTimestamp);
+                initializationTimestamp,
+                mainThreadExecutor);
 
         this.log = log;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
@@ -61,7 +62,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final ShuffleMaster<?> shuffleMaster,
             final JobMasterPartitionTracker partitionTracker,
             final ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            final ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
 
         final DefaultSchedulerComponents schedulerComponents =
@@ -107,6 +109,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 new ExecutionVertexVersioner(),
                 schedulerComponents.getAllocatorFactory(),
                 executionDeploymentTracker,
-                initializationTimestamp);
+                initializationTimestamp,
+                mainThreadExecutor);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategyFactoryLoader;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategyFactoryLoader;
@@ -63,7 +64,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final JobMasterPartitionTracker partitionTracker,
             final ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            final ComponentMainThreadExecutor mainThreadExecutor)
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final JobStatusListener jobStatusListener)
             throws Exception {
 
         final DefaultSchedulerComponents schedulerComponents =
@@ -110,6 +112,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 schedulerComponents.getAllocatorFactory(),
                 executionDeploymentTracker,
                 initializationTimestamp,
-                mainThreadExecutor);
+                mainThreadExecutor,
+                jobStatusListener);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -233,8 +233,7 @@ public abstract class SchedulerBase implements SchedulerNG {
         inputsLocationsRetriever =
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
 
-        this.coordinatorMap = createCoordinatorMap();
-        initializeOperatorCoordinators(this.mainThreadExecutor);
+        this.coordinatorMap = createCoordinatorMap(this.mainThreadExecutor);
     }
 
     private void registerShutDownCheckpointServicesOnExecutionGraphTermination(
@@ -1222,12 +1221,6 @@ public abstract class SchedulerBase implements SchedulerNG {
         }
     }
 
-    private void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
-        for (OperatorCoordinatorHolder coordinatorHolder : getAllCoordinators()) {
-            coordinatorHolder.lazyInitialize(this, mainThreadExecutor);
-        }
-    }
-
     private void startAllOperatorCoordinators() {
         final Collection<OperatorCoordinatorHolder> coordinators = getAllCoordinators();
         try {
@@ -1249,10 +1242,12 @@ public abstract class SchedulerBase implements SchedulerNG {
         return coordinatorMap.values();
     }
 
-    private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap() {
+    private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap(
+            ComponentMainThreadExecutor mainThreadExecutor) {
         Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
         for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
             for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
+                holder.lazyInitialize(this, mainThreadExecutor);
                 coordinatorMap.put(holder.operatorId(), holder);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -181,7 +181,8 @@ public abstract class SchedulerBase implements SchedulerNG {
             final ExecutionVertexVersioner executionVertexVersioner,
             final ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            final ComponentMainThreadExecutor mainThreadExecutor)
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final JobStatusListener jobStatusListener)
             throws Exception {
 
         this.log = checkNotNull(log);
@@ -219,7 +220,8 @@ public abstract class SchedulerBase implements SchedulerNG {
                         checkNotNull(partitionTracker),
                         checkNotNull(executionDeploymentTracker),
                         initializationTimestamp,
-                        mainThreadExecutor);
+                        mainThreadExecutor,
+                        jobStatusListener);
 
         registerShutDownCheckpointServicesOnExecutionGraphTermination(executionGraph);
 
@@ -275,7 +277,8 @@ public abstract class SchedulerBase implements SchedulerNG {
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            ComponentMainThreadExecutor mainThreadExecutor)
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobStatusListener jobStatusListener)
             throws Exception {
 
         ExecutionGraph newExecutionGraph =
@@ -305,6 +308,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
         newExecutionGraph.setInternalTaskFailuresListener(
                 new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
+        newExecutionGraph.registerJobStatusListener(jobStatusListener);
         newExecutionGraph.start(mainThreadExecutor);
 
         return newExecutionGraph;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -235,6 +235,7 @@ public abstract class SchedulerBase implements SchedulerNG {
                 new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
 
         this.coordinatorMap = createCoordinatorMap();
+        initializeOperatorCoordinators(this.mainThreadExecutor);
     }
 
     private void registerShutDownCheckpointServicesOnExecutionGraphTermination(
@@ -304,6 +305,10 @@ public abstract class SchedulerBase implements SchedulerNG {
                         newExecutionGraph, jobGraph.getSavepointRestoreSettings());
             }
         }
+
+        newExecutionGraph.setInternalTaskFailuresListener(
+                new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
+        newExecutionGraph.start(mainThreadExecutor);
 
         return newExecutionGraph;
     }
@@ -608,14 +613,6 @@ public abstract class SchedulerBase implements SchedulerNG {
     // ------------------------------------------------------------------------
     // SchedulerNG
     // ------------------------------------------------------------------------
-
-    @Override
-    public void initialize(final ComponentMainThreadExecutor mainThreadExecutor) {
-        initializeOperatorCoordinators(this.mainThreadExecutor);
-        executionGraph.setInternalTaskFailuresListener(
-                new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
-        executionGraph.start(this.mainThreadExecutor);
-    }
 
     @Override
     public void registerJobStatusListener(final JobStatusListener jobStatusListener) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -616,11 +616,6 @@ public abstract class SchedulerBase implements SchedulerNG {
     // ------------------------------------------------------------------------
 
     @Override
-    public void registerJobStatusListener(final JobStatusListener jobStatusListener) {
-        executionGraph.registerJobStatusListener(jobStatusListener);
-    }
-
-    @Override
     public final void startScheduling() {
         mainThreadExecutor.assertRunningInMainThread();
         registerJobMetrics();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -147,8 +147,6 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     private final ClassLoader userCodeLoader;
 
-    private final CheckpointRecoveryFactory checkpointRecoveryFactory;
-
     private final CompletedCheckpointStore completedCheckpointStore;
 
     private final CheckpointsCleaner checkpointsCleaner;
@@ -192,7 +190,6 @@ public abstract class SchedulerBase implements SchedulerNG {
         this.jobMasterConfiguration = checkNotNull(jobMasterConfiguration);
         this.futureExecutor = checkNotNull(futureExecutor);
         this.userCodeLoader = checkNotNull(userCodeLoader);
-        this.checkpointRecoveryFactory = checkNotNull(checkpointRecoveryFactory);
         this.rpcTimeout = checkNotNull(rpcTimeout);
 
         this.blobWriter = checkNotNull(blobWriter);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -165,10 +165,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
 
-    private ComponentMainThreadExecutor mainThreadExecutor =
-            new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
-                    "SchedulerBase is not initialized with proper main thread executor. "
-                            + "Call to SchedulerBase.setMainThreadExecutor(...) required.");
+    private final ComponentMainThreadExecutor mainThreadExecutor;
 
     public SchedulerBase(
             final Logger log,
@@ -185,7 +182,8 @@ public abstract class SchedulerBase implements SchedulerNG {
             final JobMasterPartitionTracker partitionTracker,
             final ExecutionVertexVersioner executionVertexVersioner,
             final ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            final ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
 
         this.log = checkNotNull(log);
@@ -200,6 +198,7 @@ public abstract class SchedulerBase implements SchedulerNG {
         this.blobWriter = checkNotNull(blobWriter);
         this.jobManagerJobMetricGroup = checkNotNull(jobManagerJobMetricGroup);
         this.executionVertexVersioner = checkNotNull(executionVertexVersioner);
+        this.mainThreadExecutor = mainThreadExecutor;
 
         this.checkpointsCleaner = new CheckpointsCleaner();
         this.completedCheckpointStore =
@@ -222,7 +221,8 @@ public abstract class SchedulerBase implements SchedulerNG {
                         checkNotNull(shuffleMaster),
                         checkNotNull(partitionTracker),
                         checkNotNull(executionDeploymentTracker),
-                        initializationTimestamp);
+                        initializationTimestamp,
+                        mainThreadExecutor);
 
         registerShutDownCheckpointServicesOnExecutionGraphTermination(executionGraph);
 
@@ -276,7 +276,8 @@ public abstract class SchedulerBase implements SchedulerNG {
             ShuffleMaster<?> shuffleMaster,
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
 
         ExecutionGraph newExecutionGraph =
@@ -610,11 +611,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 
     @Override
     public void initialize(final ComponentMainThreadExecutor mainThreadExecutor) {
-        this.mainThreadExecutor = checkNotNull(mainThreadExecutor);
-        initializeOperatorCoordinators(mainThreadExecutor);
+        initializeOperatorCoordinators(this.mainThreadExecutor);
         executionGraph.setInternalTaskFailuresListener(
                 new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
-        executionGraph.start(mainThreadExecutor);
+        executionGraph.start(this.mainThreadExecutor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -67,8 +66,6 @@ import java.util.concurrent.CompletableFuture;
  * invocations will originate from a thread in the {@link ComponentMainThreadExecutor}.
  */
 public interface SchedulerNG {
-
-    void registerJobStatusListener(JobStatusListener jobStatusListener);
 
     void startScheduling();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -64,12 +64,9 @@ import java.util.concurrent.CompletableFuture;
  * instantiated.
  *
  * <p>Implementations can expect that methods will not be invoked concurrently. In fact, all
- * invocations will originate from a thread in the {@link ComponentMainThreadExecutor}, which will
- * be passed via {@link #initialize(ComponentMainThreadExecutor)}.
+ * invocations will originate from a thread in the {@link ComponentMainThreadExecutor}.
  */
 public interface SchedulerNG {
-
-    void initialize(ComponentMainThreadExecutor mainThreadExecutor);
 
     void registerJobStatusListener(JobStatusListener jobStatusListener);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
@@ -56,6 +57,7 @@ public interface SchedulerNGFactory {
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            ComponentMainThreadExecutor mainThreadExecutor)
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobStatusListener jobStatusListener)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
@@ -54,6 +55,7 @@ public interface SchedulerNGFactory {
             ShuffleMaster<?> shuffleMaster,
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception;
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -168,8 +168,6 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
                         .setRpcTimeout(timeout)
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         return scheduler;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -161,7 +161,8 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
         jobGraph.setSnapshotSettings(checkpointingSettings);
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setCheckpointRecoveryFactory(
                                 new TestingCheckpointRecoveryFactory(store, counter))
                         .setRpcTimeout(timeout)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -113,7 +113,6 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         SchedulerBase scheduler =
                 SchedulerTestingUtils.createScheduler(
                         jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread());
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         runtimeGraph = scheduler.getExecutionGraph();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -110,7 +110,9 @@ public class ArchivedExecutionGraphTest extends TestLogger {
                         null);
         jobGraph.setSnapshotSettings(checkpointingSettings);
 
-        SchedulerBase scheduler = SchedulerTestingUtils.createScheduler(jobGraph);
+        SchedulerBase scheduler =
+                SchedulerTestingUtils.createScheduler(
+                        jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         runtimeGraph = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -73,7 +73,8 @@ public class ExecutionGraphCoLocationRestartTest {
         final ManuallyTriggeredScheduledExecutorService delayExecutor =
                 new ManuallyTriggeredScheduledExecutorService();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider.create(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -92,8 +92,6 @@ public class ExecutionGraphCoLocationRestartTest {
         final ExecutionGraph eg = scheduler.getExecutionGraph();
 
         // enable the queued scheduling for the slot pool
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         assertEquals(JobStatus.CREATED, eg.getState());
 
         scheduler.startScheduling();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -468,7 +468,8 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
         // execution graph that executes actions synchronously
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(graph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                graph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider
@@ -528,7 +529,9 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
         // execution graph that executes actions synchronously
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(v1, v2))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(v1, v2),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setFutureExecutor(executorService)
@@ -615,7 +618,8 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithoutImmediatePhysicalSlotCreation();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -478,8 +478,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
                         .setBlobWriter(blobWriter)
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         final ExecutionGraph eg = scheduler.getExecutionGraph();
 
         checkJobOffloaded(eg);
@@ -540,8 +538,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
         final ExecutionGraph eg = scheduler.getExecutionGraph();
 
         checkJobOffloaded(eg);
-
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         // schedule, this triggers mock deployment
         scheduler.startScheduling();
@@ -626,8 +622,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
                         .setFutureExecutor(new DirectScheduledExecutorService())
                         .build();
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
-
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         scheduler.startScheduling();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -264,7 +264,8 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
 
         final JobGraph jobGraph = new JobGraph(new JobID(), "test job", vertices);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, mainThreadExecutor.getMainThreadExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setPartitionTracker(partitionTracker)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -271,7 +271,6 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                         .setPartitionTracker(partitionTracker)
                         .build();
 
-        scheduler.initialize(mainThreadExecutor.getMainThreadExecutor());
         mainThreadExecutor.execute(scheduler::startScheduling);
 
         return scheduler;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -105,7 +105,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
         try (SlotPool slotPool = createSlotPoolImpl()) {
             TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph())
+                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(
                                             slotPool, taskManagerLocation))
@@ -140,7 +140,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testCancelWhileFailing() throws Exception {
         try (SlotPool slotPool = createSlotPoolImpl()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph())
+                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -173,7 +173,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testFailWhileCanceling() throws Exception {
         try (SlotPool slotPool = createSlotPoolImpl()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph())
+                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraph(), mainThreadExecutor)
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(slotPool))
                             .setRestartBackoffTimeStrategy(
@@ -219,7 +219,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
         try (SlotPool slotPool = createSlotPoolImpl()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                    SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(
                                             slotPool, new LocalTaskManagerLocation(), 2))
@@ -276,7 +276,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
     public void testFailExecutionAfterCancel() throws Exception {
         try (SlotPool slotPool = createSlotPoolImpl()) {
             SchedulerBase scheduler =
-                    SchedulerTestingUtils.newSchedulerBuilder(createJobGraphToCancel())
+                    SchedulerTestingUtils.newSchedulerBuilder(
+                                    createJobGraphToCancel(), mainThreadExecutor)
                             .setExecutionSlotAllocatorFactory(
                                     createExecutionSlotAllocatorFactory(
                                             slotPool, new LocalTaskManagerLocation(), 2))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -311,7 +311,6 @@ public class ExecutionGraphRestartTest extends TestLogger {
     // ------------------------------------------------------------------------
 
     private static void startScheduling(SchedulerBase scheduler) throws Exception {
-        scheduler.initialize(mainThreadExecutor);
         assertThat(scheduler.getExecutionGraph().getState(), is(JobStatus.CREATED));
         scheduler.startScheduling();
         assertThat(scheduler.getExecutionGraph().getState(), is(JobStatus.RUNNING));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -228,7 +228,9 @@ public class ExecutionGraphSuspendTest extends TestLogger {
         final ManuallyTriggeredScheduledExecutor taskRestartExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph())
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setRestartBackoffTimeStrategy(
                                 new TestRestartBackoffTimeStrategy(true, Long.MAX_VALUE))
                         .setDelayExecutor(taskRestartExecutor)
@@ -311,7 +313,9 @@ public class ExecutionGraphSuspendTest extends TestLogger {
         vertex.setParallelism(parallelism);
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(vertex))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(vertex),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -236,7 +236,6 @@ public class ExecutionGraphSuspendTest extends TestLogger {
                         .setDelayExecutor(taskRestartExecutor)
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
@@ -322,7 +321,6 @@ public class ExecutionGraphSuspendTest extends TestLogger {
                                                 .createWithLimitedAmountOfPhysicalSlots(
                                                         parallelism, gateway)))
                         .build();
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         return scheduler;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -412,8 +412,6 @@ public class ExecutionGraphTestUtils {
                         .setFutureExecutor(executor)
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         return scheduler.getExecutionJobVertex(jobVertex.getID());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -406,7 +406,8 @@ public class ExecutionGraphTestUtils {
         jobGraph.setScheduleMode(scheduleMode);
 
         SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setIoExecutor(executor)
                         .setFutureExecutor(executor)
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
@@ -43,7 +43,10 @@ public class ExecutionGraphVariousFailuesTest extends TestLogger {
     @Test
     public void testFailingNotifyPartitionDataAvailable() throws Exception {
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph()).build();
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
+                        .build();
         scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphVariousFailuesTest.java
@@ -47,7 +47,6 @@ public class ExecutionGraphVariousFailuesTest extends TestLogger {
                                 new JobGraph(),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .build();
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -276,7 +276,8 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
         final JobGraph jobGraph =
                 new JobGraph(new JobID(), "test job", producerVertex, consumerVertex);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -287,8 +287,6 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 
         final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         final ExecutionJobVertex executionJobVertex =
                 executionGraph.getJobVertex(producerVertex.getID());
         final ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -80,7 +80,9 @@ public class ExecutionTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(jobVertex))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(jobVertex),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -123,7 +125,9 @@ public class ExecutionTest extends TestLogger {
         final JobVertexID jobVertexId = jobVertex.getID();
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(jobVertex))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(jobVertex),
+                                ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider
@@ -167,7 +171,8 @@ public class ExecutionTest extends TestLogger {
                                                 .withTaskManagerGateway(taskManagerGateway)
                                                 .build()));
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(jobVertex))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(jobVertex), testMainThreadUtil.getMainThreadExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -206,7 +211,8 @@ public class ExecutionTest extends TestLogger {
         final TestingPhysicalSlotProvider physicalSlotProvider =
                 TestingPhysicalSlotProvider.createWithLimitedAmountOfPhysicalSlots(1);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(new JobGraph(jobVertex))
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                new JobGraph(jobVertex), testMainThreadUtil.getMainThreadExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -88,8 +88,6 @@ public class ExecutionTest extends TestLogger {
                                         physicalSlotProvider))
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         ExecutionJobVertex executionJobVertex = scheduler.getExecutionJobVertex(jobVertexId);
 
         ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
@@ -134,8 +132,6 @@ public class ExecutionTest extends TestLogger {
                                                 .createWithLimitedAmountOfPhysicalSlots(1)))
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
         ExecutionJobVertex executionJobVertex = scheduler.getExecutionJobVertex(jobVertexId);
 
         ExecutionVertex executionVertex = executionJobVertex.getTaskVertices()[0];
@@ -177,8 +173,6 @@ public class ExecutionTest extends TestLogger {
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
                         .build();
-
-        scheduler.initialize(testMainThreadUtil.getMainThreadExecutor());
 
         ExecutionJobVertex executionJobVertex = scheduler.getExecutionJobVertex(jobVertexId);
 
@@ -224,7 +218,6 @@ public class ExecutionTest extends TestLogger {
                         .getTaskVertices()[0]
                         .getCurrentExecutionAttempt();
 
-        scheduler.initialize(testMainThreadUtil.getMainThreadExecutor());
         testMainThreadUtil.execute(scheduler::startScheduling);
 
         // wait until the slot has been requested

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -241,7 +241,9 @@ public class ExecutionVertexCancelTest extends TestLogger {
     @Test
     public void testSendCancelAndReceiveFail() throws Exception {
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.createScheduler(new JobGraph(createNoOpVertex(10)));
+                SchedulerTestingUtils.createScheduler(
+                        new JobGraph(createNoOpVertex(10)),
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
         scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -246,7 +246,6 @@ public class ExecutionVertexCancelTest extends TestLogger {
                         ComponentMainThreadExecutorServiceAdapter.forMainThread());
         final ExecutionGraph graph = scheduler.getExecutionGraph();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         ExecutionGraphTestUtils.switchAllVerticesToRunning(graph);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -59,7 +59,8 @@ public class ExecutionVertexTest extends TestLogger {
 
         final JobGraph jobGraph = new JobGraph(producerJobVertex, consumerJobVertex);
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setPartitionTracker(partitionTracker)
                         .build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexTest.java
@@ -64,7 +64,6 @@ public class ExecutionVertexTest extends TestLogger {
                         .setPartitionTracker(partitionTracker)
                         .build();
 
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         final ExecutionJobVertex producerExecutionJobVertex =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -55,7 +55,6 @@ public class FinalizeOnMasterTest extends TestLogger {
                 createScheduler(
                         new JobGraph("Test Job", vertex1, vertex2),
                         ComponentMainThreadExecutorServiceAdapter.forMainThread());
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();
@@ -84,7 +83,6 @@ public class FinalizeOnMasterTest extends TestLogger {
                 createScheduler(
                         new JobGraph("Test Job", vertex),
                         ComponentMainThreadExecutorServiceAdapter.forMainThread());
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
         final ExecutionGraph eg = scheduler.getExecutionGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -51,7 +51,10 @@ public class FinalizeOnMasterTest extends TestLogger {
         vertex2.setInvokableClass(NoOpInvokable.class);
         vertex2.setParallelism(2);
 
-        final SchedulerBase scheduler = createScheduler(new JobGraph("Test Job", vertex1, vertex2));
+        final SchedulerBase scheduler =
+                createScheduler(
+                        new JobGraph("Test Job", vertex1, vertex2),
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 
@@ -77,7 +80,10 @@ public class FinalizeOnMasterTest extends TestLogger {
         vertex.setInvokableClass(NoOpInvokable.class);
         vertex.setParallelism(1);
 
-        final SchedulerBase scheduler = createScheduler(new JobGraph("Test Job", vertex));
+        final SchedulerBase scheduler =
+                createScheduler(
+                        new JobGraph("Test Job", vertex),
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
         scheduler.startScheduling();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -128,7 +128,6 @@ public class UpdatePartitionConsumersTest extends TestLogger {
                         .setExecutionSlotAllocatorFactory(
                                 new TestExecutionSlotAllocatorFactory(taskManagerGateway))
                         .build();
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
         final ExecutionVertex ev1 =
                 scheduler.getExecutionVertex(new ExecutionVertexID(v1.getID(), 0));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -123,7 +123,8 @@ public class UpdatePartitionConsumersTest extends TestLogger {
                 new SimpleAckingTaskManagerGateway();
 
         final SchedulerBase scheduler =
-                SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+                SchedulerTestingUtils.newSchedulerBuilder(
+                                jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread())
                         .setExecutionSlotAllocatorFactory(
                                 new TestExecutionSlotAllocatorFactory(taskManagerGateway))
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
@@ -101,7 +102,8 @@ public class JobMasterSchedulerTest extends TestLogger {
                 JobMasterPartitionTracker partitionTracker,
                 ExecutionDeploymentTracker executionDeploymentTracker,
                 long initializationTimestamp,
-                ComponentMainThreadExecutor mainThreadExecutor) {
+                ComponentMainThreadExecutor mainThreadExecutor,
+                JobStatusListener jobStatusListener) {
             return TestingSchedulerNG.newBuilder()
                     .setStartSchedulingRunnable(
                             () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
@@ -99,7 +100,8 @@ public class JobMasterSchedulerTest extends TestLogger {
                 ShuffleMaster<?> shuffleMaster,
                 JobMasterPartitionTracker partitionTracker,
                 ExecutionDeploymentTracker executionDeploymentTracker,
-                long initializationTimestamp) {
+                long initializationTimestamp,
+                ComponentMainThreadExecutor mainThreadExecutor) {
             return TestingSchedulerNG.newBuilder()
                     .setStartSchedulingRunnable(
                             () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -126,7 +126,7 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
             final GloballyTerminalJobStatusListener jobStatusListener =
                     new GloballyTerminalJobStatusListener();
             scheduler.registerJobStatusListener(jobStatusListener);
-            startScheduling(scheduler, mainThreadExecutor);
+            CompletableFuture.runAsync(scheduler::startScheduling, mainThreadExecutor).join();
 
             // wait until the batch slot timeout has been reached
             Thread.sleep(batchSlotTimeout.toMilliseconds());
@@ -171,12 +171,6 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
                         },
                         mainThreadExecutor)
                 .join();
-    }
-
-    private void startScheduling(
-            SchedulerNG scheduler, ComponentMainThreadExecutor mainThreadExecutor) {
-        scheduler.initialize(mainThreadExecutor);
-        CompletableFuture.runAsync(scheduler::startScheduling, mainThreadExecutor).join();
     }
 
     private SlotPoolImpl createSlotPool(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -120,7 +120,8 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
             final PhysicalSlotProvider slotProvider =
                     new PhysicalSlotProviderImpl(
                             LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
-            final SchedulerNG scheduler = createScheduler(jobGraph, slotProvider, batchSlotTimeout);
+            final SchedulerNG scheduler =
+                    createScheduler(jobGraph, mainThreadExecutor, slotProvider, batchSlotTimeout);
 
             final GloballyTerminalJobStatusListener jobStatusListener =
                     new GloballyTerminalJobStatusListener();
@@ -212,9 +213,12 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
     }
 
     private SchedulerNG createScheduler(
-            JobGraph jobGraph, PhysicalSlotProvider physicalSlotProvider, Time slotRequestTimeout)
+            JobGraph jobGraph,
+            ComponentMainThreadExecutor mainThreadExecutor,
+            PhysicalSlotProvider physicalSlotProvider,
+            Time slotRequestTimeout)
             throws Exception {
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
                 .setExecutionSlotAllocatorFactory(
                         SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                 physicalSlotProvider, slotRequestTimeout))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -120,12 +120,16 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
             final PhysicalSlotProvider slotProvider =
                     new PhysicalSlotProviderImpl(
                             LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
-            final SchedulerNG scheduler =
-                    createScheduler(jobGraph, mainThreadExecutor, slotProvider, batchSlotTimeout);
-
             final GloballyTerminalJobStatusListener jobStatusListener =
                     new GloballyTerminalJobStatusListener();
-            scheduler.registerJobStatusListener(jobStatusListener);
+            final SchedulerNG scheduler =
+                    createScheduler(
+                            jobGraph,
+                            mainThreadExecutor,
+                            slotProvider,
+                            batchSlotTimeout,
+                            jobStatusListener);
+
             CompletableFuture.runAsync(scheduler::startScheduling, mainThreadExecutor).join();
 
             // wait until the batch slot timeout has been reached
@@ -210,12 +214,14 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
             JobGraph jobGraph,
             ComponentMainThreadExecutor mainThreadExecutor,
             PhysicalSlotProvider physicalSlotProvider,
-            Time slotRequestTimeout)
+            Time slotRequestTimeout,
+            JobStatusListener jobStatusListener)
             throws Exception {
         return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
                 .setExecutionSlotAllocatorFactory(
                         SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                 physicalSlotProvider, slotRequestTimeout))
+                .setJobStatusListener(jobStatusListener)
                 .build();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -182,7 +182,7 @@ public class DefaultSchedulerTest extends TestLogger {
                         schedulingStrategyFactory);
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
-        startScheduling(scheduler);
+        scheduler.startScheduling();
 
         final List<ExecutionVertexID> verticesToSchedule =
                 Arrays.asList(
@@ -374,7 +374,7 @@ public class DefaultSchedulerTest extends TestLogger {
                         new RestartPipelinedRegionFailoverStrategy.Factory());
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
-        startScheduling(scheduler);
+        scheduler.startScheduling();
 
         final ExecutionVertexID vid11 = new ExecutionVertexID(v1.getID(), 0);
         final ExecutionVertexID vid12 = new ExecutionVertexID(v1.getID(), 1);
@@ -470,7 +470,7 @@ public class DefaultSchedulerTest extends TestLogger {
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
         final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
 
-        startScheduling(scheduler);
+        scheduler.startScheduling();
 
         final SchedulingExecutionVertex onlySchedulingVertex =
                 Iterables.getOnlyElement(topology.getVertices());
@@ -504,7 +504,7 @@ public class DefaultSchedulerTest extends TestLogger {
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
         final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
 
-        startScheduling(scheduler);
+        scheduler.startScheduling();
 
         final ExecutionVertexID onlySchedulingVertexId =
                 Iterables.getOnlyElement(topology.getVertices()).getId();
@@ -892,7 +892,7 @@ public class DefaultSchedulerTest extends TestLogger {
                         ComponentMainThreadExecutorServiceAdapter.forMainThread(),
                         new PipelinedRegionSchedulingStrategy.Factory(),
                         new RestartAllFailoverStrategy.Factory());
-        startScheduling(scheduler);
+        scheduler.startScheduling();
 
         Iterator<ArchivedExecutionVertex> vertexIterator =
                 scheduler.requestJob().getAllExecutionVertices().iterator();
@@ -973,7 +973,7 @@ public class DefaultSchedulerTest extends TestLogger {
                             jobGraph,
                             ComponentMainThreadExecutorServiceAdapter.forMainThread(),
                             schedulingStrategyFactory);
-            startScheduling(scheduler);
+            scheduler.startScheduling();
             return scheduler;
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -1011,11 +1011,6 @@ public class DefaultSchedulerTest extends TestLogger {
                 .setExecutionVertexVersioner(executionVertexVersioner)
                 .setExecutionSlotAllocatorFactory(executionSlotAllocatorFactory)
                 .build();
-    }
-
-    private void startScheduling(final SchedulerNG scheduler) {
-        scheduler.initialize(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-        scheduler.startScheduling();
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.hooks.TestMasterHook;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -174,7 +175,11 @@ public class DefaultSchedulerTest extends TestLogger {
         testExecutionSlotAllocator.disableAutoCompletePendingRequests();
         final TestSchedulingStrategy.Factory schedulingStrategyFactory =
                 new TestSchedulingStrategy.Factory();
-        final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
+        final DefaultScheduler scheduler =
+                createScheduler(
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        schedulingStrategyFactory);
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
         startScheduling(scheduler);
@@ -211,7 +216,10 @@ public class DefaultSchedulerTest extends TestLogger {
 
         final TestSchedulingStrategy.Factory schedulingStrategyFactory =
                 new TestSchedulingStrategy.Factory();
-        createScheduler(jobGraph, schedulingStrategyFactory);
+        createScheduler(
+                jobGraph,
+                ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                schedulingStrategyFactory);
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
 
@@ -361,6 +369,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final DefaultScheduler scheduler =
                 createScheduler(
                         jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
                         schedulingStrategyFactory,
                         new RestartPipelinedRegionFailoverStrategy.Factory());
         final TestSchedulingStrategy schedulingStrategy =
@@ -452,7 +461,11 @@ public class DefaultSchedulerTest extends TestLogger {
 
         final TestSchedulingStrategy.Factory schedulingStrategyFactory =
                 new TestSchedulingStrategy.Factory();
-        final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
+        final DefaultScheduler scheduler =
+                createScheduler(
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        schedulingStrategyFactory);
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
         final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
@@ -482,7 +495,11 @@ public class DefaultSchedulerTest extends TestLogger {
 
         final TestSchedulingStrategy.Factory schedulingStrategyFactory =
                 new TestSchedulingStrategy.Factory();
-        final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
+        final DefaultScheduler scheduler =
+                createScheduler(
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        schedulingStrategyFactory);
         final TestSchedulingStrategy schedulingStrategy =
                 schedulingStrategyFactory.getLastCreatedSchedulingStrategy();
         final SchedulingTopology topology = schedulingStrategy.getSchedulingTopology();
@@ -872,6 +889,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final DefaultScheduler scheduler =
                 createScheduler(
                         jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
                         new PipelinedRegionSchedulingStrategy.Factory(),
                         new RestartAllFailoverStrategy.Factory());
         startScheduling(scheduler);
@@ -950,7 +968,11 @@ public class DefaultSchedulerTest extends TestLogger {
                 new PipelinedRegionSchedulingStrategy.Factory();
 
         try {
-            final DefaultScheduler scheduler = createScheduler(jobGraph, schedulingStrategyFactory);
+            final DefaultScheduler scheduler =
+                    createScheduler(
+                            jobGraph,
+                            ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                            schedulingStrategyFactory);
             startScheduling(scheduler);
             return scheduler;
         } catch (Exception e) {
@@ -959,20 +981,24 @@ public class DefaultSchedulerTest extends TestLogger {
     }
 
     private DefaultScheduler createScheduler(
-            final JobGraph jobGraph, final SchedulingStrategyFactory schedulingStrategyFactory)
+            final JobGraph jobGraph,
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final SchedulingStrategyFactory schedulingStrategyFactory)
             throws Exception {
         return createScheduler(
                 jobGraph,
+                mainThreadExecutor,
                 schedulingStrategyFactory,
                 new RestartPipelinedRegionFailoverStrategy.Factory());
     }
 
     private DefaultScheduler createScheduler(
             final JobGraph jobGraph,
+            final ComponentMainThreadExecutor mainThreadExecutor,
             final SchedulingStrategyFactory schedulingStrategyFactory,
             final FailoverStrategy.Factory failoverStrategyFactory)
             throws Exception {
-        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph)
+        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
                 .setLogger(log)
                 .setIoExecutor(executor)
                 .setJobMasterConfiguration(configuration)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.NoRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
@@ -410,6 +411,8 @@ public class SchedulerTestingUtils {
         private ExecutionVertexVersioner executionVertexVersioner = new ExecutionVertexVersioner();
         private ExecutionSlotAllocatorFactory executionSlotAllocatorFactory =
                 new TestExecutionSlotAllocatorFactory();
+        private JobStatusListener jobStatusListener =
+                (ignoredA, ignoredB, ignoredC, ignoredD) -> {};
 
         public DefaultSchedulerBuilder(
                 final JobGraph jobGraph, ComponentMainThreadExecutor mainThreadExecutor) {
@@ -518,6 +521,11 @@ public class SchedulerTestingUtils {
             return this;
         }
 
+        public DefaultSchedulerBuilder setJobStatusListener(JobStatusListener jobStatusListener) {
+            this.jobStatusListener = jobStatusListener;
+            return this;
+        }
+
         public DefaultScheduler build() throws Exception {
             return new DefaultScheduler(
                     log,
@@ -542,7 +550,8 @@ public class SchedulerTestingUtils {
                     executionSlotAllocatorFactory,
                     new DefaultExecutionDeploymentTracker(),
                     System.currentTimeMillis(),
-                    mainThreadExecutor);
+                    mainThreadExecutor,
+                    jobStatusListener);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -68,9 +67,6 @@ public class TestingSchedulerNG implements SchedulerNG {
         this.suspendConsumer = suspendConsumer;
         this.triggerSavepointFunction = triggerSavepointFunction;
     }
-
-    @Override
-    public void registerJobStatusListener(JobStatusListener jobStatusListener) {}
 
     @Override
     public void startScheduling() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -24,7 +24,6 @@ import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -69,9 +68,6 @@ public class TestingSchedulerNG implements SchedulerNG {
         this.suspendConsumer = suspendConsumer;
         this.triggerSavepointFunction = triggerSavepointFunction;
     }
-
-    @Override
-    public void initialize(ComponentMainThreadExecutor mainThreadExecutor) {}
 
     @Override
     public void registerJobStatusListener(JobStatusListener jobStatusListener) {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
@@ -64,7 +65,8 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
             long initializationTimestamp,
-            ComponentMainThreadExecutor mainThreadExecutor)
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobStatusListener jobStatusListener)
             throws Exception {
         return schedulerNG;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
@@ -62,7 +63,8 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             ShuffleMaster<?> shuffleMaster,
             JobMasterPartitionTracker partitionTracker,
             ExecutionDeploymentTracker executionDeploymentTracker,
-            long initializationTimestamp)
+            long initializationTimestamp,
+            ComponentMainThreadExecutor mainThreadExecutor)
             throws Exception {
         return schedulerNG;
     }


### PR DESCRIPTION
This PR removes unnecessary methods from `SchedulerNG`.

cf0146c [FLINK-20903] Pass ComponentMainThreadExecutor to constructor of SchedulerBase

This commit passes the ComponentMainThreadExecutor into the SchedulerBase instance via its constructor.

c7b0a19 [FLINK-20903] Remove SchedulerNG.initialize() 

Since we can pass a ComponentMainThreadExecutor into the SchedulerNG, we no longer need SchedulerNG.initialize().

c1c19df [FLINK-20903] Pass JobStatusListener to SchedulerBase

f6ada81 [FLINK-20903] Remove SchedulerNG.registerJobStatusListener

Since we can pass in the JobStatusListener into the SchedulerNG implementations, we no longer need the SchedulerNG.registerJobStatusListener and can remove it.