### PR TITLE
[FLINK-20921][python] Support SqlTimeTypeInfo in Python DataStream

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -650,6 +650,25 @@ class DataStreamTests(PyFlinkTestCase):
         expected.sort()
         self.assertEqual(expected, results)
 
+    def test_sql_timestamp_type_info(self):
+        ds = self.env.from_collection([(datetime.date(2021, 1, 9),
+                                        datetime.time(12, 0, 0),
+                                        datetime.datetime(2021, 1, 9, 12, 0, 0, 11000))],
+                                      type_info=Types.ROW([Types.SQL_DATE(),
+                                                           Types.SQL_TIME(),
+                                                           Types.SQL_TIMESTAMP()]))
+
+        ds.map(lambda x: x, output_type=Types.ROW([Types.SQL_DATE(),
+                                                   Types.SQL_TIME(),
+                                                   Types.SQL_TIMESTAMP()]))\
+            .add_sink(self.test_sink)
+        self.env.execute("test sql timestamp type info")
+        results = self.test_sink.get_results()
+        expected = ['+I[2021-01-09, 12:00:00, 2021-01-09 12:00:00.011]']
+        results.sort()
+        expected.sort()
+        self.assertEqual(expected, results)
+
     def test_timestamp_assigner_and_watermark_strategy(self):
         self.env.set_parallelism(1)
         self.env.get_config().set_auto_watermark_interval(2000)

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -665,8 +665,6 @@ class DataStreamTests(PyFlinkTestCase):
         self.env.execute("test sql timestamp type info")
         results = self.test_sink.get_results()
         expected = ['+I[2021-01-09, 12:00:00, 2021-01-09 12:00:00.011]']
-        results.sort()
-        expected.sort()
         self.assertEqual(expected, results)
 
     def test_timestamp_assigner_and_watermark_strategy(self):

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -589,7 +589,7 @@ _type_info_name_mappings = {
     type_info_name.BIG_DEC: BigDecimalCoder(),
     type_info_name.SQL_DATE: DateCoder(),
     type_info_name.SQL_TIME: TimeCoder(),
-    type_info_name.SQL_TIMESTAMP: TimeCoder(),
+    type_info_name.SQL_TIMESTAMP: TimestampCoder(3),
     type_info_name.PICKLED_BYTES: PickledBytesCoder()
 }
 

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.utils;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -41,7 +42,10 @@ import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 
 import org.junit.Test;
 
@@ -82,6 +86,10 @@ public class PythonTypeUtilsTest {
                 FlinkFnApi.TypeInfo.TypeName.PICKLED_BYTES);
         typeInformationTypeNameMap.put(
                 BasicTypeInfo.BOOLEAN_TYPE_INFO, FlinkFnApi.TypeInfo.TypeName.BOOLEAN);
+        typeInformationTypeNameMap.put(SqlTimeTypeInfo.DATE, FlinkFnApi.TypeInfo.TypeName.SQL_DATE);
+        typeInformationTypeNameMap.put(SqlTimeTypeInfo.TIME, FlinkFnApi.TypeInfo.TypeName.SQL_TIME);
+        typeInformationTypeNameMap.put(
+                SqlTimeTypeInfo.TIMESTAMP, FlinkFnApi.TypeInfo.TypeName.SQL_TIMESTAMP);
 
         for (Map.Entry<TypeInformation, FlinkFnApi.TypeInfo.TypeName> entry :
                 typeInformationTypeNameMap.entrySet()) {
@@ -151,6 +159,9 @@ public class PythonTypeUtilsTest {
                 BytePrimitiveArraySerializer.INSTANCE);
         typeInformationTypeSerializerMap.put(
                 BasicTypeInfo.BOOLEAN_TYPE_INFO, BooleanSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.DATE, DateSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.TIME, TimeSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.TIMESTAMP, new TimestampSerializer(3));
 
         for (Map.Entry<TypeInformation, TypeSerializer> entry :
                 typeInformationTypeSerializerMap.entrySet()) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request Support SqlTimeTypeInfo in Python DataStream*


## Brief change log

  - *Support SqlTimeTypeInfo in Python DataStream*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added relational UT in `PythonTypeUtilsTest`*
  - *Added IT in `test_sql_timestamp_type_info` in `test_data_stream.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
