### PR TITLE
[FLINK-12461][API / Scala] Upgrade Scala 2.12 version to 2.12.13

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -202,7 +202,7 @@ object EnumValueSerializerCompatibilityTest {
 
     run.compile(List(file.getAbsolutePath))
 
-    reporter.printSummary()
+    reporter.finish()
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -872,7 +872,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.13</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>


### PR DESCRIPTION
## What is the purpose of the change

Flink is compiled with Scala 2.12.7, that was released in 2018.

The latest version of the 2.12 series is 2.12.13, and upgrading will bring build performance improvements as well as improving compatibility for projects using more recent versions of Scala.

## Brief change log

- Bump Scala 2.12 version to 2.12.13
- Fix tests because of a call that has been removed. Note that the `finish()` method already existed in 2.12.7, and all it did was calling `printSummary()`.

## Verifying this change

This change doesn't introduce any new behavior, so it is covered by the existing test suite of the Scala API.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
