### PR TITLE
[FLINK-20933][python] Config Python Operator Use Managed Memory In Python DataStream

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1736,6 +1736,9 @@ class StreamTableEnvironment(TableEnvironment):
         .. versionadded:: 1.12.0
         """
         j_data_stream = data_stream._j_data_stream
+        get_gateway().jvm \
+            .org.apache.flink.python.util.PythonConfigUtil.setManagedMemory(
+            j_data_stream.getTransformation(), self._j_tenv.getConfig().getConfiguration())
         if len(fields) == 0:
             return Table(j_table=self._j_tenv.fromDataStream(j_data_stream), t_env=self)
         elif all(isinstance(f, Expression) for f in fields):

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1738,7 +1738,9 @@ class StreamTableEnvironment(TableEnvironment):
         j_data_stream = data_stream._j_data_stream
         get_gateway().jvm \
             .org.apache.flink.python.util.PythonConfigUtil.setManagedMemory(
-            j_data_stream.getTransformation(), self._j_tenv.getConfig().getConfiguration())
+            j_data_stream.getTransformation(),
+            self._get_j_env(),
+            self._j_tenv.getConfig())
         if len(fields) == 0:
             return Table(j_table=self._j_tenv.fromDataStream(j_data_stream), t_env=self)
         elif all(isinstance(f, Expression) for f in fields):

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -414,6 +414,7 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         expected = ['+I[1, Hi, Hello]', '+I[2, Hello, Hi]']
         self.assert_equals(result, expected)
 
+        ds = ds.map(lambda x: x, Types.ROW([Types.INT(), Types.STRING(), Types.STRING()]))
         table = t_env.from_data_stream(ds, col('a'), col('b'), col('c'))
         t_env.register_table_sink("ExprSink",
                                   source_sink_utils.TestAppendSink(field_names, field_types))

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
@@ -73,7 +73,7 @@ public class BatchExecPythonGroupAggregate extends CommonExecPythonAggregate
         final RowType inputRowType = (RowType) inputNode.getOutputType();
         final RowType outputRowType = InternalTypeInfo.of(getOutputType()).toRowType();
         Configuration config =
-                CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig());
+                CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> transform =
                 createPythonOneInputTransformation(
                         inputTransform, inputRowType, outputRowType, config);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -77,7 +77,7 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData> {
         final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
         final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
         final Configuration config =
-                CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig());
+                CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> ret =
                 createPythonOneInputTransformation(inputTransform, calcProgram, getDesc(), config);
         if (inputsContainSingleton()) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -76,18 +76,15 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData> {
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
         final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final Configuration config =
+                CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> ret =
-                createPythonOneInputTransformation(
-                        inputTransform,
-                        calcProgram,
-                        getDesc(),
-                        CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig()));
+                createPythonOneInputTransformation(inputTransform, calcProgram, getDesc(), config);
         if (inputsContainSingleton()) {
             ret.setParallelism(1);
             ret.setMaxParallelism(1);
         }
-        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(
-                planner.getTableConfig().getConfiguration())) {
+        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(config)) {
             ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
         }
         return ret;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -74,7 +74,7 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData> {
         final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
         final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
         final Configuration config =
-                CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig());
+                CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> transform =
                 createPythonOneInputTransformation(inputTransform, config);
         if (inputsContainSingleton()) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -73,16 +73,15 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData> {
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
         final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final Configuration config =
+                CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> transform =
-                createPythonOneInputTransformation(
-                        inputTransform,
-                        CommonPythonUtil.getConfig(planner.getExecEnv(), planner.getTableConfig()));
+                createPythonOneInputTransformation(inputTransform, config);
         if (inputsContainSingleton()) {
             transform.setParallelism(1);
             transform.setMaxParallelism(1);
         }
-        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(
-                planner.getTableConfig().getConfiguration())) {
+        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(config)) {
             transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
         }
         return transform;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -111,9 +111,10 @@ public class StreamExecPythonGroupAggregate extends CommonExecPythonAggregate
                         extractPythonAggregateFunctionInfos(aggInfoList, aggCalls);
         PythonAggregateFunctionInfo[] pythonFunctionInfos = aggInfosAndDataViewSpecs.f0;
         DataViewUtils.DataViewSpec[][] dataViewSpecs = aggInfosAndDataViewSpecs.f1;
+        Configuration config = CommonPythonUtil.getConfig(planner.getExecEnv(), tableConfig);
         final OneInputStreamOperator<RowData, RowData> operator =
                 getPythonAggregateFunctionOperator(
-                        CommonPythonUtil.getConfig(planner.getExecEnv(), tableConfig),
+                        config,
                         inputRowType,
                         InternalTypeInfo.of(getOutputType()).toRowType(),
                         pythonFunctionInfos,
@@ -136,7 +137,7 @@ public class StreamExecPythonGroupAggregate extends CommonExecPythonAggregate
             transform.setMaxParallelism(1);
         }
 
-        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(tableConfig.getConfiguration())) {
+        if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(config)) {
             transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -111,7 +111,7 @@ public class StreamExecPythonGroupAggregate extends CommonExecPythonAggregate
                         extractPythonAggregateFunctionInfos(aggInfoList, aggCalls);
         PythonAggregateFunctionInfo[] pythonFunctionInfos = aggInfosAndDataViewSpecs.f0;
         DataViewUtils.DataViewSpec[][] dataViewSpecs = aggInfosAndDataViewSpecs.f1;
-        Configuration config = CommonPythonUtil.getConfig(planner.getExecEnv(), tableConfig);
+        Configuration config = CommonPythonUtil.getMergedConfig(planner.getExecEnv(), tableConfig);
         final OneInputStreamOperator<RowData, RowData> operator =
                 getPythonAggregateFunctionOperator(
                         config,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
@@ -64,15 +64,16 @@ public class CommonPythonUtil {
     }
 
     @SuppressWarnings("unchecked")
-    public static Configuration getConfig(StreamExecutionEnvironment env, TableConfig tableConfig) {
+    public static Configuration getMergedConfig(
+            StreamExecutionEnvironment env, TableConfig tableConfig) {
         Class clazz = loadClass(PYTHON_CONFIG_UTILS_CLASS);
         try {
             Method method =
                     clazz.getDeclaredMethod(
-                            "getConfig", StreamExecutionEnvironment.class, TableConfig.class);
+                            "getMergedConfig", StreamExecutionEnvironment.class, TableConfig.class);
             return (Configuration) method.invoke(null, env, tableConfig);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new TableException("Method getConfig accessed failed.", e);
+            throw new TableException("Method getMergedConfig accessed failed.", e);
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.scala
@@ -71,6 +71,7 @@ class BatchExecPythonGroupWindowAggregate(
     val groupBufferLimitSize = planner.getTableConfig.getConfiguration.getInteger(
       ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
 
+    val config = getConfig(planner.getExecEnv, planner.getTableConfig)
     val transform = createPythonOneInputTransformation(
       inputTransform,
       inputNode.getOutputType.asInstanceOf[RowType],
@@ -79,9 +80,9 @@ class BatchExecPythonGroupWindowAggregate(
       groupBufferLimitSize,
       windowSizeAndSlideSize.f0,
       windowSizeAndSlideSize.f1,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     transform

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.scala
@@ -85,15 +85,16 @@ class BatchExecPythonOverAggregate(
         windowBoundary.append(boundary)
         group.getAggCalls.map((_, index))
     }
+    val config = getConfig(planner.getExecEnv, planner.getTableConfig)
     val transform = createPythonOneInputTransformation(
       input,
       aggCallToWindowIndex,
       windowBoundary.toArray,
       inputNode.getOutputType.asInstanceOf[RowType],
       outputType,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     transform

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.scala
@@ -88,8 +88,9 @@ class StreamExecPythonGroupTableAggregate(
       dataViewSpecs = Array(Array())
     }
 
+    val config = getConfig(planner.getExecEnv, tableConfig)
     val operator = getPythonTableAggregateFunctionOperator(
-      getConfig(planner.getExecEnv, tableConfig),
+      config,
       inputRowType,
       outputType,
       pythonFunctionInfos,
@@ -115,7 +116,7 @@ class StreamExecPythonGroupTableAggregate(
       ret.setMaxParallelism(1)
     }
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.scala
@@ -103,6 +103,7 @@ class StreamExecPythonGroupWindowAggregate(
 
     val inputTransform = inputNode.translateToPlan(planner)
     val (windowAssigner, trigger) = generateWindowAssignerAndTrigger()
+    val mergedConfig = getConfig(planner.getExecEnv, planner.getTableConfig)
     val transform = createPythonStreamWindowGroupOneInputTransformation(
       inputTransform,
       inputNode.getOutputType.asInstanceOf[RowType],
@@ -111,7 +112,7 @@ class StreamExecPythonGroupWindowAggregate(
       windowAssigner,
       trigger,
       emitStrategy.getAllowLateness,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      mergedConfig)
 
     if (inputsContainSingleton()) {
       transform.setParallelism(1)
@@ -124,7 +125,7 @@ class StreamExecPythonGroupWindowAggregate(
     transform.setStateKeySelector(selector)
     transform.setStateKeyType(selector.getProducedType)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(mergedConfig)) {
       transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     transform

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.scala
@@ -111,6 +111,7 @@ class StreamExecPythonOverAggregate(
     }
     // bounded OVER window
     val precedingOffset = -1 * boundValue.asInstanceOf[Long]
+    val config = getConfig(planner.getExecEnv, tableConfig)
     val transform = createPythonOneInputTransformation(
       inputTransform,
       inputRowType,
@@ -122,9 +123,9 @@ class StreamExecPythonOverAggregate(
       partitionKeys,
       tableConfig.getMinIdleStateRetentionTime,
       tableConfig.getMaxIdleStateRetentionTime,
-      getConfig(planner.getExecEnv, tableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(tableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
@@ -86,69 +86,24 @@ trait CommonPythonBase {
     }
   }
 
-  protected def getConfig(
+  protected def getMergedConfig(
       env: ExecutionEnvironment,
       tableConfig: TableConfig): Configuration = {
-    val field = classOf[ExecutionEnvironment].getDeclaredField("cacheFile")
-    field.setAccessible(true)
-    val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
+    val clazz = loadClass(CommonPythonBase.PythonConfigUtil)
     val method = clazz.getDeclaredMethod(
-      "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(
-      null, field.get(env), getMergedConfiguration(env, tableConfig))
-      .asInstanceOf[Configuration]
-    config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
+      "getMergedConfig", classOf[ExecutionEnvironment], classOf[TableConfig])
+    val config = method.invoke(null, env, tableConfig).asInstanceOf[Configuration]
     config
   }
 
-  protected def getConfig(
+  protected def getMergedConfig(
       env: StreamExecutionEnvironment,
       tableConfig: TableConfig): Configuration = {
-    val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
-    val realEnv = getRealEnvironment(env)
+    val clazz = loadClass(CommonPythonBase.PythonConfigUtil)
     val method = clazz.getDeclaredMethod(
-      "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(
-      null, realEnv.getCachedFiles, getMergedConfiguration(realEnv, tableConfig))
-      .asInstanceOf[Configuration]
-    config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
+      "getMergedConfig", classOf[StreamExecutionEnvironment], classOf[TableConfig])
+    val config = method.invoke(null, env, tableConfig).asInstanceOf[Configuration]
     config
-  }
-
-  private def getMergedConfiguration(
-      env: StreamExecutionEnvironment,
-      tableConfig: TableConfig): Configuration = {
-    // As the python dependency configurations may appear in both
-    // `StreamExecutionEnvironment#getConfiguration` (e.g. parsed from flink-conf.yaml and command
-    // line) and `TableConfig#getConfiguration` (e.g. user specified), we need to merge them and
-    // ensure the user specified configuration has priority over others.
-    val method = classOf[StreamExecutionEnvironment].getDeclaredMethod("getConfiguration")
-    method.setAccessible(true)
-    val config = new Configuration(method.invoke(env).asInstanceOf[Configuration])
-    config.addAll(tableConfig.getConfiguration)
-    config
-  }
-
-  private def getMergedConfiguration(
-      env: ExecutionEnvironment,
-      tableConfig: TableConfig): Configuration = {
-    // As the python dependency configurations may appear in both
-    // `ExecutionEnvironment#getConfiguration` (e.g. parsed from flink-conf.yaml and command
-    // line) and `TableConfig#getConfiguration` (e.g. user specified), we need to merge them and
-    // ensure the user specified configuration has priority over others.
-    val config = new Configuration(env.getConfiguration)
-    config.addAll(tableConfig.getConfiguration)
-    config
-  }
-
-  private def getRealEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment = {
-    val realExecEnvField = classOf[DummyStreamExecutionEnvironment].getDeclaredField("realExecEnv")
-    realExecEnvField.setAccessible(true)
-    var realEnv = env
-    while (realEnv.isInstanceOf[DummyStreamExecutionEnvironment]) {
-      realEnv = realExecEnvField.get(realEnv).asInstanceOf[StreamExecutionEnvironment]
-    }
-    realEnv
   }
 
   protected def isPythonWorkerUsingManagedMemory(config: Configuration): Boolean = {
@@ -159,5 +114,5 @@ trait CommonPythonBase {
 }
 
 object CommonPythonBase {
-  val PYTHON_DEPENDENCY_UTILS_CLASS = "org.apache.flink.python.util.PythonDependencyUtils"
+  val PythonConfigUtil = "org.apache.flink.python.util.PythonConfigUtil"
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -80,7 +80,7 @@ class DataSetPythonCalc(
     val flatMapFunctionOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       flatMapFunctionResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val flatMapFunction = getPythonScalarFunctionFlatMap(
-      getConfig(tableEnv.execEnv, tableEnv.getConfig),
+      getMergedConfig(tableEnv.execEnv, tableEnv.getConfig),
       flatMapFunctionInputRowType,
       flatMapFunctionOutputRowType,
       calcProgram)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCorrelate.scala
@@ -87,7 +87,7 @@ class DataSetPythonCorrelate(
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
     val flatMapFunction = getPythonTableFunctionFlatMap(
-      getConfig(tableEnv.execEnv, tableEnv.getConfig),
+      getMergedConfig(tableEnv.execEnv, tableEnv.getConfig),
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -81,8 +81,9 @@ class DataStreamPythonCalc(
       inputSchema.typeInfo).getLogicalType.asInstanceOf[RowType]
     val pythonOperatorOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       pythonOperatorResultTypeInfo).getLogicalType.asInstanceOf[RowType]
+    val config = getMergedConfig(planner.getExecutionEnvironment, planner.getConfig)
     val pythonOperator = getPythonScalarFunctionOperator(
-      getConfig(planner.getExecutionEnvironment, planner.getConfig),
+      config,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       calcProgram)
@@ -95,7 +96,7 @@ class DataStreamPythonCalc(
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputParallelism)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.getTransformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -93,8 +93,9 @@ class DataStreamPythonCorrelate(
 
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
+    val config = getMergedConfig(planner.getExecutionEnvironment, planner.getConfig)
     val pythonOperator = getPythonTableFunctionOperator(
-      getConfig(planner.getExecutionEnvironment, planner.getConfig),
+      config,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,
@@ -114,7 +115,7 @@ class DataStreamPythonCorrelate(
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputDataStream.getParallelism)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.getTransformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Config Python Operator Use Managed Memory In Python DataStream*


## Brief change log

  - *Add method `setManagedMemory` to set all Python Operator to use Managed Memory*

## Verifying this change

This change added tests and can be verified as follows:

  - *Correct original test `test_from_data_stream` to cover this feature*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
