### PR TITLE
[FLINK-20861][format/json] Provide an option for serializing DECIMALs in JSON as plain number instead of scientific notation

### DIFF
--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -281,6 +281,13 @@ Format Options
       <td>Specify string literal to replace null key when <code>'canal-json.map-null-key.mode'</code> is LITERAL.</td>
     </tr>        
     <tr>
+      <td><h5>canal-json.encode.decimal-as-plain-number</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
+    </tr>
+    <tr>
       <td><h5>canal-json.database.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -279,6 +279,13 @@ Format 参数
       <td>当 <code>'canal-json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
     </tr>       
     <tr>
+      <td><h5>canal-json.encode.decimal-as-plain-number</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
+    </tr>
+    <tr>
       <td><h5>canal-json.database.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/dev/table/connectors/formats/debezium.md
+++ b/docs/dev/table/connectors/formats/debezium.md
@@ -361,7 +361,14 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
       <td style="word-wrap: break-word;">'null'</td>
       <td>String</td>
       <td>Specify string literal to replace null key when <code>'debezium-json.map-null-key.mode'</code> is LITERAL.</td>
-    </tr>        
+    </tr>     
+    <tr>
+      <td><h5>debezium-json.encode.decimal-as-plain-number</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
+    </tr>   
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/debezium.zh.md
+++ b/docs/dev/table/connectors/formats/debezium.zh.md
@@ -360,6 +360,13 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
       <td>String</td>
       <td>当 <code>'debezium-json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
     </tr>
+    <tr>
+      <td><h5>debezium-json.encode.decimal-as-plain-number</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/json.md
+++ b/docs/dev/table/connectors/formats/json.md
@@ -136,6 +136,13 @@ Format Options
       <td>String</td>
       <td>Specify string literal to replace null key when <code>'json.map-null-key.mode'</code> is LITERAL.</td>
     </tr>     
+    <tr>
+      <td><h5>json.encode.decimal-as-plain-number</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/json.zh.md
+++ b/docs/dev/table/connectors/formats/json.zh.md
@@ -135,6 +135,13 @@ Format 参数
       <td>String</td>
       <td>当 <code>'json.map-null-key.mode'</code> 是 LITERAL 的时候，指定字符串常量替换 Map 中的空 key 值。</td>
     </tr>        
+    <tr>
+      <td><h5>json.encode.decimal-as-plain-number</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/maxwell.md
+++ b/docs/dev/table/connectors/formats/maxwell.md
@@ -187,6 +187,13 @@ Format Options
       <td>String</td>
       <td>Specify string literal to replace null key when <code>'maxwell-json.map-null-key.mode'</code> is LITERAL.</td>
     </tr>
+    <tr>
+      <td><h5>maxwell-json.encode.decimal-as-plain-number</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Encode all decimals as plain numbers instead of possible scientific notations. By default, decimals may be written using scientific notation. For example, <code>0.000000027</code> is encoded as <code>2.7E-8</code> by default, and will be written as <code>0.000000027</code> if set this option to true.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/dev/table/connectors/formats/maxwell.zh.md
+++ b/docs/dev/table/connectors/formats/maxwell.zh.md
@@ -187,6 +187,13 @@ Format Options
       <td>String</td>
       <td>Specify string literal to replace null key when <code>'maxwell-json.map-null-key.mode'</code> is LITERAL.</td>
     </tr>
+    <tr>
+      <td><h5>maxwell-json.encode.decimal-as-plain-number</h5></td>
+      <td>选填</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>将所有 DECIMAL 类型的数据保持原状，不使用科学计数法表示。例：<code>0.000000027</code> 默认会表示为 <code>2.7E-8</code>。当此选项设为 true 时，则会表示为 <code>0.000000027</code>。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.formats.json.JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.JsonOptions.FAIL_ON_MISSING_FIELD;
 import static org.apache.flink.formats.json.JsonOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.JsonOptions.MAP_NULL_KEY_LITERAL;
