### PR TITLE
[FLINK-20953][canal][json] Option 'canal-json.database.include' and 'canal-json.table.include' support regular expression

### DIFF
--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -292,14 +292,14 @@ Format Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Only read changelog rows which match the specific database (by regular matching the "database" meta field in the Canal record).</td>
+      <td>An optional regular expression to only read the specific databases changelog rows by regular matching the "database" meta field in the Canal record. The pattern string is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a>.</td>
     </tr>
     <tr>
       <td><h5>canal-json.table.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Only read changelog rows which match the specific table (by regular matching the "table" meta field in the Canal record).</td>
+      <td>An optional regular expression to only read the specific tables changelog rows by regular matching the "table" meta field in the Canal record. The pattern string is compatible with Java's <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a>.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -292,14 +292,14 @@ Format Options
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Only read changelog rows which match the specific database (by comparing the "database" meta field in the Canal record).</td>
+      <td>Only read changelog rows which match the specific database (by regular matching the "database" meta field in the Canal record).</td>
     </tr>
     <tr>
       <td><h5>canal-json.table.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>Only read changelog rows which match the specific table (by comparing the "table" meta field in the Canal record).</td>
+      <td>Only read changelog rows which match the specific table (by regular matching the "table" meta field in the Canal record).</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -290,14 +290,14 @@ Format 参数
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>仅读取指定数据库的 changelog 记录（通过正则匹配 Canal 记录中的 "database" 元数据字段）</td>
+      <td>一个可选的正则表达式，通过正则匹配 Canal 记录中的 "database" 元字段，仅读取指定数据库的 changelog 记录。正则字符串与 Java 的 <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a> 兼容。</td>
     </tr>
     <tr>
       <td><h5>canal-json.table.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>仅读取指定表的 changelog 记录（通过正则匹配 Canal 记录中的 "table" 元数据字段）。</td>
+      <td>一个可选的正则表达式，通过正则匹配 Canal 记录中的 "table" 元字段，仅读取指定表的 changelog 记录。正则字符串与 Java 的 <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html">Pattern</a> 兼容。</td>
     </tr>
     </tbody>
 </table>

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -290,14 +290,14 @@ Format 参数
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>仅读取指定数据库的 changelog 记录（通过对比 Canal 记录中的 "database" 元数据字段）</td>
+      <td>仅读取指定数据库的 changelog 记录（通过正则匹配 Canal 记录中的 "database" 元数据字段）</td>
     </tr>
     <tr>
       <td><h5>canal-json.table.include</h5></td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
-      <td>仅读取指定表的 changelog 记录（通过对比 Canal 记录中的 "table" 元数据字段）。</td>
+      <td>仅读取指定表的 changelog 记录（通过正则匹配 Canal 记录中的 "table" 元数据字段）。</td>
     </tr>
     </tbody>
 </table>

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -197,12 +198,12 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
         try {
             final JsonNode root = jsonDeserializer.deserializeToJsonNode(message);
             if (database != null) {
-                if (!database.equals(root.get(ReadableMetadata.DATABASE.key).asText())) {
+                if (!Pattern.matches(database, root.get(ReadableMetadata.DATABASE.key).asText())) {
                     return;
                 }
             }
             if (table != null) {
-                if (!table.equals(root.get(ReadableMetadata.TABLE.key).asText())) {
+                if (!Pattern.matches(table, root.get(ReadableMetadata.TABLE.key).asText())) {
                     return;
                 }
             }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
@@ -90,6 +90,12 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
     /** Number of fields. */
     private final int fieldCount;
 
+    /** Pattern of the specific database. */
+    private final Pattern databasePattern;
+
+    /** Pattern of the specific table. */
+    private final Pattern tablePattern;
+
     private CanalJsonDeserializationSchema(
             DataType physicalDataType,
             List<ReadableMetadata> requestedMetadata,
@@ -116,6 +122,8 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
         this.table = table;
         this.ignoreParseErrors = ignoreParseErrors;
         this.fieldCount = ((RowType) physicalDataType.getLogicalType()).getFieldCount();
+        this.databasePattern = database == null ? null : Pattern.compile(database);
+        this.tablePattern = table == null ? null : Pattern.compile(table);
     }
 
     // ------------------------------------------------------------------------------------------
@@ -198,12 +206,16 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
         try {
             final JsonNode root = jsonDeserializer.deserializeToJsonNode(message);
             if (database != null) {
-                if (!Pattern.matches(database, root.get(ReadableMetadata.DATABASE.key).asText())) {
+                if (!databasePattern
+                        .matcher(root.get(ReadableMetadata.DATABASE.key).asText())
+                        .matches()) {
                     return;
                 }
             }
             if (table != null) {
-                if (!Pattern.matches(table, root.get(ReadableMetadata.TABLE.key).asText())) {
+                if (!tablePattern
+                        .matcher(root.get(ReadableMetadata.TABLE.key).asText())
+                        .matches()) {
                     return;
                 }
             }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonOptions.java
@@ -40,14 +40,16 @@ public class CanalJsonOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Only read changelog rows which match the specific database (by comparing the \"database\" meta field in the record).");
+                            "An optional regular expression to only read the specific databases changelog rows by regular matching the \"database\" meta field in the Canal record."
+                                    + "The pattern string is compatible with Java's Pattern.");
 
     public static final ConfigOption<String> TABLE_INCLUDE =
             ConfigOptions.key("table.include")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Only read changelog rows which match the specific table (by comparing the \"table\" meta field in the record).");
+                            "An optional regular expression to only read the specific tables changelog rows by regular matching the \"table\" meta field in the Canal record."
+                                    + "The pattern string is compatible with Java's Pattern.");
 
     // --------------------------------------------------------------------------------------------
     // Validation

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -75,8 +75,8 @@ public class CanalJsonSerDeSchemaTest {
                                 PHYSICAL_DATA_TYPE,
                                 Collections.emptyList(),
                                 InternalTypeInfo.of(PHYSICAL_DATA_TYPE.getLogicalType()))
-                        .setDatabase("mydb")
-                        .setTable("product")
+                        .setDatabase("^my.*")
+                        .setTable("^prod.*")
                         .build();
         runTest(lines, deserializationSchema);
     }


### PR DESCRIPTION
## What is the purpose of the change

*Currently Canal format option 'canal-json.database.include' and 'canal-json.table.include' don't support regular expression to match. It's necessary to use regular expression to match the field 'database' and 'table' of Canal binlog record.*

## Brief change log

  - *`CanalJsonDeserializationSchema` matches the field 'database' and 'table' of Canal binlog message using regular expression for Canal format option 'canal-json.database.include' and 'canal-json.table.include'.*

## Verifying this change

  - *`CanalJsonSerDeSchemaTest` modifies the `testFilteringTables` test case to use regular expression for option 'canal-json.database.include' and 'canal-json.table.include' to verify the regular matching of the field 'database' and 'table' of Canal binlog record.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)