### PR TITLE
[FLINK-20966][table-planner-blink] Rename Stream(/Batch)ExecIntermediateTableScan to Stream(/Batch)PhysicalIntermediateTableScan

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalIntermediateTableScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalIntermediateTableScan.scala
@@ -26,9 +26,9 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.`type`.RelDataType
 
 /**
-  * Batch physical TableScan that wraps [[IntermediateRelTable]]
-  */
-class BatchExecIntermediateTableScan(
+ * Batch physical TableScan that wraps [[IntermediateRelTable]]
+ */
+class BatchPhysicalIntermediateTableScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
@@ -39,6 +39,6 @@ class BatchExecIntermediateTableScan(
   override def deriveRowType(): RelDataType = outputRowType
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    new BatchExecIntermediateTableScan(cluster, traitSet, getTable, getRowType)
+    new BatchPhysicalIntermediateTableScan(cluster, traitSet, getTable, getRowType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntermediateTableScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIntermediateTableScan.scala
@@ -28,9 +28,9 @@ import org.apache.calcite.rel.`type`.RelDataType
 import java.util
 
 /**
-  * Stream physical TableScan that wraps [[IntermediateRelTable]]
-  */
-class StreamExecIntermediateTableScan(
+ * Stream physical TableScan that wraps [[IntermediateRelTable]]
+ */
+class StreamPhysicalIntermediateTableScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     table: RelOptTable,
@@ -43,6 +43,6 @@ class StreamExecIntermediateTableScan(
   override def deriveRowType(): RelDataType = outputRowType
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
-    new StreamExecIntermediateTableScan(cluster, traitSet, getTable, outputRowType)
+    new StreamPhysicalIntermediateTableScan(cluster, traitSet, getTable, outputRowType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode, ModifyKindSet, ModifyKindSetTraitDef, UpdateKind, UpdateKindTraitDef}
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.calcite.{LegacySink, Sink}
-import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamExecIntermediateTableScan, StreamPhysicalDataStreamScan, StreamPhysicalRel}
+import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalDataStreamScan, StreamPhysicalIntermediateTableScan, StreamPhysicalRel}
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkStreamProgram, StreamOptimizeContext}
 import org.apache.flink.table.planner.plan.schema.IntermediateRelTable
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
@@ -246,7 +246,7 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
         rel: RelNode,
         miniBatchInterval: MiniBatchInterval): Unit = {
       rel match {
-        case _: StreamPhysicalDataStreamScan | _: StreamExecIntermediateTableScan =>
+        case _: StreamPhysicalDataStreamScan | _: StreamPhysicalIntermediateTableScan =>
           val scan = rel.asInstanceOf[TableScan]
           val updateKindTrait = scan.getTraitSet.getTrait(UpdateKindTraitDef.INSTANCE)
           val miniBatchIntervalTrait = scan.getTraitSet.getTrait(MiniBatchIntervalTraitDef.INSTANCE)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -301,7 +301,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
         // DataStream, TableSource and Values only support producing insert-only messages
         createNewNode(rel, List(), ModifyKindSetTrait.INSERT_ONLY, requiredTrait, requester)
 
-      case scan: StreamExecIntermediateTableScan =>
+      case scan: StreamPhysicalIntermediateTableScan =>
         val providedTrait = new ModifyKindSetTrait(scan.intermediateTable.modifyKindSet)
         createNewNode(scan, List(), providedTrait, requiredTrait, requester)
 
@@ -639,7 +639,7 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
            _: StreamPhysicalValues =>
         createNewNode(rel, Some(List()), UpdateKindTrait.NONE)
 
-      case scan: StreamExecIntermediateTableScan =>
+      case scan: StreamPhysicalIntermediateTableScan =>
         val providedTrait = if (scan.intermediateTable.isUpdateBeforeRequired) {
           // we can't drop UPDATE_BEFORE if it is required by other parent blocks
           UpdateKindTrait.BEFORE_AND_AFTER

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -397,7 +397,7 @@ object FlinkBatchRuleSets {
     BatchPhysicalBoundedStreamScanRule.INSTANCE,
     BatchPhysicalTableSourceScanRule.INSTANCE,
     BatchPhysicalLegacyTableSourceScanRule.INSTANCE,
-    BatchExecIntermediateTableScanRule.INSTANCE,
+    BatchPhysicalIntermediateTableScanRule.INSTANCE,
     BatchPhysicalValuesRule.INSTANCE,
     // calc
     BatchPhysicalCalcRule.INSTANCE,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -401,7 +401,7 @@ object FlinkStreamRuleSets {
     StreamPhysicalDataStreamScanRule.INSTANCE,
     StreamPhysicalTableSourceScanRule.INSTANCE,
     StreamPhysicalLegacyTableSourceScanRule.INSTANCE,
-    StreamExecIntermediateTableScanRule.INSTANCE,
+    StreamPhysicalIntermediateTableScanRule.INSTANCE,
     StreamPhysicalWatermarkAssignerRule.INSTANCE,
     StreamPhysicalValuesRule.INSTANCE,
     // calc

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalIntermediateTableScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalIntermediateTableScanRule.scala
@@ -20,29 +20,30 @@ package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalIntermediateTableScan
-import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecIntermediateTableScan
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalIntermediateTableScan
 
 import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 
 /**
-  * Rule that converts [[FlinkLogicalIntermediateTableScan]] to [[BatchExecIntermediateTableScan]].
-  */
-class BatchExecIntermediateTableScanRule
+ * Rule that converts [[FlinkLogicalIntermediateTableScan]] to
+ * [[BatchPhysicalIntermediateTableScan]].
+ */
+class BatchPhysicalIntermediateTableScanRule
   extends ConverterRule(
     classOf[FlinkLogicalIntermediateTableScan],
     FlinkConventions.LOGICAL,
     FlinkConventions.BATCH_PHYSICAL,
-    "BatchExecIntermediateTableScanRule") {
+    "BatchPhysicalIntermediateTableScanRule") {
 
   def convert(rel: RelNode): RelNode = {
     val scan = rel.asInstanceOf[FlinkLogicalIntermediateTableScan]
     val newTrait = rel.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
-    new BatchExecIntermediateTableScan(rel.getCluster, newTrait, scan.getTable, rel.getRowType)
+    new BatchPhysicalIntermediateTableScan(rel.getCluster, newTrait, scan.getTable, rel.getRowType)
   }
 }
 
-object BatchExecIntermediateTableScanRule {
-  val INSTANCE: RelOptRule = new BatchExecIntermediateTableScanRule
+object BatchPhysicalIntermediateTableScanRule {
+  val INSTANCE: RelOptRule = new BatchPhysicalIntermediateTableScanRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntermediateTableScanRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalIntermediateTableScanRule.scala
@@ -20,29 +20,30 @@ package org.apache.flink.table.planner.plan.rules.physical.stream
 
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalIntermediateTableScan
-import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecIntermediateTableScan
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalIntermediateTableScan
 
 import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 
 /**
-  * Rule that converts [[FlinkLogicalIntermediateTableScan]] to [[StreamExecIntermediateTableScan]].
-  */
-class StreamExecIntermediateTableScanRule
+ * Rule that converts [[FlinkLogicalIntermediateTableScan]] to
+ * [[StreamPhysicalIntermediateTableScan]].
+ */
+class StreamPhysicalIntermediateTableScanRule
   extends ConverterRule(
     classOf[FlinkLogicalIntermediateTableScan],
     FlinkConventions.LOGICAL,
     FlinkConventions.STREAM_PHYSICAL,
-    "StreamExecIntermediateTableScanRule") {
+    "StreamPhysicalIntermediateTableScanRule") {
 
   def convert(rel: RelNode): RelNode = {
     val scan = rel.asInstanceOf[FlinkLogicalIntermediateTableScan]
     val newTrait = rel.getTraitSet.replace(FlinkConventions.STREAM_PHYSICAL)
-    new StreamExecIntermediateTableScan(rel.getCluster, newTrait, scan.getTable, rel.getRowType)
+    new StreamPhysicalIntermediateTableScan(rel.getCluster, newTrait, scan.getTable, rel.getRowType)
   }
 }
 
-object StreamExecIntermediateTableScanRule {
-  val INSTANCE: RelOptRule = new StreamExecIntermediateTableScanRule
+object StreamPhysicalIntermediateTableScanRule {
+  val INSTANCE: RelOptRule = new StreamPhysicalIntermediateTableScanRule
 }


### PR DESCRIPTION
## What is the purpose of the change

*Rename Stream(/Batch)ExecIntermediateTableScan to Stream(/Batch)PhysicalIntermediateTableScan*


## Brief change log

  - *Rename StreamExecIntermediateTableScan to StreamPhysicalIntermediateTableScan*
  - *Rename BatchExecIntermediateTableScan to BatchPhysicalIntermediateTableScan*

## Verifying this change

This change is a refactoring rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
