### PR TITLE
[FLINK-20675][checkpointing] Ensure asynchronous checkpoint failure could fail the job by default

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -980,7 +980,9 @@ public class CheckpointCoordinator {
         }
 
         final long checkpointId = message.getCheckpointId();
-        final String reason = (message.getReason() != null ? message.getReason().getMessage() : "");
+        final CheckpointException checkpointException =
+                message.getSerializedCheckpointException().unwrap();
+        final String reason = checkpointException.getMessage();
 
         PendingCheckpoint checkpoint;
 
@@ -1004,16 +1006,7 @@ public class CheckpointCoordinator {
                         message.getTaskExecutionId(),
                         job,
                         taskManagerLocationInfo,
-                        message.getReason());
-                final CheckpointException checkpointException;
-                if (message.getReason() == null) {
-                    checkpointException =
-                            new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED);
-                } else {
-                    checkpointException =
-                            getCheckpointException(
-                                    CheckpointFailureReason.JOB_FAILURE, message.getReason());
-                }
+                        checkpointException.getCause());
                 abortPendingCheckpoint(
                         checkpoint, checkpointException, message.getTaskExecutionId());
             } else if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -33,6 +33,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CheckpointFailureManager {
 
     public static final int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
+    public static final String EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE =
+            "Exceeded checkpoint tolerable failure threshold.";
 
     private final int tolerableCpFailureNumber;
     private final FailJobCallback failureCallback;
@@ -94,8 +96,7 @@ public class CheckpointFailureManager {
             if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
                 clearCount();
                 errorHandler.accept(
-                        new FlinkRuntimeException(
-                                "Exceeded checkpoint tolerable failure threshold."));
+                        new FlinkRuntimeException(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE));
             }
         }
     }
