### PR TITLE
[FLINK-20491] Support Broadcast Operation in BATCH execution mode (backport)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -248,7 +248,7 @@ public class StreamConfig implements Serializable {
         }
     }
 
-    public void setTypeSerializersIn(TypeSerializer<?>... serializers) {
+    public void setupNetworkInputs(TypeSerializer<?>... serializers) {
         InputConfig[] inputs = new InputConfig[serializers.length];
         for (int i = 0; i < serializers.length; i++) {
             inputs[i] = new NetworkInputConfig(serializers[i], i);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -734,10 +734,6 @@ public class StreamGraph implements Pipeline {
         getStreamNode(vertexID).setOutputFormat(outputFormat);
     }
 
-    void setSortedInputs(int vertexId, boolean shouldSort) {
-        getStreamNode(vertexId).setSortedInputs(shouldSort);
-    }
-
     public void setTransformationUID(Integer nodeId, String transformationId) {
         StreamNode node = streamNodes.get(nodeId);
         if (node != null) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionState
 import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
 import org.apache.flink.streaming.api.transformations.CoFeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.FeedbackTransformation;
+import org.apache.flink.streaming.api.transformations.KeyedBroadcastStateTransformation;
 import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
@@ -55,6 +56,7 @@ import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
 import org.apache.flink.streaming.runtime.translators.BroadcastStateTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.KeyedBroadcastStateTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySinkTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySourceTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.MultiInputTransformationTranslator;
@@ -177,6 +179,9 @@ public class StreamGraphGenerator {
                 TimestampsAndWatermarksTransformation.class,
                 new TimestampsAndWatermarksTransformationTranslator<>());
         tmp.put(BroadcastStateTransformation.class, new BroadcastStateTransformationTranslator<>());
+        tmp.put(
+                KeyedBroadcastStateTransformation.class,
+                new KeyedBroadcastStateTransformationTranslator<>());
         translatorMap = Collections.unmodifiableMap(tmp);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -84,7 +84,8 @@ public class StreamNode {
 
     private String transformationUID;
     private String userHash;
-    private boolean sortedInputs = false;
+
+    private final Map<Integer, StreamConfig.InputRequirement> inputRequirements = new HashMap<>();
 
     @VisibleForTesting
     public StreamNode(
@@ -343,12 +344,13 @@ public class StreamNode {
         this.userHash = userHash;
     }
 
-    public void setSortedInputs(boolean sortedInputs) {
-        this.sortedInputs = sortedInputs;
+    public void addInputRequirement(
+            int inputIndex, StreamConfig.InputRequirement inputRequirement) {
+        inputRequirements.put(inputIndex, inputRequirement);
     }
 
-    public boolean getSortedInputs() {
-        return sortedInputs;
+    public Map<Integer, StreamConfig.InputRequirement> getInputRequirements() {
+        return inputRequirements;
     }
 
     public Optional<OperatorCoordinator.Provider> getCoordinatorProvider(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -649,16 +649,23 @@ public class StreamingJobGraphGenerator {
                 // network input. null if we move to a new input, non-null if this is a further edge
                 // that is union-ed into the same input
                 if (inputConfigs[inputIndex] == null) {
+                    // PASS_THROUGH is a sensible default for streaming jobs. Only for BATCH
+                    // execution can we have sorted inputs
+                    StreamConfig.InputRequirement inputRequirement =
+                            vertex.getInputRequirements()
+                                    .getOrDefault(
+                                            inputIndex, StreamConfig.InputRequirement.PASS_THROUGH);
                     inputConfigs[inputIndex] =
                             new StreamConfig.NetworkInputConfig(
-                                    inputSerializers[inputIndex], inputGateCount++);
+                                    inputSerializers[inputIndex],
+                                    inputGateCount++,
+                                    inputRequirement);
                 }
             }
         }
         config.setInputs(inputConfigs);
 
         config.setTypeSerializerOut(vertex.getTypeSerializerOut());
-        config.setShouldSortInputs(vertex.getSortedInputs());
 
         // iterate edges, find sideOutput edges create and save serializers for each outputTag type
         for (StreamEdge edge : chainableOutputs) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/BatchCoBroadcastWithKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/BatchCoBroadcastWithKeyedOperator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TwoInputStreamOperator} for executing {@link KeyedBroadcastProcessFunction
+ * KeyedBroadcastProcessFunctions} in {@link org.apache.flink.api.common.RuntimeExecutionMode#BATCH}
+ * execution mode.
+ *
+ * <p>Compared to {@link CoBroadcastWithKeyedOperator} this does an additional sanity check on the
+ * input processing order requirement.
+ *
+ * @param <KS> The key type of the input keyed stream.
+ * @param <IN1> The input type of the keyed (non-broadcast) side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@Internal
+public class BatchCoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
+        extends CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT> implements BoundedMultiInput {
+
+    private static final long serialVersionUID = 5926499536290284870L;
+
+    private transient volatile boolean isBroadcastSideDone = false;
+
+    public BatchCoBroadcastWithKeyedOperator(
+            final KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> function,
+            final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors) {
+        super(function, broadcastStateDescriptors);
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (inputId == 2) {
+            // finished with the broadcast side
+            isBroadcastSideDone = true;
+        }
+    }
+
+    @Override
+    public void processElement1(StreamRecord<IN1> element) throws Exception {
+        checkState(
+                isBroadcastSideDone,
+                "Should not process regular input before broadcast side is done.");
+
+        super.processElement1(element);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/BatchCoBroadcastWithNonKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/BatchCoBroadcastWithNonKeyedOperator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TwoInputStreamOperator} for executing {@link BroadcastProcessFunction
+ * BroadcastProcessFunctions} in {@link org.apache.flink.api.common.RuntimeExecutionMode#BATCH}
+ * execution mode.
+ *
+ * <p>Compared to {@link CoBroadcastWithNonKeyedOperator} this uses {@link BoundedMultiInput} and
+ * {@link InputSelectable} to enforce the requirement that the broadcast side is processed before
+ * the regular input.
+ *
+ * @param <IN1> The input type of the regular (non-broadcast) side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@Internal
+public class BatchCoBroadcastWithNonKeyedOperator<IN1, IN2, OUT>
+        extends CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT>
+        implements BoundedMultiInput, InputSelectable {
+
+    private static final long serialVersionUID = -1869740381935471752L;
+
+    private transient volatile boolean isBroadcastSideDone = false;
+
+    public BatchCoBroadcastWithNonKeyedOperator(
+            final BroadcastProcessFunction<IN1, IN2, OUT> function,
+            final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors) {
+        super(function, broadcastStateDescriptors);
+    }
+
+    @Override
+    public void endInput(int inputId) throws Exception {
+        if (inputId == 2) {
+            // finished with the broadcast side
+            isBroadcastSideDone = true;
+        }
+    }
+
+    @Override
+    public InputSelection nextSelection() {
+        if (!isBroadcastSideDone) {
+            return InputSelection.SECOND;
+        } else {
+            return InputSelection.FIRST;
+        }
+    }
+
+    @Override
+    public void processElement1(StreamRecord<IN1> element) throws Exception {
+        checkState(
+                isBroadcastSideDone,
+                "Should not process regular input before broadcast side is done.");
+
+        super.processElement1(element);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/ObservableStreamTaskInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/ObservableStreamTaskInput.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.sort;
+
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.runtime.io.StreamTaskInput;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A wrapping {@link StreamTaskInput} that invokes a given {@link BoundedMultiInput} when reaching
+ * {@link InputStatus#END_OF_INPUT}.
+ */
+class ObservableStreamTaskInput<T> implements StreamTaskInput<T> {
+
+    private final StreamTaskInput<T> wrappedInput;
+    private final BoundedMultiInput endOfInputObserver;
+
+    public ObservableStreamTaskInput(
+            StreamTaskInput<T> wrappedInput, BoundedMultiInput endOfInputObserver) {
+        this.wrappedInput = wrappedInput;
+        this.endOfInputObserver = endOfInputObserver;
+    }
+
+    @Override
+    public InputStatus emitNext(DataOutput<T> output) throws Exception {
+        InputStatus result = wrappedInput.emitNext(output);
+        if (result == InputStatus.END_OF_INPUT) {
+            endOfInputObserver.endInput(wrappedInput.getInputIndex());
+        }
+        return result;
+    }
+
+    @Override
+    public int getInputIndex() {
+        return wrappedInput.getInputIndex();
+    }
+
+    @Override
+    public CompletableFuture<Void> prepareSnapshot(
+            ChannelStateWriter channelStateWriter, long checkpointId) throws IOException {
+        return wrappedInput.prepareSnapshot(channelStateWriter, checkpointId);
+    }
+
+    @Override
+    public void close() throws IOException {
+        wrappedInput.close();
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return wrappedInput.getAvailableFuture();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return wrappedInput.isAvailable();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -44,6 +44,9 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
@@ -65,6 +68,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * BATCH style execution.
  */
 class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedStateBackend<K> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(BatchExecutionKeyedStateBackend.class);
+
     @SuppressWarnings("rawtypes")
     private static final Map<Class<? extends StateDescriptor>, StateFactory> STATE_FACTORIES =
             Stream.of(
@@ -130,20 +136,28 @@ class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedStateBack
             TypeSerializer<N> namespaceSerializer,
             StateDescriptor<S, T> stateDescriptor,
             KeyedStateFunction<K, S> function) {
-        throw new UnsupportedOperationException(
-                "applyToAllKeys() is not supported in BATCH execution mode.");
+        // we don't do anything here. This is correct because the BATCH broadcast operators
+        // process the broadcast side first, meaning we know that the keyed side will always be
+        // empty when this is called
+        LOG.debug("Not iterating over all keyed in BATCH execution mode in applyToAllKeys().");
     }
 
     @Override
     public <N> Stream<K> getKeys(String state, N namespace) {
-        throw new UnsupportedOperationException(
-                "getKeys() is not supported in BATCH execution mode.");
+        LOG.debug("Returning an empty stream in BATCH execution mode in getKeys().");
+        // We return an empty Stream here. This is correct because the BATCH broadcast operators
+        // process the broadcast side first, meaning we know that the keyed side will always be
+        // empty when this is called
+        return Stream.empty();
     }
 
     @Override
     public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
-        throw new UnsupportedOperationException(
-                "getKeysAndNamespaces() is not supported in BATCH execution mode.");
+        LOG.debug("Returning an empty stream in BATCH execution mode in getKeysAndNamespaces().");
+        // We return an empty Stream here. This is correct because the BATCH broadcast operators
+        // process the broadcast side first, meaning we know that the keyed side will always be
+        // empty when this is called
+        return Stream.empty();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base class for Broadcast State transformations. In a nutshell, this transformation allows to take
+ * a broadcast (non-keyed) stream, connect it with another keyed or non-keyed stream, and apply a
+ * function on the resulting connected stream.
+ *
+ * <p>For more information see the <a
+ * href="https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/broadcast_state.html">
+ * Broadcast State Pattern documentation page</a>.
+ *
+ * @param <IN1> The type of the elements in the non-broadcasted input.
+ * @param <IN2> The type of the elements in the broadcasted input.
+ * @param <OUT> The type of the elements that result from this transformation.
+ */
+@Internal
+public class AbstractBroadcastStateTransformation<IN1, IN2, OUT>
+        extends PhysicalTransformation<OUT> {
+
+    private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
+
+    private final Transformation<IN1> regularInput;
+
+    private final Transformation<IN2> broadcastInput;
+
+    private ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
+
+    protected AbstractBroadcastStateTransformation(
+            final String name,
+            final Transformation<IN1> regularInput,
+            final Transformation<IN2> broadcastInput,
+            final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors,
+            final TypeInformation<OUT> outTypeInfo,
+            final int parallelism) {
+        super(name, outTypeInfo, parallelism);
+        this.regularInput = checkNotNull(regularInput);
+        this.broadcastInput = checkNotNull(broadcastInput);
+        this.broadcastStateDescriptors = broadcastStateDescriptors;
+    }
+
+    public Transformation<IN2> getBroadcastInput() {
+        return broadcastInput;
+    }
+
+    public Transformation<IN1> getRegularInput() {
+        return regularInput;
+    }
+
+    public List<MapStateDescriptor<?, ?>> getBroadcastStateDescriptors() {
+        return broadcastStateDescriptors;
+    }
+
+    public ChainingStrategy getChainingStrategy() {
+        return chainingStrategy;
+    }
+
+    @Override
+    public void setChainingStrategy(ChainingStrategy chainingStrategy) {
+        this.chainingStrategy = checkNotNull(chainingStrategy);
+    }
+
+    @Override
+    public List<Transformation<?>> getTransitivePredecessors() {
+        final List<Transformation<?>> predecessors = new ArrayList<>();
+        predecessors.add(this);
+        predecessors.add(regularInput);
+        predecessors.add(broadcastInput);
+        return predecessors;
+    }
+
+    @Override
+    public List<Transformation<?>> getInputs() {
+        final List<Transformation<?>> predecessors = new ArrayList<>();
+        predecessors.add(regularInput);
+        predecessors.add(broadcastInput);
+        return predecessors;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -142,6 +142,7 @@ public class StreamMultipleInputProcessorFactory {
                                                             idx, userClassloader))
                                     .toArray(TypeSerializer[]::new),
                             streamConfig.getStateKeySerializer(userClassloader),
+                            new StreamTaskInput[0],
                             memoryManager,
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
@@ -151,7 +152,7 @@ public class StreamMultipleInputProcessorFactory {
                                     userClassloader),
                             jobConfig);
 
-            inputs = selectableSortingInputs.getSortingInputs();
+            inputs = selectableSortingInputs.getSortedInputs();
             inputSelectable = selectableSortingInputs.getInputSelectable();
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.streaming.api.graph.StreamConfig.requiresSorting;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -118,31 +119,48 @@ public class StreamMultipleInputProcessorFactory {
 
         InputSelectable inputSelectable =
                 mainOperator instanceof InputSelectable ? (InputSelectable) mainOperator : null;
-        if (streamConfig.shouldSortInputs()) {
+
+        StreamConfig.InputConfig[] inputConfigs = streamConfig.getInputs(userClassloader);
+        boolean anyRequiresSorting =
+                Arrays.stream(inputConfigs).anyMatch(StreamConfig::requiresSorting);
+
+        if (anyRequiresSorting) {
 
             if (inputSelectable != null) {
                 throw new IllegalStateException(
                         "The InputSelectable interface is not supported with sorting inputs");
             }
 
+            StreamTaskInput[] sortingInputs =
+                    IntStream.range(0, inputsCount)
+                            .filter(idx -> requiresSorting(inputConfigs[idx]))
+                            .mapToObj(idx -> inputs[idx])
+                            .toArray(StreamTaskInput[]::new);
+            KeySelector[] sortingInputKeySelectors =
+                    IntStream.range(0, inputsCount)
+                            .filter(idx -> requiresSorting(inputConfigs[idx]))
+                            .mapToObj(idx -> streamConfig.getStatePartitioner(idx, userClassloader))
+                            .toArray(KeySelector[]::new);
+            TypeSerializer[] sortingInputKeySerializers =
+                    IntStream.range(0, inputsCount)
+                            .filter(idx -> requiresSorting(inputConfigs[idx]))
+                            .mapToObj(idx -> streamConfig.getTypeSerializerIn(idx, userClassloader))
+                            .toArray(TypeSerializer[]::new);
+
+            StreamTaskInput[] passThroughInputs =
+                    IntStream.range(0, inputsCount)
+                            .filter(idx -> !requiresSorting(inputConfigs[idx]))
+                            .mapToObj(idx -> inputs[idx])
+                            .toArray(StreamTaskInput[]::new);
+
             SelectableSortingInputs selectableSortingInputs =
                     MultiInputSortingDataInput.wrapInputs(
                             ownerTask,
-                            inputs,
-                            IntStream.range(0, inputsCount)
-                                    .mapToObj(
-                                            idx ->
-                                                    streamConfig.getStatePartitioner(
-                                                            idx, userClassloader))
-                                    .toArray(KeySelector[]::new),
-                            IntStream.range(0, inputsCount)
-                                    .mapToObj(
-                                            idx ->
-                                                    streamConfig.getTypeSerializerIn(
-                                                            idx, userClassloader))
-                                    .toArray(TypeSerializer[]::new),
+                            sortingInputs,
+                            sortingInputKeySelectors,
+                            sortingInputKeySerializers,
                             streamConfig.getStateKeySerializer(userClassloader),
-                            new StreamTaskInput[0],
+                            passThroughInputs,
                             memoryManager,
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
@@ -152,7 +170,20 @@ public class StreamMultipleInputProcessorFactory {
                                     userClassloader),
                             jobConfig);
 
-            inputs = selectableSortingInputs.getSortedInputs();
+            StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();
+            StreamTaskInput<?>[] passedThroughInputs =
+                    selectableSortingInputs.getPassThroughInputs();
+            int sortedIndex = 0;
+            int passThroughIndex = 0;
+            for (int i = 0; i < inputs.length; i++) {
+                if (requiresSorting(inputConfigs[i])) {
+                    inputs[i] = sortedInputs[sortedIndex];
+                    sortedIndex++;
+                } else {
+                    inputs[i] = passedThroughInputs[passThroughIndex];
+                    passThroughIndex++;
+                }
+            }
             inputSelectable = selectableSortingInputs.getInputSelectable();
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -108,6 +108,7 @@ public class StreamTwoInputProcessorFactory {
                             },
                             new TypeSerializer[] {typeSerializer1, typeSerializer2},
                             streamConfig.getStateKeySerializer(userClassloader),
+                            new StreamTaskInput[0],
                             memoryManager,
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
@@ -117,8 +118,8 @@ public class StreamTwoInputProcessorFactory {
                                     userClassloader),
                             jobConfig);
             inputSelectable = selectableSortingInputs.getInputSelectable();
-            input1 = getSortedInput(selectableSortingInputs.getSortingInputs()[0]);
-            input2 = getSortedInput(selectableSortingInputs.getSortingInputs()[1]);
+            input1 = getSortedInput(selectableSortingInputs.getSortedInputs()[0]);
+            input2 = getSortedInput(selectableSortingInputs.getSortedInputs()[1]);
         }
 
         StreamTaskNetworkOutput<IN1> output1 =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -43,6 +43,10 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.util.function.ThrowingConsumer;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.streaming.api.graph.StreamConfig.requiresSorting;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A factory for {@link StreamTwoInputProcessor}. */
@@ -90,25 +94,47 @@ public class StreamTwoInputProcessorFactory {
 
         InputSelectable inputSelectable =
                 streamOperator instanceof InputSelectable ? (InputSelectable) streamOperator : null;
-        if (streamConfig.shouldSortInputs()) {
+
+        // this is a bit verbose because we're manually handling input1 and input2
+        // TODO: extract method
+        StreamConfig.InputConfig[] inputConfigs = streamConfig.getInputs(userClassloader);
+        boolean input1IsSorted = requiresSorting(inputConfigs[0]);
+        boolean input2IsSorted = requiresSorting(inputConfigs[1]);
+
+        if (input1IsSorted || input2IsSorted) {
+            // as soon as one input requires sorting we need to treat all inputs differently, to
+            // make sure that pass-through inputs have precedence
 
             if (inputSelectable != null) {
                 throw new IllegalStateException(
                         "The InputSelectable interface is not supported with sorting inputs");
             }
 
+            List<StreamTaskInput<?>> sortedTaskInputs = new ArrayList<>();
+            List<KeySelector<?, ?>> keySelectors = new ArrayList<>();
+            List<StreamTaskInput<?>> passThroughTaskInputs = new ArrayList<>();
+            if (input1IsSorted) {
+                sortedTaskInputs.add(input1);
+                keySelectors.add(streamConfig.getStatePartitioner(0, userClassloader));
+            } else {
+                passThroughTaskInputs.add(input1);
+            }
+            if (input2IsSorted) {
+                sortedTaskInputs.add(input2);
+                keySelectors.add(streamConfig.getStatePartitioner(1, userClassloader));
+            } else {
+                passThroughTaskInputs.add(input2);
+            }
+
             @SuppressWarnings("unchecked")
             SelectableSortingInputs selectableSortingInputs =
                     MultiInputSortingDataInput.wrapInputs(
                             ownerTask,
-                            new StreamTaskInput[] {input1, input2},
-                            new KeySelector[] {
-                                streamConfig.getStatePartitioner(0, userClassloader),
-                                streamConfig.getStatePartitioner(1, userClassloader)
-                            },
+                            sortedTaskInputs.toArray(new StreamTaskInput[0]),
+                            keySelectors.toArray(new KeySelector[0]),
                             new TypeSerializer[] {typeSerializer1, typeSerializer2},
                             streamConfig.getStateKeySerializer(userClassloader),
-                            new StreamTaskInput[0],
+                            passThroughTaskInputs.toArray(new StreamTaskInput[0]),
                             memoryManager,
                             ioManager,
                             executionConfig.isObjectReuseEnabled(),
@@ -118,8 +144,18 @@ public class StreamTwoInputProcessorFactory {
                                     userClassloader),
                             jobConfig);
             inputSelectable = selectableSortingInputs.getInputSelectable();
-            input1 = getSortedInput(selectableSortingInputs.getSortedInputs()[0]);
-            input2 = getSortedInput(selectableSortingInputs.getSortedInputs()[1]);
+            StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();
+            StreamTaskInput<?>[] passThroughInputs = selectableSortingInputs.getPassThroughInputs();
+            if (input1IsSorted) {
+                input1 = toTypedInput(sortedInputs[0]);
+            } else {
+                input1 = toTypedInput(passThroughInputs[0]);
+            }
+            if (input2IsSorted) {
+                input2 = toTypedInput(sortedInputs[sortedInputs.length - 1]);
+            } else {
+                input2 = toTypedInput(passThroughInputs[passThroughInputs.length - 1]);
+            }
         }
 
         StreamTaskNetworkOutput<IN1> output1 =
@@ -151,7 +187,7 @@ public class StreamTwoInputProcessorFactory {
     }
 
     @SuppressWarnings("unchecked")
-    private static <IN1> StreamTaskInput<IN1> getSortedInput(StreamTaskInput<?> multiInput) {
+    private static <IN1> StreamTaskInput<IN1> toTypedInput(StreamTaskInput<?> multiInput) {
         return (StreamTaskInput<IN1>) multiInput;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -45,6 +45,7 @@ import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
 import javax.annotation.Nullable;
 
+import static org.apache.flink.streaming.api.graph.StreamConfig.requiresSorting;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -90,7 +91,10 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
             DataOutput<IN> output = createDataOutput(numRecordsIn);
             StreamTaskInput<IN> input = createTaskInput(inputGate);
 
-            if (configuration.shouldSortInputs()) {
+            StreamConfig.InputConfig[] inputConfigs =
+                    configuration.getInputs(getUserCodeClassLoader());
+            StreamConfig.InputConfig inputConfig = inputConfigs[0];
+            if (requiresSorting(inputConfig)) {
                 checkState(
                         !configuration.isCheckpointingEnabled(),
                         "Checkpointing is not allowed with sorted inputs.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.translators;
 
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -40,7 +41,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 class BatchExecutionUtils {
     private static final Logger LOG = LoggerFactory.getLogger(BatchExecutionUtils.class);
 
-    static void applySortingInputs(int transformationId, TransformationTranslator.Context context) {
+    static void applyBatchExecutionSettings(
+            int transformationId,
+            TransformationTranslator.Context context,
+            StreamConfig.InputRequirement... inputRequirements) {
         StreamNode node = context.getStreamGraph().getStreamNode(transformationId);
         boolean sortInputs = context.getGraphGeneratorConfig().get(ExecutionOptions.SORT_INPUTS);
         boolean isInputSelectable = isInputSelectable(node);
@@ -52,8 +56,10 @@ class BatchExecutionUtils {
                 "Batch state backend and sorting inputs are not supported in graphs with an InputSelectable operator.");
 
         if (sortInputs) {
-            LOG.debug("Enabling sorting inputs for an operator {}.", node);
-            node.setSortedInputs(true);
+            LOG.debug("Applying sorting/pass-through input requirements for operator {}.", node);
+            for (int i = 0; i < inputRequirements.length; i++) {
+                node.addInputRequirement(i, inputRequirements[i]);
+            }
             Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights = new HashMap<>();
             operatorScopeUseCaseWeights.put(ManagedMemoryUseCase.BATCH_OP, 1);
             node.setManagedMemoryUseCaseWeights(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BroadcastStateTransformationTranslator.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.translators;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.co.BatchCoBroadcastWithNonKeyedOperator;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
 import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
 
@@ -46,8 +47,23 @@ public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
     protected Collection<Integer> translateForBatchInternal(
             final BroadcastStateTransformation<IN1, IN2, OUT> transformation,
             final Context context) {
-        throw new UnsupportedOperationException(
-                "The Broadcast State Pattern is not support in BATCH execution mode.");
+        checkNotNull(transformation);
+        checkNotNull(context);
+
+        BatchCoBroadcastWithNonKeyedOperator<IN1, IN2, OUT> operator =
+                new BatchCoBroadcastWithNonKeyedOperator<>(
+                        transformation.getUserFunction(),
+                        transformation.getBroadcastStateDescriptors());
+
+        return translateInternal(
+                transformation,
+                transformation.getRegularInput(),
+                transformation.getBroadcastInput(),
+                SimpleOperatorFactory.of(operator),
+                null /* no key type*/,
+                null /* no first key selector */,
+                null /* no second */,
+                context);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/KeyedBroadcastStateTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/KeyedBroadcastStateTransformationTranslator.java
@@ -21,30 +21,31 @@ package org.apache.flink.streaming.runtime.translators;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
-import org.apache.flink.streaming.api.transformations.BroadcastStateTransformation;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.api.transformations.KeyedBroadcastStateTransformation;
 
 import java.util.Collection;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * A {@link TransformationTranslator} for the {@link BroadcastStateTransformation}.
+ * A {@link TransformationTranslator} for the {@link KeyedBroadcastStateTransformation}.
  *
  * @param <IN1> The type of the elements in the non-broadcasted input of the {@link
- *     BroadcastStateTransformation}.
+ *     KeyedBroadcastStateTransformation}.
  * @param <IN2> The type of the elements in the broadcasted input of the {@link
- *     BroadcastStateTransformation}.
- * @param <OUT> The type of the elements that result from the {@link BroadcastStateTransformation}.
+ *     KeyedBroadcastStateTransformation}.
+ * @param <OUT> The type of the elements that result from the {@link
+ *     KeyedBroadcastStateTransformation}.
  */
 @Internal
-public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
+public class KeyedBroadcastStateTransformationTranslator<KEY, IN1, IN2, OUT>
         extends AbstractTwoInputTransformationTranslator<
-                IN1, IN2, OUT, BroadcastStateTransformation<IN1, IN2, OUT>> {
+                IN1, IN2, OUT, KeyedBroadcastStateTransformation<KEY, IN1, IN2, OUT>> {
 
     @Override
     protected Collection<Integer> translateForBatchInternal(
-            final BroadcastStateTransformation<IN1, IN2, OUT> transformation,
+            final KeyedBroadcastStateTransformation<KEY, IN1, IN2, OUT> transformation,
             final Context context) {
         throw new UnsupportedOperationException(
                 "The Broadcast State Pattern is not support in BATCH execution mode.");
@@ -52,13 +53,13 @@ public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
 
     @Override
     protected Collection<Integer> translateForStreamingInternal(
-            final BroadcastStateTransformation<IN1, IN2, OUT> transformation,
+            final KeyedBroadcastStateTransformation<KEY, IN1, IN2, OUT> transformation,
             final Context context) {
         checkNotNull(transformation);
         checkNotNull(context);
 
-        CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT> operator =
-                new CoBroadcastWithNonKeyedOperator<>(
+        CoBroadcastWithKeyedOperator<KEY, IN1, IN2, OUT> operator =
+                new CoBroadcastWithKeyedOperator<>(
                         transformation.getUserFunction(),
                         transformation.getBroadcastStateDescriptors());
 
@@ -67,9 +68,9 @@ public class BroadcastStateTransformationTranslator<IN1, IN2, OUT>
                 transformation.getRegularInput(),
                 transformation.getBroadcastInput(),
                 SimpleOperatorFactory.of(operator),
-                null /* no key type*/,
-                null /* no first key selector */,
-                null /* no key selector on broadcast input*/,
+                transformation.getStateKeyType(),
+                transformation.getKeySelector(),
+                null /* no key selector on broadcast input */,
                 context);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.graph.SimpleTransformationTranslator;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
@@ -49,7 +50,8 @@ public class LegacySinkTransformationTranslator<IN>
         final Collection<Integer> ids = translateInternal(transformation, context);
         boolean isKeyed = transformation.getStateKeySelector() != null;
         if (isKeyed) {
-            BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+            BatchExecutionUtils.applyBatchExecutionSettings(
+                    transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
         }
         return ids;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.translators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 
@@ -51,7 +52,8 @@ public final class OneInputTransformationTranslator<IN, OUT>
                         context);
         boolean isKeyed = keySelector != null;
         if (isKeyed) {
-            BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+            BatchExecutionUtils.applyBatchExecutionSettings(
+                    transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
         }
 
         return ids;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/ReduceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/ReduceTransformationTranslator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.translators;
 
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.operators.BatchGroupedReduceOperator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
@@ -53,7 +54,8 @@ public class ReduceTransformationTranslator<IN, KEY>
                         transformation.getKeySelector(),
                         transformation.getKeyTypeInfo(),
                         context);
-        BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+        BatchExecutionUtils.applyBatchExecutionSettings(
+                transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
 
         return ids;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -43,15 +43,21 @@ public class TwoInputTransformationTranslator<IN1, IN2, OUT>
     protected Collection<Integer> translateForBatchInternal(
             final TwoInputTransformation<IN1, IN2, OUT> transformation, final Context context) {
         Collection<Integer> ids = translateInternal(transformation, context);
-        boolean isKeyed =
+
+        StreamConfig.InputRequirement input1Requirement =
                 transformation.getStateKeySelector1() != null
-                        && transformation.getStateKeySelector2() != null;
-        if (isKeyed) {
+                        ? StreamConfig.InputRequirement.SORTED
+                        : StreamConfig.InputRequirement.PASS_THROUGH;
+
+        StreamConfig.InputRequirement input2Requirement =
+                transformation.getStateKeySelector2() != null
+                        ? StreamConfig.InputRequirement.SORTED
+                        : StreamConfig.InputRequirement.PASS_THROUGH;
+
+        if (input1Requirement == StreamConfig.InputRequirement.SORTED
+                || input2Requirement == StreamConfig.InputRequirement.SORTED) {
             BatchExecutionUtils.applyBatchExecutionSettings(
-                    transformation.getId(),
-                    context,
-                    StreamConfig.InputRequirement.SORTED,
-                    StreamConfig.InputRequirement.SORTED);
+                    transformation.getId(), context, input1Requirement, input2Requirement);
         }
         return ids;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.translators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 
@@ -46,7 +47,11 @@ public class TwoInputTransformationTranslator<IN1, IN2, OUT>
                 transformation.getStateKeySelector1() != null
                         && transformation.getStateKeySelector2() != null;
         if (isKeyed) {
-            BatchExecutionUtils.applySortingInputs(transformation.getId(), context);
+            BatchExecutionUtils.applyBatchExecutionSettings(
+                    transformation.getId(),
+                    context,
+                    StreamConfig.InputRequirement.SORTED,
+                    StreamConfig.InputRequirement.SORTED);
         }
         return ids;
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorBatchExecutionTest.java
@@ -96,7 +96,9 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(true));
+        assertThat(
+                processNode.getInputRequirements().get(0),
+                equalTo(StreamConfig.InputRequirement.SORTED));
         assertThat(
                 processNode.getOperatorFactory().getChainingStrategy(),
                 equalTo(ChainingStrategy.HEAD));
@@ -124,7 +126,9 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(true));
+        assertThat(
+                processNode.getInputRequirements().get(0),
+                equalTo(StreamConfig.InputRequirement.SORTED));
         assertThat(
                 processNode.getOperatorFactory().getChainingStrategy(),
                 equalTo(ChainingStrategy.HEAD));
@@ -152,7 +156,7 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(false));
+        assertThat(processNode.getInputRequirements().get(0), nullValue());
         assertThat(graph.getStateBackend(), nullValue());
         assertThat(graph.getTimerServiceProvider(), nullValue());
     }
@@ -201,7 +205,12 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(true));
+        assertThat(
+                processNode.getInputRequirements().get(0),
+                equalTo(StreamConfig.InputRequirement.SORTED));
+        assertThat(
+                processNode.getInputRequirements().get(1),
+                equalTo(StreamConfig.InputRequirement.SORTED));
         assertThat(
                 processNode.getOperatorFactory().getChainingStrategy(),
                 equalTo(ChainingStrategy.HEAD));
@@ -234,7 +243,12 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(true));
+        assertThat(
+                processNode.getInputRequirements().get(0),
+                equalTo(StreamConfig.InputRequirement.SORTED));
+        assertThat(
+                processNode.getInputRequirements().get(1),
+                equalTo(StreamConfig.InputRequirement.SORTED));
         assertThat(
                 processNode.getOperatorFactory().getChainingStrategy(),
                 equalTo(ChainingStrategy.HEAD));
@@ -267,7 +281,8 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode processNode = graph.getStreamNode(process.getId());
-        assertThat(processNode.getSortedInputs(), equalTo(false));
+        assertThat(processNode.getInputRequirements().get(0), nullValue());
+        assertThat(processNode.getInputRequirements().get(1), nullValue());
         assertThat(graph.getStateBackend(), nullValue());
         assertThat(graph.getTimerServiceProvider(), nullValue());
     }
@@ -368,7 +383,12 @@ public class StreamGraphGeneratorBatchExecutionTest extends TestLogger {
 
         StreamGraph graph = graphGenerator.generate();
         StreamNode operatorNode = graph.getStreamNode(multipleInputTransformation.getId());
-        assertThat(operatorNode.getSortedInputs(), equalTo(true));
+        assertThat(
+                operatorNode.getInputRequirements().get(0),
+                equalTo(StreamConfig.InputRequirement.SORTED));
+        assertThat(
+                operatorNode.getInputRequirements().get(1),
+                equalTo(StreamConfig.InputRequirement.SORTED));
         assertThat(
                 operatorNode.getOperatorFactory().getChainingStrategy(),
                 equalTo(ChainingStrategy.HEAD));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/LargeSortingDataInputITCase.java
@@ -137,13 +137,14 @@ public class LargeSortingDataInputITCase {
                                 GeneratedRecordsDataInput.SERIALIZER
                             },
                             new StringSerializer(),
+                            new StreamTaskInput[0],
                             environment.getMemoryManager(),
                             environment.getIOManager(),
                             true,
                             1.0,
                             new Configuration());
 
-            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortingInputs();
+            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortedInputs();
             try (StreamTaskInput<Tuple3<Integer, String, byte[]>> sortedInput1 =
                             (StreamTaskInput<Tuple3<Integer, String, byte[]>>)
                                     sortingDataInputs[0];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInputsTest.java
@@ -45,6 +45,106 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for {@link MultiInputSortingDataInput}. */
 public class MultiInputSortingDataInputsTest {
+
+    @Test
+    public void passThroughThenSortedInput() throws Exception {
+        twoInputOrderTest(1, 0);
+    }
+
+    @Test
+    public void sortedThenPassThroughInput() throws Exception {
+        twoInputOrderTest(0, 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void twoInputOrderTest(int preferredIndex, int sortedIndex) throws Exception {
+        CollectingDataOutput<Object> collectingDataOutput = new CollectingDataOutput<>();
+
+        List<StreamElement> sortedInputElements =
+                Arrays.asList(
+                        new StreamRecord<>(1, 3),
+                        new StreamRecord<>(1, 1),
+                        new StreamRecord<>(2, 1),
+                        new StreamRecord<>(2, 3),
+                        new StreamRecord<>(1, 2),
+                        new StreamRecord<>(2, 2),
+                        Watermark.MAX_WATERMARK);
+        CollectionDataInput<Integer> sortedInput =
+                new CollectionDataInput<>(sortedInputElements, sortedIndex);
+
+        List<StreamElement> preferredInputElements =
+                Arrays.asList(
+                        new StreamRecord<>(99, 3), new StreamRecord<>(99, 1), new Watermark(99L));
+        CollectionDataInput<Integer> preferredInput =
+                new CollectionDataInput<>(preferredInputElements, preferredIndex);
+
+        KeySelector<Integer, Integer> keySelector = value -> value;
+
+        try (MockEnvironment environment = MockEnvironment.builder().build()) {
+            SelectableSortingInputs selectableSortingInputs =
+                    MultiInputSortingDataInput.wrapInputs(
+                            new DummyInvokable(),
+                            new StreamTaskInput[] {sortedInput},
+                            new KeySelector[] {keySelector},
+                            new TypeSerializer[] {new IntSerializer()},
+                            new IntSerializer(),
+                            new StreamTaskInput[] {preferredInput},
+                            environment.getMemoryManager(),
+                            environment.getIOManager(),
+                            true,
+                            1.0,
+                            new Configuration());
+
+            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortedInputs();
+            StreamTaskInput<?>[] preferredDataInputs =
+                    selectableSortingInputs.getPassThroughInputs();
+
+            try (StreamTaskInput<Object> preferredTaskInput =
+                            (StreamTaskInput<Object>) preferredDataInputs[0];
+                    StreamTaskInput<Object> sortedTaskInput =
+                            (StreamTaskInput<Object>) sortingDataInputs[0]) {
+
+                MultipleInputSelectionHandler selectionHandler =
+                        new MultipleInputSelectionHandler(
+                                selectableSortingInputs.getInputSelectable(), 2);
+
+                @SuppressWarnings("rawtypes")
+                StreamOneInputProcessor[] inputProcessors = new StreamOneInputProcessor[2];
+                inputProcessors[preferredIndex] =
+                        new StreamOneInputProcessor<>(
+                                preferredTaskInput, collectingDataOutput, new DummyOperatorChain());
+
+                inputProcessors[sortedIndex] =
+                        new StreamOneInputProcessor<>(
+                                sortedTaskInput, collectingDataOutput, new DummyOperatorChain());
+
+                StreamMultipleInputProcessor processor =
+                        new StreamMultipleInputProcessor(selectionHandler, inputProcessors);
+
+                InputStatus inputStatus;
+                do {
+                    inputStatus = processor.processInput();
+                } while (inputStatus != InputStatus.END_OF_INPUT);
+            }
+        }
+
+        assertThat(
+                collectingDataOutput.events,
+                equalTo(
+                        Arrays.asList(
+                                new StreamRecord<>(99, 3),
+                                new StreamRecord<>(99, 1),
+                                new Watermark(99L), // max watermark from the preferred input
+                                new StreamRecord<>(1, 1),
+                                new StreamRecord<>(1, 2),
+                                new StreamRecord<>(1, 3),
+                                new StreamRecord<>(2, 1),
+                                new StreamRecord<>(2, 2),
+                                new StreamRecord<>(2, 3),
+                                Watermark.MAX_WATERMARK // max watermark from the sorted input
+                                )));
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void simpleFixedLengthKeySorting() throws Exception {
@@ -69,13 +169,14 @@ public class MultiInputSortingDataInputsTest {
                             new KeySelector[] {keySelector, keySelector},
                             new TypeSerializer[] {new IntSerializer(), new IntSerializer()},
                             new IntSerializer(),
+                            new StreamTaskInput[0],
                             environment.getMemoryManager(),
                             environment.getIOManager(),
                             true,
                             1.0,
                             new Configuration());
 
-            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortingInputs();
+            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortedInputs();
             try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInputs[0];
                     StreamTaskInput<Object> input2 =
                             (StreamTaskInput<Object>) sortingDataInputs[1]) {
@@ -148,13 +249,14 @@ public class MultiInputSortingDataInputsTest {
                             new KeySelector[] {keySelector, keySelector},
                             new TypeSerializer[] {new IntSerializer(), new IntSerializer()},
                             new IntSerializer(),
+                            new StreamTaskInput[0],
                             environment.getMemoryManager(),
                             environment.getIOManager(),
                             true,
                             1.0,
                             new Configuration());
 
-            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortingInputs();
+            StreamTaskInput<?>[] sortingDataInputs = selectableSortingInputs.getSortedInputs();
             try (StreamTaskInput<Object> input1 = (StreamTaskInput<Object>) sortingDataInputs[0];
                     StreamTaskInput<Object> input2 =
                             (StreamTaskInput<Object>) sortingDataInputs[1]) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
@@ -18,21 +18,16 @@
 
 package org.apache.flink.streaming.api.operators.sorted.state;
 
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.VoidNamespace;
-import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import static org.junit.Assert.fail;
 
 /**
  * Tests that verify an exception is thrown in methods that are not supported in the BATCH runtime
@@ -43,29 +38,6 @@ public class BatchExecutionStateBackendVerificationTest extends TestLogger {
     private static final LongSerializer LONG_SERIALIZER = new LongSerializer();
 
     @Rule public ExpectedException expectedException = ExpectedException.none();
-
-    @Test
-    public void verifyGetKeysNotSupported() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("getKeys() is not supported in BATCH execution mode.");
-
-        BatchExecutionKeyedStateBackend<Long> stateBackend =
-                new BatchExecutionKeyedStateBackend<>(LONG_SERIALIZER, new KeyGroupRange(0, 9));
-
-        stateBackend.getKeys("state", VoidNamespace.INSTANCE);
-    }
-
-    @Test
-    public void verifyGetKeysAndNamespacesNotSupported() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage(
-                "getKeysAndNamespaces() is not supported in BATCH execution mode.");
-
-        BatchExecutionKeyedStateBackend<Long> stateBackend =
-                new BatchExecutionKeyedStateBackend<>(LONG_SERIALIZER, new KeyGroupRange(0, 9));
-
-        stateBackend.getKeysAndNamespaces("state");
-    }
 
     @Test
     public void verifySnapshotNotSupported() {
@@ -82,24 +54,5 @@ public class BatchExecutionStateBackendVerificationTest extends TestLogger {
                 0L,
                 streamFactory,
                 CheckpointOptions.forCheckpointWithDefaultLocation());
-    }
-
-    @Test
-    public void verifyApplyToAllKeysNotSupported() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage(
-                "applyToAllKeys() is not supported in BATCH execution mode.");
-
-        BatchExecutionKeyedStateBackend<Long> stateBackend =
-                new BatchExecutionKeyedStateBackend<>(LONG_SERIALIZER, new KeyGroupRange(0, 9));
-
-        ValueStateDescriptor<Long> stateDescriptor =
-                new ValueStateDescriptor<>("state", LONG_SERIALIZER);
-
-        stateBackend.applyToAllKeys(
-                VoidNamespace.INSTANCE,
-                new VoidNamespaceSerializer(),
-                stateDescriptor,
-                (key, state) -> fail("Should never be called"));
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -997,7 +997,7 @@ public class OneInputStreamTaskTest extends TestLogger {
         for (int chainedIndex = 1; chainedIndex < numberChainedTasks; chainedIndex++) {
             TestingStreamOperator<Integer, Integer> chainedOperator = new TestingStreamOperator<>();
             StreamConfig chainedConfig = new StreamConfig(new Configuration());
-            chainedConfig.setTypeSerializersIn(StringSerializer.INSTANCE);
+            chainedConfig.setupNetworkInputs(StringSerializer.INSTANCE);
             chainedConfig.setStreamOperator(chainedOperator);
             chainedConfig.setOperatorID(new OperatorID(0L, chainedIndex));
             chainedTaskConfigs.put(chainedIndex, chainedConfig);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -133,7 +133,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
         }
 
         streamConfig.setNumberOfNetworkInputs(1);
-        streamConfig.setTypeSerializersIn(inputSerializer);
+        streamConfig.setupNetworkInputs(inputSerializer);
     }
 
     public <K> void configureForKeyedStream(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -144,7 +144,7 @@ public class StreamConfigChainer<OWNER> {
         tailConfig = new StreamConfig(new Configuration());
         tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
         tailConfig.setOperatorID(checkNotNull(operatorID));
-        tailConfig.setTypeSerializersIn(inputSerializer);
+        tailConfig.setupNetworkInputs(inputSerializer);
         tailConfig.setTypeSerializerOut(outputSerializer);
         if (createKeyedStateBackend) {
             // used to test multiple stateful operators chained in a single task.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -179,7 +179,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 
         streamConfig.setInPhysicalEdges(inPhysicalEdges);
         streamConfig.setNumberOfNetworkInputs(numInputGates);
-        streamConfig.setTypeSerializersIn(inputSerializer1, inputSerializer2);
+        streamConfig.setupNetworkInputs(inputSerializer1, inputSerializer2);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -58,7 +58,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
             throws Exception {
         this(operator, 1, 1, 0);
 
-        config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
     }
 
     public OneInputStreamOperatorTestHarness(
@@ -75,7 +75,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
                 parallelism,
                 subtaskIndex,
                 operatorID);
-        config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
     }
 
     public OneInputStreamOperatorTestHarness(
@@ -85,7 +85,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
             throws Exception {
         this(operator, environment);
 
-        config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
     }
 
     public OneInputStreamOperatorTestHarness(OneInputStreamOperator<IN, OUT> operator)
@@ -139,7 +139,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
             throws Exception {
         this(factory, environment);
 
-        config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
     }
 
     public OneInputStreamOperatorTestHarness(
@@ -153,7 +153,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
             throws Exception {
         this(factory, 1, 1, 0);
 
-        config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
     }
 
     public OneInputStreamOperatorTestHarness(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
@@ -285,7 +285,7 @@ public abstract class MultipleInputStreamOperatorBase extends AbstractStreamOper
         streamConfig.setOperatorName(wrapper.getOperatorName());
         streamConfig.setNumberOfNetworkInputs(wrapper.getAllInputTypes().size());
         streamConfig.setNumberOfOutputs(wrapper.getOutputEdges().size());
-        streamConfig.setTypeSerializersIn(
+        streamConfig.setupNetworkInputs(
                 wrapper.getAllInputTypes().stream()
                         .map(t -> t.createSerializer(executionConfig))
                         .toArray(TypeSerializer[]::new));

--- a/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamBatchExecutionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamBatchExecutionITCase.java
@@ -19,18 +19,29 @@
 package org.apache.flink.api.datastream;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReadOnlyBroadcastState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Collector;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -180,6 +191,113 @@ public class DataStreamBatchExecutionITCase {
         }
     }
 
+    /** Verifies that all broadcast input is processed before keyed input. */
+    @Test
+    public void batchKeyedBroadcastExecution() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        DataStream<Tuple2<String, Integer>> bcInput =
+                env.fromElements(Tuple2.of("bc1", 1), Tuple2.of("bc2", 2), Tuple2.of("bc3", 3))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.<Tuple2<String, Integer>>forMonotonousTimestamps()
+                                        .withTimestampAssigner((in, ts) -> in.f1));
+
+        DataStream<Tuple2<String, Integer>> regularInput =
+                env.fromElements(
+                                Tuple2.of("regular1", 1),
+                                Tuple2.of("regular1", 2),
+                                Tuple2.of("regular2", 2),
+                                Tuple2.of("regular1", 3),
+                                Tuple2.of("regular1", 4),
+                                Tuple2.of("regular1", 3),
+                                Tuple2.of("regular2", 5),
+                                Tuple2.of("regular1", 5),
+                                Tuple2.of("regular2", 3),
+                                Tuple2.of("regular1", 3))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.<Tuple2<String, Integer>>forMonotonousTimestamps()
+                                        .withTimestampAssigner((in, ts) -> in.f1));
+
+        BroadcastStream<Tuple2<String, Integer>> broadcastStream =
+                bcInput.broadcast(STATE_DESCRIPTOR);
+
+        DataStream<String> result =
+                regularInput
+                        .keyBy((input) -> input.f0)
+                        .connect(broadcastStream)
+                        .process(new TestKeyedBroadcastFunction());
+
+        try (CloseableIterator<String> resultIterator = result.executeAndCollect()) {
+            List<String> results = CollectionUtil.iteratorToList(resultIterator);
+            assertThat(
+                    results,
+                    equalTo(
+                            Arrays.asList(
+                                    "(regular1,1): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,2): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,4): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,5): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular2,2): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular2,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular2,5): [bc2=bc2, bc1=bc1, bc3=bc3]")));
+        }
+    }
+
+    /** Verifies that all broadcast input is processed before regular input. */
+    @Test
+    public void batchBroadcastExecution() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+
+        DataStream<Tuple2<String, Integer>> bcInput =
+                env.fromElements(Tuple2.of("bc1", 1), Tuple2.of("bc2", 2), Tuple2.of("bc3", 3))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.<Tuple2<String, Integer>>forMonotonousTimestamps()
+                                        .withTimestampAssigner((in, ts) -> in.f1));
+
+        DataStream<Tuple2<String, Integer>> regularInput =
+                env.fromElements(
+                                Tuple2.of("regular1", 1),
+                                Tuple2.of("regular1", 2),
+                                Tuple2.of("regular1", 3),
+                                Tuple2.of("regular1", 4),
+                                Tuple2.of("regular1", 3),
+                                Tuple2.of("regular1", 5),
+                                Tuple2.of("regular1", 3))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.<Tuple2<String, Integer>>forMonotonousTimestamps()
+                                        .withTimestampAssigner((in, ts) -> in.f1));
+
+        BroadcastStream<Tuple2<String, Integer>> broadcastStream =
+                bcInput.broadcast(STATE_DESCRIPTOR);
+
+        DataStream<String> result =
+                regularInput.connect(broadcastStream).process(new TestBroadcastFunction());
+
+        try (CloseableIterator<String> resultIterator = result.executeAndCollect()) {
+            List<String> results = CollectionUtil.iteratorToList(resultIterator);
+            // regular, that is non-keyed input is not sorted by timestamp. For keyed inputs
+            // this is a by-product of the grouping/sorting we use to get the keyed groups.
+            assertThat(
+                    results,
+                    equalTo(
+                            Arrays.asList(
+                                    "(regular1,1): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,2): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,4): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,5): [bc2=bc2, bc1=bc1, bc3=bc3]",
+                                    "(regular1,3): [bc2=bc2, bc1=bc1, bc3=bc3]")));
+        }
+    }
+
     private StreamExecutionEnvironment getExecutionEnvironment() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
@@ -225,6 +343,63 @@ public class DataStreamBatchExecutionITCase {
                 throw new RuntimeException("FAILING");
             }
             return value + "-" + suffix + getRuntimeContext().getAttemptNumber();
+        }
+    }
+
+    static final MapStateDescriptor<String, String> STATE_DESCRIPTOR =
+            new MapStateDescriptor<>(
+                    "bc-input", StringSerializer.INSTANCE, StringSerializer.INSTANCE);
+
+    static final ValueStateDescriptor<String> KEYED_STATE_DESCRIPTOR =
+            new ValueStateDescriptor<>("keyed-state", StringSerializer.INSTANCE);
+
+    private static class TestKeyedBroadcastFunction
+            extends KeyedBroadcastProcessFunction<
+                    String, Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
+        @Override
+        public void processElement(
+                Tuple2<String, Integer> value, ReadOnlyContext ctx, Collector<String> out)
+                throws Exception {
+            ReadOnlyBroadcastState<String, String> state = ctx.getBroadcastState(STATE_DESCRIPTOR);
+
+            out.collect(value + ": " + state.immutableEntries().toString());
+        }
+
+        @Override
+        public void processBroadcastElement(
+                Tuple2<String, Integer> value, Context ctx, Collector<String> out)
+                throws Exception {
+            BroadcastState<String, String> state = ctx.getBroadcastState(STATE_DESCRIPTOR);
+            state.put(value.f0, value.f0);
+
+            // iterating over keys is a no-op in BATCH execution mode
+            ctx.applyToKeyedState(
+                    KEYED_STATE_DESCRIPTOR,
+                    (key, state1) -> {
+                        throw new RuntimeException("Shouldn't happen");
+                    });
+        }
+    }
+
+    private static class TestBroadcastFunction
+            extends BroadcastProcessFunction<
+                    Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
+
+        @Override
+        public void processElement(
+                Tuple2<String, Integer> value, ReadOnlyContext ctx, Collector<String> out)
+                throws Exception {
+            ReadOnlyBroadcastState<String, String> state = ctx.getBroadcastState(STATE_DESCRIPTOR);
+
+            out.collect(value + ": " + state.immutableEntries().toString());
+        }
+
+        @Override
+        public void processBroadcastElement(
+                Tuple2<String, Integer> value, Context ctx, Collector<String> out)
+                throws Exception {
+            BroadcastState<String, String> state = ctx.getBroadcastState(STATE_DESCRIPTOR);
+            state.put(value.f0, value.f0);
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.test.streaming.runtime;
 
-import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -40,9 +39,7 @@ import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -169,44 +166,6 @@ public class BroadcastStateITCase extends AbstractTestBase {
                 srcOne.connect(broadcast).process(new TestBroadcastProcessFunction());
 
         output.addSink(new TestSink(0)).setParallelism(1);
-        env.execute();
-    }
-
-    @Test
-    public void testBroadcastBatchTranslationThrowsException() throws Exception {
-        final MapStateDescriptor<Long, Long> utterDescriptor =
-                new MapStateDescriptor<>(
-                        "broadcast-state",
-                        BasicTypeInfo.LONG_TYPE_INFO,
-                        BasicTypeInfo.LONG_TYPE_INFO);
-
-        final List<Long> input = new ArrayList<>();
-        input.add(1L);
-        input.add(2L);
-        input.add(3L);
-
-        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
-
-        final DataStream<Long> srcOne = env.fromCollection(input);
-        final DataStream<Long> srcTwo = env.fromCollection(input);
-        final BroadcastStream<Long> broadcast = srcTwo.broadcast(utterDescriptor);
-
-        srcOne.connect(broadcast)
-                .process(
-                        new BroadcastProcessFunction<Long, Long, Long>() {
-                            @Override
-                            public void processElement(
-                                    Long value, ReadOnlyContext ctx, Collector<Long> out) {}
-
-                            @Override
-                            public void processBroadcastElement(
-                                    Long value, Context ctx, Collector<Long> out) {}
-                        });
-
-        thrown.expect(UnsupportedOperationException.class);
-        thrown.expectMessage("The Broadcast State Pattern is not support in BATCH execution mode.");
-
         env.execute();
     }
 


### PR DESCRIPTION
This is a backport of #14312 for Flink 1.12. The changes applied cleanly.

Please see the ML discussion, where there was consensus for this backport: https://lists.apache.org/thread.html/rb0de666ca8d1c34ab3a042fc265d89765a68e385c521522a63130200%40%3Cdev.flink.apache.org%3E