### PR TITLE
[FLINK-13194][docs] Add explicit clarification about thread-safety of state

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -49,6 +49,7 @@ Flink 内置了以下这些开箱即用的 state backends ：
 
 如果不设置，默认使用 HashMapStateBackend。
 
+**NOTE:** 由于Flink operator内对状态的访问都是单线程的，所以目前state backends的实现都不是线程安全的。
 
 <a name="the-hashmapstatebackend"></a>
 

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -48,6 +48,8 @@ Out of the box, Flink bundles these state backends:
 
 If nothing else is configured, the system will use the HashMapStateBackend.
 
+**NOTE:** Current implementations of state backends are not thread-safety as state access within Flink operator assumes to be single-threaded.
+
 ### The HashMapStateBackend
 
 The *HashMapStateBackend* holds data internally as objects on the Java heap. Key/value state and window operators hold hash tables

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -30,6 +30,11 @@ import java.util.stream.Stream;
 /**
  * A keyed state backend provides methods for managing keyed state.
  *
+ * <h2>Not Thread-Safe</h2>
+ *
+ * State access in keyed state backend dose not require thread safety as each task is executed by
+ * one thread. Current implementations (Heap/RocksDB keyed state backend) are not thread-safe.
+ *
  * @param <K> The key by which state is keyed.
  */
 public interface KeyedStateBackend<K>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateBackend.java
@@ -26,6 +26,11 @@ import java.io.Closeable;
 /**
  * Interface that combines both, the user facing {@link OperatorStateStore} interface and the system
  * interface {@link Snapshotable}
+ *
+ * <h2>Not Thread-Safe</h2>
+ *
+ * State access in operator state backend does not require thread safety as each task is executed by
+ * one thread. Current implementation (Default operator state backend) is not thread-safe.
  */
 public interface OperatorStateBackend
         extends OperatorStateStore,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -71,10 +71,10 @@ import java.util.Collection;
  * structures. That way, the State Backend can be very lightweight (contain only configurations)
  * which makes it easier to be serializable.
  *
- * <h2>Thread Safety</h2>
+ * <h2>Thread Safety when Creating Keyed-/Operator State Backend</h2>
  *
- * <p>State backend implementations have to be thread-safe. Multiple threads may be creating
- * keyed-/operator state backends concurrently.
+ * Please ensure implementations of this class guarantee thread-safety when creating keyed-/operator
+ * state backends as multiple threads may create them concurrently.
  */
 @PublicEvolving
 public interface StateBackend extends java.io.Serializable {


### PR DESCRIPTION
## What is the purpose of the change
Add explicit clarification about thread-safety of state access.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable