### PR TITLE
[FLINK-20927][yarn] Update configuration option in YarnConfigOptions class

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -118,9 +118,9 @@
         </tr>
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
-            <td style="word-wrap: break-word;">"ORDER"</td>
-            <td>String</td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER"). "DISABLED" means the user-jars are excluded from the system class path.</td>
+            <td style="word-wrap: break-word;">ORDER</td>
+            <td><p>Enum</p>Possible values: [DISABLED, FIRST, LAST, ORDER]</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning (FIRST), at the end (LAST), or be positioned based on their name (ORDER). DISABLED means the user-jars are excluded from the system class path.</td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
@@ -134,7 +134,7 @@ public class YARNApplicationITCase extends YarnTestBase {
         configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
         configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
         configuration.set(DeploymentOptions.TARGET, YarnDeploymentTarget.APPLICATION.getName());
-        configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
+        configuration.set(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion);
         configuration.set(PipelineOptions.JARS, Collections.singletonList(userJar.toString()));
 
         return configuration;

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
@@ -141,8 +141,7 @@ public class YARNFileReplicationITCase extends YarnTestBase {
         configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(768));
         configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
         configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
-        configuration.setString(
-                CLASSPATH_INCLUDE_USER_JAR, YarnConfigOptions.UserJarInclusion.DISABLED.toString());
+        configuration.set(CLASSPATH_INCLUDE_USER_JAR, YarnConfigOptions.UserJarInclusion.DISABLED);
 
         return configuration;
     }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -226,7 +226,7 @@ public class YARNITCase extends YarnTestBase {
         configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(768));
         configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
         configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
