### PR TITLE
[FLINK-20909][table-planner-blink] Fix deduplicate mini-batch interval infer

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalDeduplicate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalDeduplicate.scala
@@ -46,7 +46,7 @@ class StreamPhysicalDeduplicate(
 
   def getUniqueKeys: Array[Int] = uniqueKeys
 
-  override def requireWatermark: Boolean = false
+  override def requireWatermark: Boolean = isRowtime
 
   override def deriveRowType(): RelDataType = getInput.getRowType
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.xml
@@ -72,6 +72,86 @@ Calc(select=[a, 3:BIGINT AS $1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMiniBatchInferFirstRowOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(b) FROM (
+  SELECT a, b
+  FROM (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime ASC) as rank_num
+    FROM T)
+  WHERE rank_num <= 1
+)
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)])
++- LogicalProject(b=[$1])
+   +- LogicalFilter(condition=[<=($4, 1)])
+      +- LogicalProject(a=[$0], b=[$1], rowtime=[$2], proctime=[$3], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 NULLS FIRST)])
+         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+            +- LogicalProject(a=[$0], b=[$1], rowtime=[$2], proctime=[PROCTIME()])
+               +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [CollectionTableSource(a, b, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GlobalGroupAggregate(select=[COUNT_RETRACT(count$0) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- LocalGroupAggregate(select=[COUNT_RETRACT(b) AS count$0, COUNT_RETRACT(*) AS count1$1])
+      +- Calc(select=[b])
+         +- Deduplicate(keep=[FirstRow], key=[a], order=[ROWTIME])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, rowtime])
+                  +- MiniBatchAssigner(interval=[1000ms], mode=[RowTime])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+                        +- Calc(select=[a, b, rowtime, PROCTIME() AS proctime])
+                           +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [CollectionTableSource(a, b, rowtime)]]], fields=[a, b, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMiniBatchInferLastRowOnRowtime">
+    <Resource name="sql">
+      <![CDATA[
+SELECT COUNT(b) FROM (
+  SELECT a, b
+  FROM (
+    SELECT *,
+        ROW_NUMBER() OVER (PARTITION BY a ORDER BY rowtime DESC) as rank_num
+    FROM T)
+  WHERE rank_num = 1
+)
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT($0)])
++- LogicalProject(b=[$1])
+   +- LogicalFilter(condition=[=($4, 1)])
+      +- LogicalProject(a=[$0], b=[$1], rowtime=[$2], proctime=[$3], rank_num=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+            +- LogicalProject(a=[$0], b=[$1], rowtime=[$2], proctime=[PROCTIME()])
+               +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [CollectionTableSource(a, b, rowtime)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GlobalGroupAggregate(select=[COUNT_RETRACT(count$0) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- LocalGroupAggregate(select=[COUNT_RETRACT(b) AS count$0, COUNT_RETRACT(*) AS count1$1])
+      +- Calc(select=[b])
+         +- Deduplicate(keep=[LastRow], key=[a], order=[ROWTIME])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, rowtime])
+                  +- MiniBatchAssigner(interval=[1000ms], mode=[RowTime])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+                        +- Calc(select=[a, b, rowtime, PROCTIME() AS proctime])
+                           +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [CollectionTableSource(a, b, rowtime)]]], fields=[a, b, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSimpleFirstRowOnBuiltinProctime">
     <Resource name="sql">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change

MiniBatch infer does not work well if job contains unbounded aggregate and deduplicate because deduplicate does not take rowtime mode into consideration when implements `requireWatermark` method.


## Brief change log
Minor update on `StreamExecDeduplicate`

## Verifying this change
UT in `DeduplicateTest` and IT in `DeduplicateITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
