### PR TITLE
[FLINK-20940][table-planner] Use session time zone in LOCALTIME/LOCALTIMSTAMP functions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -487,6 +487,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   def addReusableLocalDateTime(): String = {
     val fieldTerm = s"localtimestamp"
 
+    val sessionTimeZone = addReusableSessionTimeZone()
     val timestamp = addReusableTimestamp()
 
     // declaration
@@ -497,7 +498,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
       s"""
          |$fieldTerm = $TIMESTAMP_DATA.fromEpochMillis(
          |  $timestamp.getMillisecond() +
-         |  java.util.TimeZone.getDefault().getOffset($timestamp.getMillisecond()));
+         |  $sessionTimeZone.getOffset($timestamp.getMillisecond()));
          |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix LOCALTIME/LOCALTIMSTAMP functions that use system default time zone but we should use session time zone.


## Brief change log

  - use session time zone rather than system default time zone


## Verifying this change

Add unit test for the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
