### PR TITLE
[FLINK-19635][hbase] Set the HBase client retry num to default value for fixing unstable test HBaseConnectorITCase

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestingClusterAutoStarter.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestingClusterAutoStarter.java
@@ -117,8 +117,8 @@ public abstract class HBaseTestingClusterAutoStarter extends AbstractTestBase {
 
     private static void initialize(Configuration c) {
         conf = HBaseConfiguration.create(c);
-        // the default retry number is 35 in hbase-1.4, set 5 for test
-        conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 5);
+        // the default retry number is 35 in hbase-1.4, set 35 for test
+        conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 35);
         try {
             admin = TEST_UTIL.getHBaseAdmin();
         } catch (MasterNotRunningException e) {

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestingClusterAutoStarter.java
@@ -112,8 +112,8 @@ public class HBaseTestingClusterAutoStarter {
 
     private static void initialize(Configuration c) {
         conf = HBaseConfiguration.create(c);
-        // the default retry number is 15 in hbase-2.2, set 5 for test
-        conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 5);
+        // the default retry number is 15 in hbase-2.2, set 15 for test
+        conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 15);
         try {
             admin = TEST_UTIL.getAdmin();
         } catch (MasterNotRunningException e) {


### PR DESCRIPTION
## What is the purpose of the change

* This pull request aims to fix the unstable test `HBaseConnectorITCase.testTableSourceSinkWithDDL`, the test result is mismatched because the hbase client retry number exceeds the retry times which means the sink task will fail and lead the data loss.


## Brief change log

  - Set HBASE_CLIENT_RETRIES_NUMBER to HBase Client default value in  `HBaseTestingClusterAutoStarter` like HBase tests do.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
