### PR TITLE
[FLINK-20921][python] Fixes the Date/Time/Timestamp type in Python DataStream API

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -589,7 +589,7 @@ _type_info_name_mappings = {
     type_info_name.BIG_DEC: BigDecimalCoder(),
     type_info_name.SQL_DATE: DateCoder(),
     type_info_name.SQL_TIME: TimeCoder(),
-    type_info_name.SQL_TIMESTAMP: TimeCoder(),
+    type_info_name.SQL_TIMESTAMP: TimestampCoder(3),
     type_info_name.PICKLED_BYTES: PickledBytesCoder()
 }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.BigIntSerializer;
@@ -50,7 +51,10 @@ import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -71,6 +75,10 @@ public class PythonTypeUtils {
 
             if (typeInformation instanceof PrimitiveArrayTypeInfo) {
                 return buildPrimitiveArrayTypeProto((PrimitiveArrayTypeInfo) typeInformation);
+            }
+
+            if (typeInformation instanceof SqlTimeTypeInfo) {
+                return buildSqlTimeTypeProto((SqlTimeTypeInfo) typeInformation);
             }
 
             if (typeInformation instanceof RowTypeInfo) {
@@ -155,6 +163,31 @@ public class PythonTypeUtils {
                         String.format(
                                 "The BasicTypeInfo: %s is not supported in PyFlink currently.",
                                 basicTypeInfo.toString()));
+            }
+
+            return FlinkFnApi.TypeInfo.FieldType.newBuilder().setTypeName(typeName).build();
+        }
+
+        private static FlinkFnApi.TypeInfo.FieldType buildSqlTimeTypeProto(
+                SqlTimeTypeInfo sqlTimeTypeInfo) {
+            FlinkFnApi.TypeInfo.TypeName typeName = null;
+            if (sqlTimeTypeInfo.equals(SqlTimeTypeInfo.DATE)) {
+                typeName = FlinkFnApi.TypeInfo.TypeName.SQL_DATE;
+            }
+
+            if (sqlTimeTypeInfo.equals(SqlTimeTypeInfo.TIME)) {
+                typeName = FlinkFnApi.TypeInfo.TypeName.SQL_TIME;
+            }
+
+            if (sqlTimeTypeInfo.equals(SqlTimeTypeInfo.TIMESTAMP)) {
+                typeName = FlinkFnApi.TypeInfo.TypeName.SQL_TIMESTAMP;
+            }
+
+            if (typeName == null) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "The SqlTimeTypeInfo: %s is not supported in PyFlink currently.",
+                                sqlTimeTypeInfo.toString()));
             }
 
             return FlinkFnApi.TypeInfo.FieldType.newBuilder().setTypeName(typeName).build();
@@ -373,6 +406,13 @@ public class PythonTypeUtils {
             typeInfoToSerialzerMap.put(
                     PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO.getTypeClass(),
                     IntPrimitiveArraySerializer.INSTANCE);
+
+            typeInfoToSerialzerMap.put(
+                    SqlTimeTypeInfo.DATE.getTypeClass(), DateSerializer.INSTANCE);
+            typeInfoToSerialzerMap.put(
+                    SqlTimeTypeInfo.TIME.getTypeClass(), TimeSerializer.INSTANCE);
+            typeInfoToSerialzerMap.put(
+                    SqlTimeTypeInfo.TIMESTAMP.getTypeClass(), new TimestampSerializer(3));
         }
 
         @SuppressWarnings("unchecked")

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.utils;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -41,7 +42,10 @@ import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
+import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
 
 import org.junit.Test;
 
@@ -150,6 +154,9 @@ public class PythonTypeUtilsTest {
                 BytePrimitiveArraySerializer.INSTANCE);
         typeInformationTypeSerializerMap.put(
                 BasicTypeInfo.BOOLEAN_TYPE_INFO, BooleanSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.DATE, DateSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.TIME, TimeSerializer.INSTANCE);
+        typeInformationTypeSerializerMap.put(SqlTimeTypeInfo.TIMESTAMP, new TimestampSerializer(3));
 
         for (Map.Entry<TypeInformation, TypeSerializer> entry :
                 typeInformationTypeSerializerMap.entrySet()) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the Date/Time/Timestamp type in Python DataStream API*


## Brief change log

  - *fix the Date/Time/Timestamp type in Python DataStream API*

## Verifying this change

This change added tests and can be verified as follows:

  - *IT `test_sql_timestamp_type_info`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
