### PR TITLE
[FLINK-20916][runtime] Remove obsolete testcase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerCustomLogHandlerTest.java
@@ -151,16 +151,6 @@ public class JobManagerCustomLogHandlerTest extends TestLogger {
     }
 
     @Test
-    public void testGetJobManagerCustomLogsExistingButForbiddenFileWithObfuscatedPath()
-            throws Exception {
-        File actualFile =
-                testInstance.getFile(
-                        createHandlerRequest(String.format("..%%252%s", FORBIDDEN_FILENAME)));
-        assertThat(actualFile, is(notNullValue()));
-        assertFalse(actualFile.exists());
-    }
-
-    @Test
     public void testGetJobManagerCustomLogsValidFilenameWithLongInvalidPath() throws Exception {
         File actualFile =
                 testInstance.getFile(


### PR DESCRIPTION
## What is the purpose of the change

The test itself does not test the functionality it complains to test. The
JobManagerCustomLogHandler does not decode the URL encoding at all. The URL
parsing and decoding happens already earlier in the process (see [RouterHandler
which utilizes QueryStringDecoder](https://github.com/apache/flink/blob/c6997c97c575d334679915c328792b8a3067cfb5/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/RouterHandler.java#L86) and parses the PathParameter objects). It
does not need to be tested individually in this test class. Hence, this
testcase is obsolete and, therefore, can be deleted.


## Brief change log

Test was deleted.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
