### PR TITLE
[FLINK-20551][docs] Make SQL documentation Blink only

### DIFF
--- a/docs/_includes/warning.html
+++ b/docs/_includes/warning.html
@@ -1,0 +1,23 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<div class="alert alert-warning">
+	<i class="fa fa-exclamation-circle"></i> <strong>Warning:</strong>
+	{{ include.content }}
+</div>

--- a/docs/dev/python/table_api_tutorial.md
+++ b/docs/dev/python/table_api_tutorial.md
@@ -71,7 +71,7 @@ t_config = TableConfig()
 t_env = BatchTableEnvironment.create(exec_env, t_config)
 {% endhighlight %}
 
-The the table environment created, you can declare source and sink tables.
+The table environment created, you can declare source and sink tables.
 
 {% highlight python %}
 t_env.connect(FileSystem().path('/tmp/input')) \

--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -22,33 +22,23 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The Table API and SQL are integrated in a joint API. The central concept of this API is a `Table` which serves as input and output of queries. This document shows the common structure of programs with Table API and SQL queries, how to register a `Table`, how to query a `Table`, and how to emit a `Table`.
+The Table API and SQL are integrated in a joint API.
+The central concept of this API is a `Table` which serves as input and output of queries.
+This document shows the common structure of programs with Table API and SQL queries, how to register a `Table`, how to query a `Table`, and how to emit a `Table`.
 
 * This will be replaced by the TOC
 {:toc}
 
-Main Differences Between the Two Planners
------------------------------------------
-
-1. Blink treats batch jobs as a special case of streaming. As such, the conversion between Table and DataSet is also not supported, and batch jobs will not be translated into `DateSet` programs but translated into `DataStream` programs, the same as the streaming jobs.
-2. The Blink planner does not support `BatchTableSource`, use bounded `StreamTableSource` instead of it.
-3. The implementations of `FilterableTableSource` for the old planner and the Blink planner are incompatible. The old planner will push down `PlannerExpression`s into `FilterableTableSource`, while the Blink planner will push down `Expression`s.
-4. String based key-value config options (Please see the documentation about [Configuration]({% link dev/table/config.md %}) for details) are only used for the Blink planner.
-5. The implementation(`CalciteConfig`) of `PlannerConfig` in two planners is different.
-6. The Blink planner will optimize multiple-sinks into one DAG on both `TableEnvironment` and `StreamTableEnvironment`. The old planner will always optimize each sink into a new DAG, where all DAGs are independent of each other.
-7. The old planner does not support catalog statistics now, while the Blink planner does.
-
-
 Structure of Table API and SQL Programs
 ---------------------------------------
 
-All Table API and SQL programs for batch and streaming follow the same pattern. The following code example shows the common structure of Table API and SQL programs.
+The following code example shows the common structure of Table API and SQL programs.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-// create a TableEnvironment for specific planner batch or streaming
+// create a TableEnvironment for batch or streaming execution
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 // create a Table
@@ -71,7 +61,7 @@ tableResult...
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-// create a TableEnvironment for specific planner batch or streaming
+// create a TableEnvironment for batch or streaming execution
 val tableEnv = ... // see "Create a TableEnvironment" section
 
 // create a Table
@@ -94,7 +84,7 @@ tableResult...
 <div data-lang="python" markdown="1">
 {% highlight python %}
 
-# create a TableEnvironment for specific planner batch or streaming
+# create a TableEnvironment for batch or streaming execution
 table_env = ... # see "Create a TableEnvironment" section
 
 # register a Table
@@ -116,152 +106,62 @@ table_result...
 </div>
 </div>
 
