### PR TITLE
[FLINK-19462][checkpointing] Update failed checkpoint stats

### DIFF
--- a/docs/ops/metrics.md
+++ b/docs/ops/metrics.md
@@ -1107,6 +1107,7 @@ Metrics related to data exchange between task executors using netty network comm
 </table>
 
 ### Checkpointing
+Note that for failed checkpoints, metrics are updated on a best efforts basis and may be not accurate.
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/docs/ops/metrics.zh.md
+++ b/docs/ops/metrics.zh.md
@@ -1107,6 +1107,7 @@ Metrics related to data exchange between task executors using netty network comm
 </table>
 
 ### Checkpointing
+Note that for failed checkpoints, metrics are updated on a best efforts basis and may be not accurate.
 <table class="table table-bordered">
   <thead>
     <tr>

--- a/docs/ops/monitoring/checkpoint_monitoring.md
+++ b/docs/ops/monitoring/checkpoint_monitoring.md
@@ -52,6 +52,8 @@ The overview tabs lists the following statistics. Note that these statistics don
 
 The checkpoint history keeps statistics about recently triggered checkpoints, including those that are currently in progress.
 
+Note that for failed checkpoints, metrics are updated on a best efforts basis and may be not accurate.
+
 <center>
   <img src="{% link /fig/checkpoint_monitoring-history.png %}" width="700px" alt="Checkpoint Monitoring: History">
 </center>

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -54,6 +54,10 @@ final class SavepointTaskStateManager implements TaskStateManager {
             @Nullable TaskStateSnapshot acknowledgedState,
             @Nullable TaskStateSnapshot localState) {}
 