@@ -98,13 +99,20 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         JsonOptions.MapNullKeyMode mapNullKeyMode = JsonOptions.getMapNullKeyMode(formatOptions);
         String mapNullKeyLiteral = formatOptions.get(MAP_NULL_KEY_LITERAL);
 
+        final boolean encodeDecimalAsPlainNumber =
+                formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
             public SerializationSchema<RowData> createRuntimeEncoder(
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
                 return new JsonRowDataSerializationSchema(
-                        rowType, timestampOption, mapNullKeyMode, mapNullKeyLiteral);
+                        rowType,
+                        timestampOption,
+                        mapNullKeyMode,
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
             }
 
             @Override
@@ -132,6 +140,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         options.add(TIMESTAMP_FORMAT);
         options.add(MAP_NULL_KEY_MODE);
         options.add(MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonOptions.java
@@ -73,6 +73,13 @@ public class JsonOptions {
                                     + " Option ISO-8601 will parse input timestamp in \"yyyy-MM-ddTHH:mm:ss.s{precision}\" format and output timestamp in the same format."
                                     + " Option SQL will parse input timestamp in \"yyyy-MM-dd HH:mm:ss.s{precision}\" format and output timestamp in the same format.");
 
+    public static final ConfigOption<Boolean> ENCODE_DECIMAL_AS_PLAIN_NUMBER =
+            ConfigOptions.key("encode.decimal-as-plain-number")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to specify whether to encode all decimals as plain numbers instead of possible scientific notations, false by default.");
+
     // --------------------------------------------------------------------------------------------
     // Option enumerations
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactory.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.formats.json.JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.canal.CanalJsonOptions.DATABASE_INCLUDE;
 import static org.apache.flink.formats.json.canal.CanalJsonOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.canal.CanalJsonOptions.JSON_MAP_NULL_KEY_LITERAL;
@@ -84,6 +85,9 @@ public class CanalJsonFormatFactory
         JsonOptions.MapNullKeyMode mapNullKeyMode = JsonOptions.getMapNullKeyMode(formatOptions);
         String mapNullKeyLiteral = formatOptions.get(JSON_MAP_NULL_KEY_LITERAL);
 
+        final boolean encodeDecimalAsPlainNumber =
+                formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+
         return new EncodingFormat<SerializationSchema<RowData>>() {
             @Override
             public ChangelogMode getChangelogMode() {
@@ -100,7 +104,11 @@ public class CanalJsonFormatFactory
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
                 return new CanalJsonSerializationSchema(
-                        rowType, timestampFormat, mapNullKeyMode, mapNullKeyLiteral);
+                        rowType,
+                        timestampFormat,
+                        mapNullKeyMode,
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
             }
         };
     }
@@ -124,6 +132,7 @@ public class CanalJsonFormatFactory
         options.add(TABLE_INCLUDE);
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
@@ -58,13 +58,15 @@ public class CanalJsonSerializationSchema implements SerializationSchema<RowData
             RowType rowType,
             TimestampFormat timestampFormat,
             JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral) {
+            String mapNullKeyLiteral,
+            boolean encodeDecimalAsPlainNumber) {
         jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),
                         timestampFormat,
                         mapNullKeyMode,
-                        mapNullKeyLiteral);
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactory.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.formats.json.JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonOptions.JSON_MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.debezium.DebeziumJsonOptions.JSON_MAP_NULL_KEY_MODE;
@@ -85,6 +86,9 @@ public class DebeziumJsonFormatFactory
         JsonOptions.MapNullKeyMode mapNullKeyMode = JsonOptions.getMapNullKeyMode(formatOptions);
         String mapNullKeyLiteral = formatOptions.get(JSON_MAP_NULL_KEY_LITERAL);
 
+        final boolean encodeDecimalAsPlainNumber =
+                formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+
         return new EncodingFormat<SerializationSchema<RowData>>() {
 
             @Override
@@ -102,7 +106,11 @@ public class DebeziumJsonFormatFactory
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
                 return new DebeziumJsonSerializationSchema(
-                        rowType, timestampFormat, mapNullKeyMode, mapNullKeyLiteral);
+                        rowType,
+                        timestampFormat,
+                        mapNullKeyMode,
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
             }
         };
     }