@@ -127,7 +128,6 @@ public class CheckpointFailureManager {
             case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
 
             case EXCEPTION:
-            case CHECKPOINT_ASYNC_EXCEPTION:
             case TASK_FAILURE:
             case TASK_CHECKPOINT_FAILURE:
             case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
@@ -136,6 +136,7 @@ public class CheckpointFailureManager {
                 // ignore
                 break;
 
+            case CHECKPOINT_ASYNC_EXCEPTION:
             case CHECKPOINT_DECLINED:
             case CHECKPOINT_EXPIRED:
                 // we should make sure one checkpoint only be counted once

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/DeclineCheckpoint.java
@@ -19,9 +19,10 @@
 package org.apache.flink.runtime.messages.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.SerializedThrowable;
+
+import javax.annotation.Nullable;
 
 /**
  * This message is sent from the {@link org.apache.flink.runtime.taskexecutor.TaskExecutor} to the
@@ -34,22 +35,21 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
     private static final long serialVersionUID = 2094094662279578953L;
 
     /** The reason why the checkpoint was declined. */
-    private final Throwable reason;
+    @Nullable private final SerializedThrowable reason;
 
     public DeclineCheckpoint(JobID job, ExecutionAttemptID taskExecutionId, long checkpointId) {
         this(job, taskExecutionId, checkpointId, null);
     }
 
     public DeclineCheckpoint(
-            JobID job, ExecutionAttemptID taskExecutionId, long checkpointId, Throwable reason) {
+            JobID job,
+            ExecutionAttemptID taskExecutionId,
+            long checkpointId,
+            @Nullable Throwable reason) {
         super(job, taskExecutionId, checkpointId);
 
-        if (reason == null || reason instanceof CheckpointException) {
-            this.reason = reason;
-        } else {
-            // some other exception. replace with a serialized throwable, to be on the safe side
-            this.reason = new SerializedThrowable(reason);
-        }
+        // some other exception. replace with a serialized throwable, to be on the safe side
+        this.reason = reason == null ? null : new SerializedThrowable(reason);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ public class DeclineCheckpoint extends AbstractCheckpointMessage implements java
      *
      * @return The reason why the checkpoint was declined
      */
-    public Throwable getReason() {
+    public SerializedThrowable getReason() {
         return reason;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/SerializedCheckpointException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/SerializedCheckpointException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages.checkpoint;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
+import org.apache.flink.util.SerializedThrowable;
+
+import java.io.Serializable;
+
+/**
+ * Serialized checkpoint exception which wraps the checkpoint failure reason and its serialized
+ * throwable.
+ */
+public class SerializedCheckpointException implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final CheckpointFailureReason checkpointFailureReason;
+    private final SerializedThrowable serializedThrowable;
+
+    public SerializedCheckpointException(CheckpointException checkpointException) {
+        this.checkpointFailureReason = checkpointException.getCheckpointFailureReason();
+        this.serializedThrowable = new SerializedThrowable(checkpointException);
+    }
+
+    public CheckpointFailureReason getCheckpointFailureReason() {
+        return checkpointFailureReason;
+    }
+
+    public SerializedThrowable getSerializedThrowable() {
+        return serializedThrowable;
+    }
+
+    public CheckpointException unwrap() {
+        return new CheckpointException(checkpointFailureReason, serializedThrowable);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor.rpc;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorGateway;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -55,7 +56,16 @@ public class RpcCheckpointResponder implements CheckpointResponder {
             long checkpointId,
             Throwable cause) {
 
+        // TODO the passed parameter 'cause' is actually always instance of CheckpointException,
+        //  we should change the interfaces to narrow all declined checkpoint's throwable to
+        // CheckpointException.
+        Preconditions.checkArgument(
+                cause instanceof CheckpointException,
+                "The given cause is "
+                        + cause.getClass()
+                        + " instead of expected CheckpointException.");
         checkpointCoordinatorGateway.declineCheckpoint(
-                new DeclineCheckpoint(jobID, executionAttemptID, checkpointId, cause));
+                new DeclineCheckpoint(
+                        jobID, executionAttemptID, checkpointId, (CheckpointException) cause));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -713,6 +713,12 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
+        public CheckpointCoordinatorBuilder setCheckpointFailureManager(
+                CheckpointFailureManager checkpointFailureManager) {
+            this.failureManager = checkpointFailureManager;
+            return this;
+        }
+
         public CheckpointCoordinatorBuilder setCompletedCheckpointStore(
                 CompletedCheckpointStore completedCheckpointStore) {
             this.completedCheckpointStore = completedCheckpointStore;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -95,7 +95,8 @@ public class CheckpointFailureManagerTest extends TestLogger {
             failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
         }
 
-        assertEquals(2, callback.getInvokeCounter());
+        // CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
+        assertEquals(3, callback.getInvokeCounter());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -38,6 +38,8 @@ import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
@@ -133,7 +135,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
@@ -410,7 +411,8 @@ public class JobMasterTest extends TestLogger {
                             System.currentTimeMillis()) {
                         @Override
                         public void declineCheckpoint(DeclineCheckpoint declineCheckpoint) {
-                            declineCheckpointMessageFuture.complete(declineCheckpoint.getReason());
+                            declineCheckpointMessageFuture.complete(
+                                    declineCheckpoint.getSerializedCheckpointException().unwrap());
                         }
                     };
 
@@ -428,6 +430,10 @@ public class JobMasterTest extends TestLogger {
             Throwable userException =
                     (Throwable) Class.forName(className, false, userClassLoader).newInstance();
 
+            CheckpointException checkpointException =
+                    new CheckpointException(
+                            CheckpointFailureReason.CHECKPOINT_DECLINED, userException);
+
             JobMasterGateway jobMasterGateway =
                     rpcService2
                             .connect(
@@ -439,13 +445,17 @@ public class JobMasterTest extends TestLogger {
             RpcCheckpointResponder rpcCheckpointResponder =
                     new RpcCheckpointResponder(jobMasterGateway);
             rpcCheckpointResponder.declineCheckpoint(
-                    jobGraph.getJobID(), new ExecutionAttemptID(), 1, userException);
+                    jobGraph.getJobID(), new ExecutionAttemptID(), 1, checkpointException);
 
             Throwable throwable =
                     declineCheckpointMessageFuture.get(
                             testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-            assertThat(throwable, instanceOf(SerializedThrowable.class));
-            assertThat(throwable.getMessage(), equalTo(userException.getMessage()));
+            assertThat(throwable, instanceOf(CheckpointException.class));
+            Optional<Throwable> throwableWithMessage =
+                    ExceptionUtils.findThrowableWithMessage(throwable, userException.getMessage());
+            assertTrue(throwableWithMessage.isPresent());
+            assertThat(
+                    throwableWithMessage.get().getMessage(), equalTo(userException.getMessage()));
         } finally {
             RpcUtils.terminateRpcServices(testingTimeout, rpcService1, rpcService2);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1005,7 +1005,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                                 checkpointOptions,
                                 checkpointMetrics,
                                 operatorChain,
-                                this::isCanceled);
+                                this::isRunning);
                     });
 
             return true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -59,7 +59,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
-            Supplier<Boolean> isCanceled)
+            Supplier<Boolean> isRunning)
             throws Exception;
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -37,12 +37,22 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /** Tests for {@link AsyncCheckpointRunnable}. */
 public class AsyncCheckpointRunnableTest {
 
     @Test
-    public void testAsyncCheckpointException() {
+    public void testDeclineWithAsyncCheckpointExceptionWhenRunning() {
+        testAsyncCheckpointException(() -> true);
+    }
+
+    @Test
+    public void testDeclineWithAsyncCheckpointExceptionWhenNotRunning() {
+        testAsyncCheckpointException(() -> false);
+    }
+
+    private void testAsyncCheckpointException(Supplier<Boolean> isTaskRunning) {
         final Map<OperatorID, OperatorSnapshotFutures> snapshotsInProgress = new HashMap<>();
         snapshotsInProgress.put(
                 new OperatorID(),
@@ -66,13 +76,18 @@ public class AsyncCheckpointRunnableTest {
                         r -> {},
                         r -> {},
                         environment,
-                        (msg, ex) -> {});
+                        (msg, ex) -> {},
+                        isTaskRunning);
         runnable.run();
 
-        Assert.assertTrue(environment.getCause() instanceof CheckpointException);
-        Assert.assertSame(
-                ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
-                CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
+        if (isTaskRunning.get()) {
+            Assert.assertTrue(environment.getCause() instanceof CheckpointException);
+            Assert.assertSame(
+                    ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
+                    CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
+        } else {
+            Assert.assertNull(environment.getCause());
+        }
     }
 
     private static class TestEnvironment extends StreamMockEnvironment {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -125,7 +125,8 @@ public class LocalStateForwardingTest extends TestLogger {
                         asyncCheckpointRunnable -> {},
                         asyncCheckpointRunnable -> {},
                         testStreamTask.getEnvironment(),
-                        testStreamTask);
+                        testStreamTask,
+                        () -> true);
 
         checkpointMetrics.setAlignmentDurationNanos(0L);
         checkpointMetrics.setBytesProcessedDuringAlignment(0L);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -48,7 +50,10 @@ public class StreamTaskExecutionDecorationTest {
 
     @Test
     public void testAbortCheckpointOnBarrierIsDecorated() throws Exception {
-        task.abortCheckpointOnBarrier(1, null);
+        task.abortCheckpointOnBarrier(
+                1,
+                new CheckpointException(
+                        CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER));
         Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -168,7 +168,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 new CheckpointOptions(SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> false);
+                () -> true);
 
         assertEquals(false, broadcastedPriorityEvent.get());
     }
@@ -191,7 +191,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 new CheckpointMetricsBuilder(),
                 new OperatorChain<>(
                         new NoOpStreamTask<>(new DummyEnvironment()), new NonRecordWriter<>()),
-                () -> false);
+                () -> true);
     }
 
     @Test
@@ -248,7 +248,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         assertFalse(checkpointOperator.isCheckpointed());
         assertEquals(-1, stateManager.getReportedCheckpointId());
         assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
@@ -299,7 +299,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
 
         assertEquals(1, recordOrEvents.size());
         Object recordOrEvent = recordOrEvents.get(0);
@@ -354,7 +354,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         rawKeyedStateHandleFuture.awaitRun();
         assertEquals(1, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
         assertFalse(rawKeyedStateHandleFuture.isCancelled());
@@ -384,7 +384,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         subtaskCheckpointCoordinator.notifyCheckpointAborted(
                 checkpointId, operatorChain, () -> true);
         assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -78,7 +78,7 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
-            Supplier<Boolean> isCanceled) {}
+            Supplier<Boolean> isRunning) {}
 
     @Override
     public void notifyCheckpointComplete(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.state.AbstractSnapshotStrategy;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+
+/** Tests to verify end-to-end logic of checkpoint failure manager. */
+public class CheckpointFailureManagerITCase extends TestLogger {
+    private static MiniClusterWithClientResource cluster;
+
+    @Before
+    public void setup() throws Exception {
+        Configuration configuration = new Configuration();
+
+        cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .build());
+        cluster.before();
+    }
+
+    @AfterClass
+    public static void shutDownExistingCluster() {
+        if (cluster != null) {
+            cluster.after();
+            cluster = null;
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testAsyncCheckpointFailureTriggerJobFailed() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        env.setStateBackend(new AsyncFailureStateBackend());
+        env.addSource(new StringGeneratingSourceFunction()).addSink(new DiscardingSink<>());
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+        try {
+            // assert that the job only execute checkpoint once and only failed once.
+            TestUtils.submitJobAndWaitForResult(
+                    cluster.getClusterClient(), jobGraph, getClass().getClassLoader());
+        } catch (JobExecutionException jobException) {
+            Optional<FlinkRuntimeException> throwable =
+                    ExceptionUtils.findThrowable(jobException, FlinkRuntimeException.class);
+            Assert.assertTrue(throwable.isPresent());
+            Assert.assertEquals(
+                    CheckpointFailureManager.EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE,
+                    throwable.get().getMessage());
+        }
+        // assert that the job only failed once.
+        Assert.assertEquals(1, StringGeneratingSourceFunction.INITIALIZE_TIMES.get());
+    }
+
+    private static class StringGeneratingSourceFunction extends RichParallelSourceFunction<String>
+            implements CheckpointedFunction {
+        private static final long serialVersionUID = 1L;
+        private static final ListStateDescriptor<Long> stateDescriptor =
+                new ListStateDescriptor<>("emitted", Long.class);
+
+        private final byte[] randomBytes = new byte[10];
+
+        private ListState<Long> listState;
+        private long emitted = 0L;
+
+        private volatile boolean isRunning = true;
+
+        public static final AtomicInteger INITIALIZE_TIMES = new AtomicInteger(0);
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            listState.clear();
+            listState.add(emitted);
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            listState = context.getOperatorStateStore().getListState(stateDescriptor);
+            INITIALIZE_TIMES.addAndGet(1);
+        }
+
+        @Override
+        public void run(SourceContext<String> ctx) throws Exception {
+            while (isRunning) {
+                ThreadLocalRandom.current().nextBytes(randomBytes);
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(new String(randomBytes));
+                    emitted += 1;
+                }
+                Thread.sleep(10);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            isRunning = false;
+        }
+    }
+
+    private static class AsyncFailureStateBackend extends MemoryStateBackend {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                @Nonnull Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) {
+            return new DefaultOperatorStateBackendBuilder(
+                    env.getUserCodeClassLoader().asClassLoader(),
+                    env.getExecutionConfig(),
+                    true,
+                    stateHandles,
+                    cancelStreamRegistry) {
+                @Override
+                @SuppressWarnings("unchecked")
+                public DefaultOperatorStateBackend build() {
+                    return new DefaultOperatorStateBackend(
+                            executionConfig,
+                            cancelStreamRegistry,
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            mock(AbstractSnapshotStrategy.class)) {
+                        @Nonnull
+                        @Override
+                        public RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot(
+                                long checkpointId,
+                                long timestamp,
+                                @Nonnull CheckpointStreamFactory streamFactory,
+                                @Nonnull CheckpointOptions checkpointOptions) {
+
+                            return new FutureTask<>(
+                                    () -> {
+                                        throw new Exception("Expected async snapshot exception.");
+                                    });
+                        }
+                    };
+                }
+            }.build();
+        }
+
+        @Override
+        public AsyncFailureStateBackend configure(ReadableConfig config, ClassLoader classLoader) {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

Since related code of checkpointing is different between Flink-1.12 and master, this PR targets for **release-1.12** branch.

Currently, no mater how many times of async checkpoint failure, job would not trigger failover. This PR ensure the mechanism of failing the job by default when async phase of checkpoint failed, which was broken in  FLINK-12364.

## Brief change log

  - Let `CHECKPOINT_ASYNC_EXCEPTION` could also be treated to fail the job.
  - Ensure decline checkpoint with specific `CheckpointException` instead of previous `throwable`.
  - If task is not running, never decline the checkpoint on task side to avoid unexpected failover again.


## Verifying this change

This change added tests and can be verified as follows:

  - Added `CheckpointFailureManagerITCase#testAsyncCheckpointFailureTriggerJobFailed` to ensure job would failed once async checkpoint failed.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
