### PR TITLE
[FLINK-20986][core] GenericTypeInfo equality issue

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
@@ -112,7 +112,7 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
 
     @Override
     public int hashCode() {
-        return typeClass.hashCode();
+        return typeClass.getName().hashCode();
     }
 
     @Override
@@ -126,7 +126,7 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
             @SuppressWarnings("unchecked")
             GenericTypeInfo<T> genericTypeInfo = (GenericTypeInfo<T>) obj;
 
-            return typeClass == genericTypeInfo.typeClass;
+            return typeClass.getName().equals(genericTypeInfo.typeClass.getName());
         } else {
             return false;
         }


### PR DESCRIPTION
## What is the purpose of the change
Make GenericTypeInfo to equal each other if they have the same class type but different instances.

## Brief change log
Change GenericTypeInfo `hashCode` and `equals` method.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
