### PR TITLE
[FLINK-20971][table-api-java] Support calling SQL expressions in Table API

### DIFF
--- a/docs/dev/table/functions/systemFunctions.md
+++ b/docs/dev/table/functions/systemFunctions.md
@@ -34,6 +34,8 @@ Scalar Functions
 
 The scalar functions take zero, one or more values as the input and return a single value as the result.
 
+Note: You can 
+
 ### Comparison Functions
 
 <div class="codetabs" markdown="1">
@@ -5636,6 +5638,21 @@ STRING.sha2(INT)
     <tr>
       <td>
 {% highlight java %}
+callSql(STRING)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>A call to a SQL expression.</p>
+        <p>The given string is parsed and translated into an Table API expression during planning. Only
+        the translated expression is evaluated during runtime.</p>
+        <p>Note: Currently, calls are limited to simple scalar expressions. Calls to aggregate or
+        table-valued functions are not supported. Sub-queries are also not allowed.</p>
+        <p>Example: <code>table.select(callSql("UPPER(myColumn)").substring(3))</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+{% highlight java %}
 ANY.as(NAME1, NAME2, ...)
 {% endhighlight %}
       </td>
@@ -5658,6 +5675,21 @@ ANY.as(NAME1, NAME2, ...)
   </thead>
 
   <tbody>
