### PR TITLE
[FLINK-20864][runtime] Apply exactly matching for fine-rained resource profiles 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceBudgetManager.java
@@ -50,7 +50,7 @@ public class ResourceBudgetManager {
 
     public boolean reserve(final ResourceProfile reservation) {
         checkResourceProfileNotNullOrUnknown(reservation);
-        if (!availableBudget.isMatching(reservation)) {
+        if (!availableBudget.allFieldsNoLessThan(reservation)) {
             return false;
         }
 
@@ -61,7 +61,7 @@ public class ResourceBudgetManager {
     public boolean release(final ResourceProfile reservation) {
         checkResourceProfileNotNullOrUnknown(reservation);
         ResourceProfile newAvailableBudget = availableBudget.merge(reservation);
-        if (!totalBudget.isMatching(newAvailableBudget)) {
+        if (!totalBudget.allFieldsNoLessThan(newAvailableBudget)) {
             return false;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -254,6 +254,7 @@ public class ResourceProfile implements Serializable {
      */
     public boolean isMatching(final ResourceProfile required) {
         checkNotNull(required, "Cannot check matching with null resources");
+        throwUnsupportedOperationExecptionIfUnknown();
 
         if (this.equals(ANY)) {
             return true;
@@ -263,21 +264,59 @@ public class ResourceProfile implements Serializable {
             return true;
         }
 
-        if (this.equals(UNKNOWN)) {
-            return false;
-        }
-
         if (required.equals(UNKNOWN)) {
             return true;
         }
 
-        if (cpuCores.getValue().compareTo(required.cpuCores.getValue()) >= 0
-                && taskHeapMemory.compareTo(required.taskHeapMemory) >= 0
-                && taskOffHeapMemory.compareTo(required.taskOffHeapMemory) >= 0
-                && managedMemory.compareTo(required.managedMemory) >= 0
-                && networkMemory.compareTo(required.networkMemory) >= 0) {
+        return false;
+    }
 
-            for (Map.Entry<String, Resource> resource : required.extendedResources.entrySet()) {
+    /**
+     * Check whether all fields of this resource profile are no less than the given resource
+     * profile.
+     *
+     * <p>It is not same with the total resource comparison. It return true iff each resource
+     * field(cpu, task heap memory, managed memory, etc.) is no less than the respective field of
+     * the given profile.
+     *
+     * <p>For example, assume that this profile has 1 core, 50 managed memory and 100 heap memory.
+     *
+     * <ol>
+     *   <li>The comparison will return false if the other profile has 2 core, 10 managed memory and
+     *       1000 heap memory.
+     *   <li>The comparison will return true if the other profile has 1 core, 50 managed memory and
+     *       150 heap memory.
+     * </ol>
+     *
+     * @param other the other resource profile
+     * @return true if all fields of this are no less than the other's, otherwise false
+     */
+    public boolean allFieldsNoLessThan(final ResourceProfile other) {
+        checkNotNull(other, "Cannot compare null resources");
+
+        if (this.equals(ANY)) {
+            return true;
+        }
+
+        if (this.equals(other)) {
+            return true;
+        }
+
+        if (this.equals(UNKNOWN)) {
+            return false;
+        }
+
+        if (other.equals(UNKNOWN)) {
+            return true;
+        }
+
+        if (cpuCores.getValue().compareTo(other.cpuCores.getValue()) >= 0
+                && taskHeapMemory.compareTo(other.taskHeapMemory) >= 0
+                && taskOffHeapMemory.compareTo(other.taskOffHeapMemory) >= 0
+                && managedMemory.compareTo(other.managedMemory) >= 0
+                && networkMemory.compareTo(other.networkMemory) >= 0) {
+
+            for (Map.Entry<String, Resource> resource : other.extendedResources.entrySet()) {
                 if (!extendedResources.containsKey(resource.getKey())
                         || extendedResources
                                         .get(resource.getKey())
@@ -376,7 +415,8 @@ public class ResourceProfile implements Serializable {
         }
 
         checkArgument(
-                isMatching(other), "Try to subtract an unmatched resource profile from this one.");
+                allFieldsNoLessThan(other),
+                "Try to subtract an unmatched resource profile from this one.");
 
         Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexSchedulingRequirements.java
@@ -134,7 +134,7 @@ public class ExecutionVertexSchedulingRequirements {
 
         public ExecutionVertexSchedulingRequirements build() {
             checkState(
-                    physicalSlotResourceProfile.isMatching(taskResourceProfile),
+                    physicalSlotResourceProfile.allFieldsNoLessThan(taskResourceProfile),
                     "The physical slot resources must fulfill the task slot requirements");
 
             return new ExecutionVertexSchedulingRequirements(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImpl.java
@@ -293,7 +293,9 @@ public class TaskSlotTableImpl<T extends TaskSlotPayload> implements TaskSlotTab
         // transfer the index to an increasing number not less than the numberSlots.
         int index = requestedIndex < 0 ? nextDynamicSlotIndex() : requestedIndex;
         ResourceProfile effectiveResourceProfile =
-                isDynamicIndex(index) ? resourceProfile : defaultSlotResourceProfile;
+                resourceProfile.equals(ResourceProfile.UNKNOWN)
+                        ? defaultSlotResourceProfile
+                        : resourceProfile;
 
         TaskSlot<T> taskSlot = allocatedSlots.get(allocationId);
         if (taskSlot != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -143,7 +143,8 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
     public void matchPreferredLocation() {
 
         SlotProfile slotProfile =
-                SlotProfile.preferredLocality(resourceProfile, Collections.singletonList(tml2));
+                SlotProfile.preferredLocality(
+                        biggerResourceProfile, Collections.singletonList(tml2));
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         Assert.assertEquals(slotInfo2, match.get().getSlotInfo());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/PreviousAllocationSlotSelectionStrategyTest.java
@@ -101,7 +101,7 @@ public class PreviousAllocationSlotSelectionStrategyTest
     @Test
     public void matchPreviousLocationNotAvailableAndSomeOthersBlacklisted() {
         HashSet<AllocationID> blacklisted = new HashSet<>(3);
-        blacklisted.add(aid1);
+        blacklisted.add(aid2);
         blacklisted.add(aid3);
         blacklisted.add(aid4);
         SlotProfile slotProfile =
@@ -114,6 +114,6 @@ public class PreviousAllocationSlotSelectionStrategyTest
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         // we expect that the candidate that is not blacklisted is returned
-        Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
+        Assert.assertEquals(slotInfo1, match.get().getSlotInfo());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterExecutionDeploymentReconciliationTest.java
@@ -257,8 +257,7 @@ public class JobMasterExecutionDeploymentReconciliationTest extends TestLogger {
                 .get();
 
         Collection<SlotOffer> slotOffers =
-                Collections.singleton(
-                        new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN));
+                Collections.singleton(new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY));
 
         jobMasterGateway
                 .offerSlots(taskManagerLocation.getResourceID(), slotOffers, testingTimeout)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -254,7 +254,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
             Collection<SlotOffer> slotOffers =
                     Collections.singleton(
-                            new SlotOffer(new AllocationID(), 0, ResourceProfile.UNKNOWN));
+                            new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY));
 
             jobMasterGateway
                     .offerSlots(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPoolTest.java
@@ -481,8 +481,7 @@ public class DefaultDeclarativeSlotPoolTest extends TestLogger {
 
         final ResourceProfile largeResourceProfile =
                 ResourceProfile.newBuilder().setManagedMemoryMB(1024).build();
-        final ResourceProfile smallResourceProfile =
-                ResourceProfile.newBuilder().setManagedMemoryMB(512).build();
+        final ResourceProfile smallResourceProfile = ResourceProfile.UNKNOWN;
 
         slotPool.increaseResourceRequirementsBy(
                 ResourceCounter.withResource(largeResourceProfile, 1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -118,7 +117,9 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
                 createAndSetUpSlotPool(directMainThreadExecutor, null, batchSlotTimeout, clock)) {
 
             SlotPoolUtils.offerSlots(
-                    slotPool, directMainThreadExecutor, Collections.singletonList(resourceProfile));
+                    slotPool,
+                    directMainThreadExecutor,
+                    Arrays.asList(resourceProfile, smallerResourceProfile));
 
             final CompletableFuture<PhysicalSlot> firstSlotFuture =
                     SlotPoolUtils.requestNewAllocatedBatchSlot(
@@ -288,7 +289,7 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
                     SlotPoolUtils.offerSlots(
                             slotPool,
                             directMainThreadExecutor,
-                            Collections.singletonList(resourceProfile));
+                            Arrays.asList(resourceProfile, smallerResourceProfile));
             final CompletableFuture<PhysicalSlot> firstSlotFuture =
                     SlotPoolUtils.requestNewAllocatedBatchSlot(
                             slotPool, directMainThreadExecutor, resourceProfile);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFailUnfulfillableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerFailUnfulfillableTest.java
@@ -63,15 +63,14 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
     @Test
     public void testTurnOnKeepsPendingFulfillableRequests() throws Exception {
         // setup
-        final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
-        final ResourceProfile fulfillableProfile = ResourceProfile.fromResources(1.0, 100);
+        final ResourceProfile resourceProfile = ResourceProfile.fromResources(2.0, 100);
 
         final SlotManager slotManager = createSlotManagerNotStartingNewTMs();
         slotManager.setFailUnfulfillableRequest(false);
-        registerFreeSlot(slotManager, availableProfile);
+        registerFreeSlot(slotManager, resourceProfile);
 
-        slotManager.registerSlotRequest(slotRequest(fulfillableProfile));
-        slotManager.registerSlotRequest(slotRequest(fulfillableProfile));
+        slotManager.registerSlotRequest(slotRequest(resourceProfile));
+        slotManager.registerSlotRequest(slotRequest(resourceProfile));
 
         // test
         slotManager.setFailUnfulfillableRequest(true);
@@ -111,7 +110,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
     public void testTurnOnKeepsRequestsWithStartingTMs() throws Exception {
         // setup
         final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
-        final ResourceProfile newTmProfile = ResourceProfile.fromResources(2.0, 200);
+        final ResourceProfile newTmProfile =
+                SlotManagerImpl.generateDefaultSlotResourceProfile(WORKER_RESOURCE_SPEC, 1);
 
         final SlotManager slotManager = createSlotManagerStartingNewTMs();
         slotManager.setFailUnfulfillableRequest(false);
@@ -172,7 +172,8 @@ public class SlotManagerFailUnfulfillableTest extends TestLogger {
     public void testStartingTmKeepsSlotPendingWhenOn() throws Exception {
         // setup
         final ResourceProfile availableProfile = ResourceProfile.fromResources(2.0, 100);
-        final ResourceProfile newTmProfile = ResourceProfile.fromResources(2.0, 200);
+        final ResourceProfile newTmProfile =
+                SlotManagerImpl.generateDefaultSlotResourceProfile(WORKER_RESOURCE_SPEC, 1);
 
         final SlotManager slotManager = createSlotManagerStartingNewTMs();
         registerFreeSlot(slotManager, availableProfile);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -207,7 +207,7 @@ public class SlotManagerImplTest extends TestLogger {
     @Test
     public void testSlotRequestWithoutFreeSlots() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-        final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
+        final ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
         final SlotRequest slotRequest =
                 new SlotRequest(new JobID(), new AllocationID(), resourceProfile, "localhost");
 
@@ -384,7 +384,7 @@ public class SlotManagerImplTest extends TestLogger {
         final SlotID slotId = new SlotID(resourceID, 0);
         final String targetAddress = "localhost";
         final AllocationID allocationId = new AllocationID();
-        final ResourceProfile resourceProfile = ResourceProfile.fromResources(42.0, 1337);
+        final ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
         final SlotRequest slotRequest =
                 new SlotRequest(jobId, allocationId, resourceProfile, targetAddress);
 
@@ -420,7 +420,7 @@ public class SlotManagerImplTest extends TestLogger {
         final TaskExecutorConnection taskExecutorConnection =
                 new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
-        final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
+        final SlotStatus slotStatus = new SlotStatus(slotId, ResourceProfile.ANY);
         final SlotReport slotReport = new SlotReport(slotStatus);
 
         try (SlotManagerImpl slotManager =
@@ -516,12 +516,10 @@ public class SlotManagerImplTest extends TestLogger {
                                 ignored -> numberAllocateResourceFunctionCalls.incrementAndGet())
                         .build();
         final AllocationID allocationId = new AllocationID();
-        final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
-        final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2.0, 1);
         final SlotRequest slotRequest1 =
-                new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
+                new SlotRequest(new JobID(), allocationId, ResourceProfile.UNKNOWN, "foobar");
         final SlotRequest slotRequest2 =
-                new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
+                new SlotRequest(new JobID(), allocationId, ResourceProfile.UNKNOWN, "barfoo");
 
         try (SlotManager slotManager =
                 createSlotManager(resourceManagerId, resourceManagerActions)) {
@@ -633,12 +631,11 @@ public class SlotManagerImplTest extends TestLogger {
                                 ignored -> allocateResourceCalls.incrementAndGet())
                         .build();
         final AllocationID allocationId = new AllocationID();
-        final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
-        final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2.0, 1);
+        final ResourceProfile resourceProfile = ResourceProfile.fromResources(2.0, 2);
         final SlotRequest slotRequest1 =
-                new SlotRequest(new JobID(), allocationId, resourceProfile1, "foobar");
+                new SlotRequest(new JobID(), allocationId, resourceProfile, "foobar");
         final SlotRequest slotRequest2 =
-                new SlotRequest(new JobID(), allocationId, resourceProfile2, "barfoo");
+                new SlotRequest(new JobID(), allocationId, resourceProfile, "barfoo");
 
         final TaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
@@ -648,7 +645,7 @@ public class SlotManagerImplTest extends TestLogger {
                 new TaskExecutorConnection(resourceID, taskExecutorGateway);
 
         final SlotID slotId = new SlotID(resourceID, 0);
-        final SlotStatus slotStatus = new SlotStatus(slotId, ResourceProfile.fromResources(2.0, 2));
+        final SlotStatus slotStatus = new SlotStatus(slotId, resourceProfile);
         final SlotReport slotReport = new SlotReport(slotStatus);
 
         try (SlotManagerImpl slotManager =
@@ -791,7 +788,7 @@ public class SlotManagerImplTest extends TestLogger {
         final JobID jobId = new JobID();
         final AllocationID allocationId = new AllocationID();
 
-        final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
+        final ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
         final SlotRequest slotRequest =
                 new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 
@@ -1022,7 +1019,7 @@ public class SlotManagerImplTest extends TestLogger {
 
         final JobID jobId = new JobID();
         final AllocationID allocationId = new AllocationID();
-        final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
+        final ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
         final SlotRequest slotRequest =
                 new SlotRequest(jobId, allocationId, resourceProfile, "foobar");
 
@@ -1041,8 +1038,8 @@ public class SlotManagerImplTest extends TestLogger {
 
         final SlotID slotId1 = new SlotID(resourceId, 0);
         final SlotID slotId2 = new SlotID(resourceId, 1);
-        final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile);
-        final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile);
+        final SlotStatus slotStatus1 = new SlotStatus(slotId1, ResourceProfile.ANY);
+        final SlotStatus slotStatus2 = new SlotStatus(slotId2, ResourceProfile.ANY);
         final SlotReport initialSlotReport =
                 new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
 
@@ -1694,7 +1691,7 @@ public class SlotManagerImplTest extends TestLogger {
         try (final SlotManagerImpl slotManager =
                 createSlotManager(ResourceManagerId.generate(), resourceActions, numberSlots)) {
             final JobID jobId = new JobID();
-            final ResourceProfile requestedSlotProfile = ResourceProfile.fromResources(1.0, 1);
+            final ResourceProfile requestedSlotProfile = ResourceProfile.UNKNOWN;
 
             assertThat(
                     slotManager.registerSlotRequest(createSlotRequest(jobId, requestedSlotProfile)),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -173,8 +173,14 @@ public class TaskSlotTableImplTest extends TestLogger {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
 
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId, SLOT_TIMEOUT), is(true));
-            assertThat(taskSlotTable.allocateSlot(0, jobId, allocationId, SLOT_TIMEOUT), is(true));
+            assertThat(
+                    taskSlotTable.allocateSlot(
+                            0, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT),
+                    is(true));
+            assertThat(
+                    taskSlotTable.allocateSlot(
+                            0, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT),
+                    is(true));
 
             assertThat(taskSlotTable.isAllocated(0, jobId, allocationId), is(true));
             assertThat(taskSlotTable.isSlotFree(1), is(true));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTableImplTest.java
@@ -252,7 +252,7 @@ public class TaskSlotTableImplTest extends TestLogger {
     }
 
     @Test
-    public void testSlotAllocationWithResourceProfile() throws Exception {
+    public void testSlotAllocationWithConcreteResourceProfile() throws Exception {
         try (final TaskSlotTable<TaskSlotPayload> taskSlotTable = createTaskSlotTableAndStart(2)) {
             final JobID jobId = new JobID();
             final AllocationID allocationId = new AllocationID();
@@ -270,6 +270,28 @@ public class TaskSlotTableImplTest extends TestLogger {
             TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
             assertThat(allocatedSlot.getIndex(), is(2));
             assertThat(allocatedSlot.getResourceProfile(), is(resourceProfile));
+            assertThat(allocatedSlots.hasNext(), is(false));
+        }
+    }
+
+    @Test
+    public void testSlotAllocationWithUnknownResourceProfile() throws Exception {
+        try (final TaskSlotTableImpl<TaskSlotPayload> taskSlotTable =
+                createTaskSlotTableAndStart(2)) {
+            final JobID jobId = new JobID();
+            final AllocationID allocationId = new AllocationID();
+
+            assertThat(
+                    taskSlotTable.allocateSlot(
+                            -1, jobId, allocationId, ResourceProfile.UNKNOWN, SLOT_TIMEOUT),
+                    is(true));
+
+            Iterator<TaskSlot<TaskSlotPayload>> allocatedSlots =
+                    taskSlotTable.getAllocatedSlots(jobId);
+            TaskSlot<TaskSlotPayload> allocatedSlot = allocatedSlots.next();
+            assertThat(allocatedSlot.getIndex(), is(2));
+            assertThat(
+                    allocatedSlot.getResourceProfile(), is(TaskSlotUtils.DEFAULT_RESOURCE_PROFILE));
             assertThat(allocatedSlots.hasNext(), is(false));
         }
     }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR proposed to replace the loose matching rules with the following exact matching rules.
- An unspecified requirement (`ResourceProfile::UNKNOWN`) can only be fulfilled by a TM's default slot resource.
- A specified requirement can only be fulfilled by a resource that is equal to itself.

## Brief change log

- Introduce DEFAULT resource profile which represents the default slot profile of a TM and matches the UNKNOWN requirement.
- Fix the `ResourceProfile#isMatching`. It's now only used in matching requirements with resources.
- Introduce `ResourceProfile#isBiggerThan`, which is used to compare two resource capacities.