-        configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
+        configuration.set(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion);
 
         return configuration;
     }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1727,9 +1727,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
     private static YarnConfigOptions.UserJarInclusion getUserJarInclusionMode(
             org.apache.flink.configuration.Configuration config) {
-        return config.getEnum(
-                YarnConfigOptions.UserJarInclusion.class,
-                YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
+        return config.get(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
     }
 
     private static boolean isUsrLibDirIncludedInShipFiles(List<File> shipFiles) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -29,6 +29,10 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.DISABLED;
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.FIRST;
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.LAST;
+import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.ORDER;
 
 /**
  * This class holds configuration constants used by Flink's YARN runners.
@@ -40,28 +44,33 @@ public class YarnConfigOptions {
     /** The vcores used by YARN application master. */
     public static final ConfigOption<Integer> APP_MASTER_VCORES =
             key("yarn.appmaster.vcores")
+                    .intType()
                     .defaultValue(1)
                     .withDescription(
                             "The number of virtual cores (vcores) used by YARN application master.");
 
     /**
      * Defines whether user-jars are included in the system class path for per-job-clusters as well
-     * as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the
-     * end ("LAST"), or be positioned based on their name ("ORDER"). "DISABLED" means the user-jars
-     * are excluded from the system class path.
+     * as their positioning in the path. They can be positioned at the beginning (FIRST), at the end
+     * (LAST), or be positioned based on their name (ORDER). DISABLED means the user-jars are
+     * excluded from the system class path.
      */
-    public static final ConfigOption<String> CLASSPATH_INCLUDE_USER_JAR =
+    public static final ConfigOption<UserJarInclusion> CLASSPATH_INCLUDE_USER_JAR =
             key("yarn.per-job-cluster.include-user-jar")
-                    .defaultValue("ORDER")
+                    .enumType(UserJarInclusion.class)
+                    .defaultValue(ORDER)
                     .withDescription(
-                            "Defines whether user-jars are included in the system class path for per-job-clusters as"
-                                    + " well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the"
-                                    + " end (\"LAST\"), or be positioned based on their name (\"ORDER\"). \"DISABLED\" means the user-jars"
-                                    + " are excluded from the system class path.");
+                            String.format(
+                                    "Defines whether user-jars are included in the system class path for per-job-clusters as"
+                                            + " well as their positioning in the path. They can be positioned at the beginning (%s), at the"
+                                            + " end (%s), or be positioned based on their name (%s). %s means the user-jars"
+                                            + " are excluded from the system class path.",
+                                    FIRST.name(), LAST.name(), ORDER.name(), DISABLED.name()));
 
     /** The vcores exposed by YARN. */
     public static final ConfigOption<Integer> VCORES =
             key("yarn.containers.vcores")
+                    .intType()
                     .defaultValue(-1)
                     .withDescription(
                             Description.builder()
@@ -101,6 +110,7 @@ public class YarnConfigOptions {
     /** The config parameter defining the attemptFailuresValidityInterval of Yarn application. */
     public static final ConfigOption<Long> APPLICATION_ATTEMPT_FAILURE_VALIDITY_INTERVAL =
             key("yarn.application-attempt-failures-validity-interval")
+                    .longType()
                     .defaultValue(10000L)
                     .withDescription(
                             Description.builder()
@@ -117,6 +127,7 @@ public class YarnConfigOptions {
     /** The heartbeat interval between the Application Master and the YARN Resource Manager. */
     public static final ConfigOption<Integer> HEARTBEAT_DELAY_SECONDS =
             key("yarn.heartbeat.interval")
+                    .intType()
                     .defaultValue(5)
                     .withDeprecatedKeys("yarn.heartbeat-delay")
                     .withDescription(
@@ -128,6 +139,7 @@ public class YarnConfigOptions {
      */
     public static final ConfigOption<Integer> CONTAINER_REQUEST_HEARTBEAT_INTERVAL_MILLISECONDS =
             key("yarn.heartbeat.container-request-interval")
+                    .intType()
                     .defaultValue(500)
                     .withDescription(
                             new Description.DescriptionBuilder()
@@ -153,6 +165,7 @@ public class YarnConfigOptions {
      */
     public static final ConfigOption<String> PROPERTIES_FILE_LOCATION =
             key("yarn.properties-file.location")
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
                             "When a Flink job is submitted to YARN, the JobManager’s host and the number of available"
@@ -168,6 +181,7 @@ public class YarnConfigOptions {
      */
     public static final ConfigOption<String> APPLICATION_MASTER_PORT =
             key("yarn.application-master.port")
+                    .stringType()
                     .defaultValue("0")
                     .withDescription(
                             "With this configuration option, users can specify a port, a range of ports or a list of ports"
@@ -189,6 +203,7 @@ public class YarnConfigOptions {
      */
     public static final ConfigOption<Integer> APPLICATION_PRIORITY =
             key("yarn.application.priority")
+                    .intType()
                     .defaultValue(-1)
                     .withDescription(
                             "A non-negative integer indicating the priority for submitting a Flink YARN application. It"
@@ -215,6 +230,7 @@ public class YarnConfigOptions {
     /** A comma-separated list of strings to use as YARN application tags. */
     public static final ConfigOption<String> APPLICATION_TAGS =
             key("yarn.tags")
+                    .stringType()
                     .defaultValue("")
                     .withDescription(
                             "A comma-separated list of tags to apply to the Flink YARN application.");

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -123,9 +123,7 @@ public class YarnEntrypointUtils {
 
     public static Optional<File> getUsrLibDir(final Configuration configuration) {
         final YarnConfigOptions.UserJarInclusion userJarInclusion =
-                configuration.getEnum(
-                        YarnConfigOptions.UserJarInclusion.class,
-                        YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
+                configuration.get(YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR);
         final Optional<File> userLibDir = tryFindUserLibDirectory();
 
         checkState(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -683,8 +683,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
     public void testDisableSystemClassPathIncludeUserJarAndWithIllegalShipDirectoryName()
             throws IOException {
         final Configuration configuration = new Configuration();
-        configuration.setString(
-                CLASSPATH_INCLUDE_USER_JAR, YarnConfigOptions.UserJarInclusion.DISABLED.toString());
+        configuration.set(CLASSPATH_INCLUDE_USER_JAR, YarnConfigOptions.UserJarInclusion.DISABLED);
 
         final YarnClusterDescriptor yarnClusterDescriptor =
                 createYarnClusterDescriptor(configuration);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypointTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypointTest.java
@@ -36,9 +36,9 @@ public class YarnJobClusterEntrypointTest {
     public void testCreateDispatcherResourceManagerComponentFactoryFailIfUsrLibDirDoesNotExist()
             throws IOException {
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR,
-                YarnConfigOptions.UserJarInclusion.DISABLED.toString());
+                YarnConfigOptions.UserJarInclusion.DISABLED);
         final YarnJobClusterEntrypoint yarnJobClusterEntrypoint =
                 new YarnJobClusterEntrypoint(configuration);
         try {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

There are many configuration options that use a not recommended method to build in `YarnConfigOptions` class, mainly include the following:
1. Use the deprecated method 'defaultValue' directly instead of specifying the data type.
![image](https://user-images.githubusercontent.com/13013780/104580641-79001b80-5698-11eb-9af0-6c91dc71c00e.png)
2. Use String instead of Enum types.
![image](https://user-images.githubusercontent.com/13013780/104580699-8a492800-5698-11eb-81bc-042882ef1e18.png)


## Brief change log

  - configuration option sets the data type in `YarnConfigOptions` class
  - `yarn.per-job-cluster.include-user-jar` uses Enum instead of String in `YarnConfigOptions` class 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