+    <tr>
+      <td>
+{% highlight scala %}
+callSql(STRING)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>A call to a SQL expression.</p>
+        <p>The given string is parsed and translated into an Table API expression during planning. Only
+        the translated expression is evaluated during runtime.</p>
+        <p>Note: Currently, calls are limited to simple scalar expressions. Calls to aggregate or
+        table-valued functions are not supported. Sub-queries are also not allowed.</p>
+        <p>Example: <code>table.select(callSql("UPPER(myColumn)").substring(3))</code></p>
+      </td>
+    </tr>
     <tr>
       <td>
 {% highlight scala %}

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -592,7 +592,7 @@ class Expression(Generic[T]):
 
         e.g. col("nullable_column").if_null(5) returns never null.
         """
-        return _binary_op("if_null")(self, null_replacement)
+        return _binary_op("ifNull")(self, null_replacement)
 
     @property
     def is_null(self) -> 'Expression[bool]':

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -29,7 +29,7 @@ __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'UNBOUNDED_ROW
            'current_timestamp', 'local_time', 'local_timestamp', 'temporal_overlaps',
            'date_format', 'timestamp_diff', 'array', 'row', 'map_', 'row_interval', 'pi', 'e',
            'rand', 'rand_integer', 'atan2', 'negative', 'concat', 'concat_ws', 'uuid', 'null_of',
-           'log', 'with_columns', 'without_columns', 'call']
+           'log', 'with_columns', 'without_columns', 'call', 'call_sql']
 
 
 def _leaf_op(op_name: str) -> Expression:
@@ -571,6 +571,21 @@ def call(f: Union[str, UserDefinedFunctionWrapper], *args) -> Expression:
         to_jarray(gateway.jvm.Object,
                   [get_function_definition(f),
                    to_jarray(gateway.jvm.Object, [_get_java_expression(arg) for arg in args])])))
+
+
+def call_sql(sql_expression: str) -> Expression:
+    """
+    A call to a SQL expression.
+
+    The given string is parsed and translated into a Table API expression during planning. Only
+    the translated expression is evaluated during runtime.
+
+    Note: Currently, calls are limited to simple scalar expressions. Calls to aggregate or
+    table-valued functions are not supported. Sub-queries are also not allowed.
+
+    :param sql_expression: SQL expression to be translated
+    """
+    return _unary_op("callSql", sql_expression)
 
 
 _add_version_doc()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -530,6 +530,19 @@ public final class Expressions {
         return apiCall(functionInstance, arguments);
     }
 
+    /**
+     * A call to a SQL expression.
+     *
+     * <p>The given string is parsed and translated into an {@link Expression} during planning. Only
+     * the translated expression is evaluated during runtime.
+     *
+     * <p>Note: Currently, calls are limited to simple scalar expressions. Calls to aggregate or
+     * table-valued functions are not supported. Sub-queries are also not allowed.
+     */
+    public static ApiExpression callSql(String sqlExpression) {
+        return apiCall(BuiltInFunctionDefinitions.CALL_SQL, sqlExpression);
+    }
+
     private static ApiExpression apiCall(FunctionDefinition functionDefinition, Object... args) {
         List<Expression> arguments =
                 Stream.of(args)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -241,6 +241,15 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                                 return Optional.empty();
                             }
                         },
+                        (sqlExpression, inputSchema) -> {
+                            try {
+                                return parser.parseSqlExpression(sqlExpression, inputSchema);
+                            } catch (Throwable t) {
+                                throw new ValidationException(
+                                        String.format("Invalid SQL expression: %s", sqlExpression),
+                                        t);
+                            }
+                        },
                         isStreamingMode);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionVisitor.java
@@ -35,6 +35,8 @@ public abstract class ApiExpressionVisitor<R> implements ExpressionVisitor<R> {
             return visit((LookupCallExpression) other);
         } else if (other instanceof UnresolvedCallExpression) {
             return visit((UnresolvedCallExpression) other);
+        } else if (other instanceof ResolvedExpression) {
+            return visit((ResolvedExpression) other);
         }
         return visitNonApiExpression(other);
     }
@@ -46,6 +48,9 @@ public abstract class ApiExpressionVisitor<R> implements ExpressionVisitor<R> {
     public abstract R visit(TableReferenceExpression tableReference);
 
     public abstract R visit(LocalReferenceExpression localReference);
+
+    /** For resolved expressions created by the planner. */
+    public abstract R visit(ResolvedExpression other);
 
     // --------------------------------------------------------------------------------------------
     // unresolved API expressions

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ResolvedExpressionVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ResolvedExpressionVisitor.java
@@ -34,6 +34,8 @@ public abstract class ResolvedExpressionVisitor<R> implements ExpressionVisitor<
             return visit((TableReferenceExpression) other);
         } else if (other instanceof LocalReferenceExpression) {
             return visit((LocalReferenceExpression) other);
+        } else if (other instanceof ResolvedExpression) {
+            return visit((ResolvedExpression) other);
         }
         throw new TableException("Unexpected unresolved expression received: " + other);
     }
@@ -41,4 +43,7 @@ public abstract class ResolvedExpressionVisitor<R> implements ExpressionVisitor<
     public abstract R visit(TableReferenceExpression tableReference);
 
     public abstract R visit(LocalReferenceExpression localReference);
+
+    /** For resolved expressions created by the planner. */
+    public abstract R visit(ResolvedExpression other);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -109,6 +109,8 @@ public class ExpressionResolver {
 
     private final DataTypeFactory typeFactory;
 
+    private final SqlExpressionResolver sqlExpressionResolver;
+
     private final PostResolverFactory postResolverFactory = new PostResolverFactory();
 
     private final Map<String, LocalReferenceExpression> localReferences;
@@ -120,6 +122,7 @@ public class ExpressionResolver {
             TableReferenceLookup tableLookup,
             FunctionLookup functionLookup,
             DataTypeFactory typeFactory,
+            SqlExpressionResolver sqlExpressionResolver,
             FieldReferenceLookup fieldLookup,
             List<OverWindow> localOverWindows,
             List<LocalReferenceExpression> localReferences) {
@@ -128,6 +131,7 @@ public class ExpressionResolver {
         this.fieldLookup = Preconditions.checkNotNull(fieldLookup);
         this.functionLookup = Preconditions.checkNotNull(functionLookup);
         this.typeFactory = Preconditions.checkNotNull(typeFactory);
+        this.sqlExpressionResolver = Preconditions.checkNotNull(sqlExpressionResolver);
 
         this.localReferences =
                 localReferences.stream()
@@ -154,9 +158,10 @@ public class ExpressionResolver {
             TableReferenceLookup tableCatalog,
             FunctionLookup functionLookup,
             DataTypeFactory typeFactory,
+            SqlExpressionResolver sqlExpressionResolver,
             QueryOperation... inputs) {
         return new ExpressionResolverBuilder(
-                inputs, config, tableCatalog, functionLookup, typeFactory);
+                inputs, config, tableCatalog, functionLookup, typeFactory, sqlExpressionResolver);
     }
 
     /**
@@ -287,6 +292,10 @@ public class ExpressionResolver {
             return typeFactory;
         }
 
+        public SqlExpressionResolver sqlExpressionResolver() {
+            return sqlExpressionResolver;
+        }
+
         @Override
         public PostResolverFactory postResolutionFactory() {
             return postResolverFactory;
@@ -409,6 +418,7 @@ public class ExpressionResolver {
         private final TableReferenceLookup tableCatalog;
         private final FunctionLookup functionLookup;
         private final DataTypeFactory typeFactory;
+        private final SqlExpressionResolver sqlExpressionResolver;
         private List<OverWindow> logicalOverWindows = new ArrayList<>();
         private List<LocalReferenceExpression> localReferences = new ArrayList<>();
 
@@ -417,12 +427,14 @@ public class ExpressionResolver {
                 TableConfig config,
                 TableReferenceLookup tableCatalog,
                 FunctionLookup functionLookup,
-                DataTypeFactory typeFactory) {
+                DataTypeFactory typeFactory,
+                SqlExpressionResolver sqlExpressionResolver) {
             this.config = config;
             this.queryOperations = Arrays.asList(queryOperations);
             this.tableCatalog = tableCatalog;
             this.functionLookup = functionLookup;
             this.typeFactory = typeFactory;
+            this.sqlExpressionResolver = sqlExpressionResolver;
         }
 
         public ExpressionResolverBuilder withOverWindows(List<OverWindow> windows) {
@@ -442,6 +454,7 @@ public class ExpressionResolver {
                     tableCatalog,
                     functionLookup,
                     typeFactory,
+                    sqlExpressionResolver,
                     new FieldReferenceLookup(queryOperations),
                     logicalOverWindows,
                     localReferences);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/SqlExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/SqlExpressionResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions.resolver;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.expressions.ResolvedExpression;
+
+/** Translates a SQL expression string into a {@link ResolvedExpression}. */
+@Internal
+public interface SqlExpressionResolver {
+
+    /** Translates the given SQL expression string or throws a {@link ValidationException}. */
+    ResolvedExpression resolveExpression(String sqlExpression, TableSchema inputSchema);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
@@ -24,8 +24,10 @@ import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.LocalReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver;
 import org.apache.flink.table.expressions.resolver.LocalOverWindow;
+import org.apache.flink.table.expressions.resolver.SqlExpressionResolver;
 import org.apache.flink.table.expressions.resolver.lookups.FieldReferenceLookup;
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup;
 import org.apache.flink.table.functions.FunctionDefinition;
@@ -69,6 +71,9 @@ public interface ResolverRule {
 
         /** Access to {@link DataTypeFactory}. */
         DataTypeFactory typeFactory();
+
+        /** Translates a SQL expression to {@link ResolvedExpression}. */
+        SqlExpressionResolver sqlExpressionResolver();
 
         /**
          * Enables the creation of resolved expressions for transformations after the actual

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/utils/ApiExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/utils/ApiExpressionDefaultVisitor.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.LocalReferenceExpression;
 import org.apache.flink.table.expressions.LookupCallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.TableReferenceExpression;
 import org.apache.flink.table.expressions.TypeLiteralExpression;
 import org.apache.flink.table.expressions.UnresolvedCallExpression;
@@ -76,6 +77,11 @@ public abstract class ApiExpressionDefaultVisitor<T> extends ApiExpressionVisito
     @Override
     public T visit(LocalReferenceExpression localReference) {
         return defaultMethod(localReference);
+    }
+
+    @Override
+    public T visit(ResolvedExpression other) {
+        return defaultMethod(other);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/utils/ResolvedExpressionDefaultVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/utils/ResolvedExpressionDefaultVisitor.java
@@ -65,5 +65,10 @@ public abstract class ResolvedExpressionDefaultVisitor<T> extends ResolvedExpres
         return defaultMethod(typeLiteral);
     }
 
+    @Override
+    public T visit(ResolvedExpression other) {
+        return defaultMethod(other);
+    }
+
     protected abstract T defaultMethod(ResolvedExpression expression);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
@@ -188,6 +188,11 @@ final class ProjectionOperationFactory {
         }
 
         @Override
+        public ResolvedExpression visit(ResolvedExpression other) {
+            return postResolverFactory.as(other, getUniqueName());
+        }
+
+        @Override
         protected ResolvedExpression defaultMethod(ResolvedExpression expression) {
             return expression;
         }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
@@ -331,6 +331,9 @@ public class ExpressionResolverTest {
                             name -> Optional.empty(),
                             new FunctionLookupMock(functions),
                             new DataTypeFactoryMock(),
+                            (sqlExpression, inputSchema) -> {
+                                throw new UnsupportedOperationException();
+                            },
                             Arrays.stream(schemas)
                                     .map(
                                             schema ->

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/utils/ValuesOperationTreeBuilderTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/utils/ValuesOperationTreeBuilderTest.java
@@ -497,6 +497,9 @@ public class ValuesOperationTreeBuilderTest {
                     new FunctionLookupMock(Collections.emptyMap()),
                     new DataTypeFactoryMock(),
                     name -> Optional.empty(), // do not support
+                    (sqlExpression, inputSchema) -> {
+                        throw new UnsupportedOperationException();
+                    },
                     true);
         }
 

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -359,6 +359,17 @@ trait ImplicitExpressionConversions {
       function,
       params: _*)
 
+  /**
+   * A call to a SQL expression.
+   *
+   * The given string is parsed and translated into an [[Expression]] during planning. Only the
+   * translated expression is evaluated during runtime.
+   *
+   * Note: Currently, calls are limited to simple scalar expressions. Calls to aggregate or
+   * table-valued functions are not supported. Sub-queries are also not allowed.
+   */
+  def callSql(sqlExpression: String): Expression = Expressions.callSql(sqlExpression)
+
   // ----------------------------------------------------------------------------------------------
   // Implicit expressions in prefix notation
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1458,6 +1458,13 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(TypeStrategies.MISSING)
                     .build();
 
+    public static final BuiltInFunctionDefinition CALL_SQL =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("CALLSQL")
+                    .kind(OTHER)
+                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .build();
+
     public static final Set<FunctionDefinition> WINDOW_PROPERTIES =
             new HashSet<>(Arrays.asList(WINDOW_START, WINDOW_END, PROCTIME, ROWTIME));
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
@@ -51,7 +51,11 @@ public class CallExpressionResolver {
                                                     throw new TableException(
                                                             "We should not need to lookup any expressions at this point");
                                                 }),
-                                context.getCatalogManager().getDataTypeFactory())
+                                context.getCatalogManager().getDataTypeFactory(),
+                                (sqlExpression, inputSchema) -> {
+                                    throw new TableException(
+                                            "SQL expression parsing is not supported at this location.");
+                                })
                         .build();
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -150,7 +150,11 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
                                                     throw new TableException(
                                                             "We should not need to lookup any expressions at this point");
                                                 }),
-                                context.getCatalogManager().getDataTypeFactory())
+                                context.getCatalogManager().getDataTypeFactory(),
+                                (sqlExpression, inputSchema) -> {
+                                    throw new TableException(
+                                            "SQL expression parsing is not supported at this location.");
+                                })
                         .build();
         SupportsFilterPushDown.Result result =
                 ((SupportsFilterPushDown) newTableSource)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -394,6 +394,8 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
   override def visit(lookupCall: LookupCallExpression): PlannerExpression =
     throw new TableException("Unsupported function call: " + lookupCall)
 
+  override def visit(other: ResolvedExpression): PlannerExpression = visitNonApiExpression(other)
+
   override def visitNonApiExpression(other: Expression): PlannerExpression = {
     other match {
       // already converted planner expressions will pass this visitor without modification

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.catalog._
 import org.apache.flink.table.catalog.exceptions.{TableNotExistException => _, _}
 import org.apache.flink.table.delegation.Parser
 import org.apache.flink.table.expressions._
+import org.apache.flink.table.expressions.resolver.SqlExpressionResolver
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSinkFactoryContextImpl}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction, _}
@@ -40,6 +41,7 @@ import org.apache.flink.table.operations.{CatalogQueryOperation, TableSourceQuer
 import org.apache.flink.table.planner.{ParserImpl, PlanningConfigurationBuilder}
 import org.apache.flink.table.sinks.{BatchSelectTableSink, BatchTableSink, OutputFormatTableSink, OverwritableTableSink, PartitionableTableSink, TableSink, TableSinkUtils}
 import org.apache.flink.table.sources.TableSource
+import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.table.types.{AbstractDataType, DataType}
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.utils.PrintUtils
@@ -107,6 +109,13 @@ abstract class TableEnvImpl(
     }),
     catalogManager.getDataTypeFactory,
     tableLookup,
+    new SqlExpressionResolver {
+      override def resolveExpression(sqlExpression: String, inputSchema: TableSchema)
+        : ResolvedExpression = {
+            throw new UnsupportedOperationException(
+              "SQL expression parsing is only supported in the Blink planner.")
+      }
+    },
     isStreamingMode)
 
   protected val planningConfigurationBuilder: PlanningConfigurationBuilder =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -47,6 +47,10 @@ class PlannerExpressionConverter private
     translateCall(unresolvedCall.getFunctionDefinition, unresolvedCall.getChildren.asScala)
   }
 
+  override def visit(other: ResolvedExpression): PlannerExpression = {
+    throw new TableException("Unsupported resolved expression:" + other)
+  }
+
   private def translateCall(
       func: FunctionDefinition,
       children: Seq[Expression])


### PR DESCRIPTION
## What is the purpose of the change

This supports calling SQL expressions in Table API. It introduces `callSql` which can be used as a regular scalar expression.

## Brief change log

- Introduces `callSql` in all APIs
- Updates several locations and visitors to deal with expressions coming from the planner

## Verifying this change

This change added tests and can be verified as follows: `MiscFunctionITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