-**Note:** Table API and SQL queries can be easily integrated with and embedded into DataStream or DataSet programs. Have a look at the [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api) section to learn how DataStreams and DataSets can be converted into Tables and vice versa.
+**Note:** Table API and SQL queries can be easily integrated with and embedded into DataStream programs.
+Have a look at the [Integration with DataStream](#integration-with-datastream) section to learn how DataStreams can be converted into Tables and vice versa.
 
 {% top %}
 
 Create a TableEnvironment
 -------------------------
 
-The `TableEnvironment` is a central concept of the Table API and SQL integration. It is responsible for:
+The `TableEnvironment` is the entrypoint for Table API and SQL integration and is responsible for:
 
 * Registering a `Table` in the internal catalog
 * Registering catalogs
 * Loading pluggable modules
 * Executing SQL queries
 * Registering a user-defined (scalar, table, or aggregation) function
-* Converting a `DataStream` or `DataSet` into a `Table`
-* Holding a reference to an `ExecutionEnvironment` or `StreamExecutionEnvironment`
+* Converting a `DataStream` into a `Table`
+* Holding a reference to a `StreamExecutionEnvironment`
 
-A `Table` is always bound to a specific `TableEnvironment`. It is not possible to combine tables of different TableEnvironments in the same query, e.g., to join or union them.
-
-A `TableEnvironment` is created by calling the static `BatchTableEnvironment.create()` or `StreamTableEnvironment.create()` method with a `StreamExecutionEnvironment` or an `ExecutionEnvironment` and an optional `TableConfig`. The `TableConfig` can be used to configure the `TableEnvironment` or to customize the query optimization and translation process (see [Query Optimization](#query-optimization)).
-
-Make sure to choose the specific planner `BatchTableEnvironment`/`StreamTableEnvironment` that matches your programming language.
-
-If both planner jars are on the classpath (the default behavior), you should explicitly set which planner to use in the current program.
+A `Table` is always bound to a specific `TableEnvironment`.
+It is not possible to combine tables of different TableEnvironments in the same query, e.g., to join or union them.
+A `TableEnvironment` is created by calling the static `TableEnvironment.create()` method.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-
-// **********************
-// FLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-
-EnvironmentSettings fsSettings = EnvironmentSettings.newInstance().useOldPlanner().inStreamingMode().build();
-StreamExecutionEnvironment fsEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment fsTableEnv = StreamTableEnvironment.create(fsEnv, fsSettings);
-// or TableEnvironment fsTableEnv = TableEnvironment.create(fsSettings);
-
-// ******************
-// FLINK BATCH QUERY
-// ******************
-import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.table.api.bridge.java.BatchTableEnvironment;
-
-ExecutionEnvironment fbEnv = ExecutionEnvironment.getExecutionEnvironment();
-BatchTableEnvironment fbTableEnv = BatchTableEnvironment.create(fbEnv);
-
-// **********************
-// BLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-
-StreamExecutionEnvironment bsEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-StreamTableEnvironment bsTableEnv = StreamTableEnvironment.create(bsEnv, bsSettings);
-// or TableEnvironment bsTableEnv = TableEnvironment.create(bsSettings);
-
-// ******************
-// BLINK BATCH QUERY
-// ******************
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
-EnvironmentSettings bbSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-TableEnvironment bbTableEnv = TableEnvironment.create(bbSettings);
+EnvironmentSettings settings = EnvironmentSettings
+    .newInstance()
+    .inStreamingMode()
+    //.inBatchMode()
+    .build();
 
+TableEnvironment tEnv = TableEnvironment.create(setting);
 {% endhighlight %}
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-
-// **********************
-// FLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.EnvironmentSettings
-import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
-
-val fsSettings = EnvironmentSettings.newInstance().useOldPlanner().inStreamingMode().build()
-val fsEnv = StreamExecutionEnvironment.getExecutionEnvironment
-val fsTableEnv = StreamTableEnvironment.create(fsEnv, fsSettings)
-// or val fsTableEnv = TableEnvironment.create(fsSettings)
-
-// ******************
-// FLINK BATCH QUERY
-// ******************
-import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.flink.table.api.bridge.scala.BatchTableEnvironment
-
-val fbEnv = ExecutionEnvironment.getExecutionEnvironment
-val fbTableEnv = BatchTableEnvironment.create(fbEnv)
-
-// **********************
-// BLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.EnvironmentSettings
-import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
-
-val bsEnv = StreamExecutionEnvironment.getExecutionEnvironment
-val bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
-val bsTableEnv = StreamTableEnvironment.create(bsEnv, bsSettings)
-// or val bsTableEnv = TableEnvironment.create(bsSettings)
-
-// ******************
-// BLINK BATCH QUERY
-// ******************
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
 
-val bbSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
-val bbTableEnv = TableEnvironment.create(bbSettings)
+val settings = EnvironmentSettings
+    .newInstance()
+    .inStreamingMode()
+    //.inBatchMode()
+    .build()
 
+val tEnv = TableEnvironment.create(setting)
 {% endhighlight %}
 </div>
-
 <div data-lang="python" markdown="1">
 {% highlight python %}
+# ***************
+# Streaming QUERY
+# ***************
 
-# **********************
-# FLINK STREAMING QUERY
-# **********************
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment, EnvironmentSettings
-
-f_s_env = StreamExecutionEnvironment.get_execution_environment()
-f_s_settings = EnvironmentSettings.new_instance().use_old_planner().in_streaming_mode().build()
-f_s_t_env = StreamTableEnvironment.create(f_s_env, environment_settings=f_s_settings)
-
-# ******************
-# FLINK BATCH QUERY
-# ******************
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.table import BatchTableEnvironment
-
-f_b_env = ExecutionEnvironment.get_execution_environment()
-f_b_t_env = BatchTableEnvironment.create(f_b_env, table_config)
-
-# **********************
-# BLINK STREAMING QUERY
-# **********************
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import StreamTableEnvironment, EnvironmentSettings
 
@@ -269,19 +169,55 @@ b_s_env = StreamExecutionEnvironment.get_execution_environment()
 b_s_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
 b_s_t_env = StreamTableEnvironment.create(b_s_env, environment_settings=b_s_settings)
 
-# ******************
-# BLINK BATCH QUERY
-# ******************
+# ***********
+# BATCH QUERY
+# ***********
+
 from pyflink.table import EnvironmentSettings, BatchTableEnvironment
 
 b_b_settings = EnvironmentSettings.new_instance().use_blink_planner().in_batch_mode().build()
 b_b_t_env = BatchTableEnvironment.create(environment_settings=b_b_settings)
-
 {% endhighlight %}
 </div>
 </div>
 
-**Note:** If there is only one planner jar in `/lib` directory, you can use `useAnyPlanner` (`use_any_planner` for python) to create specific `EnvironmentSettings`.
+Alternatively, users can create a `StreamTableEnvironment` from an existing `StreamExecutionEnvironment`
+to interoperate with the `DataStream` API.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+
+val env = StreamExecutionEnvironment.getExecutionEnvironment
+val tEnv = StreamTableEnvironment.create(env)
+{% endhighlight %}
+</div>
+
+<div data-lang="python" markdown="1">
+{% highlight python %}
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment, EnvironmentSettings
+
+b_s_env = StreamExecutionEnvironment.get_execution_environment()
+b_s_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
+b_s_t_env = StreamTableEnvironment.create(b_s_env, environment_settings=b_s_settings)
+{% endhighlight %}
+</div>
+</div>
 
 {% top %}
 
@@ -817,11 +753,8 @@ Translate and Execute a Query
 -----------------------------
 
 The behavior of translating and executing a query is different for the two planners.
-
-<div class="codetabs" markdown="1">
-
-<div data-lang="Blink planner" markdown="1">
-Table API and SQL queries are translated into [DataStream]({% link dev/datastream_api.md %}) programs whether their input is streaming or batch. A query is internally represented as a logical query plan and is translated in two phases:
+Table API and SQL queries are translated into [DataStream]({% link dev/datastream_api.md %}) programs whether their input is streaming or batch.
+A query is internally represented as a logical query plan and is translated in two phases:
 
 1. Optimization of the logical plan,
 2. Translation into a DataStream program.
@@ -832,59 +765,35 @@ a Table API or SQL query is translated when:
 * `Table.executeInsert()` is called. This method is used for inserting the table content to the given sink path, and the Table API is translated immediately once this method is called.
 * `Table.execute()` is called. This method is used for collecting the table content to local client, and the Table API is translated immediately once this method is called.
 * `StatementSet.execute()` is called. A `Table` (emitted to a sink through `StatementSet.addInsert()`) or an INSERT statement (specified through `StatementSet.addInsertSql()`) will be buffered in `StatementSet` first. They are translated once `StatementSet.execute()` is called. All sinks will be optimized into one DAG.
-* A `Table` is translated when it is converted into a `DataStream` (see [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api)). Once translated, it's a regular DataStream program and is executed when `StreamExecutionEnvironment.execute()` is called.
+* A `Table` is translated when it is converted into a `DataStream` (see [Integration with DataStream](#integration-with-datastream)). Once translated, it's a regular DataStream program and is executed when `StreamExecutionEnvironment.execute()` is called.
 
 <span class="label label-danger">Attention</span> **Since 1.11 version, `sqlUpdate()` method and `insertInto()` method are deprecated. If the Table program is built from these two methods, we must use `StreamTableEnvironment.execute()` method instead of `StreamExecutionEnvironment.execute()` method to execute it.**
 
-</div>
-
-<div data-lang="Old planner" markdown="1">
-Table API and SQL queries are translated into [DataStream]({% link dev/datastream_api.md %}) or [DataSet]({% link dev/batch/index.md %}) programs depending on whether their input is a streaming or batch input. A query is internally represented as a logical query plan and is translated in two phases:
-
-1. Optimization of the logical plan
-2. Translation into a DataStream or DataSet program
-
-A Table API or SQL query is translated when:
-
-* `TableEnvironment.executeSql()` is called. This method is used for executing a given statement, and the sql query is translated immediately once this method is called.
-* `Table.executeInsert()` is called. This method is used for inserting the table content to the given sink path, and the Table API is translated immediately once this method is called.
-* `Table.execute()` is called. This method is used for collecting the table content to local client, and the Table API is translated immediately once this method is called.
-* `StatementSet.execute()` is called. A `Table` (emitted to a sink through `StatementSet.addInsert()`) or an INSERT statement (specified through `StatementSet.addInsertSql()`) will be buffered in `StatementSet` first. They are translated once `StatementSet.execute()` is called. Each sink will be optimized independently. The execution graph contains multiple independent sub-DAGs.
-* For streaming, a `Table` is translated when it is converted into a `DataStream` (see [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api)). Once translated, it's a regular DataStream program and is executed when `StreamExecutionEnvironment.execute()` is called. For batch, a `Table` is translated when it is converted into a `DataSet` (see [Integration with DataStream and DataSet API](#integration-with-datastream-and-dataset-api)). Once translated, it's a regular DataSet program and is executed when `ExecutionEnvironment.execute()` is called.
-
-<span class="label label-danger">Attention</span> **Since 1.11 version, `sqlUpdate()` method and `insertInto()` method are deprecated. For streaming, if the Table program is built from these two methods, we must use `StreamTableEnvironment.execute()` method instead of `StreamExecutionEnvironment.execute()` method to execute it. For batch, if the Table program is built from these two methods, we must use `BatchTableEnvironment.execute()` method instead of `ExecutionEnvironment.execute()` method to execute it.**
-
-</div>
-
-</div>
-
 {% top %}
 
-Integration with DataStream and DataSet API
--------------------------------------------
+Integration with DataStream 
+---------------------------
 
-Both planners on stream can integrate with the `DataStream` API. Only old planner can integrate with the `DataSet API`, Blink planner on batch could not be combined with both.
-**Note:** The `DataSet` API discussed below is only relevant for the old planner on batch.
-
-Table API and SQL queries can be easily integrated with and embedded into [DataStream]({% link dev/datastream_api.md %}) and [DataSet]({% link dev/batch/index.md %}) programs. For instance, it is possible to query an external table (for example from a RDBMS), do some pre-processing, such as filtering, projecting, aggregating, or joining with meta data, and then further process the data with either the DataStream or DataSet API (and any of the libraries built on top of these APIs, such as CEP or Gelly). Inversely, a Table API or SQL query can also be applied on the result of a DataStream or DataSet program.
-
-This interaction can be achieved by converting a `DataStream` or `DataSet` into a `Table` and vice versa. In this section, we describe how these conversions are done.
+Table API and SQL queries can be easily integrated with and embedded into [DataStream]({% link dev/datastream_api.md %}) programs.
+For instance, it is possible to query an external table (for example from a RDBMS), do some pre-processing, such as filtering, projecting, aggregating, or joining with metadata,
+and then further process the data with the DataStream API.
+Inversely, a Table API or SQL query can also be applied on the result of a DataStream program.
 
 ### Implicit Conversion for Scala
 
-The Scala Table API features implicit conversions for the `DataSet`, `DataStream`, and `Table` classes. These conversions are enabled by importing the package `org.apache.flink.table.api.bridge.scala._` in addition to `org.apache.flink.api.scala._` for the Scala DataStream API.
+The Scala Table API features implicit conversions for `DataStream` and `Table` classes.
+These conversions are enabled by importing the package `org.apache.flink.table.api.bridge.scala._` in addition to `org.apache.flink.api.scala._` for the Scala DataStream API.
 
-### Create a View from a DataStream or DataSet
+### Create a View from a DataStream
 
-A `DataStream` or `DataSet` can be registered in a `TableEnvironment` as a View. The schema of the resulting view depends on the data type of the registered `DataStream` or `DataSet`. Please check the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
+A `DataStream` can be registered in a `TableEnvironment` as a View and the schema is dependent only the `DataStream`s underlying data type.
+Please see the section about [mapping of data types to table schema](#mapping-of-data-types-to-table-schema) for details.
 
-**Note:** Views created from a `DataStream` or `DataSet` can be registered as temporary views only.
+**Note:** Views created from a `DataStream` can only be registered as temporary views.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get StreamTableEnvironment
-// registration of a DataSet in a BatchTableEnvironment is equivalent
 StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 DataStream<Tuple2<Long, String>> stream = ...
@@ -896,59 +805,42 @@ tableEnv.createTemporaryView("myTable", stream);
 tableEnv.createTemporaryView("myTable2", stream, $("myLong"), $("myString"));
 {% endhighlight %}
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-// get TableEnvironment 
-// registration of a DataSet is equivalent
-val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" section
+val tableEnv: StreamTableEnvironment = ???
 
 val stream: DataStream[(Long, String)] = ...
 
-// register the DataStream as View "myTable" with fields "f0", "f1"
+// Register the DataStream as View "myTable" with fields "f0", "f1"
 tableEnv.createTemporaryView("myTable", stream)
 
-// register the DataStream as View "myTable2" with fields "myLong", "myString"
-tableEnv.createTemporaryView("myTable2", stream, 'myLong, 'myString)
+// Register the DataStream as View "myTable2" with fields "myLong", "myString"
+tableEnv.createTemporaryView("myTable2", stream, $"myLong", $"myString");
 {% endhighlight %}
 </div>
 </div>
 
 {% top %}
 
-### Convert a DataStream or DataSet into a Table
+### Convert a DataStream into a Table
 
-Instead of registering a `DataStream` or `DataSet` in a `TableEnvironment`, it can also be directly converted into a `Table`. This is convenient if you want to use the Table in a Table API query. 
+A `DataStream` can be directly converted to a `Table` in a `StreamTableEnvironment`.
+The schema of the resulting view depends on the data type of the registered collection.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get StreamTableEnvironment
-// registration of a DataSet in a BatchTableEnvironment is equivalent
-StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
-
+StreamTableEnvironment tableEnv = ...; 
 DataStream<Tuple2<Long, String>> stream = ...
 
-// Convert the DataStream into a Table with default fields "f0", "f1"
-Table table1 = tableEnv.fromDataStream(stream);
-
-// Convert the DataStream into a Table with fields "myLong", "myString"
 Table table2 = tableEnv.fromDataStream(stream, $("myLong"), $("myString"));
 {% endhighlight %}
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-// get TableEnvironment
-// registration of a DataSet is equivalent
-val tableEnv = ... // see "Create a TableEnvironment" section
+val tableEnv: StreamTableEnvironment = ???
+val stream: DataStream[(Long, String)] = ???
 
-val stream: DataStream[(Long, String)] = ...
-
-// convert the DataStream into a Table with default fields "_1", "_2"
-val table1: Table = tableEnv.fromDataStream(stream)
-
-// convert the DataStream into a Table with fields "myLong", "myString"
 val table2: Table = tableEnv.fromDataStream(stream, $"myLong", $"myString")
 {% endhighlight %}
 </div>
@@ -956,11 +848,14 @@ val table2: Table = tableEnv.fromDataStream(stream, $"myLong", $"myString")
 
 {% top %}
 
-### Convert a Table into a DataStream or DataSet
+### Convert a Table into a DataStream 
 
-A `Table` can be converted into a `DataStream` or `DataSet`. In this way, custom DataStream or DataSet programs can be run on the result of a Table API or SQL query.
+A results of a `Table` can be converted into a `DataStream`.
+In this way, custom DataStream programs can be run on the result of a Table API or SQL query.
 
-When converting a `Table` into a `DataStream` or `DataSet`, you need to specify the data type of the resulting `DataStream` or `DataSet`, i.e., the data type into which the rows of the `Table` are to be converted. Often the most convenient conversion type is `Row`. The following list gives an overview of the features of the different options:
+When converting a `Table` into a `DataStream` you need to specify the data type of the resulting records, i.e., the data type into which the rows of the `Table` are to be converted.
+Often the most convenient conversion type is `Row`.
+The following list gives an overview of the features of the different options:
 
 - **Row**: fields are mapped by position, arbitrary number of fields, support for `null` values, no type-safe access.
 - **POJO**: fields are mapped by name (POJO fields must be named as `Table` fields), arbitrary number of fields, support for `null` values, type-safe access.
@@ -980,53 +875,54 @@ There are two modes to convert a `Table` into a `DataStream`:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get StreamTableEnvironment. 
-StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+StreamTableEnvironment tableEnv = ...; 
 
-// Table with two fields (String name, Integer age)
-Table table = ...
+Table table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
 
-// convert the Table into an append DataStream of Row by specifying the class
+// Convert the Table into an append DataStream of Row by specifying the class
 DataStream<Row> dsRow = tableEnv.toAppendStream(table, Row.class);
 
-// convert the Table into an append DataStream of Tuple2<String, Integer> 
-//   via a TypeInformation
-TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(
-  Types.STRING(),
-  Types.INT());
-DataStream<Tuple2<String, Integer>> dsTuple = 
-  tableEnv.toAppendStream(table, tupleType);
+// Convert the Table into an append DataStream of Tuple2<String, Integer> with TypeInformation
+TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(Types.STRING(), Types.INT());
+DataStream<Tuple2<String, Integer>> dsTuple = tableEnv.toAppendStream(table, tupleType);
 
-// convert the Table into a retract DataStream of Row.
-//   A retract stream of type X is a DataStream<Tuple2<Boolean, X>>. 
-//   The boolean field indicates the type of the change. 
-//   True is INSERT, false is DELETE.
-DataStream<Tuple2<Boolean, Row>> retractStream = 
-  tableEnv.toRetractStream(table, Row.class);
+// Convert the Table into a retract DataStream of Row.
+// A retract stream of type X is a DataStream<Tuple2<Boolean, X>>. 
+// The boolean field indicates the type of the change. 
+// True is INSERT, false is DELETE.
+DataStream<Tuple2<Boolean, Row>> retractStream = tableEnv.toRetractStream(table, Row.class);
 
 {% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-// get TableEnvironment. 
-// registration of a DataSet is equivalent
-val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" section
+val tableEnv: StreamTableEnvironment = ???
 
 // Table with two fields (String name, Integer age)
-val table: Table = ...
+val table: Table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
 
-// convert the Table into an append DataStream of Row
+// Convert the Table into an append DataStream of Row by specifying the class
 val dsRow: DataStream[Row] = tableEnv.toAppendStream[Row](table)
 
-// convert the Table into an append DataStream of Tuple2[String, Int]
+// Convert the Table into an append DataStream of (String, Integer) with TypeInformation
 val dsTuple: DataStream[(String, Int)] dsTuple = 
   tableEnv.toAppendStream[(String, Int)](table)
 
-// convert the Table into a retract DataStream of Row.
-//   A retract stream of type X is a DataStream[(Boolean, X)]. 
-//   The boolean field indicates the type of the change. 
-//   True is INSERT, false is DELETE.
+// Convert the Table into a retract DataStream of Row.
+// A retract stream of type X is a DataStream<Tuple2<Boolean, X>>. 
+// The boolean field indicates the type of the change. 
+// True is INSERT, false is DELETE.
 val retractStream: DataStream[(Boolean, Row)] = tableEnv.toRetractStream[Row](table)
 {% endhighlight %}
 </div>
@@ -1036,56 +932,12 @@ val retractStream: DataStream[(Boolean, Row)] = tableEnv.toRetractStream[Row](ta
 
 <span class="label label-danger">Attention</span> **Once the Table is converted to a DataStream, please use the `StreamExecutionEnvironment.execute()` method to execute the DataStream program.**
 
-#### Convert a Table into a DataSet
-
-A `Table` is converted into a `DataSet` as follows:
-
-<div class="codetabs" markdown="1">
-<div data-lang="java" markdown="1">
-{% highlight java %}
-// get BatchTableEnvironment
-BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
-
-// Table with two fields (String name, Integer age)
-Table table = ...
-
-// convert the Table into a DataSet of Row by specifying a class
-DataSet<Row> dsRow = tableEnv.toDataSet(table, Row.class);
-
-// convert the Table into a DataSet of Tuple2<String, Integer> via a TypeInformation
-TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(
-  Types.STRING(),
-  Types.INT());
-DataSet<Tuple2<String, Integer>> dsTuple = 
-  tableEnv.toDataSet(table, tupleType);
-{% endhighlight %}
-</div>
-
-<div data-lang="scala" markdown="1">
-{% highlight scala %}
-// get TableEnvironment 
-// registration of a DataSet is equivalent
-val tableEnv = BatchTableEnvironment.create(env)
-
-// Table with two fields (String name, Integer age)
-val table: Table = ...
-
-// convert the Table into a DataSet of Row
-val dsRow: DataSet[Row] = tableEnv.toDataSet[Row](table)
-
-// convert the Table into a DataSet of Tuple2[String, Int]
-val dsTuple: DataSet[(String, Int)] = tableEnv.toDataSet[(String, Int)](table)
-{% endhighlight %}
-</div>
-</div>
-
-<span class="label label-danger">Attention</span> **Once the Table is converted to a DataSet, we must use the ExecutionEnvironment.execute method to execute the DataSet program.**
-
 {% top %}
 
 ### Mapping of Data Types to Table Schema
 
-Flink's DataStream and DataSet APIs support very diverse types. Composite types such as Tuples (built-in Scala and Flink Java tuples), POJOs, Scala case classes, and Flink's Row type allow for nested data structures with multiple fields that can be accessed in table expressions. Other types are treated as atomic types. In the following, we describe how the Table API converts these types into an internal row representation and show examples of converting a `DataStream` into a `Table`.
+Flink's DataStream API support many diverse types.
+Composite types such as Tuples (built-in Scala and Flink Java tuples), POJOs, Scala case classes, and Flink's Row type allow for nested data structures with multiple fields that can be accessed in table expressions. Other types are treated as atomic types. In the following, we describe how the Table API converts these types into an internal row representation and show examples of converting a `DataStream` into a `Table`.
 
 The mapping of a data type to a table schema can happen in two ways: **based on the field positions** or **based on the field names**.
 
@@ -1185,35 +1037,35 @@ val table: Table = tableEnv.fromDataStream(stream, $"_2" as "myInt", $"_1" as "m
 
 #### Atomic Types
 
-Flink treats primitives (`Integer`, `Double`, `String`) or generic types (types that cannot be analyzed and decomposed) as atomic types. A `DataStream` or `DataSet` of an atomic type is converted into a `Table` with a single attribute. The type of the attribute is inferred from the atomic type and the name of the attribute can be specified.
+Flink treats primitives (`Integer`, `Double`, `String`) or generic types (types that cannot be analyzed and decomposed) as atomic types.
+A `DataStream` of an atomic type is converted into a `Table` with a single column.
+The type of the column is inferred from the atomic type and the name of the column can be specified.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+StreamTableEnvironment tableEnv = ...;
 
 DataStream<Long> stream = ...
 
-// convert DataStream into Table with default field name "f0"
+// Convert DataStream into Table with default field name "f0"
 Table table = tableEnv.fromDataStream(stream);
 
-// convert DataStream into Table with field name "myLong"
+// Convert DataStream into Table with field name "myLong"
 Table table = tableEnv.fromDataStream(stream, $("myLong"));
 {% endhighlight %}
 </div>
 
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-// get a TableEnvironment
-val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" section
+val tableEnv: StreamTableEnvironment = ???
 
 val stream: DataStream[Long] = ...
 
-// convert DataStream into Table with default field name "f0"
+// Convert DataStream into Table with default field name "f0"
 val table: Table = tableEnv.fromDataStream(stream)
 
-// convert DataStream into Table with field name "myLong"
+// Convert DataStream into Table with field name "myLong"
 val table: Table = tableEnv.fromDataStream(stream, $"myLong")
 {% endhighlight %}
 </div>
@@ -1221,7 +1073,12 @@ val table: Table = tableEnv.fromDataStream(stream, $"myLong")
 
 #### Tuples (Scala and Java) and Case Classes (Scala only)
 
-Flink supports Scala's built-in tuples and provides its own tuple classes for Java. DataStreams and DataSets of both kinds of tuples can be converted into tables. Fields can be renamed by providing names for all fields (mapping based on position). If no field names are specified, the default field names are used. If the original field names (`f0`, `f1`, ... for Flink Tuples and `_1`, `_2`, ... for Scala Tuples) are referenced, the API assumes that the mapping is name-based instead of position-based. Name-based mapping allows for reordering fields and projection with alias (`as`).
+Flink supports Scala's built-in tuples and provides its own tuple classes for Java.
+DataStreams of both kinds of tuples can be converted into tables.
+Fields can be renamed by providing names for all fields (mapping based on position).
+If no field names are specified, the default field names are used.
+If the original field names (`f0`, `f1`, ... for Flink Tuples and `_1`, `_2`, ... for Scala Tuples) are referenced, the API assumes that the mapping is name-based instead of position-based.
+Name-based mapping allows for reordering fields and projection with alias (`as`).
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -1291,7 +1148,7 @@ val table: Table = tableEnv.fromDataStream(stream, $"age" as "myAge", $"name" as
 
 Flink supports POJOs as composite types. The rules for what determines a POJO are documented [here]({% link dev/types_serialization.md %}#pojos).
 
-When converting a POJO `DataStream` or `DataSet` into a `Table` without specifying field names, the names of the original POJO fields are used. The name mapping requires the original names and cannot be done by positions. Fields can be renamed using an alias (with the `as` keyword), reordered, and projected.
+When converting a POJO `DataStream` into a `Table` without specifying field names, the names of the original POJO fields are used. The name mapping requires the original names and cannot be done by positions. Fields can be renamed using an alias (with the `as` keyword), reordered, and projected.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -1341,55 +1198,54 @@ val table: Table = tableEnv.fromDataStream(stream, $"name" as "myName")
 
 #### Row
 
-The `Row` data type supports an arbitrary number of fields and fields with `null` values. Field names can be specified via a `RowTypeInfo` or when converting a `Row` `DataStream` or `DataSet` into a `Table`. The row type supports mapping of fields by position and by name. Fields can be renamed by providing names for all fields (mapping based on position) or selected individually for projection/ordering/renaming (mapping based on name).
+The `Row` data type supports an arbitrary number of fields and fields with `null` values. Field names can be specified via a `RowTypeInfo` or when converting a `Row` `DataStream` into a `Table`.
+The row type supports mapping of fields by position and by name.
+Fields can be renamed by providing names for all fields (mapping based on position) or selected individually for projection/ordering/renaming (mapping based on name).
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
-StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+StreamTableEnvironment tableEnv = ...; 
 
 // DataStream of Row with two fields "name" and "age" specified in `RowTypeInfo`
 DataStream<Row> stream = ...
 
-// convert DataStream into Table with default field names "name", "age"
+// Convert DataStream into Table with default field names "name", "age"
 Table table = tableEnv.fromDataStream(stream);
 
-// convert DataStream into Table with renamed field names "myName", "myAge" (position-based)
+// Convert DataStream into Table with renamed field names "myName", "myAge" (position-based)
 Table table = tableEnv.fromDataStream(stream, $("myName"), $("myAge"));
 
-// convert DataStream into Table with renamed fields "myName", "myAge" (name-based)
+// Convert DataStream into Table with renamed fields "myName", "myAge" (name-based)
 Table table = tableEnv.fromDataStream(stream, $("name").as("myName"), $("age").as("myAge"));
 
-// convert DataStream into Table with projected field "name" (name-based)
+// Convert DataStream into Table with projected field "name" (name-based)
 Table table = tableEnv.fromDataStream(stream, $("name"));
 
-// convert DataStream into Table with projected and renamed field "myName" (name-based)
+// Convert DataStream into Table with projected and renamed field "myName" (name-based)
 Table table = tableEnv.fromDataStream(stream, $("name").as("myName"));
 {% endhighlight %}
 </div>
-
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
-// get a TableEnvironment
-val tableEnv: StreamTableEnvironment = ... // see "Create a TableEnvironment" section
+val tableEnv: StreamTableEnvironment = ???
 
 // DataStream of Row with two fields "name" and "age" specified in `RowTypeInfo`
 val stream: DataStream[Row] = ...
 
-// convert DataStream into Table with default field names "name", "age"
+// Convert DataStream into Table with default field names "name", "age"
 val table: Table = tableEnv.fromDataStream(stream)
 
-// convert DataStream into Table with renamed field names "myName", "myAge" (position-based)
+// Convert DataStream into Table with renamed field names "myName", "myAge" (position-based)
 val table: Table = tableEnv.fromDataStream(stream, $"myName", $"myAge")
 
-// convert DataStream into Table with renamed fields "myName", "myAge" (name-based)
+// Convert DataStream into Table with renamed fields "myName", "myAge" (name-based)
 val table: Table = tableEnv.fromDataStream(stream, $"name" as "myName", $"age" as "myAge")
 
-// convert DataStream into Table with projected field "name" (name-based)
+// Convert DataStream into Table with projected field "name" (name-based)
 val table: Table = tableEnv.fromDataStream(stream, $"name")
 
-// convert DataStream into Table with projected and renamed field "myName" (name-based)
+// Convert DataStream into Table with projected and renamed field "myName" (name-based)
 val table: Table = tableEnv.fromDataStream(stream, $"name" as "myName")
 {% endhighlight %}
 </div>
@@ -1401,8 +1257,6 @@ val table: Table = tableEnv.fromDataStream(stream, $"name" as "myName")
 Query Optimization
 ------------------
 
-<div class="codetabs" markdown="1">
-<div data-lang="Blink planner" markdown="1">
 Apache Flink leverages and extends Apache Calcite to perform sophisticated query optimization.
 This includes a series of rule and cost-based optimizations such as:
 
@@ -1422,14 +1276,6 @@ This includes a series of rule and cost-based optimizations such as:
 The optimizer makes intelligent decisions, based not only on the plan but also rich statistics available from the data sources and fine-grain costs for each operator such as io, cpu, network, and memory.
 
 Advanced users may provide custom optimizations via a `CalciteConfig` object that can be provided to the table environment by calling `TableEnvironment#getConfig#setPlannerConfig`.
-</div>
-
-<div data-lang="Old planner" markdown="1">
-Apache Flink leverages Apache Calcite to optimize and translate queries. The optimization currently performed include projection and filter push-down, subquery decorrelation, and other kinds of query rewriting. Old planner does not yet optimize the order of joins, but executes them in the same order as defined in the query (order of Tables in the `FROM` clause and/or order of join predicates in the `WHERE` clause).
-
-It is possible to tweak the set of optimization rules which are applied in different phases by providing a `CalciteConfig` object. This can be created via a builder by calling `CalciteConfig.createBuilder())` and is provided to the TableEnvironment by calling `tableEnv.getConfig.setPlannerConfig(calciteConfig)`.
-</div>
-</div>
 
 
 Explaining a Table

--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -122,7 +122,7 @@ The `TableEnvironment` is the entrypoint for Table API and SQL integration and i
 * Executing SQL queries
 * Registering a user-defined (scalar, table, or aggregation) function
 * Converting a `DataStream` into a `Table`
-* Holding a reference to a `StreamExecutionEnvironment`
+* In case of StreamTableEnvironment holding a reference to a `StreamExecutionEnvironment`
 
 A `Table` is always bound to a specific `TableEnvironment`.
 It is not possible to combine tables of different TableEnvironments in the same query, e.g., to join or union them.
@@ -158,25 +158,16 @@ val tEnv = TableEnvironment.create(setting)
 </div>
 <div data-lang="python" markdown="1">
 {% highlight python %}
-# ***************
-# Streaming QUERY
-# ***************
+from pyflink.table import EnvironmentSettings, StreamTableEnvironment, BatchTableEnvironment
 
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment, EnvironmentSettings
+# create a blink streaming TableEnvironment
+env_settings = EnvironmentSettings.new_instance().use_blink_planner().build()
+table_env = StreamTableEnvironment.create(environment_settings=env_settings)
 
-b_s_env = StreamExecutionEnvironment.get_execution_environment()
-b_s_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
-b_s_t_env = StreamTableEnvironment.create(b_s_env, environment_settings=b_s_settings)
+# create a blink batch TableEnvironment
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+table_env = BatchTableEnvironment.create(environment_settings=env_settings)
 
-# ***********
-# BATCH QUERY
-# ***********
-
-from pyflink.table import EnvironmentSettings, BatchTableEnvironment
-
-b_b_settings = EnvironmentSettings.new_instance().use_blink_planner().in_batch_mode().build()
-b_b_t_env = BatchTableEnvironment.create(environment_settings=b_b_settings)
 {% endhighlight %}
 </div>
 </div>
@@ -850,8 +841,8 @@ val table2: Table = tableEnv.fromDataStream(stream, $"myLong", $"myString")
 
 ### Convert a Table into a DataStream 
 
-A results of a `Table` can be converted into a `DataStream`.
-In this way, custom DataStream programs can be run on the result of a Table API or SQL query.
+The results of a `Table` can be converted into a `DataStream`.
+In this way, custom `DataStream` programs can be run on the result of a Table API or SQL query.
 
 When converting a `Table` into a `DataStream` you need to specify the data type of the resulting records, i.e., the data type into which the rows of the `Table` are to be converted.
 Often the most convenient conversion type is `Row`.
@@ -950,7 +941,6 @@ When defining a position-based mapping, the specified names must not exist in th
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
 StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section;
 
 DataStream<Tuple2<Long, Integer>> stream = ...
@@ -994,7 +984,6 @@ If no field names are specified, the default field names and field order of the 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
 StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 DataStream<Tuple2<Long, Integer>> stream = ...
@@ -1083,7 +1072,6 @@ Name-based mapping allows for reordering fields and projection with alias (`as`)
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
 StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 DataStream<Tuple2<Long, String>> stream = ...
@@ -1153,7 +1141,6 @@ When converting a POJO `DataStream` into a `Table` without specifying field name
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-// get a StreamTableEnvironment, works for BatchTableEnvironment equivalently
 StreamTableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 // Person is a POJO with fields "name" and "age"

--- a/docs/dev/table/config.md
+++ b/docs/dev/table/config.md
@@ -90,9 +90,6 @@ configuration.set_string("table.exec.mini-batch.size", "5000");
 </div>
 </div>
 
-<span class="label label-danger">Attention</span> Currently, key-value options are only supported
-for the Blink planner.
-
 ### Execution Options
 
 The following options can be used to tune the performance of the query execution.

--- a/docs/dev/table/functions/systemFunctions.md
+++ b/docs/dev/table/functions/systemFunctions.md
@@ -1487,7 +1487,6 @@ PI()
       </td>
       <td>
       <p>Returns the value of π (pi).</p>
-      <p>Only supported in blink planner.</p>
       </td>
     </tr> 
         
@@ -2722,7 +2721,6 @@ ASCII(string)
       </td>
       <td>
         <p>Returns the numeric value of the first character of <i>string</i>. Returns NULL if <i>string</i> is NULL.</p>
-        <p>Only supported in blink planner.</p>
         <p>E.g., <code>ascii('abc')</code> returns 97, and <code>ascii(CAST(NULL AS VARCHAR))</code> returns NULL.</p>
       </td>
     </tr>
@@ -2735,7 +2733,6 @@ CHR(integer)
       </td>
       <td>
         <p>Returns the ASCII character having the binary equivalent to <i>integer</i>. If <i>integer</i> is larger than 255, we will get the modulus of <i>integer</i> divided by 255 first, and returns <i>CHR</i> of the modulus. Returns NULL if <i>integer</i> is NULL.</p>
-        <p>Only supported in blink planner.</p>
         <p>E.g., <code>chr(97)</code> returns a, <code>chr(353)</code> returns a, and <code>ascii(CAST(NULL AS VARCHAR))</code> returns NULL.</p>
       </td>
     </tr>
@@ -2748,7 +2745,6 @@ DECODE(binary, string)
       </td>
       <td>
         <p>Decodes the first argument into a String using the provided character set (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'). If either argument is null, the result will also be null.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -2760,7 +2756,6 @@ ENCODE(string1, string2)
       </td>
       <td>
         <p>Encodes the <i>string1</i> into a BINARY using the provided <i>string2</i> character set (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'). If either argument is null, the result will also be null.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -2772,7 +2767,6 @@ INSTR(string1, string2)
       </td>
       <td>
         Returns the position of the first occurrence of <i>string2</i> in <i>string1</i>. Returns NULL if any of arguments is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2784,7 +2778,6 @@ LEFT(string, integer)
       </td>
       <td>
         <p>Returns the leftmost <i>integer</i> characters from the <i>string</i>. Returns EMPTY String if <i>integer</i> is negative. Returns NULL if any argument is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2796,7 +2789,6 @@ RIGHT(string, integer)
       </td>
       <td>
         <p>Returns the rightmost <i>integer</i> characters from the <i>string</i>. Returns EMPTY String if <i>integer</i> is negative. Returns NULL if any argument is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2808,7 +2800,6 @@ LOCATE(string1, string2[, integer])
       </td>
       <td>
         <p>Returns the position of the first occurrence of <i>string1</i> in <i>string2</i> after position <i>integer</i>. Returns 0 if not found. Returns NULL if any of arguments is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2823,7 +2814,6 @@ PARSE_URL(string1, string2[, string3])
         <p>E.g., <code>parse_url('http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'HOST')</code>, returns 'facebook.com'.</p>
         <p>Also a value of a particular key in QUERY can be extracted by providing the key as the third argument <i>string3</i>.</p>
         <p>E.g., <code>parse_url('http://facebook.com/path1/p.php?k1=v1&k2=v2#Ref1', 'QUERY', 'k1')</code> returns 'v1'. </p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2835,7 +2825,6 @@ REGEXP(string1, string2)
       </td>
       <td>
         <p>Returns TRUE if any (possibly empty) substring of <i>string1</i> matches the Java regular expression <i>string2</i>, otherwise FALSE. Returns NULL if any of arguments is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2847,7 +2836,6 @@ REVERSE(string)
       </td>
       <td>
         <p>Returns the reversed string. Returns NULL if <i>string</i> is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2859,7 +2847,6 @@ SPLIT_INDEX(string1, string2, integer1)
       </td>
       <td>
         <p>Splits <i>string1</i> by the delimiter <i>string2</i>, returns the <i>integer</i>th (zero-based) string of the split strings. Returns NULL if <i>integer</i> is negative. Returns NULL if any of arguments is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -2871,7 +2858,6 @@ STR_TO_MAP(string1[, string2, string3]])
       </td>
       <td>
         <p>Returns a map after splitting the <i>string1</i> into key/value pairs using delimiters. <i>string2</i> is the pair delimiter, default is ','. And <i>string3</i> is the key-value delimiter, default is '='.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -2883,7 +2869,6 @@ SUBSTR(string[, integer1[, integer2]])
       </td>
       <td>
         <p>Returns a substring of string starting from position integer1 with length integer2 (to the end by default).</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
         
@@ -3711,8 +3696,7 @@ DATE_FORMAT(timestamp, string)
 {% endhighlight %}
       </td>
       <td>
-        <p><span class="label label-danger">Attention for old planner</span> This function has serious bugs and should not be used for now. Please implement a custom UDF instead or use EXTRACT as a workaround.</p>
-        <p>For blink planner, this converts <i>timestamp</i> to a value of string in the format specified by the date format <i>string</i>. The format string is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>.</p>
+        <p>Converts <i>timestamp</i> to a value of string in the format specified by the date format <i>string</i>. The format string is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html">SimpleDateFormat</a>.</p>
       </td>
     </tr>
 
@@ -3749,7 +3733,6 @@ CONVERT_TZ(string1, string2, string3)
       <td>
         <p>Converts a datetime <i>string1</i> (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time zone <i>string2</i> to time zone <i>string3</i>. The format of time zone should be either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-8:00".</p>
         <p>E.g., <code>CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles')</code> returns '1969-12-31 16:00:00'.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
         
@@ -3762,7 +3745,6 @@ FROM_UNIXTIME(numeric[, string])
       <td>
         <p>Returns a representation of the <i>numeric</i> argument as a value in <i>string</i> format (default is 'YYYY-MM-DD hh:mm:ss'). <i>numeric</i> is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC, such as produced by the UNIX_TIMESTAMP() function. The return value is expressed in the session time zone (specified in TableConfig).</p>
         <p>E.g., <code>FROM_UNIXTIME(44)</code> returns '1970-01-01 00:00:44' if in UTC time zone, but returns '1970-01-01 09:00:44' if in 'Asia/Tokyo' time zone.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -3775,7 +3757,6 @@ UNIX_TIMESTAMP()
       <td>
         <p>Gets current Unix timestamp in seconds.</p>
         <p><b>Note:</b> This function is not deterministic which means the value would be recalculated for each record.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -3787,7 +3768,6 @@ UNIX_TIMESTAMP(string1[, string2])
       </td>
       <td>
         <p>Converts date time string <i>string1</i> in format <i>string2</i> (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
         
@@ -3799,7 +3779,6 @@ TO_DATE(string1[, string2])
       </td>
       <td>
         <p>Converts a date string <i>string1</i> with format <i>string2</i> (by default 'yyyy-MM-dd') to a date.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr> 
        
@@ -3811,7 +3790,6 @@ TO_TIMESTAMP(string1[, string2])
       </td>
       <td>
         <p>Converts date time string <i>string1</i> with format <i>string2</i> (by default: 'yyyy-MM-dd HH:mm:ss') under the session time zone (specified by TableConfig) to a timestamp.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
         
@@ -3824,7 +3802,6 @@ NOW()
       <td>
         <p>Returns the current SQL timestamp in the UTC time zone.</p>
         <p><b>Note:</b> This function is not deterministic which means the value would be recalculated for each record.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -4477,7 +4454,6 @@ IF(condition, true_value, false_value)
       </td>
       <td>
         <p>Returns the <i>true_value</i> if <i>condition</i> is met, otherwise <i>false_value</i>.</p>
-        <p>Only supported in blink planner.</p>
         <p>E.g., <code>IF(5 > 3, 5, 3)</code> returns 5.</p>
       </td>
     </tr>
@@ -4507,7 +4483,6 @@ IS_ALPHA(string)
       </td>
       <td>
         <p>Returns true if all characters in <i>string</i> are letter, otherwise false.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>    
 
@@ -4519,7 +4494,6 @@ IS_DECIMAL(string)
       </td>
       <td>
         <p>Returns true if <i>string</i> can be parsed to a valid numeric, otherwise false.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>    
 
@@ -4531,7 +4505,6 @@ IS_DIGIT(string)
       </td>
       <td>
         <p>Returns true if all characters in <i>string</i> are digit, otherwise false.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
     
@@ -5819,7 +5792,6 @@ VARIANCE([ ALL | DISTINCT ] expression)
       </td>
       <td>
         <p>Synonyms for VAR_SAMP().</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5831,7 +5803,6 @@ RANK()
       </td>
       <td>
         <p>Returns the rank of a value in a group of values. The result is one plus the number of rows preceding or equal to the current row in the ordering of the partition. The values will produce gaps in the sequence.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5843,7 +5814,6 @@ DENSE_RANK()
       </td>
       <td>
         <p>Returns the rank of a value in a group of values. The result is one plus the previously assigned rank value. Unlike the function rank, dense_rank will not produce gaps in the ranking sequence.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5856,7 +5826,6 @@ ROW_NUMBER()
       <td>
         <p>Assigns a unique, sequential number to each row, starting with one, according to the ordering of rows within the window partition.</p>
         <p>ROW_NUMBER and RANK are similar. ROW_NUMBER numbers all rows sequentially (for example 1, 2, 3, 4, 5). RANK provides the same numeric value for ties (for example 1, 2, 2, 4, 5).</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5868,7 +5837,6 @@ LEAD(expression [, offset] [, default] )
       </td>
       <td>
         <p>Returns the value of <i>expression</i> at the <i>offset</i>th row before the current row in the window. The default value of <i>offset</i> is 1 and the default value of <i>default</i> is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5880,7 +5848,6 @@ LAG(expression [, offset] [, default])
       </td>
       <td>
         <p>Returns the value of <i>expression</i> at the <i>offset</i>th row after the current row in the window. The default value of <i>offset</i> is 1 and the default value of <i>default</i> is NULL.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
         
@@ -5892,7 +5859,6 @@ FIRST_VALUE(expression)
       </td>
       <td>
         <p>Returns the first value in an ordered set of values.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5904,7 +5870,6 @@ LAST_VALUE(expression)
       </td>
       <td>
         <p>Returns the last value in an ordered set of values.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
 
@@ -5916,7 +5881,6 @@ LISTAGG(expression [, separator])
       </td>
       <td>
         <p>Concatenates the values of string expressions and places separator values between them. The separator is not added at the end of string. The default value of <i>separator</i> is ','.</p>
-        <p>Only supported in blink planner.</p>
       </td>
     </tr>
            

--- a/docs/dev/table/index.md
+++ b/docs/dev/table/index.md
@@ -37,15 +37,7 @@ You can easily switch between all APIs and libraries which build upon them.
 For instance, you can detect patterns from a table using [`MATCH_RECOGNIZE` clause]({% link dev/table/streaming/match_recognize.md %})
 and later use the DataStream API to build alerting based on the matched patterns.
 
-Table Planners
---------------
-
-Table planners are responsible for translating relational operators into an executable, optimized Flink job.
-Flink supports two different planner implementations; the modern Blink planner and the legacy planner.
-For production use cases, we recommend the Blink planner which has been the default planner since 1.11.
-See the [common API]({% link dev/table/common.md %}) page for more information on how to switch between the two planners.
-
-### Table Program Dependencies
+## Table Program Dependencies
 
 Depending on the target programming language, you need to add the Java or Scala API to a project
 in order to use the Table API & SQL for defining pipelines.
@@ -83,10 +75,8 @@ $ python -m pip install apache-flink
 </div>
 
 Additionally, if you want to run the Table API & SQL programs locally within your IDE, you must add the
-following set of modules, depending which planner you want to use.
+following set of modules.
 
-<div class="codetabs" markdown="1">
-<div data-lang="Blink Planner" markdown="1">
 {% highlight xml %}
 <dependency>
   <groupId>org.apache.flink</groupId>
@@ -101,24 +91,6 @@ following set of modules, depending which planner you want to use.
   <scope>provided</scope>
 </dependency>
 {% endhighlight %}
-</div>
-<div data-lang="Legacy Planner" markdown="1">
-{% highlight xml %}
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version}}</version>
-  <scope>provided</scope>
-</dependency>
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-streaming-scala{{ site.scala_version_suffix }}</artifactId>
-  <version>{{site.version}}</version>
-  <scope>provided</scope>
-</dependency>
-{% endhighlight %}
-</div>
-</div>
 
 ### Extension Dependencies
 

--- a/docs/dev/table/legacy_planner.md
+++ b/docs/dev/table/legacy_planner.md
@@ -118,8 +118,8 @@ val tEnv = BatchTableEnvironment.create(env)
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.table import BatchTableEnvironment
 
-f_b_env = ExecutionEnvironment.get_execution_environment()
-f_b_t_env = BatchTableEnvironment.create(f_b_env, table_config)
+b_env = ExecutionEnvironment.get_execution_environment()
+t_env = BatchTableEnvironment.create(b_env, table_config)
 {% endhighlight %}
 </div>
 </div>
@@ -238,8 +238,6 @@ val dsTuple: DataSet[(String, Int)] = tableEnv.toDataSet[(String, Int)](table)
 
 ## Data Types
 
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
 The legacy planner, introduced before Flink 1.9, primarily supports type information.
 It has only limited support for data types.
 It is possible to declare data types that can be translated into type information such that the legacy planner understands them.
@@ -277,8 +275,8 @@ For the *Data Type Representation* column the table omits the prefix `org.apache
 | `MAP(..., ...)` | `MAP<...,...>` | `MAP(...)` | |
 | other generic types | | `RAW(...)` | |
 
-</div>
-</div>
+<span class="label label-danger">Attention</span> If there is a problem with the new type system. Users
+can fallback to type information defined in `org.apache.flink.table.api.Types` at any time.
 
 ## Unsupported Features
 

--- a/docs/dev/table/legacy_planner.md
+++ b/docs/dev/table/legacy_planner.md
@@ -1,0 +1,341 @@
+---
+title: "Legacy Planner"
+nav-parent_id: tableapi
+nav-pos: 1001
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Table planners are responsible for translating relational operators into an executable, optimized Flink job.
+Flink supports two different planner implementations; the modern planner (sometimes referred to as `Blink`) and the legacy planner.
+For production use cases, we recommend the modern planner which is the default.
+
+The legacy planner is in maintenance mode and no longer under active development.
+The primary reason to continue using the legacy planner is [DataSet]({% link dev/batch/index.md %}) interop.
+
+{% capture dataset_interop_note %}
+If you are not using the Legacy planner for DataSet interop, the community strongly
+encourages you to consider the modern table planner.
+The legacy planner will be dropped at some point in the future.
+{% endcapture %}
+{% include warning.html content=dataset_interop_note %}
+
+This page describes how to use the Legacy planner and where its semantics differ from the 
+modern planner. 
+
+* This will be replaced by the TOC
+{:toc}
+
+## Setup
+
+### Dependencies
+
+When deploying to a cluster, the legacy planner is bundled in Flinks distribution by default.
+If you want to run the Table API & SQL programs locally within your IDE, you must add the
+following set of modules to your application.
+
+{% highlight xml %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-scala{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+  <scope>provided</scope>
+</dependency>
+{% endhighlight %}
+
+### Configuring the TableEnvironment 
+
+When creating a `TableEnvironment` the Legacy planner is configured via the `EnvironmentSettings`.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+EnvironmentSettings settings = EnvironmentSettings
+    .newInstance()
+    .useOldPlanner()
+    .inStreamingMode()
+    // or in batch mode
+    //.inBatchMode()
+    .build();
+
+TableEnvironment tEnv = TableEnvironment.create(settings);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val settings = EnvironmentSettings
+    .newInstance()
+    .useOldPlanner()
+    .inStreamingMode()
+    // or in batch mode
+    //.inBatchMode()
+    .build()
+
+val tEnv = TableEnvironment.create(settings)
+{% endhighlight %}
+</div>
+</div>
+
+`BatchTableEnvironment` may used for [DataSet]({% link dev/batch/index.md %}) and [DataStream]({% link dev/datastream_api.md %}) interop respectively.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment()
+val tEnv = BatchTableEnvironment.create(env)
+{% endhighlight %}
+</div>
+<div data-lang="python" markdown="1">
+{% highlight python %}
+from pyflink.dataset import ExecutionEnvironment
+from pyflink.table import BatchTableEnvironment
+
+f_b_env = ExecutionEnvironment.get_execution_environment()
+f_b_t_env = BatchTableEnvironment.create(f_b_env, table_config)
+{% endhighlight %}
+</div>
+</div>
+
+## Integration with DataSet
+
+The primary use case for the Legacy planner is interoperation with the DataSet API. 
+To translate `DataSet`s to and from tables, applications must use the `BatchTableEnvironment`.
+
+### Create a View from a DataSet
+
+A `DataSet` can be registered in a `BatchTableEnvironment` as a `View`.
+The schema of the resulting view depends on the data type of the registered collection.
+
+**Note:** Views created from a `DataSet` can be registered as temporary views only.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tEnv = ...; 
+DataSet<Tuple2<Long, String>> dataset = ...;
+
+tEnv.createTemporaryView("my-table", dataset, $("myLong"), $("myString"))
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight java %}
+val tEnv: BatchTableEnvironment = ??? 
+val dataset: DataSet[(Long, String)] = ???
+
+tEnv.createTemporaryView("my-table", dataset, $"myLong", $"myString")
+{% endhighlight %}
+</div>
+</div>
+
+### Create a Table from a DataSet
+
+A `DataSet` can be directly converted to a `Table` in a `BatchTableEnvironment`.
+The schema of the resulting view depends on the data type of the registered collection.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tEnv = ...; 
+DataSet<Tuple2<Long, String>> dataset = ...;
+
+Table myTable = tEnv.fromDataSet("my-table", dataset, $("myLong"), $("myString"))
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight java %}
+val tEnv: BatchTableEnvironment = ??? 
+val dataset: DataSet[(Long, String)] = ???
+
+val table = tEnv.fromDataSet("my-table", dataset, $"myLong", $"myString")
+{% endhighlight %}
+</div>
+</div>
+
+### Convert a Table to a DataSet
+
+A `Table` can be converted to a `DataSet`.
+In this way, custom DataSet programs can be run on the result of a Table API or SQL query.
+
+When converting from a `Table`, users must specify the data type of the results.
+Often the most convenient conversion type is `Row`.
+The following list gives an overview of the features of the different options.
+
+- **Row**: fields are mapped by position, arbitrary number of fields, support for `null` values, no type-safe access.
+- **POJO**: fields are mapped by name (POJO fields must be named as `Table` fields), arbitrary number of fields, support for `null` values, type-safe access.
+- **Case Class**: fields are mapped by position, no support for `null` values, type-safe access.
+- **Tuple**: fields are mapped by position, limitation to 22 (Scala) or 25 (Java) fields, no support for `null` values, type-safe access.
+- **Atomic Type**: `Table` must have a single field, no support for `null` values, type-safe access.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
+
+Table table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
+
+// Convert the Table into a DataSet of Row by specifying a class
+DataSet<Row> dsRow = tableEnv.toDataSet(table, Row.class);
+
+// Convert the Table into a DataSet of Tuple2<String, Integer> via a TypeInformation
+TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(Types.STRING(), Types.INT());
+DataSet<Tuple2<String, Integer>> dsTuple = tableEnv.toDataSet(table, tupleType);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val tableEnv = BatchTableEnvironment.create(env)
+
+val table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
+
+// Convert the Table into a DataSet of Row
+val dsRow: DataSet[Row] = tableEnv.toDataSet[Row](table)
+
+// Convert the Table into a DataSet of Tuple2[String, Int]
+val dsTuple: DataSet[(String, Int)] = tableEnv.toDataSet[(String, Int)](table)
+{% endhighlight %}
+</div>
+</div>
+
+<span class="label label-danger">Attention</span> **Once the Table is converted to a DataSet, we must use the ExecutionEnvironment.execute method to execute the DataSet program.**
+
+## Data Types
+
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+The legacy planner, introduced before Flink 1.9, primarily supports type information.
+It has only limited support for data types.
+It is possible to declare data types that can be translated into type information such that the legacy planner understands them.
+
+The following table summarizes the difference between data type and type information.
+Most simple types, as well as the row type remain the same.
+Time types, array types, and the decimal type need special attention.
+Other hints as the ones mentioned are not allowed.
+
+For the *Type Information* column the table omits the prefix `org.apache.flink.table.api.Types`.
+
+For the *Data Type Representation* column the table omits the prefix `org.apache.flink.table.api.DataTypes`.
+
+| Type Information | Java Expression String | Data Type Representation | Remarks for Data Type |
+|:-----------------|:-----------------------|:-------------------------|:----------------------|
+| `STRING()` | `STRING` | `STRING()` | |
+| `BOOLEAN()` | `BOOLEAN` | `BOOLEAN()` | |
+| `BYTE()` | `BYTE` | `TINYINT()` | |
+| `SHORT()` | `SHORT` | `SMALLINT()` | |
+| `INT()` | `INT` | `INT()` | |
+| `LONG()` | `LONG` | `BIGINT()` | |
+| `FLOAT()` | `FLOAT` | `FLOAT()` | |
+| `DOUBLE()` | `DOUBLE` | `DOUBLE()` | |
+| `ROW(...)` | `ROW<...>` | `ROW(...)` | |
+| `BIG_DEC()` | `DECIMAL` | [`DECIMAL()`] | Not a 1:1 mapping as precision and scale are ignored and Java's variable precision and scale are used. |
+| `SQL_DATE()` | `SQL_DATE` | `DATE()`<br>`.bridgedTo(java.sql.Date.class)` | |
+| `SQL_TIME()` | `SQL_TIME` | `TIME(0)`<br>`.bridgedTo(java.sql.Time.class)` | |
+| `SQL_TIMESTAMP()` | `SQL_TIMESTAMP` | `TIMESTAMP(3)`<br>`.bridgedTo(java.sql.Timestamp.class)` | |
+| `INTERVAL_MONTHS()` | `INTERVAL_MONTHS` | `INTERVAL(MONTH())`<br>`.bridgedTo(Integer.class)` | |
+| `INTERVAL_MILLIS()` | `INTERVAL_MILLIS` | `INTERVAL(DataTypes.SECOND(3))`<br>`.bridgedTo(Long.class)` | |
+| `PRIMITIVE_ARRAY(...)` | `PRIMITIVE_ARRAY<...>` | `ARRAY(DATATYPE.notNull()`<br>`.bridgedTo(PRIMITIVE.class))` | Applies to all JVM primitive types except for `byte`. |
+| `PRIMITIVE_ARRAY(BYTE())` | `PRIMITIVE_ARRAY<BYTE>` | `BYTES()` | |
+| `OBJECT_ARRAY(...)` | `OBJECT_ARRAY<...>` | `ARRAY(`<br>`DATATYPE.bridgedTo(OBJECT.class))` | |
+| `MULTISET(...)` | | `MULTISET(...)` | |
+| `MAP(..., ...)` | `MAP<...,...>` | `MAP(...)` | |
+| other generic types | | `RAW(...)` | |
+
+</div>
+</div>
+
+## Unsupported Features
+
+The following features are not supported by the legacy planner.
+
+- [Deduplication]({% link dev/table/sql/queries.md %}#deduplication %})
+- [Key Value Configurations]({% link dev/table/config.md %}#overview)
+- [Streaming Aggregation Optimization]({% link dev/table/tuning/streaming_aggregation_optimization.md %})
+- Streaming mode Grouping sets, Rollup and Cube aggregations
+- [Top-N]({% link dev/table/sql/queries.md %}#top-n)
+- [Versioned Tables]({% link dev/table/streaming/versioned_tables.md %})
+
+## Unsupported Built-In Functions
+
+The following built-in functions are not supported by the legacy planner.
+
+- `PI`
+- `ASCII(string)`
+- `CHR(integer)`
+- `DECODE(binary, string)`
+- `ENCODE(string1, string2)`
+- `INSTR(string1, string2)`
+- `LEFT(string, integer)`
+- `RIGHT(string, integer)`
+- `LOCATE(string1, string2[, integer])`
+- `PARSE_URL(string1, string2[, string3])`
+- `REGEXP(string1, string2)`
+- `REVERSE(string)`
+- `SPLIT_INDEX(string1, string2, integer1)`
+- `STR_TO_MAP(string1[, string2, string3]])`
+- `SUBSTR(string[, integer1[, integer2]])`
+- `CONVERT_TZ(string1, string2, string3)`
+- `FROM_UNIXTIME(numeric[, string])`
+- `UNIX_TIMESTAMP()`
+- `UNIX_TIMESTAMP(string1[, string2])`
+- `TO_DATE(string1[, string2])`
+- `TO_TIMESTAMP(string1[, string2])`
+- `NOW()`
+- `IF(condition, true_value, false_value)`
+- `IS_ALPHA(string)`
+- `IS_DECIMAL(string)`
+- `IS_DIGIT(string)`
+- `VARIANCE([ ALL | DISTINCT ] expression)`
+- `RANK()`
+- `DENSE_RANK()`
+- `ROW_NUMBER()`
+- `LEAD(expression [, offset] [, default] )`
+- `LAG(expression [, offset] [, default])`
+- `FIRST_VALUE(expression)`
+- `LAST_VALUE(expression)`
+- `LISTAGG(expression [, separator])`
+
+{% capture date_format_note %}
+<code>DATE_FORMAT(timestamp, string)</code> is available in the legacy planner but has serious bugs and should not be used.
+Please implement a custom UDF instead or use <code>EXTRACT</code as a workaround.
+{% endcapture %}
+{% include warning.html content=date_format_note %}
+
+
+

--- a/docs/dev/table/legacy_planner.zh.md
+++ b/docs/dev/table/legacy_planner.zh.md
@@ -1,0 +1,341 @@
+---
+title: "Legacy Planner"
+nav-parent_id: tableapi
+nav-pos: 1001
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+Table planners are responsible for translating relational operators into an executable, optimized Flink job.
+Flink supports two different planner implementations; the modern planner (sometimes referred to as `Blink`) and the legacy planner.
+For production use cases, we recommend the modern planner which is the default.
+
+The legacy planner is in maintenance mode and no longer under active development.
+The primary reason to continue using the legacy planner is [DataSet]({% link dev/batch/index.md %}) interop.
+
+{% capture dataset_interop_note %}
+If you are not using the Legacy planner for DataSet interop, the community strongly
+encourages you to consider the modern table planner.
+The legacy planner will be dropped at some point in the future.
+{% endcapture %}
+{% include warning.html content=dataset_interop_note %}
+
+This page describes how to use the Legacy planner and where its semantics differ from the 
+modern planner. 
+
+* This will be replaced by the TOC
+{:toc}
+
+## Setup
+
+### Dependencies
+
+When deploying to a cluster, the legacy planner is bundled in Flinks distribution by default.
+If you want to run the Table API & SQL programs locally within your IDE, you must add the
+following set of modules to your application.
+
+{% highlight xml %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-table-planner{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+  <scope>provided</scope>
+</dependency>
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-streaming-scala{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+  <scope>provided</scope>
+</dependency>
+{% endhighlight %}
+
+### Configuring the TableEnvironment 
+
+When creating a `TableEnvironment` the Legacy planner is configured via the `EnvironmentSettings`.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+EnvironmentSettings settings = EnvironmentSettings
+    .newInstance()
+    .useOldPlanner()
+    .inStreamingMode()
+    // or in batch mode
+    //.inBatchMode()
+    .build();
+
+TableEnvironment tEnv = TableEnvironment.create(settings);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val settings = EnvironmentSettings
+    .newInstance()
+    .useOldPlanner()
+    .inStreamingMode()
+    // or in batch mode
+    //.inBatchMode()
+    .build()
+
+val tEnv = TableEnvironment.create(settings)
+{% endhighlight %}
+</div>
+</div>
+
+`BatchTableEnvironment` may used for [DataSet]({% link dev/batch/index.md %}) and [DataStream]({% link dev/datastream_api.md %}) interop respectively.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val env = ExecutionEnvironment.getExecutionEnvironment()
+val tEnv = BatchTableEnvironment.create(env)
+{% endhighlight %}
+</div>
+<div data-lang="python" markdown="1">
+{% highlight python %}
+from pyflink.dataset import ExecutionEnvironment
+from pyflink.table import BatchTableEnvironment
+
+f_b_env = ExecutionEnvironment.get_execution_environment()
+f_b_t_env = BatchTableEnvironment.create(f_b_env, table_config)
+{% endhighlight %}
+</div>
+</div>
+
+## Integration with DataSet
+
+The primary use case for the Legacy planner is interoperation with the DataSet API. 
+To translate `DataSet`s to and from tables, applications must use the `BatchTableEnvironment`.
+
+### Create a View from a DataSet
+
+A `DataSet` can be registered in a `BatchTableEnvironment` as a `View`.
+The schema of the resulting view depends on the data type of the registered collection.
+
+**Note:** Views created from a `DataSet` can be registered as temporary views only.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tEnv = ...; 
+DataSet<Tuple2<Long, String>> dataset = ...;
+
+tEnv.createTemporaryView("my-table", dataset, $("myLong"), $("myString"))
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight java %}
+val tEnv: BatchTableEnvironment = ??? 
+val dataset: DataSet[(Long, String)] = ???
+
+tEnv.createTemporaryView("my-table", dataset, $"myLong", $"myString")
+{% endhighlight %}
+</div>
+</div>
+
+### Create a Table from a DataSet
+
+A `DataSet` can be directly converted to a `Table` in a `BatchTableEnvironment`.
+The schema of the resulting view depends on the data type of the registered collection.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tEnv = ...; 
+DataSet<Tuple2<Long, String>> dataset = ...;
+
+Table myTable = tEnv.fromDataSet("my-table", dataset, $("myLong"), $("myString"))
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight java %}
+val tEnv: BatchTableEnvironment = ??? 
+val dataset: DataSet[(Long, String)] = ???
+
+val table = tEnv.fromDataSet("my-table", dataset, $"myLong", $"myString")
+{% endhighlight %}
+</div>
+</div>
+
+### Convert a Table to a DataSet
+
+A `Table` can be converted to a `DataSet`.
+In this way, custom DataSet programs can be run on the result of a Table API or SQL query.
+
+When converting from a `Table`, users must specify the data type of the results.
+Often the most convenient conversion type is `Row`.
+The following list gives an overview of the features of the different options.
+
+- **Row**: fields are mapped by position, arbitrary number of fields, support for `null` values, no type-safe access.
+- **POJO**: fields are mapped by name (POJO fields must be named as `Table` fields), arbitrary number of fields, support for `null` values, type-safe access.
+- **Case Class**: fields are mapped by position, no support for `null` values, type-safe access.
+- **Tuple**: fields are mapped by position, limitation to 22 (Scala) or 25 (Java) fields, no support for `null` values, type-safe access.
+- **Atomic Type**: `Table` must have a single field, no support for `null` values, type-safe access.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
+
+Table table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
+
+// Convert the Table into a DataSet of Row by specifying a class
+DataSet<Row> dsRow = tableEnv.toDataSet(table, Row.class);
+
+// Convert the Table into a DataSet of Tuple2<String, Integer> via a TypeInformation
+TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(Types.STRING(), Types.INT());
+DataSet<Tuple2<String, Integer>> dsTuple = tableEnv.toDataSet(table, tupleType);
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val tableEnv = BatchTableEnvironment.create(env)
+
+val table = tableEnv.fromValues(
+    DataTypes.Row(
+        DataTypes.FIELD("name", DataTypes.STRING()),
+        DataTypes.FIELD("age", DataTypes.INT()),
+    row("john", 35),
+    row("sarah", 32));
+
+// Convert the Table into a DataSet of Row
+val dsRow: DataSet[Row] = tableEnv.toDataSet[Row](table)
+
+// Convert the Table into a DataSet of Tuple2[String, Int]
+val dsTuple: DataSet[(String, Int)] = tableEnv.toDataSet[(String, Int)](table)
+{% endhighlight %}
+</div>
+</div>
+
+<span class="label label-danger">Attention</span> **Once the Table is converted to a DataSet, we must use the ExecutionEnvironment.execute method to execute the DataSet program.**
+
+## Data Types
+
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+The legacy planner, introduced before Flink 1.9, primarily supports type information.
+It has only limited support for data types.
+It is possible to declare data types that can be translated into type information such that the legacy planner understands them.
+
+The following table summarizes the difference between data type and type information.
+Most simple types, as well as the row type remain the same.
+Time types, array types, and the decimal type need special attention.
+Other hints as the ones mentioned are not allowed.
+
+For the *Type Information* column the table omits the prefix `org.apache.flink.table.api.Types`.
+
+For the *Data Type Representation* column the table omits the prefix `org.apache.flink.table.api.DataTypes`.
+
+| Type Information | Java Expression String | Data Type Representation | Remarks for Data Type |
+|:-----------------|:-----------------------|:-------------------------|:----------------------|
+| `STRING()` | `STRING` | `STRING()` | |
+| `BOOLEAN()` | `BOOLEAN` | `BOOLEAN()` | |
+| `BYTE()` | `BYTE` | `TINYINT()` | |
+| `SHORT()` | `SHORT` | `SMALLINT()` | |
+| `INT()` | `INT` | `INT()` | |
+| `LONG()` | `LONG` | `BIGINT()` | |
+| `FLOAT()` | `FLOAT` | `FLOAT()` | |
+| `DOUBLE()` | `DOUBLE` | `DOUBLE()` | |
+| `ROW(...)` | `ROW<...>` | `ROW(...)` | |
+| `BIG_DEC()` | `DECIMAL` | [`DECIMAL()`] | Not a 1:1 mapping as precision and scale are ignored and Java's variable precision and scale are used. |
+| `SQL_DATE()` | `SQL_DATE` | `DATE()`<br>`.bridgedTo(java.sql.Date.class)` | |
+| `SQL_TIME()` | `SQL_TIME` | `TIME(0)`<br>`.bridgedTo(java.sql.Time.class)` | |
+| `SQL_TIMESTAMP()` | `SQL_TIMESTAMP` | `TIMESTAMP(3)`<br>`.bridgedTo(java.sql.Timestamp.class)` | |
+| `INTERVAL_MONTHS()` | `INTERVAL_MONTHS` | `INTERVAL(MONTH())`<br>`.bridgedTo(Integer.class)` | |
+| `INTERVAL_MILLIS()` | `INTERVAL_MILLIS` | `INTERVAL(DataTypes.SECOND(3))`<br>`.bridgedTo(Long.class)` | |
+| `PRIMITIVE_ARRAY(...)` | `PRIMITIVE_ARRAY<...>` | `ARRAY(DATATYPE.notNull()`<br>`.bridgedTo(PRIMITIVE.class))` | Applies to all JVM primitive types except for `byte`. |
+| `PRIMITIVE_ARRAY(BYTE())` | `PRIMITIVE_ARRAY<BYTE>` | `BYTES()` | |
+| `OBJECT_ARRAY(...)` | `OBJECT_ARRAY<...>` | `ARRAY(`<br>`DATATYPE.bridgedTo(OBJECT.class))` | |
+| `MULTISET(...)` | | `MULTISET(...)` | |
+| `MAP(..., ...)` | `MAP<...,...>` | `MAP(...)` | |
+| other generic types | | `RAW(...)` | |
+
+</div>
+</div>
+
+## Unsupported Features
+
+The following features are not supported by the legacy planner.
+
+- [Deduplication]({% link dev/table/sql/queries.md %}#deduplication %})
+- [Key Value Configurations]({% link dev/table/config.md %}#overview)
+- [Streaming Aggregation Optimization]({% link dev/table/tuning/streaming_aggregation_optimization.md %})
+- Streaming mode Grouping sets, Rollup and Cube aggregations
+- [Top-N]({% link dev/table/sql/queries.md %}#top-n)
+- [Versioned Tables]({% link dev/table/streaming/versioned_tables.md %})
+
+## Unsupported Built-In Functions
+
+The following built-in functions are not supported by the legacy planner.
+
+- `PI`
+- `ASCII(string)`
+- `CHR(integer)`
+- `DECODE(binary, string)`
+- `ENCODE(string1, string2)`
+- `INSTR(string1, string2)`
+- `LEFT(string, integer)`
+- `RIGHT(string, integer)`
+- `LOCATE(string1, string2[, integer])`
+- `PARSE_URL(string1, string2[, string3])`
+- `REGEXP(string1, string2)`
+- `REVERSE(string)`
+- `SPLIT_INDEX(string1, string2, integer1)`
+- `STR_TO_MAP(string1[, string2, string3]])`
+- `SUBSTR(string[, integer1[, integer2]])`
+- `CONVERT_TZ(string1, string2, string3)`
+- `FROM_UNIXTIME(numeric[, string])`
+- `UNIX_TIMESTAMP()`
+- `UNIX_TIMESTAMP(string1[, string2])`
+- `TO_DATE(string1[, string2])`
+- `TO_TIMESTAMP(string1[, string2])`
+- `NOW()`
+- `IF(condition, true_value, false_value)`
+- `IS_ALPHA(string)`
+- `IS_DECIMAL(string)`
+- `IS_DIGIT(string)`
+- `VARIANCE([ ALL | DISTINCT ] expression)`
+- `RANK()`
+- `DENSE_RANK()`
+- `ROW_NUMBER()`
+- `LEAD(expression [, offset] [, default] )`
+- `LAG(expression [, offset] [, default])`
+- `FIRST_VALUE(expression)`
+- `LAST_VALUE(expression)`
+- `LISTAGG(expression [, separator])`
+
+{% capture date_format_note %}
+<code>DATE_FORMAT(timestamp, string)</code> is available in the legacy planner but has serious bugs and should not be used.
+Please implement a custom UDF instead or use <code>EXTRACT</code as a workaround.
+{% endcapture %}
+{% include warning.html content=date_format_note %}
+
+
+

--- a/docs/dev/table/sql/queries.md
+++ b/docs/dev/table/sql/queries.md
@@ -28,13 +28,20 @@ under the License.
 <div class="codetabs" data-hide-tabs="1" markdown="1">
 <div data-lang="java/scala" markdown="1">
 
-SELECT statements and VALUES statements are specified with the `sqlQuery()` method of the `TableEnvironment`. The method returns the result of the SELECT statement (or the VALUES statements) as a `Table`. A `Table` can be used in [subsequent SQL and Table API queries]({% link dev/table/common.md %}#mixing-table-api-and-sql), be [converted into a DataSet or DataStream]({% link dev/table/common.md %}#integration-with-datastream-and-dataset-api), or [written to a TableSink]({% link dev/table/common.md %}#emit-a-table). SQL and Table API queries can be seamlessly mixed and are holistically optimized and translated into a single program.
+`SELECT` statements and `VALUES` statements are specified with the `sqlQuery()` method of the `TableEnvironment`.
+The method returns the result of the SELECT statement (or the VALUES statements) as a `Table`.
+A `Table` can be used in [subsequent SQL and Table API queries]({% link dev/table/common.md %}#mixing-table-api-and-sql), be [converted into a DataStream]({% link dev/table/common.md %}#integration-with-datastream), or [written to a TableSink]({% link dev/table/common.md %}#emit-a-table).
+SQL and Table API queries can be seamlessly mixed and are holistically optimized and translated into a single program.
 
-In order to access a table in a SQL query, it must be [registered in the TableEnvironment]({% link dev/table/common.md %}#register-tables-in-the-catalog). A table can be registered from a [TableSource]({% link dev/table/common.md %}#register-a-tablesource), [Table]({% link dev/table/common.md %}#register-a-table), [CREATE TABLE statement](#create-table), [DataStream, or DataSet]({% link dev/table/common.md %}#register-a-datastream-or-dataset-as-table). Alternatively, users can also [register catalogs in a TableEnvironment]({% link dev/table/catalogs.md %}) to specify the location of the data sources.
+In order to access a table in a SQL query, it must be [registered in the TableEnvironment]({% link dev/table/common.md %}#register-tables-in-the-catalog).
+A table can be registered from a [TableSource]({% link dev/table/common.md %}#register-a-tablesource), [Table]({% link dev/table/common.md %}#register-a-table), [CREATE TABLE statement](#create-table), [DataStream]({% link dev/table/common.md %}#register-a-datastream).
+Alternatively, users can also [register catalogs in a TableEnvironment]({% link dev/table/catalogs.md %}) to specify the location of the data sources.
 
-For convenience, `Table.toString()` automatically registers the table under a unique name in its `TableEnvironment` and returns the name. So, `Table` objects can be directly inlined into SQL queries as shown in the examples below.
+For convenience, `Table.toString()` automatically registers the table under a unique name in its `TableEnvironment` and returns the name.
+So, `Table` objects can be directly inlined into SQL queries as shown in the examples below.
 
-**Note:** Queries that include unsupported SQL features cause a `TableException`. The supported features of SQL on batch and streaming tables are listed in the following sections.
+**Note:** Queries that include unsupported SQL features cause a `TableException`.
+The supported features of SQL on batch and streaming tables are listed in the following sections.
 
 </div>
 
@@ -563,7 +570,6 @@ SELECT SUM(amount)
 FROM Orders
 GROUP BY GROUPING SETS ((user), (product))
 {% endhighlight %}
-        <p><b>Note:</b> Streaming mode Grouping sets, Rollup and Cube are only supported in Blink planner.</p>
       </td>
     </tr>
     <tr>
@@ -745,8 +751,7 @@ FROM
   ON r.currency = o.currency
 {% endhighlight %}
         <p>The RHS table can be named with an alias using optional clause <code>[[<strong>AS</strong>] correlationName]</code>, note that the <code><strong>AS</strong></code> keyword is also optional.</p>
-        <p>For more information please check the more detailed <a href="{% link dev/table/streaming/legacy.md %}">Temporal Tables</a> concept description.</p>
-        <p>Only supported in Blink planner.</p>
+        <p>For more information please check the more detailed <a href="{% link dev/table/streaming/versioned_tables.md %}">versioned table</a> concept description.</p>
       </td>
     </tr>    
     <tr>
@@ -940,8 +945,6 @@ LIMIT 3
 
 ### Top-N
 
-<span class="label label-danger">Attention</span> Top-N is only supported in Blink planner.
-
 Top-N queries ask for the N smallest or largest values ordered by columns. Both smallest and largest values sets are considered Top-N queries. Top-N queries are useful in cases where the need is to display only the N bottom-most or the N top-
 most records from batch/streaming table on a condition. This result set can be used for further analysis.
 
@@ -1081,8 +1084,6 @@ val result1 = tableEnv.sqlQuery(
 {% top %}
 
 ### Deduplication
-
-<span class="label label-danger">Attention</span> Deduplication is only supported in Blink planner.
 
 Deduplication is removing rows that duplicate over a set of columns, keeping only the first one or the last one. In some cases, the upstream ETL jobs are not end-to-end exactly-once, this may result in there are duplicate records in the sink in case of failover. However, the duplicate records will affect the correctness of downstream analytical jobs (e.g. `SUM`, `COUNT`). So a deduplication is needed before further analysis.
 

--- a/docs/dev/table/streaming/versioned_tables.md
+++ b/docs/dev/table/streaming/versioned_tables.md
@@ -25,8 +25,6 @@ under the License.
 Flink SQL operates over dynamic tables that evolve, which may either be append-only or updating. 
 Versioned tables represent a special type of updating table that remembers the past values for each key.
 
-<span class="label label-danger">Attention</span> The Legacy planner does not support versioned tables.
-
 * This will be replaced by the TOC
 {:toc}
 

--- a/docs/dev/table/tuning/streaming_aggregation_optimization.md
+++ b/docs/dev/table/tuning/streaming_aggregation_optimization.md
@@ -26,9 +26,8 @@ SQL is the most widely used language for data analytics. Flink's Table API and S
 
 In this page, we will introduce some useful optimization options and the internals of streaming aggregation which will bring great improvement in some cases.
 
-<span class="label label-danger">Attention</span> Currently, the optimization options mentioned in this page are only supported in the Blink planner.
-
-<span class="label label-danger">Attention</span> Currently, the streaming aggregations optimization are only supported for [unbounded-aggregations]({% link dev/table/sql/queries.md %}#aggregations). Optimizations for [window aggregations]({% link dev/table/sql/queries.md %}#group-windows) will be supported in the future.
+<span class="label label-danger">Attention</span> The streaming aggregations optimization are only supported for [unbounded-aggregations]({% link dev/table/sql/queries.md %}#aggregations).
+Optimizations for [window aggregations]({% link dev/table/sql/queries.md %}#group-windows) will be supported in the future.
 
 * This will be replaced by the TOC
 {:toc}

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -22,39 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<div class="codetabs" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-Due to historical reasons, before Flink 1.9, Flink's Table & SQL API data types were
-tightly coupled to Flink's `TypeInformation`. `TypeInformation` is used in the DataStream
-and DataSet API and is sufficient to describe all information needed to serialize and
-deserialize JVM-based objects in a distributed setting.
-
-However, `TypeInformation` was not designed to represent logical types independent of
-an actual JVM class. In the past, it was difficult to map SQL standard types to this
-abstraction. Furthermore, some types were not SQL-compliant and introduced without a
-bigger picture in mind.
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
-Starting with Flink 1.9, the Table & SQL API will receive a new type system that serves as a long-term
-solution for API stability and standard compliance.
-
-Reworking the type system is a major effort that touches almost all user-facing interfaces. Therefore, its
-introduction spans multiple releases, and the community aims to finish this effort by Flink 1.12.
-
-Due to the simultaneous addition of a new planner for table programs (see [FLINK-11439](https://issues.apache.org/jira/browse/FLINK-11439)),
-not every combination of planner and data type is supported. Furthermore, planners might not support every
-data type with the desired precision or parameter.
-
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-<span class="label label-danger">Attention</span> Please see the planner compatibility table and limitations
-section before using a data type.
-</div>
-<div data-lang="Python" markdown="1">
-</div>
-</div>
+Flink SQL has a rich set of native data types available to users.
 
 * This will be replaced by the TOC
 {:toc}
@@ -62,8 +30,8 @@ section before using a data type.
 Data Type
 ---------
 
-A *data type* describes the logical type of a value in the table ecosystem. It can be used to declare input and/or
-output types of operations.
+A *data type* describes the logical type of a value in the table ecosystem.
+It can be used to declare input and/or output types of operations.
 
 Flink's data types are similar to the SQL standard's *data type* terminology but also contain information
 about the nullability of a value for efficient handling of scalar expressions.
@@ -103,7 +71,6 @@ For Python language, those types are available in `pyflink.table.types.DataTypes
 </div>
 
 <div class="codetabs" markdown="1">
-
 <div data-lang="Java" markdown="1">
 It is recommended to add a star import to your table programs for having a fluent API:
 
@@ -123,7 +90,6 @@ import org.apache.flink.table.api.DataTypes._
 val t: DataType = INTERVAL(DAY(), SECOND(3));
 {% endhighlight %}
 </div>
-
 <div data-lang="Python" markdown="1">
 
 {% highlight python %}
@@ -183,126 +149,6 @@ a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are
 
 </div>
 <div data-lang="Python" markdown="1">
-</div>
-</div>
-
-Planner Compatibility
----------------------
-
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-As mentioned in the introduction, reworking the type system will span multiple releases, and the support of each data
-type depends on the used planner. This section aims to summarize the most significant differences.
-</div>
-<div data-lang="Python" markdown="1">
-This part is for Java/Scala users.
-There are no known similiar planner compatibility issues on the data types of Python Table API currently. 
-</div>
-</div>
-
-### Old Planner
-
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-Flink's old planner, introduced before Flink 1.9, primarily supports type information. It has only limited
-support for data types. It is possible to declare data types that can be translated into type information such that the
-old planner understands them.
-
-The following table summarizes the difference between data type and type information. Most simple types, as well as the
-row type remain the same. Time types, array types, and the decimal type need special attention. Other hints as the ones
-mentioned are not allowed.
-
-For the *Type Information* column the table omits the prefix `org.apache.flink.table.api.Types`.
-
-For the *Data Type Representation* column the table omits the prefix `org.apache.flink.table.api.DataTypes`.
-
-| Type Information | Java Expression String | Data Type Representation | Remarks for Data Type |
-|:-----------------|:-----------------------|:-------------------------|:----------------------|
-| `STRING()` | `STRING` | `STRING()` | |
-| `BOOLEAN()` | `BOOLEAN` | `BOOLEAN()` | |
-| `BYTE()` | `BYTE` | `TINYINT()` | |
-| `SHORT()` | `SHORT` | `SMALLINT()` | |
-| `INT()` | `INT` | `INT()` | |
-| `LONG()` | `LONG` | `BIGINT()` | |
-| `FLOAT()` | `FLOAT` | `FLOAT()` | |
-| `DOUBLE()` | `DOUBLE` | `DOUBLE()` | |
-| `ROW(...)` | `ROW<...>` | `ROW(...)` | |
-| `BIG_DEC()` | `DECIMAL` | [`DECIMAL()`] | Not a 1:1 mapping as precision and scale are ignored and Java's variable precision and scale are used. |
-| `SQL_DATE()` | `SQL_DATE` | `DATE()`<br>`.bridgedTo(java.sql.Date.class)` | |
-| `SQL_TIME()` | `SQL_TIME` | `TIME(0)`<br>`.bridgedTo(java.sql.Time.class)` | |
-| `SQL_TIMESTAMP()` | `SQL_TIMESTAMP` | `TIMESTAMP(3)`<br>`.bridgedTo(java.sql.Timestamp.class)` | |
-| `INTERVAL_MONTHS()` | `INTERVAL_MONTHS` | `INTERVAL(MONTH())`<br>`.bridgedTo(Integer.class)` | |
-| `INTERVAL_MILLIS()` | `INTERVAL_MILLIS` | `INTERVAL(DataTypes.SECOND(3))`<br>`.bridgedTo(Long.class)` | |
-| `PRIMITIVE_ARRAY(...)` | `PRIMITIVE_ARRAY<...>` | `ARRAY(DATATYPE.notNull()`<br>`.bridgedTo(PRIMITIVE.class))` | Applies to all JVM primitive types except for `byte`. |
-| `PRIMITIVE_ARRAY(BYTE())` | `PRIMITIVE_ARRAY<BYTE>` | `BYTES()` | |
-| `OBJECT_ARRAY(...)` | `OBJECT_ARRAY<...>` | `ARRAY(`<br>`DATATYPE.bridgedTo(OBJECT.class))` | |
-| `MULTISET(...)` | | `MULTISET(...)` | |
-| `MAP(..., ...)` | `MAP<...,...>` | `MAP(...)` | |
-| other generic types | | `RAW(...)` | |
-
-<span class="label label-danger">Attention</span> If there is a problem with the new type system. Users
-can fallback to type information defined in `org.apache.flink.table.api.Types` at any time.
-</div>
-<div data-lang="Python" markdown="1">
-N/A
-</div>
-</div>
-
-### New Blink Planner
-
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-The new Blink planner supports all of types of the old planner. This includes in particular
-the listed Java expression strings and type information.
-
-The following data types are supported:
-
-| Data Type | Remarks for Data Type |
-|:----------|:----------------------|
-| `CHAR` | |
-| `VARCHAR` | |
-| `STRING` | |
-| `BOOLEAN` | |
-| `BYTES` | `BINARY` and `VARBINARY` are not supported yet. |
-| `DECIMAL` | Supports fixed precision and scale. |
-| `TINYINT` | |
-| `SMALLINT` | |
-| `INTEGER` | |
-| `BIGINT` | |
-| `FLOAT` | |
-| `DOUBLE` | |
-| `DATE` | |
-| `TIME` | Supports only a precision of `0`. |
-| `TIMESTAMP` | |
-| `TIMESTAMP WITH LOCAL TIME ZONE` | |
-| `INTERVAL` | Supports only interval of `MONTH` and `SECOND(3)`. |
-| `ARRAY` | |
-| `MULTISET` | |
-| `MAP` | |
-| `ROW` | |
-| `RAW` | |
-| structured types | Only exposed in user-defined functions yet. |
-
-</div>
-<div data-lang="Python" markdown="1">
-N/A
-</div>
-</div>
-
-Limitations
------------
-
-<div class="codetabs" data-hide-tabs="1" markdown="1">
-<div data-lang="Java/Scala" markdown="1">
-**Java Expression String**: Java expression strings in the Table API such as `table.select("field.cast(STRING)")`
-have not been updated to the new type system yet. Use the string representations declared in
-the [old planner section](#old-planner).
-
-**User-defined Functions**: User-defined aggregate functions cannot declare a data type yet. Scalar and table functions fully support data types.
-</div>
-<div data-lang="Python" markdown="1">
-This part is for Java/Scala users.
-There are no known similiar limitations on the data types of Python Table API currently.
 </div>
 </div>
 

--- a/docs/dev/table/types.md
+++ b/docs/dev/table/types.md
@@ -152,6 +152,42 @@ a table program (e.g. `field.cast(TIMESTAMP(3).bridgedTo(Timestamp.class))`) are
 </div>
 </div>
 
+<div class="codetabs" data-hide-tabs="1" markdown="1">
+<div data-lang="Java/Scala" markdown="1">
+The default planner supports the following set of SQL types:
+
+| Data Type | Remarks for Data Type |
+|:----------|:----------------------|
+| `CHAR` | |
+| `VARCHAR` | |
+| `STRING` | |
+| `BOOLEAN` | |
+| `BYTES` | `BINARY` and `VARBINARY` are not supported yet. |
+| `DECIMAL` | Supports fixed precision and scale. |
+| `TINYINT` | |
+| `SMALLINT` | |
+| `INTEGER` | |
+| `BIGINT` | |
+| `FLOAT` | |
+| `DOUBLE` | |
+| `DATE` | |
+| `TIME` | Supports only a precision of `0`. |
+| `TIMESTAMP` | |
+| `TIMESTAMP WITH LOCAL TIME ZONE` | |
+| `INTERVAL` | Supports only interval of `MONTH` and `SECOND(3)`. |
+| `ARRAY` | |
+| `MULTISET` | |
+| `MAP` | |
+| `ROW` | |
+| `RAW` | |
+| structured types | Only exposed in user-defined functions yet. |
+
+</div>
+<div data-lang="Python" markdown="1">
+N/A
+</div>
+</div>
+
 List of Data Types
 ------------------
 


### PR DESCRIPTION
## What is the purpose of the change

As Blink has been the default planner for some time, and 1.12 now offers bounded data stream support, we should make the documentation "blink only". I think there is more we can do to improve the docs now that we don't have to worry about the legacy planner but that's a bigger update. 

Note to reviewers: I did not update the `.zh.md` pages. So many of them have been translated that I was unable to without just replacing whole sections with English. I will open a follow-up ticket. 