@@ -125,6 +133,7 @@ public class DebeziumJsonFormatFactory
         options.add(TIMESTAMP_FORMAT);
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
@@ -55,13 +55,15 @@ public class DebeziumJsonSerializationSchema implements SerializationSchema<RowD
             RowType rowType,
             TimestampFormat timestampFormat,
             JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral) {
+            String mapNullKeyLiteral,
+            boolean encodeDecimalAsPlainNumber) {
         jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),
                         timestampFormat,
                         mapNullKeyMode,
-                        mapNullKeyLiteral);
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactory.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.flink.formats.json.JsonOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonOptions.JSON_MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.maxwell.MaxwellJsonOptions.JSON_MAP_NULL_KEY_MODE;
@@ -101,6 +102,9 @@ public class MaxwellJsonFormatFactory
         JsonOptions.MapNullKeyMode mapNullKeyMode = JsonOptions.getMapNullKeyMode(formatOptions);
         String mapNullKeyLiteral = formatOptions.get(JSON_MAP_NULL_KEY_LITERAL);
 
+        final boolean encodeDecimalAsPlainNumber =
+                formatOptions.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+
         return new EncodingFormat<SerializationSchema<RowData>>() {
 
             @Override
@@ -118,7 +122,11 @@ public class MaxwellJsonFormatFactory
                     DynamicTableSink.Context context, DataType consumedDataType) {
                 final RowType rowType = (RowType) consumedDataType.getLogicalType();
                 return new MaxwellJsonSerializationSchema(
-                        rowType, timestampFormat, mapNullKeyMode, mapNullKeyLiteral);
+                        rowType,
+                        timestampFormat,
+                        mapNullKeyMode,
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
             }
         };
     }