+    @Override
+    public void reportIncompleteTaskStateSnapshots(
+            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {}
+
     @Nonnull
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
@@ -99,7 +99,7 @@
         <td>{{ subTask['index'] }}</td>
         <ng-container *ngIf="subTask['status'] == 'completed'">
           <td >{{ subTask['ack_timestamp'] | date:'yyyy-MM-dd HH:mm:ss' }}</td>
-          <td>{{ subTask['end_to_end_duration'] | humanizeDuration}}</td>
+          <td>{{ subTask['end_to_end_duration'] | humanizeDuration}} <span *ngIf="subTask['aborted']">(aborted)</span></td>
           <td>{{ subTask['state_size'] | humanizeBytes }}</td>
           <td>{{ subTask['checkpoint']['sync'] | humanizeDuration}}</td>
           <td>{{ subTask['checkpoint']['async'] | humanizeDuration}}</td>

--- a/flink-runtime-web/web-dashboard/src/app/share/pipes/humanize-bytes.pipe.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/pipes/humanize-bytes.pipe.ts
@@ -24,9 +24,9 @@ import { isNil } from 'utils';
 })
 export class HumanizeBytesPipe implements PipeTransform {
   transform(value: number): any {
-    if (isNil(value)) {
+    if (isNil(value) || value < 0) {
       return '-';
-    }
+	}
     const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
     const converter = (v: number, p: number): string => {
       const base = Math.pow(1024, p);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -79,6 +79,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
+import static java.util.stream.Collectors.toMap;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -728,12 +729,7 @@ public class CheckpointCoordinator {
                         checkpointStorageLocation,
                         onCompletionPromise);
 
-        if (statsTracker != null) {
-            PendingCheckpointStats callback =
-                    statsTracker.reportPendingCheckpoint(checkpointID, timestamp, props);
-
-            checkpoint.setStatsCallback(callback);
-        }
+        reportToStatsTracker(checkpoint, ackTasks);
 
         synchronized (lock) {
             pendingCheckpoints.put(checkpointID, checkpoint);
@@ -2100,5 +2096,26 @@ public class CheckpointCoordinator {
 
         /** Coordinators are not restored during this checkpoint restore. */
         SKIP;
+    }
+
+    private void reportToStatsTracker(
+            PendingCheckpoint checkpoint, Map<ExecutionAttemptID, ExecutionVertex> tasks) {
+        if (statsTracker == null) {
+            return;
+        }
+        Map<JobVertexID, Integer> vertices =
+                tasks.values().stream()
+                        .map(ExecutionVertex::getJobVertex)
+                        .distinct()
+                        .collect(
+                                toMap(
+                                        ExecutionJobVertex::getJobVertexId,
+                                        ExecutionJobVertex::getParallelism));
+        checkpoint.setStatsCallback(
+                statsTracker.reportPendingCheckpoint(
+                        checkpoint.getCheckpointID(),
+                        checkpoint.getCheckpointTimestamp(),
+                        checkpoint.getProps(),
+                        vertices));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -223,6 +223,7 @@ public class CheckpointCoordinator {
     private boolean isTriggering = false;
 
     private final CheckpointRequestDecider requestDecider;
+    private final LinkedHashMap<ExecutionAttemptID, ExecutionVertex> cachedTasksById;
 
     // --------------------------------------------------------------------------------------------
 
@@ -349,6 +350,15 @@ public class CheckpointCoordinator {
                         this.minPauseBetweenCheckpoints,
                         this.pendingCheckpoints::size,
                         this.checkpointsCleaner::getNumberOfCheckpointsToClean);
+        this.cachedTasksById =
+                new LinkedHashMap<ExecutionAttemptID, ExecutionVertex>(tasksToWaitFor.length) {
+
+                    @Override
+                    protected boolean removeEldestEntry(
+                            Map.Entry<ExecutionAttemptID, ExecutionVertex> eldest) {
+                        return size() > CheckpointCoordinator.this.tasksToWaitFor.length;
+                    }
+                };
     }
 
     // --------------------------------------------------------------------------------------------
@@ -1133,6 +1143,10 @@ public class CheckpointCoordinator {
                         "Received message for discarded but non-removed checkpoint "
                                 + checkpointId);
             } else {
+                reportStats(
+                        message.getCheckpointId(),
+                        message.getTaskExecutionId(),
+                        message.getCheckpointMetrics());
                 boolean wasPendingCheckpoint;
 
                 // message is for an unknown checkpoint, or comes too late (checkpoint disposed)
@@ -1827,6 +1841,14 @@ public class CheckpointCoordinator {
         }
     }
 
+    public void reportStats(long id, ExecutionAttemptID attemptId, CheckpointMetrics metrics)
+            throws CheckpointException {
+        if (statsTracker != null) {
+            getVertex(attemptId)
+                    .ifPresent(ev -> statsTracker.reportIncompleteStats(id, ev, metrics));
+        }
+    }
+
     // ------------------------------------------------------------------------
 
     private final class ScheduledTrigger implements Runnable {
@@ -2096,6 +2118,17 @@ public class CheckpointCoordinator {
 
         /** Coordinators are not restored during this checkpoint restore. */
         SKIP;
+    }
+
+    private Optional<ExecutionVertex> getVertex(ExecutionAttemptID id) throws CheckpointException {
+        if (!cachedTasksById.containsKey(id)) {
+            cachedTasksById.putAll(getAckTasks());
+            if (!cachedTasksById.containsKey(id)) {
+                // the task probably gone after a restart
+                cachedTasksById.put(id, null);
+            }
+        }
+        return Optional.ofNullable(cachedTasksById.get(id));
     }
 
     private void reportToStatsTracker(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorGateway.java
@@ -34,4 +34,10 @@ public interface CheckpointCoordinatorGateway extends RpcGateway {
             final TaskStateSnapshot subtaskState);
 
     void declineCheckpoint(DeclineCheckpoint declineCheckpoint);
+
+    void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -46,8 +48,11 @@ public class CheckpointMetrics implements Serializable {
     /** Is the checkpoint completed as an unaligned checkpoint. */
     private final boolean unalignedCheckpoint;
 
+    private final long totalBytesPersisted;
+
+    @VisibleForTesting
     public CheckpointMetrics() {
-        this(-1L, -1L, -1L, -1L, -1L, -1L, false);
+        this(-1L, -1L, -1L, -1L, -1L, -1L, false, 0L);
     }
 
     public CheckpointMetrics(
@@ -57,7 +62,8 @@ public class CheckpointMetrics implements Serializable {
             long syncDurationMillis,
             long asyncDurationMillis,
             long checkpointStartDelayNanos,
-            boolean unalignedCheckpoint) {
+            boolean unalignedCheckpoint,
+            long totalBytesPersisted) {
 
         // these may be "-1", in case the values are unknown or not set
         checkArgument(bytesProcessedDuringAlignment >= -1);
@@ -66,6 +72,7 @@ public class CheckpointMetrics implements Serializable {
         checkArgument(asyncDurationMillis >= -1);
         checkArgument(alignmentDurationNanos >= -1);
         checkArgument(checkpointStartDelayNanos >= -1);
+        checkArgument(totalBytesPersisted >= 0);
 
         this.bytesProcessedDuringAlignment = bytesProcessedDuringAlignment;
         this.bytesPersistedDuringAlignment = bytesPersistedDuringAlignment;
@@ -74,6 +81,7 @@ public class CheckpointMetrics implements Serializable {
         this.asyncDurationMillis = asyncDurationMillis;
         this.checkpointStartDelayNanos = checkpointStartDelayNanos;
         this.unalignedCheckpoint = unalignedCheckpoint;
+        this.totalBytesPersisted = totalBytesPersisted;
     }
 
     public long getBytesProcessedDuringAlignment() {
@@ -104,6 +112,10 @@ public class CheckpointMetrics implements Serializable {
         return unalignedCheckpoint;
     }
 
+    public long getTotalBytesPersisted() {
+        return totalBytesPersisted;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -121,7 +133,8 @@ public class CheckpointMetrics implements Serializable {
                 && syncDurationMillis == that.syncDurationMillis
                 && asyncDurationMillis == that.asyncDurationMillis
                 && checkpointStartDelayNanos == that.checkpointStartDelayNanos
-                && unalignedCheckpoint == that.unalignedCheckpoint;
+                && unalignedCheckpoint == that.unalignedCheckpoint
+                && totalBytesPersisted == that.totalBytesPersisted;
     }
 
     @Override
@@ -133,7 +146,8 @@ public class CheckpointMetrics implements Serializable {
                 syncDurationMillis,
                 asyncDurationMillis,
                 checkpointStartDelayNanos,
-                unalignedCheckpoint);
+                unalignedCheckpoint,
+                totalBytesPersisted);
     }
 
     @Override
@@ -153,6 +167,8 @@ public class CheckpointMetrics implements Serializable {
                 + checkpointStartDelayNanos
                 + ", unalignedCheckpoint="
                 + unalignedCheckpoint
+                + ", totalBytesPersisted="
+                + totalBytesPersisted
                 + '}';
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
@@ -41,6 +41,7 @@ public class CheckpointMetricsBuilder {
     private long asyncDurationMillis = -1L;
     private long checkpointStartDelayNanos = -1L;
     private boolean unalignedCheckpoint = false;
+    private long totalBytesPersisted = -1L;
 
     public CheckpointMetricsBuilder setBytesProcessedDuringAlignment(
             long bytesProcessedDuringAlignment) {
@@ -122,6 +123,11 @@ public class CheckpointMetricsBuilder {
         return this;
     }
 
+    public CheckpointMetricsBuilder setTotalBytesPersisted(long totalBytesPersisted) {
+        this.totalBytesPersisted = totalBytesPersisted;
+        return this;
+    }
+
     public CheckpointMetrics build() {
         return new CheckpointMetrics(
                 checkStateAndGet(bytesProcessedDuringAlignment),
@@ -130,6 +136,7 @@ public class CheckpointMetricsBuilder {
                 syncDurationMillis,
                 asyncDurationMillis,
                 checkpointStartDelayNanos,
-                unalignedCheckpoint);
+                unalignedCheckpoint,
+                totalBytesPersisted);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
@@ -274,7 +274,8 @@ public class CheckpointStatsTracker {
                                         metrics.getBytesPersistedDuringAlignment(),
                                         metrics.getAlignmentDurationNanos() / 1_000_000,
                                         metrics.getCheckpointStartDelayNanos() / 1_000_000,
-                                        metrics.getUnalignedCheckpoint()));
+                                        metrics.getUnalignedCheckpoint(),
+                                        false));
                 dirty = true;
             }
         } finally {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -439,7 +439,8 @@ public class PendingCheckpoint implements Checkpoint {
                                 metrics.getBytesPersistedDuringAlignment(),
                                 alignmentDurationMillis,
                                 checkpointStartDelayMillis,
-                                metrics.getUnalignedCheckpoint());
+                                metrics.getUnalignedCheckpoint(),
+                                true);
 
                 statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -389,8 +389,6 @@ public class PendingCheckpoint implements Checkpoint {
             int subtaskIndex = vertex.getParallelSubtaskIndex();
             long ackTimestamp = System.currentTimeMillis();
 
-            long stateSize = 0L;
-
             if (operatorSubtaskStates != null) {
                 for (OperatorIDPair operatorID : operatorIDs) {
 
@@ -416,7 +414,6 @@ public class PendingCheckpoint implements Checkpoint {
                     }
 
                     operatorState.putState(subtaskIndex, operatorSubtaskState);
-                    stateSize += operatorSubtaskState.getStateSize();
                 }
             }
 
@@ -435,7 +432,7 @@ public class PendingCheckpoint implements Checkpoint {
                         new SubtaskStateStats(
                                 subtaskIndex,
                                 ackTimestamp,
-                                stateSize,
+                                metrics.getTotalBytesPersisted(),
                                 metrics.getSyncDurationMillis(),
                                 metrics.getAsyncDurationMillis(),
                                 metrics.getBytesProcessedDuringAlignment(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -187,8 +187,10 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
         TaskStateStats taskStateStats = taskStats.get(jobVertexId);
 
         if (taskStateStats != null && taskStateStats.reportSubtaskStats(subtask)) {
-            currentNumAcknowledgedSubtasks++;
-            latestAcknowledgedSubtask = subtask;
+            if (subtask.isCompleted()) {
+                currentNumAcknowledgedSubtasks++;
+                latestAcknowledgedSubtask = subtask;
+            }
 
             currentStateSize += subtask.getStateSize();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -106,9 +106,40 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
             int totalSubtaskCount,
             Map<JobVertexID, TaskStateStats> taskStats,
             CheckpointStatsTracker.PendingCheckpointStatsCallback trackerCallback) {
+        this(
+                checkpointId,
+                triggerTimestamp,
+                props,
+                totalSubtaskCount,
+                0,
+                taskStats,
+                trackerCallback,
+                0,
+                0,
+                0,
+                null);
+    }
+
+    PendingCheckpointStats(
+            long checkpointId,
+            long triggerTimestamp,
+            CheckpointProperties props,
+            int totalSubtaskCount,
+            int acknowledgedSubtaskCount,
+            Map<JobVertexID, TaskStateStats> taskStats,
+            CheckpointStatsTracker.PendingCheckpointStatsCallback trackerCallback,
+            long currentStateSize,
+            long processedData,
+            long persistedData,
+            @Nullable SubtaskStateStats latestAcknowledgedSubtask) {
 
         super(checkpointId, triggerTimestamp, props, totalSubtaskCount, taskStats);
         this.trackerCallback = checkNotNull(trackerCallback);
+        this.currentStateSize = currentStateSize;
+        this.currentPersistedData = processedData;
+        this.currentPersistedData = persistedData;
+        this.latestAcknowledgedSubtask = latestAcknowledgedSubtask;
+        this.currentNumAcknowledgedSubtasks = acknowledgedSubtaskCount;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -61,6 +61,9 @@ public class SubtaskStateStats implements Serializable {
     /** Is the checkpoint completed as an unaligned checkpoint. */
     private final boolean unalignedCheckpoint;
 
+    /** Is the checkpoint completed by this subtask. */
+    private final boolean completed;
+
     SubtaskStateStats(
             int subtaskIndex,
             long ackTimestamp,
@@ -71,7 +74,8 @@ public class SubtaskStateStats implements Serializable {
             long persistedData,
             long alignmentDuration,
             long checkpointStartDelay,
-            boolean unalignedCheckpoint) {
+            boolean unalignedCheckpoint,
+            boolean completed) {
 
         checkArgument(subtaskIndex >= 0, "Negative subtask index");
         this.subtaskIndex = subtaskIndex;
@@ -85,6 +89,7 @@ public class SubtaskStateStats implements Serializable {
         this.alignmentDuration = alignmentDuration;
         this.checkpointStartDelay = checkpointStartDelay;
         this.unalignedCheckpoint = unalignedCheckpoint;
+        this.completed = completed;
     }
 
     public int getSubtaskIndex() {
@@ -162,5 +167,9 @@ public class SubtaskStateStats implements Serializable {
 
     public boolean getUnalignedCheckpoint() {
         return unalignedCheckpoint;
+    }
+
+    public boolean isCompleted() {
+        return completed;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
@@ -64,8 +64,10 @@ public class TaskStateStats implements Serializable {
         if (subtaskStats[subtaskIndex] == null) {
             subtaskStats[subtaskIndex] = subtask;
 
-            latestAckedSubtaskStats = subtask;
-            numAcknowledgedSubtasks++;
+            if (subtask.isCompleted()) {
+                latestAckedSubtaskStats = subtask;
+                numAcknowledgedSubtasks++;
+            }
 
             summaryStats.updateSummary(subtask);
 
@@ -175,7 +177,9 @@ public class TaskStateStats implements Serializable {
 
         void updateSummary(SubtaskStateStats subtaskStats) {
             stateSize.add(subtaskStats.getStateSize());
-            ackTimestamp.add(subtaskStats.getAckTimestamp());
+            if (subtaskStats.isCompleted()) {
+                ackTimestamp.add(subtaskStats.getAckTimestamp());
+            }
             syncCheckpointDuration.add(subtaskStats.getSyncCheckpointDuration());
             asyncCheckpointDuration.add(subtaskStats.getAsyncCheckpointDuration());
             processedData.add(subtaskStats.getProcessedData());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -210,7 +210,6 @@ public class ExecutionGraphBuilder {
             CheckpointStatsTracker checkpointStatsTracker =
                     new CheckpointStatsTracker(
                             historySize,
-                            ackVertices,
                             snapshotSettings.getCheckpointCoordinatorConfiguration(),
                             metrics);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -512,6 +512,17 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                 jobID, executionAttemptID, checkpointId, checkpointMetrics, checkpointState);
     }
 
+    @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {
+
+        schedulerNG.reportCheckpointMetrics(
+                jobID, executionAttemptID, checkpointId, checkpointMetrics);
+    }
+
     // TODO: This method needs a leader session ID
     @Override
     public void declineCheckpoint(DeclineCheckpoint decline) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -210,7 +210,8 @@ public class TaskCheckpointStatisticDetailsHandler
                                         subtask.getPersistedData(),
                                         subtask.getAlignmentDuration()),
                                 subtask.getCheckpointStartDelay(),
-                                subtask.getUnalignedCheckpoint()));
+                                subtask.getUnalignedCheckpoint(),
+                                !subtask.isCompleted()));
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
@@ -108,6 +108,8 @@ public class SubtaskCheckpointStatistics {
 
         public static final String FIELD_NAME_UNALIGNED_CHECKPOINT = "unaligned_checkpoint";
 
+        public static final String FIELD_NAME_ABORTED = "aborted";
+
         @JsonProperty(FIELD_NAME_ACK_TIMESTAMP)
         private final long ackTimestamp;
 
@@ -129,6 +131,9 @@ public class SubtaskCheckpointStatistics {
         @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINT)
         private boolean unalignedCheckpoint;
 
+        @JsonProperty(FIELD_NAME_ABORTED)
+        private final boolean aborted;
+
         @JsonCreator
         public CompletedSubtaskCheckpointStatistics(
                 @JsonProperty(FIELD_NAME_INDEX) int index,
@@ -138,7 +143,8 @@ public class SubtaskCheckpointStatistics {
                 @JsonProperty(FIELD_NAME_CHECKPOINT_DURATION) CheckpointDuration checkpointDuration,
                 @JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment alignment,
                 @JsonProperty(FIELD_NAME_START_DELAY) long startDelay,
-                @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINT) boolean unalignedCheckpoint) {
+                @JsonProperty(FIELD_NAME_UNALIGNED_CHECKPOINT) boolean unalignedCheckpoint,
+                @JsonProperty(FIELD_NAME_ABORTED) boolean aborted) {
             super(index, "completed");
             this.ackTimestamp = ackTimestamp;
             this.duration = duration;
@@ -147,6 +153,7 @@ public class SubtaskCheckpointStatistics {
             this.alignment = alignment;
             this.startDelay = startDelay;
             this.unalignedCheckpoint = unalignedCheckpoint;
+            this.aborted = aborted;
         }
 
         public long getAckTimestamp() {
@@ -177,6 +184,10 @@ public class SubtaskCheckpointStatistics {
             return unalignedCheckpoint;
         }
 
+        public boolean isAborted() {
+            return aborted;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -192,7 +203,8 @@ public class SubtaskCheckpointStatistics {
                     && Objects.equals(checkpointDuration, that.checkpointDuration)
                     && Objects.equals(alignment, that.alignment)
                     && startDelay == that.startDelay
-                    && unalignedCheckpoint == that.unalignedCheckpoint;
+                    && unalignedCheckpoint == that.unalignedCheckpoint
+                    && aborted == that.aborted;
         }
 
         @Override
@@ -204,7 +216,8 @@ public class SubtaskCheckpointStatistics {
                     checkpointDuration,
                     alignment,
                     startDelay,
-                    unalignedCheckpoint);
+                    unalignedCheckpoint,
+                    aborted);
         }
 
         /** Duration of the checkpoint. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -204,11 +204,11 @@ public abstract class SchedulerBase implements SchedulerNG {
                         jobGraph,
                         jobMasterConfiguration,
                         userCodeLoader,
-                        checkpointRecoveryFactory,
+                        checkNotNull(checkpointRecoveryFactory),
                         log);
         this.checkpointIdCounter =
                 SchedulerUtils.createCheckpointIDCounterIfCheckpointingIsEnabled(
-                        jobGraph, checkpointRecoveryFactory);
+                        jobGraph, checkNotNull(checkpointRecoveryFactory));
 
         this.executionGraph =
                 createAndRestoreExecutionGraph(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -136,6 +136,12 @@ public interface SchedulerNG {
             CheckpointMetrics checkpointMetrics,
             TaskStateSnapshot checkpointState);
 
+    void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics);
+
     void declineCheckpoint(DeclineCheckpoint decline);
 
     CompletableFuture<String> stopWithSavepoint(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
@@ -57,6 +57,15 @@ public interface TaskStateManager extends CheckpointListener, AutoCloseable {
             @Nullable TaskStateSnapshot localState);
 
     /**
+     * Report the stats for state snapshots for an aborted checkpoint.
+     *
+     * @param checkpointMetaData meta data from the checkpoint request.
+     * @param checkpointMetrics task level metrics for the checkpoint.
+     */
+    void reportIncompleteTaskStateSnapshots(
+            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics);
+
+    /**
      * Returns means to restore previously reported state of an operator running in the owning task.
      *
      * @param operatorID the id of the operator for which we request state.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -122,6 +122,14 @@ public class TaskStateManagerImpl implements TaskStateManager {
                 jobId, executionAttemptID, checkpointId, checkpointMetrics, acknowledgedState);
     }
 
+    @Override
+    public void reportIncompleteTaskStateSnapshots(
+            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {
+
+        checkpointResponder.reportCheckpointMetrics(
+                jobId, executionAttemptID, checkpointMetaData.getCheckpointId(), checkpointMetrics);
+    }
+
     @Nonnull
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -49,6 +49,16 @@ public class RpcCheckpointResponder implements CheckpointResponder {
     }
 
     @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {
+        checkpointCoordinatorGateway.reportCheckpointMetrics(
+                jobID, executionAttemptID, checkpointId, checkpointMetrics);
+    }
+
+    @Override
     public void declineCheckpoint(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 
 /** Responder for checkpoint acknowledge and decline messages in the {@link Task}. */
+@Internal
 public interface CheckpointResponder {
 
     /**
@@ -41,6 +43,20 @@ public interface CheckpointResponder {
             long checkpointId,
             CheckpointMetrics checkpointMetrics,
             TaskStateSnapshot subtaskState);
+
+    /**
+     * Report metrics for the given checkpoint. Can be used upon receiving abortion notification.
+     *
+     * @param jobID Job ID of the running job
+     * @param executionAttemptID Execution attempt ID of the running task
+     * @param checkpointId Meta data for this checkpoint
+     * @param checkpointMetrics Metrics of this checkpoint
+     */
+    void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics);
 
     /**
      * Declines the given checkpoint.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.CheckpointCoordinatorBuilder;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
@@ -62,6 +63,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
+import org.apache.flink.util.function.TriFunctionWithException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -100,6 +102,7 @@ import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUt
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.mockExecutionVertex;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_EXPIRED;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -120,6 +123,100 @@ import static org.mockito.Mockito.when;
 
 /** Tests for the checkpoint coordinator. */
 public class CheckpointCoordinatorTest extends TestLogger {
+
+    @Test
+    public void testCheckpointStatsUpdatedAfterFailure() throws Exception {
+        JobID jobID = new JobID();
+        testReportStatsAfterFailure(
+                jobID,
+                1L,
+                (coordinator, attemptID, metrics) ->
+                        coordinator.receiveAcknowledgeMessage(
+                                new AcknowledgeCheckpoint(
+                                        jobID, attemptID, 1L, metrics, new TaskStateSnapshot()),
+                                TASK_MANAGER_LOCATION_INFO));
+    }
+
+    private void testReportStatsAfterFailure(
+            JobID jobID,
+            long checkpointId,
+            TriFunctionWithException<
+                            CheckpointCoordinator,
+                            ExecutionAttemptID,
+                            CheckpointMetrics,
+                            ?,
+                            CheckpointException>
+                    reportFn)
+            throws Exception {
+        ExecutionVertex decliningVertex = mockExecutionVertex(new ExecutionAttemptID());
+        ExecutionVertex lateReportVertex = mockExecutionVertex(new ExecutionAttemptID());
+        CheckpointStatsTracker statsTracker =
+                new CheckpointStatsTracker(
+                        Integer.MAX_VALUE,
+                        CheckpointCoordinatorConfiguration.builder().build(),
+                        new UnregisteredMetricsGroup());
+        CheckpointCoordinator coordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setJobId(jobID)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .setTasks(decliningVertex, lateReportVertex)
+                        .build();
+        coordinator.setCheckpointStatsTracker(statsTracker);
+
+        CompletableFuture<CompletedCheckpoint> result = coordinator.triggerCheckpoint(false);
+        manuallyTriggeredScheduledExecutor.triggerAll();
+        checkState(
+                coordinator.getNumberOfPendingCheckpoints() == 1,
+                "wrong number of pending checkpoints: %s",
+                coordinator.getNumberOfPendingCheckpoints());
+        if (result.isDone()) {
+            result.get();
+        }
+
+        coordinator.receiveDeclineMessage(
+                new DeclineCheckpoint(
+                        jobID,
+                        decliningVertex.getCurrentExecutionAttempt().getAttemptId(),
+                        checkpointId),
+                "test");
+
+        CheckpointMetrics lateReportedMetrics =
+                new CheckpointMetricsBuilder()
+                        .setTotalBytesPersisted(18)
+                        .setBytesProcessedDuringAlignment(19)
+                        .setAsyncDurationMillis(20)
+                        .setAlignmentDurationNanos(123 * 1_000_000)
+                        .setCheckpointStartDelayNanos(567 * 1_000_000)
+                        .build();
+
+        reportFn.apply(
+                coordinator,
+                lateReportVertex.getCurrentExecutionAttempt().getAttemptId(),
+                lateReportedMetrics);
+
+        assertStatsEqual(
+                checkpointId,
+                lateReportedMetrics,
+                statsTracker.createSnapshot().getHistory().getCheckpointById(checkpointId));
+    }
+
+    private void assertStatsEqual(
+            long checkpointId, CheckpointMetrics expected, AbstractCheckpointStats actual) {
+        assertEquals(checkpointId, actual.getCheckpointId());
+        assertEquals(CheckpointStatsStatus.FAILED, actual.getStatus());
+        assertEquals(1, actual.getNumberOfAcknowledgedSubtasks());
+        assertEquals(expected.getTotalBytesPersisted(), actual.getStateSize());
+        SubtaskStateStats taskStats = actual.getLatestAcknowledgedSubtaskStats();
+        assertEquals(
+                expected.getAlignmentDurationNanos() / 1_000_000, taskStats.getAlignmentDuration());
+        assertEquals(expected.getUnalignedCheckpoint(), taskStats.getUnalignedCheckpoint());
+        assertEquals(expected.getAsyncDurationMillis(), taskStats.getAsyncCheckpointDuration());
+        assertEquals(
+                expected.getAlignmentDurationNanos() / 1_000_000, taskStats.getAlignmentDuration());
+        assertEquals(
+                expected.getCheckpointStartDelayNanos() / 1_000_000,
+                taskStats.getCheckpointStartDelay());
+    }
 
     private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -60,10 +60,10 @@ import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStor
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.TriFunctionWithException;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
-import org.apache.flink.util.function.TriFunctionWithException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -123,6 +123,18 @@ import static org.mockito.Mockito.when;
 
 /** Tests for the checkpoint coordinator. */
 public class CheckpointCoordinatorTest extends TestLogger {
+
+    @Test
+    public void testAbortedCheckpointStatsUpdatedAfterFailure() throws Exception {
+        JobID jobID = new JobID();
+        testReportStatsAfterFailure(
+                jobID,
+                1L,
+                (coordinator, attemptID, metrics) -> {
+                    coordinator.reportStats(1L, attemptID, metrics);
+                    return null;
+                });
+    }
 
     @Test
     public void testCheckpointStatsUpdatedAfterFailure() throws Exception {
@@ -196,17 +208,28 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         assertStatsEqual(
                 checkpointId,
+                lateReportVertex.getJobvertexId(),
+                0,
                 lateReportedMetrics,
                 statsTracker.createSnapshot().getHistory().getCheckpointById(checkpointId));
     }
 
     private void assertStatsEqual(
-            long checkpointId, CheckpointMetrics expected, AbstractCheckpointStats actual) {
+            long checkpointId,
+            JobVertexID jobVertexID,
+            int subtasIdx,
+            CheckpointMetrics expected,
+            AbstractCheckpointStats actual) {
         assertEquals(checkpointId, actual.getCheckpointId());
         assertEquals(CheckpointStatsStatus.FAILED, actual.getStatus());
-        assertEquals(1, actual.getNumberOfAcknowledgedSubtasks());
         assertEquals(expected.getTotalBytesPersisted(), actual.getStateSize());
-        SubtaskStateStats taskStats = actual.getLatestAcknowledgedSubtaskStats();
+        assertEquals(0, actual.getNumberOfAcknowledgedSubtasks());
+        SubtaskStateStats taskStats =
+                actual.getAllTaskStateStats().stream()
+                        .filter(s -> s.getJobVertexId().equals(jobVertexID))
+                        .findAny()
+                        .get()
+                        .getSubtaskStats()[subtasIdx];
         assertEquals(
                 expected.getAlignmentDurationNanos() / 1_000_000, taskStats.getAlignmentDuration());
         assertEquals(expected.getUnalignedCheckpoint(), taskStats.getUnalignedCheckpoint());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2338,7 +2338,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
         CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
         checkpointCoordinator.setCheckpointStatsTracker(tracker);
 
-        when(tracker.reportPendingCheckpoint(anyLong(), anyLong(), any(CheckpointProperties.class)))
+        when(tracker.reportPendingCheckpoint(
+                        anyLong(), anyLong(), any(CheckpointProperties.class), any(Map.class)))
                 .thenReturn(mock(PendingCheckpointStats.class));
 
         // Trigger a checkpoint and verify callback
@@ -2353,7 +2354,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
                         any(Long.class),
                         eq(
                                 CheckpointProperties.forCheckpoint(
-                                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION)));
+                                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION)),
+                        any());
     }
 
     /** Tests that the restore callbacks are called if registered. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -681,7 +681,7 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinatorBuilder setTasks(ExecutionVertex[] tasks) {
+        public CheckpointCoordinatorBuilder setTasks(ExecutionVertex... tasks) {
             this.tasksToTrigger = tasks;
             this.tasksToWaitFor = tasks;
             this.tasksToCommitTo = tasks;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -496,6 +496,8 @@ public class CheckpointCoordinatorTestingUtils {
             operatorIDPairs.add(OperatorIDPair.generatedIDOnly(operatorID));
         }
         when(jobVertex.getOperatorIDs()).thenReturn(operatorIDPairs);
+        when(jobVertex.getJobVertexId()).thenReturn(jobVertexID);
+        when(jobVertex.getParallelism()).thenReturn(parallelism);
 
         when(vertex.getJobVertex()).thenReturn(jobVertex);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -445,7 +445,8 @@ public class CheckpointStatsTrackerTest {
                         persistedData,
                         ignored,
                         ignored,
-                        false);
+                        false,
+                        true);
 
         assertTrue(pending.reportSubtaskStats(vertexID, subtaskStats));
 
@@ -518,6 +519,6 @@ public class CheckpointStatsTrackerTest {
     // ------------------------------------------------------------------------
 
     private SubtaskStateStats createSubtaskStats(int index) {
-        return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0, 0, 0, false);
+        return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0, 0, 0, false, true);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
@@ -36,23 +35,19 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CheckpointStatsTrackerTest {
 
     /** Tests access to the snapshotting settings. */
     @Test
     public void testGetSnapshottingSettings() throws Exception {
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(1);
-
         JobCheckpointingSettings snapshottingSettings =
                 new JobCheckpointingSettings(
                         Collections.singletonList(new JobVertexID()),
@@ -73,7 +68,6 @@ public class CheckpointStatsTrackerTest {
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
                         0,
-                        Collections.singletonList(jobVertex),
                         snapshottingSettings.getCheckpointCoordinatorConfiguration(),
                         new UnregisteredMetricsGroup());
 
@@ -87,14 +81,11 @@ public class CheckpointStatsTrackerTest {
     public void testTrackerWithoutHistory() throws Exception {
         int numberOfSubtasks = 3;
 
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(numberOfSubtasks);
+        JobVertexID vertexID = new JobVertexID();
 
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
                         0,
-                        Collections.singletonList(jobVertex),
                         mock(CheckpointCoordinatorConfiguration.class),
                         new UnregisteredMetricsGroup());
 
@@ -103,11 +94,12 @@ public class CheckpointStatsTrackerTest {
                         0,
                         1,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        singletonMap(vertexID, numberOfSubtasks));
 
-        pending.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(0));
-        pending.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(1));
-        pending.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(2));
+        pending.reportSubtaskStats(vertexID, createSubtaskStats(0));
+        pending.reportSubtaskStats(vertexID, createSubtaskStats(1));
+        pending.reportSubtaskStats(vertexID, createSubtaskStats(2));
 
         pending.reportCompletedCheckpoint(null);
 
@@ -135,14 +127,12 @@ public class CheckpointStatsTrackerTest {
     public void testCheckpointTracking() throws Exception {
         int numberOfSubtasks = 3;
 
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(numberOfSubtasks);
+        JobVertexID vertexID = new JobVertexID();
+        Map<JobVertexID, Integer> vertexToDop = singletonMap(vertexID, numberOfSubtasks);
 
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
                         10,
-                        Collections.singletonList(jobVertex),
                         mock(CheckpointCoordinatorConfiguration.class),
                         new UnregisteredMetricsGroup());
 
@@ -152,11 +142,12 @@ public class CheckpointStatsTrackerTest {
                         0,
                         1,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        vertexToDop);
 
-        completed1.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(0));
-        completed1.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(1));
-        completed1.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(2));
+        completed1.reportSubtaskStats(vertexID, createSubtaskStats(0));
+        completed1.reportSubtaskStats(vertexID, createSubtaskStats(1));
+        completed1.reportSubtaskStats(vertexID, createSubtaskStats(2));
 
         completed1.reportCompletedCheckpoint(null);
 
@@ -166,17 +157,19 @@ public class CheckpointStatsTrackerTest {
                         1,
                         1,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        vertexToDop);
 
         failed.reportFailedCheckpoint(12, null);
 
         // Completed savepoint
         PendingCheckpointStats savepoint =
-                tracker.reportPendingCheckpoint(2, 1, CheckpointProperties.forSavepoint(true));
+                tracker.reportPendingCheckpoint(
+                        2, 1, CheckpointProperties.forSavepoint(true), vertexToDop);
 
-        savepoint.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(0));
-        savepoint.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(1));
-        savepoint.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(2));
+        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(0));
+        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(1));
+        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(2));
 
         savepoint.reportCompletedCheckpoint(null);
 
@@ -186,7 +179,8 @@ public class CheckpointStatsTrackerTest {
                         3,
                         1,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        vertexToDop);
 
         RestoredCheckpointStats restored =
                 new RestoredCheckpointStats(
@@ -253,14 +247,11 @@ public class CheckpointStatsTrackerTest {
     /** Tests that snapshots are only created if a new snapshot has been reported or updated. */
     @Test
     public void testCreateSnapshot() throws Exception {
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(1);
+        JobVertexID jobVertexId = new JobVertexID();
 
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
                         10,
-                        Collections.singletonList(jobVertex),
                         mock(CheckpointCoordinatorConfiguration.class),
                         new UnregisteredMetricsGroup());
 
@@ -272,9 +263,10 @@ public class CheckpointStatsTrackerTest {
                         0,
                         1,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        singletonMap(jobVertexId, 1));
 
-        pending.reportSubtaskStats(jobVertex.getJobVertexId(), createSubtaskStats(0));
+        pending.reportSubtaskStats(jobVertexId, createSubtaskStats(0));
 
         CheckpointStatsSnapshot snapshot2 = tracker.createSnapshot();
         assertNotEquals(snapshot1, snapshot2);
@@ -317,15 +309,7 @@ public class CheckpointStatsTrackerTest {
                     }
                 };
 
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(1);
-
-        new CheckpointStatsTracker(
-                0,
-                Collections.singletonList(jobVertex),
-                mock(CheckpointCoordinatorConfiguration.class),
-                metricGroup);
+        new CheckpointStatsTracker(0, mock(CheckpointCoordinatorConfiguration.class), metricGroup);
 
         // Make sure this test is adjusted when further metrics are added
         assertTrue(
@@ -365,16 +349,11 @@ public class CheckpointStatsTrackerTest {
                     }
                 };
 
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(1);
+        JobVertexID vertexID = new JobVertexID();
 
         CheckpointStatsTracker stats =
                 new CheckpointStatsTracker(
-                        0,
-                        Collections.singletonList(jobVertex),
-                        mock(CheckpointCoordinatorConfiguration.class),
-                        metricGroup);
+                        0, mock(CheckpointCoordinatorConfiguration.class), metricGroup);
 
         // Make sure to adjust this test if metrics are added/removed
         assertEquals(10, registeredGauges.size());
@@ -439,7 +418,8 @@ public class CheckpointStatsTrackerTest {
                         0,
                         0,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        singletonMap(vertexID, 1));
 
         // Check counts
         assertEquals(Long.valueOf(1), numCheckpoints.getValue());
@@ -467,7 +447,7 @@ public class CheckpointStatsTrackerTest {
                         ignored,
                         false);
 
-        assertTrue(pending.reportSubtaskStats(jobVertex.getJobVertexId(), subtaskStats));
+        assertTrue(pending.reportSubtaskStats(vertexID, subtaskStats));
 
         pending.reportCompletedCheckpoint(externalPath);
 
@@ -489,7 +469,8 @@ public class CheckpointStatsTrackerTest {
                         1,
                         11,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        singletonMap(vertexID, 1));
 
         long failureTimestamp = 1230123L;
         nextPending.reportFailedCheckpoint(failureTimestamp, null);
@@ -524,9 +505,10 @@ public class CheckpointStatsTrackerTest {
                         2,
                         5000,
                         CheckpointProperties.forCheckpoint(
-                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION));
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+                        singletonMap(vertexID, 1));
 
-        thirdPending.reportSubtaskStats(jobVertex.getJobVertexId(), subtaskStats);
+        thirdPending.reportSubtaskStats(vertexID, subtaskStats);
         thirdPending.reportCompletedCheckpoint(null);
 
         // Verify external path is "n/a", because internal checkpoint won't generate external path.
@@ -534,19 +516,6 @@ public class CheckpointStatsTrackerTest {
     }
 
     // ------------------------------------------------------------------------
-
-    /** Creates a "disabled" checkpoint tracker for tests. */
-    static CheckpointStatsTracker createTestTracker() {
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        when(jobVertex.getJobVertexId()).thenReturn(new JobVertexID());
-        when(jobVertex.getParallelism()).thenReturn(1);
-
-        return new CheckpointStatsTracker(
-                0,
-                Collections.singletonList(jobVertex),
-                mock(CheckpointCoordinatorConfiguration.class),
-                new UnregisteredMetricsGroup());
-    }
 
     private SubtaskStateStats createSubtaskStats(int index) {
         return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0, 0, 0, false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -379,7 +379,7 @@ public class CompletedCheckpointTest {
                         123129837912L,
                         42L,
                         44L,
-                        new SubtaskStateStats(123, 213123, 123123, 0, 0, 0, 0, 0, 0, false),
+                        new SubtaskStateStats(123, 213123, 123123, 0, 0, 0, 0, 0, 0, false, true),
                         null);
 
         CompletedCheckpointStats copy = CommonTestUtils.createCopySerializable(completed);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
@@ -295,6 +295,7 @@ public class PendingCheckpointStatsTest {
                 Integer.MAX_VALUE + (long) index,
                 Integer.MAX_VALUE + (long) index,
                 Integer.MAX_VALUE + (long) index,
-                false);
+                false,
+                true);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
@@ -50,7 +50,8 @@ public class SubtaskStateStatsTest {
                         Integer.MAX_VALUE + 9L,
                         Integer.MAX_VALUE + 6L,
                         Integer.MAX_VALUE + 7L,
-                        false);
+                        false,
+                        true);
 
         stats = serialize ? CommonTestUtils.createCopySerializable(stats) : stats;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
@@ -76,7 +76,8 @@ public class TaskStateStatsTest {
                             rand.nextInt(128),
                             rand.nextInt(128),
                             rand.nextInt(128),
-                            false);
+                            false,
+                            true);
 
             stateSize += subtasks[i].getStateSize();
             processedData += subtasks[i].getProcessedData();
@@ -97,7 +98,7 @@ public class TaskStateStatsTest {
 
         assertFalse(
                 taskStats.reportSubtaskStats(
-                        new SubtaskStateStats(0, 0, 0, 0, 0, 0, 0, 0, 0, false)));
+                        new SubtaskStateStats(0, 0, 0, 0, 0, 0, 0, 0, 0, false, true)));
 
         taskStats = serialize ? CommonTestUtils.createCopySerializable(taskStats) : taskStats;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -435,6 +435,13 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     }
 
     @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {}
+
+    @Override
     public JobMasterId getFencingToken() {
         return fencingTokenSupplier.get();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -65,7 +65,8 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest
                         new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics
                                 .CheckpointAlignment(2L, 4L, 5L, 3L),
                         42L,
-                        true));
+                        true,
+                        false));
 
         return new TaskCheckpointStatisticsWithSubtaskDetails(
                 4L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNG.java
@@ -208,6 +208,13 @@ public class TestingSchedulerNG implements SchedulerNG {
         return null;
     }
 
+    @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {}
+
     public static Builder newBuilder() {
         return new Builder();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateUtilTest.java
@@ -20,11 +20,31 @@ package org.apache.flink.runtime.state;
 
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.flink.runtime.concurrent.FutureUtils.completedExceptionally;
+import static org.apache.flink.runtime.state.StateUtil.discardStateFuture;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /** Tests for {@link StateUtil}. */
 public class StateUtilTest {
+
+    @Test
+    public void testDiscardStateSize() throws Exception {
+        assertEquals(1234, discardStateFuture(completedFuture(new TestStateObject(1234))));
+        assertEquals(0, discardStateFuture(null));
+        assertEquals(0, discardStateFuture(new CompletableFuture<>()));
+        assertEquals(0, discardStateFuture(completedExceptionally(new RuntimeException())));
+        assertEquals(0, discardStateFuture(emptyFuture(false, true)));
+        assertEquals(0, discardStateFuture(emptyFuture(false, false)));
+        assertEquals(0, discardStateFuture(emptyFuture(true, true)));
+        assertEquals(0, discardStateFuture(emptyFuture(true, false)));
+    }
 
     @Test
     public void unexpectedStateExceptionForSingleExpectedType() {
@@ -50,5 +70,51 @@ public class StateUtilTest {
                 exception.getMessage(),
                 containsString(
                         "Unexpected state handle type, expected one of: class org.apache.flink.runtime.state.KeyGroupsStateHandle, class org.apache.flink.runtime.state.KeyGroupsStateHandle, but found: class org.apache.flink.runtime.state.KeyGroupsStateHandle. This can mostly happen when a different StateBackend from the one that was used for taking a checkpoint/savepoint is used when restoring."));
+    }
+
+    private static <T> Future<T> emptyFuture(boolean done, boolean canBeCancelled) {
+        return new Future<T>() {
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return canBeCancelled;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return done;
+            }
+
+            @Override
+            public T get() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T get(long timeout, TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private static class TestStateObject implements StateObject {
+        private static final long serialVersionUID = -8070326169926626355L;
+        private final int size;
+
+        private TestStateObject(int size) {
+            this.size = size;
+        }
+
+        @Override
+        public long getStateSize() {
+            return size;
+        }
+
+        @Override
+        public void discardState() {}
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -117,6 +117,10 @@ public class TestTaskStateManager implements TaskStateManager {
         }
     }
 
+    @Override
+    public void reportIncompleteTaskStateSnapshots(
+            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {}
+
     @Nonnull
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpCheckpointResponder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpCheckpointResponder.java
@@ -33,4 +33,11 @@ public enum NoOpCheckpointResponder implements CheckpointResponder {
 
     @Override
     public void declineCheckpoint(JobID j, ExecutionAttemptID e, long l, Throwable t) {}
+
+    @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestCheckpointResponder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestCheckpointResponder.java
@@ -61,6 +61,13 @@ public class TestCheckpointResponder implements CheckpointResponder {
     }
 
     @Override
+    public void reportCheckpointMetrics(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics) {}
+
+    @Override
     public void declineCheckpoint(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -186,6 +186,13 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
                     }
 
                     @Override
+                    public void reportCheckpointMetrics(
+                            JobID jobID,
+                            ExecutionAttemptID executionAttemptID,
+                            long checkpointId,
+                            CheckpointMetrics checkpointMetrics) {}
+
+                    @Override
                     public void declineCheckpoint(
                             JobID jobID,
                             ExecutionAttemptID executionAttemptID,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -194,7 +194,10 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                 .getTaskStateManager()
                 .reportTaskStateSnapshots(
                         checkpointMetaData,
-                        checkpointMetrics.build(),
+                        checkpointMetrics
+                                .setTotalBytesPersisted(
+                                        acknowledgedTaskStateSnapshot.getStateSize())
+                                .build(),
                         hasAckState ? acknowledgedTaskStateSnapshot : null,
                         hasLocalState ? localTaskStateSnapshot : null);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -312,7 +312,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception {
         if (isRunning.get()) {
-            LOG.debug("Notification of complete checkpoint for task {}", taskName);
+            LOG.debug(
+                    "Notification of completed checkpoint {} for task {}", checkpointId, taskName);
 
             for (StreamOperatorWrapper<?, ?> operatorWrapper :
                     operatorChain.getAllOperators(true)) {
@@ -320,7 +321,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             }
         } else {
             LOG.debug(
-                    "Ignoring notification of complete checkpoint for not-running task {}",
+                    "Ignoring notification of complete checkpoint {} for not-running task {}",
+                    checkpointId,
                     taskName);
         }
         env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
@@ -333,7 +335,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
         Exception previousException = null;
         if (isRunning.get()) {
-            LOG.debug("Notification of aborted checkpoint for task {}", taskName);
+            LOG.debug("Notification of aborted checkpoint {} for task {}", checkpointId, taskName);
 
             boolean canceled = cancelAsyncCheckpointRunnable(checkpointId);
 
@@ -360,7 +362,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
         } else {
             LOG.debug(
-                    "Ignoring notification of aborted checkpoint for not-running task {}",
+                    "Ignoring notification of aborted checkpoint {} for not-running task {}",
+                    checkpointId,
                     taskName);
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
@@ -21,11 +21,15 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.streaming.runtime.tasks.ExceptionallyDoneFuture;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -33,12 +37,34 @@ import org.junit.Test;
 import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 /** Tests for {@link OperatorSnapshotFutures}. */
 public class OperatorSnapshotFuturesTest extends TestLogger {
+
+    @Test
+    public void testCancelReturnsStateSize() throws Exception {
+        KeyGroupsStateHandle s1 =
+                new KeyGroupsStateHandle(
+                        new KeyGroupRangeOffsets(0, 0),
+                        new ByteStreamStateHandle("", new byte[123]));
+        KeyGroupsStateHandle s2 =
+                new KeyGroupsStateHandle(
+                        new KeyGroupRangeOffsets(0, 0),
+                        new ByteStreamStateHandle("", new byte[456]));
+        OperatorSnapshotFutures futures =
+                new OperatorSnapshotFutures(
+                        DoneFuture.of(SnapshotResult.of(s1)),
+                        DoneFuture.of(SnapshotResult.of(s2)),
+                        DoneFuture.of(SnapshotResult.empty()),
+                        ExceptionallyDoneFuture.of(new RuntimeException()),
+                        ExceptionallyDoneFuture.of(new RuntimeException()),
+                        ExceptionallyDoneFuture.of(new RuntimeException()));
+        assertEquals(s1.getStateSize() + s2.getStateSize(), futures.cancel());
+    }
 
     /**
      * Tests that all runnable futures in an OperatorSnapshotResult are properly cancelled and if

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -264,6 +264,13 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
         }
 
         @Override
+        public void reportCheckpointMetrics(
+                JobID jobID,
+                ExecutionAttemptID executionAttemptID,
+                long checkpointId,
+                CheckpointMetrics checkpointMetrics) {}
+
+        @Override
         public void declineCheckpoint(
                 JobID jobID,
                 ExecutionAttemptID executionAttemptID,


### PR DESCRIPTION
## What is the purpose of the change

Update checkpoint statistics (shown in the web UI) even after a checkpoint fails
(this would facilitate investigation of issues with slow checkpointing).

With this change, failed checkpoint stats is updated when:
1. Subtask acks a checkpoint too late or after some other failure. `AsyncCheckpointRunnable` completes normally and reports snapshot as usual. `CheckpointCoordinator` was updated to handle these calls
1. Subtask receives abortion notification and cancels the runnable before it completes. In this case it only reports the metrics. Both TM and JM sides were updated and a **new RPC added**

## Verifying this change

This change added tests and can be verified as follows:
- `CheckpointCoordinatorTest.testCheckpointStatsUpdatedAfterFailure`
- `CheckpointCoordinatorTest.testAbortedCheckpointStatsUpdatedAfterFailure`
- Manually verified the change by running `DataStreamAllroundTestProgram` on local cluser:
```
execution.checkpointing.interval: 10s
execution.checkpointing.min-pause: 1s
execution.checkpointing.timeout: 1s
execution.checkpointing.tolerable-failed-checkpoints: 1000000
execution.checkpointing.unaligned: true
taskmanager.numberOfTaskSlots: 8
web.checkpoints.history: 100
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
