### PR TITLE
[FLINK-20911][state-backend-rocksdb] Support configuration of RocksDB log level

### DIFF
--- a/docs/_includes/generated/rocksdb_configurable_configuration.html
+++ b/docs/_includes/generated/rocksdb_configurable_configuration.html
@@ -51,6 +51,12 @@
             <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '-1'.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.log.level</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td><p>Enum</p>Possible values: [DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL, NUM_INFO_LOG_LEVELS]</td>
+            <td>The specified log level for DB. Candidate log level is DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL or NUM_INFO_LOG_LEVELS, and Flink choose 'HEADER_LEVEL' as default style. Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/DefaultConfigurableOptionsFactory.java
@@ -27,6 +27,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.InfoLogLevel;
 import org.rocksdb.PlainTableConfig;
 import org.rocksdb.TableFormatConfig;
 
@@ -41,6 +42,7 @@ import java.util.Set;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_CACHE_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.BLOCK_SIZE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.COMPACTION_STYLE;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.LOG_LEVEL;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_OPEN_FILES;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE;
@@ -70,6 +72,10 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
 
         if (isOptionConfigured(MAX_OPEN_FILES)) {
             currentOptions.setMaxOpenFiles(getMaxOpenFiles());
+        }
+
+        if (isOptionConfigured(LOG_LEVEL)) {
+            currentOptions.setInfoLogLevel(getLogLevel());
         }
 
         return currentOptions;
@@ -164,6 +170,19 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
 
     public DefaultConfigurableOptionsFactory setMaxOpenFiles(int maxOpenFiles) {
         configuredOptions.put(MAX_OPEN_FILES.key(), String.valueOf(maxOpenFiles));
+        return this;
+    }
+
+    // --------------------------------------------------------------------------
+    // The log level for DB.
+    // --------------------------------------------------------------------------
+
+    private InfoLogLevel getLogLevel() {
+        return InfoLogLevel.valueOf(getInternal(LOG_LEVEL.key()).toUpperCase());
+    }
+
+    public DefaultConfigurableOptionsFactory setLogLevel(InfoLogLevel logLevel) {
+        setInternal(LOG_LEVEL.key(), logLevel.name());
         return this;
     }
 
@@ -318,6 +337,7 @@ public class DefaultConfigurableOptionsFactory implements ConfigurableRocksDBOpt
                 // configurable DBOptions
                 MAX_BACKGROUND_THREADS,
                 MAX_OPEN_FILES,
+                LOG_LEVEL,
 
                 // configurable ColumnFamilyOptions
                 COMPACTION_STYLE,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 
 import org.rocksdb.CompactionStyle;
+import org.rocksdb.InfoLogLevel;
 
 import java.io.Serializable;
 
@@ -31,6 +32,13 @@ import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.rocksdb.CompactionStyle.FIFO;
 import static org.rocksdb.CompactionStyle.LEVEL;
 import static org.rocksdb.CompactionStyle.UNIVERSAL;
+import static org.rocksdb.InfoLogLevel.DEBUG_LEVEL;
+import static org.rocksdb.InfoLogLevel.ERROR_LEVEL;
+import static org.rocksdb.InfoLogLevel.FATAL_LEVEL;
+import static org.rocksdb.InfoLogLevel.HEADER_LEVEL;
+import static org.rocksdb.InfoLogLevel.INFO_LEVEL;
+import static org.rocksdb.InfoLogLevel.NUM_INFO_LOG_LEVELS;
+import static org.rocksdb.InfoLogLevel.WARN_LEVEL;
 
 /**
  * This class contains the configuration options for the {@link DefaultConfigurableOptionsFactory}.
@@ -63,6 +71,26 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .withDescription(
                             "The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. "
                                     + "RocksDB has default configuration as '-1'.");
+
+    public static final ConfigOption<InfoLogLevel> LOG_LEVEL =
+            key("state.backend.rocksdb.log.level")
+                    .enumType(InfoLogLevel.class)
+                    .noDefaultValue()
+                    .withDescription(
+                            String.format(
+                                    "The specified log level for DB. Candidate log level is %s, %s, %s, %s, %s, %s or %s, "
+                                            + "and Flink choose '%s' as default style. "
+                                            + "Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. "
+                                            + "If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. "
+                                            + "There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.",
+                                    DEBUG_LEVEL.name(),
+                                    INFO_LEVEL.name(),
+                                    WARN_LEVEL.name(),
+                                    ERROR_LEVEL.name(),
+                                    FATAL_LEVEL.name(),
+                                    HEADER_LEVEL.name(),
+                                    NUM_INFO_LOG_LEVELS.name(),
+                                    HEADER_LEVEL.name()));
 
     // --------------------------------------------------------------------------
     // Provided configurable ColumnFamilyOptions within Flink

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -54,6 +54,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.InfoLogLevel;
 import org.rocksdb.util.SizeUnit;
 
 import java.io.File;
@@ -470,6 +471,7 @@ public class RocksDBStateBackendConfigTest {
                 new DefaultConfigurableOptionsFactory()
                         .setMaxBackgroundThreads(4)
                         .setMaxOpenFiles(-1)
+                        .setLogLevel(InfoLogLevel.DEBUG_LEVEL)
                         .setCompactionStyle(CompactionStyle.LEVEL)
                         .setUseDynamicLevelSize(true)
                         .setTargetFileSizeBase("4MB")
@@ -485,6 +487,7 @@ public class RocksDBStateBackendConfigTest {
 
             DBOptions dbOptions = optionsContainer.getDbOptions();
             assertEquals(-1, dbOptions.maxOpenFiles());
+            assertEquals(InfoLogLevel.DEBUG_LEVEL, dbOptions.infoLogLevel());
 
             ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
             assertEquals(CompactionStyle.LEVEL, columnOptions.compactionStyle());
@@ -511,6 +514,7 @@ public class RocksDBStateBackendConfigTest {
         // verify illegal configuration
         {
             verifyIllegalArgument(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, "-1");
+            verifyIllegalArgument(RocksDBConfigurableOptions.LOG_LEVEL, "DEBUG");
             verifyIllegalArgument(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER, "-1");
             verifyIllegalArgument(
                     RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE, "-1");
@@ -528,6 +532,7 @@ public class RocksDBStateBackendConfigTest {
 
         // verify legal configuration
         {
+            configuration.setString(RocksDBConfigurableOptions.LOG_LEVEL.key(), "DEBUG_LEVEL");
             configuration.setString(RocksDBConfigurableOptions.COMPACTION_STYLE.key(), "level");
             configuration.setString(
                     RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE.key(), "TRUE");
@@ -550,6 +555,7 @@ public class RocksDBStateBackendConfigTest {
 
                 DBOptions dbOptions = optionsContainer.getDbOptions();
                 assertEquals(-1, dbOptions.maxOpenFiles());
+                assertEquals(InfoLogLevel.DEBUG_LEVEL, dbOptions.infoLogLevel());
 
                 ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
                 assertEquals(CompactionStyle.LEVEL, columnOptions.compactionStyle());


### PR DESCRIPTION
## What is the purpose of the change

Support configuration of RocksDB log level

## Brief change log

  - add config `state.backend.rocksdb.log.level`

## Verifying this change

This change added tests and can be verified as follows:

  - Check whether the configuration takes effect 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  docs 
