### PR TITLE
[FLINK-20981][coordination] Allow initializing jobs to be suspended

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -373,10 +373,11 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 
         ErrorInfo failureInfo = null;
         if (throwable != null) {
-            Preconditions.checkState(jobStatus == JobStatus.FAILED);
+            Preconditions.checkState(
+                    jobStatus == JobStatus.FAILED || jobStatus == JobStatus.SUSPENDED);
             long failureTime = System.currentTimeMillis();
             failureInfo = new ErrorInfo(throwable, failureTime);
-            timestamps[JobStatus.FAILED.ordinal()] = failureTime;
+            timestamps[jobStatus.ordinal()] = failureTime;
         }
 
         return new ArchivedExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.core.testutils.CommonTestUtils;
@@ -51,9 +52,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link ArchivedExecutionGraph}. */
@@ -132,6 +136,20 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         ArchivedExecutionGraph archivedGraph = ArchivedExecutionGraph.createFrom(runtimeGraph);
 
         verifySerializability(archivedGraph);
+    }
+
+    @Test
+    public void testCreateFromInitializingJobForSuspendedJob() {
+        final ArchivedExecutionGraph suspendedExecutionGraph =
+                ArchivedExecutionGraph.createFromInitializingJob(
+                        new JobID(),
+                        "TestJob",
+                        JobStatus.SUSPENDED,
+                        new Exception("Test suspension exception"),
+                        System.currentTimeMillis());
+
+        assertThat(suspendedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
+        assertThat(suspendedExecutionGraph.getFailureInfo(), notNullValue());
     }
 
     private static void compareExecutionGraph(


### PR DESCRIPTION
`ArchivedExecutionGraph#createFromInitializingJob` assumes that a `Throwable` is only passed if the final job state is FAILED, but this would also be done if the job were SUSPENDED.