@@ -140,6 +148,7 @@ public class MaxwellJsonFormatFactory
         options.add(TIMESTAMP_FORMAT);
         options.add(JSON_MAP_NULL_KEY_MODE);
         options.add(JSON_MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
         return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
@@ -55,13 +55,15 @@ public class MaxwellJsonSerializationSchema implements SerializationSchema<RowDa
             RowType rowType,
             TimestampFormat timestampFormat,
             JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral) {
+            String mapNullKeyLiteral,
+            boolean encodeDecimalAsPlainNumber) {
         this.jsonSerializer =
                 new JsonRowDataSerializationSchema(
                         createJsonRowType(fromLogicalToDataType(rowType)),
                         timestampFormat,
                         mapNullKeyMode,
-                        mapNullKeyLiteral);
+                        mapNullKeyLiteral,
+                        encodeDecimalAsPlainNumber);
         this.timestampFormat = timestampFormat;
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -174,7 +174,8 @@ public class JsonFormatFactoryTest extends TestLogger {
                         ROW_TYPE,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         final DynamicTableSink actualSink = createTableSink(options);
         assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
@@ -211,6 +212,7 @@ public class JsonFormatFactoryTest extends TestLogger {
         options.put("json.timestamp-format.standard", "ISO-8601");
         options.put("json.map-null-key.mode", "LITERAL");
         options.put("json.map-null-key.literal", "null");
+        options.put("json.encode.decimal-as-plain-number", "true");
         return options;
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -195,7 +195,8 @@ public class JsonRowDataSerDeSchemaTest {
                         schema,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         byte[] actualBytes = serializationSchema.serialize(rowData);
         assertEquals(new String(serializedJson), new String(actualBytes));
@@ -284,7 +285,8 @@ public class JsonRowDataSerDeSchemaTest {
                         rowType,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -368,7 +370,8 @@ public class JsonRowDataSerDeSchemaTest {
                         rowType,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         for (int i = 0; i < jsons.length; i++) {
             String json = jsons[i];
@@ -484,7 +487,11 @@ public class JsonRowDataSerDeSchemaTest {
                         rowType, InternalTypeInfo.of(rowType), false, false, TimestampFormat.SQL);
         JsonRowDataSerializationSchema serializationSchema =
                 new JsonRowDataSerializationSchema(
-                        rowType, TimestampFormat.SQL, JsonOptions.MapNullKeyMode.LITERAL, "null");
+                        rowType,
+                        TimestampFormat.SQL,
+                        JsonOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true);
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -523,7 +530,11 @@ public class JsonRowDataSerDeSchemaTest {
 
         JsonRowDataSerializationSchema serializationSchema1 =
                 new JsonRowDataSerializationSchema(
-                        rowType, TimestampFormat.SQL, JsonOptions.MapNullKeyMode.FAIL, "null");
+                        rowType,
+                        TimestampFormat.SQL,
+                        JsonOptions.MapNullKeyMode.FAIL,
+                        "null",
+                        true);
         // expect message for serializationSchema1
         String errorMessage1 =
                 "JSON format doesn't support to serialize map data with null keys."
@@ -531,7 +542,11 @@ public class JsonRowDataSerDeSchemaTest {
 
         JsonRowDataSerializationSchema serializationSchema2 =
                 new JsonRowDataSerializationSchema(
-                        rowType, TimestampFormat.SQL, JsonOptions.MapNullKeyMode.DROP, "null");
+                        rowType,
+                        TimestampFormat.SQL,
+                        JsonOptions.MapNullKeyMode.DROP,
+                        "null",
+                        true);
         // expect result for serializationSchema2
         String expectResult2 = "{\"nestedMap\":{\"no-null key\":{\"no-null key\":1}}}";
 
@@ -540,7 +555,8 @@ public class JsonRowDataSerDeSchemaTest {
                         rowType,
                         TimestampFormat.SQL,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "nullKey");
+                        "nullKey",
+                        true);
         // expect result for serializationSchema3
         String expectResult3 =
                 "{\"nestedMap\":{\"no-null key\":{\"no-null key\":1,\"nullKey\":2},\"nullKey\":{\"no-null key\":1,\"nullKey\":2}}}";
@@ -560,6 +576,51 @@ public class JsonRowDataSerDeSchemaTest {
         // mapNullKey Mode is literal
         byte[] actual3 = serializationSchema3.serialize(rowData);
         assertEquals(expectResult3, new String(actual3));
+    }
+
+    @Test
+    public void testSerializationDecimalEncode() throws Exception {
+        RowType schema =
+                (RowType)
+                        ROW(
+                                        FIELD("decimal1", DECIMAL(9, 6)),
+                                        FIELD("decimal2", DECIMAL(20, 0)),
+                                        FIELD("decimal3", DECIMAL(11, 9)))
+                                .getLogicalType();
+
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+
+        JsonRowDataDeserializationSchema deserializer =
+                new JsonRowDataDeserializationSchema(
+                        schema, resultTypeInfo, false, false, TimestampFormat.ISO_8601);
+
+        JsonRowDataSerializationSchema plainDecimalSerializer =
+                new JsonRowDataSerializationSchema(
+                        schema,
+                        TimestampFormat.ISO_8601,
+                        JsonOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true);
+        JsonRowDataSerializationSchema scientificDecimalSerializer =
+                new JsonRowDataSerializationSchema(
+                        schema,
+                        TimestampFormat.ISO_8601,
+                        JsonOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        false);
+
+        String plainDecimalJson =
+                "{\"decimal1\":123.456789,\"decimal2\":454621864049246170,\"decimal3\":0.000000027}";
+        RowData rowData = deserializer.deserialize(plainDecimalJson.getBytes());
+
+        String plainDecimalResult = new String(plainDecimalSerializer.serialize(rowData));
+        assertEquals(plainDecimalJson, plainDecimalResult);
+
+        String scientificDecimalJson =
+                "{\"decimal1\":123.456789,\"decimal2\":4.5462186404924617E+17,\"decimal3\":2.7E-8}";
+
+        String scientificDecimalResult = new String(scientificDecimalSerializer.serialize(rowData));
+        assertEquals(scientificDecimalJson, scientificDecimalResult);
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonFormatFactoryTest.java
@@ -86,7 +86,11 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
         // test Ser
         CanalJsonSerializationSchema expectedSer =
                 new CanalJsonSerializationSchema(
-                        ROW_TYPE, TimestampFormat.SQL, JsonOptions.MapNullKeyMode.FAIL, "null");
+                        ROW_TYPE,
+                        TimestampFormat.SQL,
+                        JsonOptions.MapNullKeyMode.FAIL,
+                        "null",
+                        false);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
         assertEquals(expectedSer, actualSer);
     }
@@ -100,6 +104,7 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
         options.put("canal-json.table.include", "mytable");
         options.put("canal-json.map-null-key.mode", "LITERAL");
         options.put("canal-json.map-null-key.literal", "nullKey");
+        options.put("canal-json.encode.decimal-as-plain-number", "true");
 
         // test Deser
         CanalJsonDeserializationSchema expectedDeser =
@@ -119,7 +124,8 @@ public class CanalJsonFormatFactoryTest extends TestLogger {
                         ROW_TYPE,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "nullKey");
+                        "nullKey",
+                        true);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
         assertEquals(expectedSer, actualSer);
     }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -217,7 +217,8 @@ public class CanalJsonSerDeSchemaTest {
                         (RowType) PHYSICAL_DATA_TYPE.getLogicalType(),
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
         serializationSchema.open(null);
 
         List<String> result = new ArrayList<>();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonFormatFactoryTest.java
@@ -95,7 +95,8 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
                         (RowType) PHYSICAL_DATA_TYPE.getLogicalType(),
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         final DynamicTableSink actualSink = createTableSink(options);
         assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;
@@ -212,6 +213,7 @@ public class DebeziumJsonFormatFactoryTest extends TestLogger {
         options.put("debezium-json.timestamp-format.standard", "ISO-8601");
         options.put("debezium-json.map-null-key.mode", "LITERAL");
         options.put("debezium-json.map-null-key.literal", "null");
+        options.put("debezium-json.encode.decimal-as-plain-number", "true");
         return options;
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerDeSchemaTest.java
@@ -257,7 +257,8 @@ public class DebeziumJsonSerDeSchemaTest {
                         (RowType) PHYSICAL_DATA_TYPE.getLogicalType(),
                         TimestampFormat.SQL,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         serializationSchema.open(null);
         actual = new ArrayList<>();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
@@ -74,7 +74,8 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
                         ROW_TYPE,
                         TimestampFormat.ISO_8601,
                         JsonOptions.MapNullKeyMode.LITERAL,
-                        "null");
+                        "null",
+                        true);
 
         final Map<String, String> options = getAllOptions();
 
@@ -167,6 +168,7 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
         options.put("maxwell-json.timestamp-format.standard", "ISO-8601");
         options.put("maxwell-json.map-null-key.mode", "LITERAL");
         options.put("maxwell-json.map-null-key.literal", "null");
+        options.put("maxwell-json.encode.decimal-as-plain-number", "true");
         return options;
     }
 

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerDerTest.java
@@ -135,7 +135,11 @@ public class MaxwellJsonSerDerTest {
 
         MaxwellJsonSerializationSchema serializationSchema =
                 new MaxwellJsonSerializationSchema(
-                        SCHEMA, TimestampFormat.SQL, JsonOptions.MapNullKeyMode.LITERAL, "null");
+                        SCHEMA,
+                        TimestampFormat.SQL,
+                        JsonOptions.MapNullKeyMode.LITERAL,
+                        "null",
+                        true);
         serializationSchema.open(null);
         List<String> result = new ArrayList<>();
         for (RowData rowData : collector.list) {


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces option `json.encode.decimal-as-plain-number` for JSON formats.

## Brief change log

- Add this option in `JsonOptions`.
- Let `JsonFormatFactory`s and `JsonRowDataSerializationSchema`s be aware of this option.

## Verifying this change

This change added tests and can be verified as follows:

- Added test in `JsonRowDataSerDeSchemaTest` to cover different decimal cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
