### PR TITLE
[FLINK-20675][checkpointing] Ensure asynchronous checkpoint failure could fail the job by default

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
@@ -245,7 +246,7 @@ public class SavepointEnvironment implements Environment {
     }
 
     @Override
-    public void declineCheckpoint(long checkpointId, Throwable cause) {
+    public void declineCheckpoint(long checkpointId, CheckpointException checkpointException) {
         throw new UnsupportedOperationException(ERROR_MSG);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1003,7 +1003,7 @@ public class CheckpointCoordinator {
                         message.getTaskExecutionId(),
                         job,
                         taskManagerLocationInfo,
-                        checkpointException);
+                        checkpointException.getCause());
                 abortPendingCheckpoint(
                         checkpoint, checkpointException, message.getTaskExecutionId());
             } else if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -977,7 +977,9 @@ public class CheckpointCoordinator {
         }
 
         final long checkpointId = message.getCheckpointId();
-        final String reason = (message.getReason() != null ? message.getReason().getMessage() : "");
+        final CheckpointException checkpointException =
+                message.getSerializedCheckpointException().unwrap();
+        final String reason = checkpointException.getMessage();
 
         PendingCheckpoint checkpoint;
 
@@ -1001,16 +1003,7 @@ public class CheckpointCoordinator {
                         message.getTaskExecutionId(),
                         job,
                         taskManagerLocationInfo,
-                        message.getReason());
-                final CheckpointException checkpointException;
-                if (message.getReason() == null) {
-                    checkpointException =
-                            new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED);
-                } else {
-                    checkpointException =
-                            getCheckpointException(
-                                    CheckpointFailureReason.JOB_FAILURE, message.getReason());
-                }
+                        checkpointException);
                 abortPendingCheckpoint(
                         checkpoint, checkpointException, message.getTaskExecutionId());
             } else if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -33,8 +33,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CheckpointFailureManager {
 
     public static final int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
-    public static final FlinkRuntimeException EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION =
-            new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold.");
+    public static final String EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE =
+            "Exceeded checkpoint tolerable failure threshold.";
 
     private final int tolerableCpFailureNumber;
     private final FailJobCallback failureCallback;
@@ -95,7 +95,8 @@ public class CheckpointFailureManager {
             checkFailureCounter(exception, checkpointId);
             if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
                 clearCount();
-                errorHandler.accept(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION);
+                errorHandler.accept(
+                        new FlinkRuntimeException(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE));
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -33,6 +33,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CheckpointFailureManager {
 
     public static final int UNLIMITED_TOLERABLE_FAILURE_NUMBER = Integer.MAX_VALUE;
+    public static final FlinkRuntimeException EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION =
+            new FlinkRuntimeException("Exceeded checkpoint tolerable failure threshold.");
 
     private final int tolerableCpFailureNumber;
     private final FailJobCallback failureCallback;
@@ -93,9 +95,7 @@ public class CheckpointFailureManager {
             checkFailureCounter(exception, checkpointId);
             if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
                 clearCount();
-                errorHandler.accept(
-                        new FlinkRuntimeException(
-                                "Exceeded checkpoint tolerable failure threshold."));
+                errorHandler.accept(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION);
             }
         }
     }
@@ -127,7 +127,6 @@ public class CheckpointFailureManager {
             case CHECKPOINT_DECLINED_INPUT_END_OF_STREAM:
 
             case EXCEPTION:
-            case CHECKPOINT_ASYNC_EXCEPTION:
             case TASK_FAILURE:
             case TASK_CHECKPOINT_FAILURE:
             case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
@@ -136,6 +135,7 @@ public class CheckpointFailureManager {
                 // ignore
                 break;
 
+            case CHECKPOINT_ASYNC_EXCEPTION:
             case CHECKPOINT_DECLINED:
             case CHECKPOINT_EXPIRED:
                 // we should make sure one checkpoint only be counted once

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -203,9 +204,9 @@ public interface Environment {
      * to successfully complete a certain checkpoint.
      *
      * @param checkpointId The ID of the declined checkpoint.
-     * @param cause An optional reason why the checkpoint was declined.
+     * @param checkpointException The exception why the checkpoint was declined.
      */
-    void declineCheckpoint(long checkpointId, Throwable cause);
+    void declineCheckpoint(long checkpointId, CheckpointException checkpointException);
 
     /**
      * Marks task execution failed for an external reason (a reason other than the task code itself

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobgraph.tasks;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -253,7 +254,8 @@ public abstract class AbstractInvokable {
      * @param checkpointId The ID of the checkpoint to be aborted.
      * @param cause The reason why the checkpoint was aborted during alignment
      */
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws IOException {
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause)
+            throws IOException {
         throw new UnsupportedOperationException(
                 String.format(
                         "abortCheckpointOnBarrier not supported by %s", this.getClass().getName()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/SerializedCheckpointException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/checkpoint/SerializedCheckpointException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.messages.checkpoint;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
+import org.apache.flink.util.SerializedThrowable;
+
+import java.io.Serializable;
+
+/**
+ * Serialized checkpoint exception which wraps the checkpoint failure reason and its serialized
+ * throwable.
+ */
+public class SerializedCheckpointException implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final CheckpointFailureReason checkpointFailureReason;
+    private final SerializedThrowable serializedThrowable;
+
+    public SerializedCheckpointException(CheckpointException checkpointException) {
+        this.checkpointFailureReason = checkpointException.getCheckpointFailureReason();
+        this.serializedThrowable = new SerializedThrowable(checkpointException);
+    }
+
+    public CheckpointFailureReason getCheckpointFailureReason() {
+        return checkpointFailureReason;
+    }
+
+    public SerializedThrowable getSerializedThrowable() {
+        return serializedThrowable;
+    }
+
+    public CheckpointException unwrap() {
+        return new CheckpointException(checkpointFailureReason, serializedThrowable);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -64,18 +64,10 @@ public class RpcCheckpointResponder implements CheckpointResponder {
             JobID jobID,
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
-            Throwable cause) {
+            CheckpointException checkpointException) {
 
-        // TODO the passed parameter 'cause' is actually always instance of CheckpointException,
-        //  we should change the interfaces to narrow all declined checkpoint's throwable to
-        // CheckpointException.
-        Preconditions.checkArgument(
-                cause instanceof CheckpointException,
-                "The given cause is "
-                        + cause.getClass()
-                        + " instead of expected CheckpointException.");
         checkpointCoordinatorGateway.declineCheckpoint(
                 new DeclineCheckpoint(
-                        jobID, executionAttemptID, checkpointId, (CheckpointException) cause));
+                        jobID, executionAttemptID, checkpointId, checkpointException));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/rpc/RpcCheckpointResponder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor.rpc;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorGateway;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -65,7 +66,16 @@ public class RpcCheckpointResponder implements CheckpointResponder {
             long checkpointId,
             Throwable cause) {
 
+        // TODO the passed parameter 'cause' is actually always instance of CheckpointException,
+        //  we should change the interfaces to narrow all declined checkpoint's throwable to
+        // CheckpointException.
+        Preconditions.checkArgument(
+                cause instanceof CheckpointException,
+                "The given cause is "
+                        + cause.getClass()
+                        + " instead of expected CheckpointException.");
         checkpointCoordinatorGateway.declineCheckpoint(
-                new DeclineCheckpoint(jobID, executionAttemptID, checkpointId, cause));
+                new DeclineCheckpoint(
+                        jobID, executionAttemptID, checkpointId, (CheckpointException) cause));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/CheckpointResponder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -64,8 +65,11 @@ public interface CheckpointResponder {
      * @param jobID Job ID of the running job
      * @param executionAttemptID Execution attempt ID of the running task
      * @param checkpointId The ID of the declined checkpoint
-     * @param cause The optional cause why the checkpoint was declined
+     * @param checkpointException The exception why the checkpoint was declined
      */
     void declineCheckpoint(
-            JobID jobID, ExecutionAttemptID executionAttemptID, long checkpointId, Throwable cause);
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointException checkpointException);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -292,8 +293,9 @@ public class RuntimeEnvironment implements Environment {
     }
 
     @Override
-    public void declineCheckpoint(long checkpointId, Throwable cause) {
-        checkpointResponder.declineCheckpoint(jobId, executionId, checkpointId, cause);
+    public void declineCheckpoint(long checkpointId, CheckpointException checkpointException) {
+        checkpointResponder.declineCheckpoint(
+                jobId, executionId, checkpointId, checkpointException);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -192,7 +192,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 new DeclineCheckpoint(
                         jobID,
                         decliningVertex.getCurrentExecutionAttempt().getAttemptId(),
-                        checkpointId),
+                        checkpointId,
+                        new CheckpointException(CHECKPOINT_DECLINED)),
                 "test");
 
         CheckpointMetrics lateReportedMetrics =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -101,6 +101,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.mockExecutionJobVertex;
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.mockExecutionVertex;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_EXPIRED;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -435,7 +437,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             // decline checkpoint from the other task
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID1, checkpointId),
+                    new DeclineCheckpoint(
+                            jobId,
+                            attemptID1,
+                            checkpointId,
+                            new CheckpointException(CHECKPOINT_DECLINED)),
                     TASK_MANAGER_LOCATION_INFO);
 
             fail("Test failed.");
@@ -481,14 +487,26 @@ public class CheckpointCoordinatorTest extends TestLogger {
         }
     }
 
+    @Test
+    public void testTriggerAndDeclineSyncCheckpointFailureSimple() {
+        testTriggerAndDeclineCheckpointSimple(CHECKPOINT_DECLINED);
+    }
+
+    @Test
+    public void testTriggerAndDeclineAsyncCheckpointFailureSimple() {
+        testTriggerAndDeclineCheckpointSimple(CHECKPOINT_ASYNC_EXCEPTION);
+    }
+
     /**
      * This test triggers a checkpoint and then sends a decline checkpoint message from one of the
      * tasks. The expected behaviour is that said checkpoint is discarded and a new checkpoint is
      * triggered.
      */
-    @Test
-    public void testTriggerAndDeclineCheckpointSimple() {
+    private void testTriggerAndDeclineCheckpointSimple(
+            CheckpointFailureReason checkpointFailureReason) {
         try {
+            final CheckpointException checkpointException =
+                    new CheckpointException(checkpointFailureReason);
             final JobID jobId = new JobID();
 
             // create some mock Execution vertices that receive the checkpoint trigger messages
@@ -497,9 +515,21 @@ public class CheckpointCoordinatorTest extends TestLogger {
             ExecutionVertex vertex1 = mockExecutionVertex(attemptID1);
             ExecutionVertex vertex2 = mockExecutionVertex(attemptID2);
 
+            TestFailJobCallback failJobCallback = new TestFailJobCallback();
             // set up the coordinator and validate the initial state
             CheckpointCoordinator checkpointCoordinator =
-                    getCheckpointCoordinator(jobId, vertex1, vertex2);
+                    new CheckpointCoordinatorBuilder()
+                            .setJobId(jobId)
+                            .setTasks(new ExecutionVertex[] {vertex1, vertex2})
+                            .setCheckpointCoordinatorConfiguration(
+                                    CheckpointCoordinatorConfiguration.builder()
+                                            .setAlignmentTimeout(Long.MAX_VALUE)
+                                            .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
+                                            .build())
+                            .setTimer(manuallyTriggeredScheduledExecutor)
+                            .setCheckpointFailureManager(
+                                    new CheckpointFailureManager(0, failJobCallback))
+                            .build();
 
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
@@ -565,7 +595,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // decline checkpoint from the other task, this should cancel the checkpoint
             // and trigger a new one
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID1, checkpointId),
+                    new DeclineCheckpoint(jobId, attemptID1, checkpointId, checkpointException),
                     TASK_MANAGER_LOCATION_INFO);
             assertTrue(checkpoint.isDisposed());
 
@@ -579,12 +609,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // decline again, nothing should happen
             // decline from the other task, nothing should happen
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID1, checkpointId),
+                    new DeclineCheckpoint(jobId, attemptID1, checkpointId, checkpointException),
                     TASK_MANAGER_LOCATION_INFO);
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID2, checkpointId),
+                    new DeclineCheckpoint(jobId, attemptID2, checkpointId, checkpointException),
                     TASK_MANAGER_LOCATION_INFO);
             assertTrue(checkpoint.isDisposed());
+            assertEquals(1, failJobCallback.getInvokeCounter());
 
             checkpointCoordinator.shutdown();
         } catch (Exception e) {
@@ -683,7 +714,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             // decline checkpoint from one of the tasks, this should cancel the checkpoint
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID1, checkpoint1Id),
+                    new DeclineCheckpoint(
+                            jobId,
+                            attemptID1,
+                            checkpoint1Id,
+                            new CheckpointException(CHECKPOINT_DECLINED)),
                     TASK_MANAGER_LOCATION_INFO);
             verify(vertex1.getCurrentExecutionAttempt(), times(1))
                     .notifyCheckpointAborted(eq(checkpoint1Id), any(Long.class));
@@ -722,10 +757,18 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // decline again, nothing should happen
             // decline from the other task, nothing should happen
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID1, checkpoint1Id),
+                    new DeclineCheckpoint(
+                            jobId,
+                            attemptID1,
+                            checkpoint1Id,
+                            new CheckpointException(CHECKPOINT_DECLINED)),
                     TASK_MANAGER_LOCATION_INFO);
             checkpointCoordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, attemptID2, checkpoint1Id),
+                    new DeclineCheckpoint(
+                            jobId,
+                            attemptID2,
+                            checkpoint1Id,
+                            new CheckpointException(CHECKPOINT_DECLINED)),
                     TASK_MANAGER_LOCATION_INFO);
             assertTrue(checkpoint1.isDisposed());
 
@@ -1569,7 +1612,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // let the checkpoint fail at the first ack vertex
         reset(subtaskStateTrigger);
         checkpointCoordinator.receiveDeclineMessage(
-                new DeclineCheckpoint(jobId, ackAttemptId1, checkpointId),
+                new DeclineCheckpoint(
+                        jobId,
+                        ackAttemptId1,
+                        checkpointId,
+                        new CheckpointException(CHECKPOINT_DECLINED)),
                 TASK_MANAGER_LOCATION_INFO);
 
         assertTrue(pendingCheckpoint.isDisposed());
@@ -2750,7 +2797,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         } catch (ExecutionException e) {
             final Throwable cause = ExceptionUtils.stripExecutionException(e);
             assertTrue(cause instanceof CheckpointException);
-            assertEquals(expectedRootCause.getMessage(), cause.getCause().getMessage());
+            assertEquals(expectedRootCause.getMessage(), cause.getCause().getCause().getMessage());
         }
 
         assertEquals(1L, invocationCounterAndException.f0.intValue());
@@ -2758,6 +2805,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 invocationCounterAndException.f1 instanceof CheckpointException
                         && invocationCounterAndException
                                 .f1
+                                .getCause()
                                 .getCause()
                                 .getMessage()
                                 .equals(expectedRootCause.getMessage()));
@@ -2837,7 +2885,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
                     coordinator.getNumQueuedRequests());
 
             coordinator.receiveDeclineMessage(
-                    new DeclineCheckpoint(jobId, new ExecutionAttemptID(), 1L), "none");
+                    new DeclineCheckpoint(
+                            jobId,
+                            new ExecutionAttemptID(),
+                            1L,
+                            new CheckpointException(CHECKPOINT_DECLINED)),
+                    "none");
             manuallyTriggeredScheduledExecutor.triggerAll();
 
             activeRequests--; // savepoint triggered
@@ -3336,7 +3389,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
                 coordinator.getPendingCheckpoints().entrySet().iterator().next().getKey();
         final PendingCheckpoint checkpoint = coordinator.getPendingCheckpoints().get(checkpointId);
         coordinator.receiveDeclineMessage(
-                new DeclineCheckpoint(jobId, attemptID, checkpointId, reason),
+                new DeclineCheckpoint(
+                        jobId,
+                        attemptID,
+                        checkpointId,
+                        new CheckpointException(CHECKPOINT_DECLINED, reason)),
                 TASK_MANAGER_LOCATION_INFO);
         return checkpoint;
     }
@@ -3431,6 +3488,26 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
         void setOwner(CheckpointCoordinator coordinator) {
             this.owner = checkNotNull(coordinator);
+        }
+    }
+
+    private static class TestFailJobCallback implements CheckpointFailureManager.FailJobCallback {
+
+        private int invokeCounter = 0;
+
+        @Override
+        public void failJob(Throwable cause) {
+            invokeCounter++;
+        }
+
+        @Override
+        public void failJobDueToTaskFailure(
+                final Throwable cause, final ExecutionAttemptID executionAttemptID) {
+            invokeCounter++;
+        }
+
+        public int getInvokeCounter() {
+            return invokeCounter;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -713,6 +713,12 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
+        public CheckpointCoordinatorBuilder setCheckpointFailureManager(
+                CheckpointFailureManager checkpointFailureManager) {
+            this.failureManager = checkpointFailureManager;
+            return this;
+        }
+
         public CheckpointCoordinatorBuilder setCompletedCheckpointStore(
                 CompletedCheckpointStore completedCheckpointStore) {
             this.completedCheckpointStore = completedCheckpointStore;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManagerTest.java
@@ -95,7 +95,8 @@ public class CheckpointFailureManagerTest extends TestLogger {
             failureManager.handleJobLevelCheckpointException(new CheckpointException(reason), -1);
         }
 
-        assertEquals(2, callback.getInvokeCounter());
+        // CHECKPOINT_DECLINED, CHECKPOINT_EXPIRED and CHECKPOINT_ASYNC_EXCEPTION
+        assertEquals(3, callback.getInvokeCounter());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -38,6 +38,8 @@ import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointProperties;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
@@ -133,7 +135,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
@@ -324,7 +325,8 @@ public class JobMasterTest extends TestLogger {
                             System.currentTimeMillis()) {
                         @Override
                         public void declineCheckpoint(DeclineCheckpoint declineCheckpoint) {
-                            declineCheckpointMessageFuture.complete(declineCheckpoint.getReason());
+                            declineCheckpointMessageFuture.complete(
+                                    declineCheckpoint.getSerializedCheckpointException().unwrap());
                         }
                     };
 
@@ -342,6 +344,10 @@ public class JobMasterTest extends TestLogger {
             Throwable userException =
                     (Throwable) Class.forName(className, false, userClassLoader).newInstance();
 
+            CheckpointException checkpointException =
+                    new CheckpointException(
+                            CheckpointFailureReason.CHECKPOINT_DECLINED, userException);
+
             JobMasterGateway jobMasterGateway =
                     rpcService2
                             .connect(
@@ -353,13 +359,17 @@ public class JobMasterTest extends TestLogger {
             RpcCheckpointResponder rpcCheckpointResponder =
                     new RpcCheckpointResponder(jobMasterGateway);
             rpcCheckpointResponder.declineCheckpoint(
-                    jobGraph.getJobID(), new ExecutionAttemptID(), 1, userException);
+                    jobGraph.getJobID(), new ExecutionAttemptID(), 1, checkpointException);
 
             Throwable throwable =
                     declineCheckpointMessageFuture.get(
                             testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-            assertThat(throwable, instanceOf(SerializedThrowable.class));
-            assertThat(throwable.getMessage(), equalTo(userException.getMessage()));
+            assertThat(throwable, instanceOf(CheckpointException.class));
+            Optional<Throwable> throwableWithMessage =
+                    ExceptionUtils.findThrowableWithMessage(throwable, userException.getMessage());
+            assertTrue(throwableWithMessage.isPresent());
+            assertThat(
+                    throwableWithMessage.get().getMessage(), equalTo(userException.getMessage()));
         } finally {
             RpcUtils.terminateRpcServices(testingTimeout, rpcService1, rpcService2);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyCheckpointInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyCheckpointInvokable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.operators.testutils;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -34,5 +35,5 @@ public class DummyCheckpointInvokable extends DummyInvokable {
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics) {}
 
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {}
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -213,7 +214,7 @@ public class DummyEnvironment implements Environment {
             TaskStateSnapshot subtaskState) {}
 
     @Override
-    public void declineCheckpoint(long checkpointId, Throwable cause) {
+    public void declineCheckpoint(long checkpointId, CheckpointException cause) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -351,7 +352,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
     }
 
     @Override
-    public void declineCheckpoint(long checkpointId, Throwable cause) {
+    public void declineCheckpoint(long checkpointId, CheckpointException cause) {
         throw new UnsupportedOperationException(cause);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpCheckpointResponder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/NoOpCheckpointResponder.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -32,12 +33,12 @@ public enum NoOpCheckpointResponder implements CheckpointResponder {
             JobID j, ExecutionAttemptID e, long i, CheckpointMetrics c, TaskStateSnapshot s) {}
 
     @Override
-    public void declineCheckpoint(JobID j, ExecutionAttemptID e, long l, Throwable t) {}
-
-    @Override
     public void reportCheckpointMetrics(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
             CheckpointMetrics checkpointMetrics) {}
+
+    @Override
+    public void declineCheckpoint(JobID j, ExecutionAttemptID e, long l, CheckpointException c) {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -290,7 +291,7 @@ public class TaskAsyncCallTest extends TestLogger {
         }
 
         @Override
-        public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+        public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
             throw new UnsupportedOperationException("Should not be called");
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestCheckpointResponder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestCheckpointResponder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -72,10 +73,10 @@ public class TestCheckpointResponder implements CheckpointResponder {
             JobID jobID,
             ExecutionAttemptID executionAttemptID,
             long checkpointId,
-            Throwable cause) {
+            CheckpointException checkpointException) {
 
         DeclineReport declineReport =
-                new DeclineReport(jobID, executionAttemptID, checkpointId, cause);
+                new DeclineReport(jobID, executionAttemptID, checkpointId, checkpointException);
 
         declineReports.add(declineReport);
 
@@ -137,19 +138,19 @@ public class TestCheckpointResponder implements CheckpointResponder {
 
     public static class DeclineReport extends AbstractReport {
 
-        public final Throwable cause;
+        public final CheckpointException cause;
 
         public DeclineReport(
                 JobID jobID,
                 ExecutionAttemptID executionAttemptID,
                 long checkpointId,
-                Throwable cause) {
+                CheckpointException cause) {
 
             super(jobID, executionAttemptID, checkpointId);
             this.cause = cause;
         }
 
-        public Throwable getCause() {
+        public CheckpointException getCause() {
             return cause;
         }
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -197,7 +198,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
                             JobID jobID,
                             ExecutionAttemptID executionAttemptID,
                             long checkpointId,
-                            Throwable cause) {}
+                            CheckpointException checkpointException) {}
                 };
 
         JobID jobID = new JobID();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -37,6 +37,7 @@ import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -50,6 +51,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
     private final String taskName;
     private final Consumer<AsyncCheckpointRunnable> registerConsumer;
     private final Consumer<AsyncCheckpointRunnable> unregisterConsumer;
+    private final Supplier<Boolean> isTaskRunning;
     private final Environment taskEnvironment;
 
     public boolean isRunning() {
@@ -79,7 +81,8 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
             Consumer<AsyncCheckpointRunnable> register,
             Consumer<AsyncCheckpointRunnable> unregister,
             Environment taskEnvironment,
-            AsyncExceptionHandler asyncExceptionHandler) {
+            AsyncExceptionHandler asyncExceptionHandler,
+            Supplier<Boolean> isTaskRunning) {
 
         this.operatorSnapshotsInProgress = checkNotNull(operatorSnapshotsInProgress);
         this.checkpointMetaData = checkNotNull(checkpointMetaData);
@@ -90,6 +93,7 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
         this.unregisterConsumer = unregister;
         this.taskEnvironment = checkNotNull(taskEnvironment);
         this.asyncExceptionHandler = checkNotNull(asyncExceptionHandler);
+        this.isTaskRunning = isTaskRunning;
     }
 
     @Override
@@ -254,19 +258,29 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                                         + '.',
                                 e);
 
-                // We only report the exception for the original cause of fail and cleanup.
-                // Otherwise this followup exception could race the original exception in failing
-                // the task.
-                try {
-                    taskEnvironment.declineCheckpoint(
+                if (isTaskRunning.get()) {
+                    // We only report the exception for the original cause of fail and cleanup.
+                    // Otherwise this followup exception could race the original exception in
+                    // failing the task.
+                    try {
+                        taskEnvironment.declineCheckpoint(
+                                checkpointMetaData.getCheckpointId(),
+                                new CheckpointException(
+                                        CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION,
+                                        checkpointException));
+                    } catch (Exception unhandled) {
+                        AsynchronousException asyncException = new AsynchronousException(unhandled);
+                        asyncExceptionHandler.handleAsyncException(
+                                "Failure in asynchronous checkpoint materialization",
+                                asyncException);
+                    }
+                } else {
+                    // We never decline checkpoint after task is not running to avoid unexpected job
+                    // failover, which caused by exceeding checkpoint tolerable failure threshold.
+                    LOG.warn(
+                            "As task is already not running, no longer decline checkpoint {}.",
                             checkpointMetaData.getCheckpointId(),
-                            new CheckpointException(
-                                    CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION,
-                                    checkpointException));
-                } catch (Exception unhandled) {
-                    AsynchronousException asyncException = new AsynchronousException(unhandled);
-                    asyncExceptionHandler.handleAsyncException(
-                            "Failure in asynchronous checkpoint materialization", asyncException);
+                            checkpointException);
                 }
 
                 currentState = AsyncCheckpointState.DISCARDED;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -250,7 +251,8 @@ public class MultipleInputStreamTask<OUT>
     }
 
     @Override
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws IOException {
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause)
+            throws IOException {
         CompletableFuture<Boolean> resultFuture =
                 pendingCheckpointCompletedFutures.remove(checkpointId);
         if (resultFuture != null) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -986,7 +986,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     }
 
     @Override
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) throws IOException {
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause)
+            throws IOException {
         subtaskCheckpointCoordinator.abortCheckpointOnBarrier(checkpointId, cause, operatorChain);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1019,7 +1019,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                                 checkpointOptions,
                                 checkpointMetrics,
                                 operatorChain,
-                                this::isCanceled);
+                                this::isRunning);
                     });
 
             return true;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -50,7 +51,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
     CheckpointStorageWorkerView getCheckpointStorage();
 
     void abortCheckpointOnBarrier(
-            long checkpointId, Throwable cause, OperatorChain<?, ?> operatorChain)
+            long checkpointId, CheckpointException cause, OperatorChain<?, ?> operatorChain)
             throws IOException;
 
     /** Must be called after {@link #initCheckpoint(long, CheckpointOptions)}. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -59,7 +59,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
-            Supplier<Boolean> isCanceled)
+            Supplier<Boolean> isRunning)
             throws Exception;
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -196,7 +196,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
     @Override
     public void abortCheckpointOnBarrier(
-            long checkpointId, Throwable cause, OperatorChain<?, ?> operatorChain)
+            long checkpointId, CheckpointException cause, OperatorChain<?, ?> operatorChain)
             throws IOException {
         LOG.debug("Aborting checkpoint via cancel-barrier {} for task {}", checkpointId, taskName);
         lastCheckpointId = Math.max(lastCheckpointId, checkpointId);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointSequenceValidator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointSequenceValidator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -79,7 +80,7 @@ class CheckpointSequenceValidator extends AbstractInvokable {
     }
 
     @Override
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
         assertTrue(
                 "Unexpected abortCheckpointOnBarrier(" + checkpointId + ")",
                 i < checkpointIDs.length);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerCancellationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -141,7 +142,7 @@ public class UnalignedControllerCancellationTest {
         }
 
         @Override
-        public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+        public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
             checkpointAborted = true;
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -968,7 +969,7 @@ public class UnalignedControllerTest {
         }
 
         @Override
-        public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+        public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
             super.abortCheckpointOnBarrier(checkpointId, cause);
             nextExpectedCheckpointId = -1;
         }
@@ -997,7 +998,7 @@ public class UnalignedControllerTest {
         protected void processInput(MailboxDefaultAction.Controller controller) {}
 
         @Override
-        public void abortCheckpointOnBarrier(long checkpointId, Throwable cause)
+        public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause)
                 throws IOException {
             abortedCheckpointId = checkpointId;
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
@@ -127,9 +127,9 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
     }
 
     @Override
-    public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+    public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
         lastCanceledCheckpointId = checkpointId;
-        failureReason = ((CheckpointException) cause).getCheckpointFailureReason();
+        failureReason = cause.getCheckpointFailureReason();
         abortedCheckpointCounter++;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -37,12 +37,22 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /** Tests for {@link AsyncCheckpointRunnable}. */
 public class AsyncCheckpointRunnableTest {
 
     @Test
-    public void testAsyncCheckpointException() {
+    public void testDeclineWithAsyncCheckpointExceptionWhenRunning() {
+        testAsyncCheckpointException(() -> true);
+    }
+
+    @Test
+    public void testDeclineWithAsyncCheckpointExceptionWhenNotRunning() {
+        testAsyncCheckpointException(() -> false);
+    }
+
+    private void testAsyncCheckpointException(Supplier<Boolean> isTaskRunning) {
         final Map<OperatorID, OperatorSnapshotFutures> snapshotsInProgress = new HashMap<>();
         snapshotsInProgress.put(
                 new OperatorID(),
@@ -66,13 +76,18 @@ public class AsyncCheckpointRunnableTest {
                         r -> {},
                         r -> {},
                         environment,
-                        (msg, ex) -> {});
+                        (msg, ex) -> {},
+                        isTaskRunning);
         runnable.run();
 
-        Assert.assertTrue(environment.getCause() instanceof CheckpointException);
-        Assert.assertSame(
-                ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
-                CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
+        if (isTaskRunning.get()) {
+            Assert.assertTrue(environment.getCause() instanceof CheckpointException);
+            Assert.assertSame(
+                    ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
+                    CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
+        } else {
+            Assert.assertNull(environment.getCause());
+        }
     }
 
     private static class TestEnvironment extends StreamMockEnvironment {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -81,9 +81,8 @@ public class AsyncCheckpointRunnableTest {
         runnable.run();
 
         if (isTaskRunning.get()) {
-            Assert.assertTrue(environment.getCause() instanceof CheckpointException);
             Assert.assertSame(
-                    ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
+                    (environment.getCause()).getCheckpointFailureReason(),
                     CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
         } else {
             Assert.assertNull(environment.getCause());
@@ -92,7 +91,7 @@ public class AsyncCheckpointRunnableTest {
 
     private static class TestEnvironment extends StreamMockEnvironment {
 
-        Throwable cause = null;
+        CheckpointException cause = null;
 
         TestEnvironment() {
             this(
@@ -124,11 +123,11 @@ public class AsyncCheckpointRunnableTest {
         }
 
         @Override
-        public void declineCheckpoint(long checkpointId, Throwable cause) {
-            this.cause = cause;
+        public void declineCheckpoint(long checkpointId, CheckpointException checkpointException) {
+            this.cause = checkpointException;
         }
 
-        Throwable getCause() {
+        CheckpointException getCause() {
             return cause;
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -125,7 +125,8 @@ public class LocalStateForwardingTest extends TestLogger {
                         asyncCheckpointRunnable -> {},
                         asyncCheckpointRunnable -> {},
                         testStreamTask.getEnvironment(),
-                        testStreamTask);
+                        testStreamTask,
+                        () -> true);
 
         checkpointMetrics.setAlignmentDurationNanos(0L);
         checkpointMetrics.setBytesProcessedDuringAlignment(0L);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
@@ -350,8 +351,9 @@ public class StreamMockEnvironment implements Environment {
     }
 
     @Override
-    public void declineCheckpoint(long checkpointId, Throwable cause) {
-        checkpointResponder.declineCheckpoint(jobID, executionAttemptID, checkpointId, cause);
+    public void declineCheckpoint(long checkpointId, CheckpointException checkpointException) {
+        checkpointResponder.declineCheckpoint(
+                jobID, executionAttemptID, checkpointId, checkpointException);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -105,7 +106,7 @@ public class StreamTaskExecutionDecorationTest {
         decorator = new CountingStreamTaskActionExecutor();
         task =
                 new StreamTask<Object, StreamOperator<Object>>(
-                        new StreamTaskTest.DeclineDummyEnvironment(),
+                        new DeclineDummyEnvironment(),
                         null,
                         FatalExitExceptionHandler.INSTANCE,
                         decorator,
@@ -158,5 +159,15 @@ public class StreamTaskExecutionDecorationTest {
             calls.incrementAndGet();
             return callable.call();
         }
+    }
+
+    private static final class DeclineDummyEnvironment extends DummyEnvironment {
+
+        DeclineDummyEnvironment() {
+            super("test", 1, 0);
+        }
+
+        @Override
+        public void declineCheckpoint(long checkpointId, CheckpointException cause) {}
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -48,7 +50,10 @@ public class StreamTaskExecutionDecorationTest {
 
     @Test
     public void testAbortCheckpointOnBarrierIsDecorated() throws Exception {
-        task.abortCheckpointOnBarrier(1, null);
+        task.abortCheckpointOnBarrier(
+                1,
+                new CheckpointException(
+                        CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER));
         Assert.assertTrue("execution decorator was not called", decorator.wasCalled());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -169,7 +169,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 new CheckpointOptions(SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> false);
+                () -> true);
 
         assertEquals(false, broadcastedPriorityEvent.get());
     }
@@ -192,7 +192,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 new CheckpointMetricsBuilder(),
                 new OperatorChain<>(
                         new NoOpStreamTask<>(new DummyEnvironment()), new NonRecordWriter<>()),
-                () -> false);
+                () -> true);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         assertFalse(checkpointOperator.isCheckpointed());
         assertEquals(-1, stateManager.getReportedCheckpointId());
         assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
@@ -300,7 +300,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
 
         assertEquals(1, recordOrEvents.size());
         Object recordOrEvent = recordOrEvents.get(0);
@@ -355,7 +355,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         rawKeyedStateHandleFuture.awaitRun();
         assertEquals(1, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
         assertFalse(rawKeyedStateHandleFuture.isCancelled());
@@ -385,7 +385,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
                 new CheckpointMetricsBuilder(),
                 operatorChain,
-                () -> true);
+                () -> false);
         subtaskCheckpointCoordinator.notifyCheckpointAborted(
                 checkpointId, operatorChain, () -> true);
         assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -199,7 +200,7 @@ public class SynchronousCheckpointITCase {
         }
 
         @Override
-        public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+        public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
             throw new UnsupportedOperationException("Should not be called");
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.VoidPermanentBlobService;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
@@ -275,7 +276,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                 JobID jobID,
                 ExecutionAttemptID executionAttemptID,
                 long checkpointId,
-                Throwable cause) {
+                CheckpointException checkpointException) {
 
             declinedLatch.trigger();
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -68,7 +69,7 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
 
     @Override
     public void abortCheckpointOnBarrier(
-            long checkpointId, Throwable cause, OperatorChain<?, ?> operatorChain) {
+            long checkpointId, CheckpointException cause, OperatorChain<?, ?> operatorChain) {
         channelStateWriter.abort(checkpointId, cause, true);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -78,7 +78,7 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics,
             OperatorChain<?, ?> operatorChain,
-            Supplier<Boolean> isCanceled) {}
+            Supplier<Boolean> isRunning) {}
 
     @Override
     public void notifyCheckpointComplete(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.checkpointing;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.state.AbstractSnapshotStrategy;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
+import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+
+/** Tests to verify end-to-end logic of checkpoint failure manager. */
+public class CheckpointFailureManagerITCase extends TestLogger {
+    private static MiniClusterWithClientResource cluster;
+
+    @Before
+    public void setup() throws Exception {
+        Configuration configuration = new Configuration();
+
+        cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setConfiguration(configuration)
+                                .build());
+        cluster.before();
+    }
+
+    @AfterClass
+    public static void shutDownExistingCluster() {
+        if (cluster != null) {
+            cluster.after();
+            cluster = null;
+        }
+    }
+
+    @Test(timeout = 10000)
+    public void testAsyncCheckpointFailureTriggerJobFailed() throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(100);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+        env.setStateBackend(new AsyncFailureStateBackend());
+        env.addSource(new StringGeneratingSourceFunction()).addSink(new DiscardingSink<>());
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
+        try {
+            // assert that the job only execute checkpoint once and only failed once.
+            TestUtils.submitJobAndWaitForResult(
+                    cluster.getClusterClient(), jobGraph, getClass().getClassLoader());
+        } catch (JobExecutionException jobException) {
+            Optional<FlinkRuntimeException> throwable =
+                    ExceptionUtils.findThrowable(jobException, FlinkRuntimeException.class);
+            Assert.assertTrue(throwable.isPresent());
+            Assert.assertEquals(
+                    CheckpointFailureManager.EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION,
+                    throwable.get());
+        }
+        // assert that the job only failed once.
+        Assert.assertEquals(1, StringGeneratingSourceFunction.INITIALIZE_TIMES.get());
+    }
+
+    private static class StringGeneratingSourceFunction extends RichParallelSourceFunction<String>
+            implements CheckpointedFunction {
+        private static final long serialVersionUID = 1L;
+        private static final ListStateDescriptor<Long> stateDescriptor =
+                new ListStateDescriptor<>("emitted", Long.class);
+
+        private final byte[] randomBytes = new byte[10];
+
+        private ListState<Long> listState;
+        private long emitted = 0L;
+
+        private volatile boolean isRunning = true;
+
+        public static final AtomicInteger INITIALIZE_TIMES = new AtomicInteger(0);
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            listState.clear();
+            listState.add(emitted);
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            listState = context.getOperatorStateStore().getListState(stateDescriptor);
+            INITIALIZE_TIMES.addAndGet(1);
+        }
+
+        @Override
+        public void run(SourceContext<String> ctx) throws Exception {
+            while (isRunning) {
+                ThreadLocalRandom.current().nextBytes(randomBytes);
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(new String(randomBytes));
+                    emitted += 1;
+                }
+                Thread.sleep(10);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            isRunning = false;
+        }
+    }
+
+    private static class AsyncFailureStateBackend extends MemoryStateBackend {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                @Nonnull Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) {
+            return new DefaultOperatorStateBackendBuilder(
+                    env.getUserCodeClassLoader().asClassLoader(),
+                    env.getExecutionConfig(),
+                    true,
+                    stateHandles,
+                    cancelStreamRegistry) {
+                @Override
+                @SuppressWarnings("unchecked")
+                public DefaultOperatorStateBackend build() {
+                    return new DefaultOperatorStateBackend(
+                            executionConfig,
+                            cancelStreamRegistry,
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            new HashMap<>(),
+                            mock(AbstractSnapshotStrategy.class)) {
+                        @Nonnull
+                        @Override
+                        public RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot(
+                                long checkpointId,
+                                long timestamp,
+                                @Nonnull CheckpointStreamFactory streamFactory,
+                                @Nonnull CheckpointOptions checkpointOptions) {
+
+                            return new FutureTask<>(
+                                    () -> {
+                                        throw new Exception("Async part snapshot exception.");
+                                    });
+                        }
+                    };
+                }
+            }.build();
+        }
+
+        @Override
+        public AsyncFailureStateBackend configure(ReadableConfig config, ClassLoader classLoader) {
+            return this;
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -109,8 +109,8 @@ public class CheckpointFailureManagerITCase extends TestLogger {
                     ExceptionUtils.findThrowable(jobException, FlinkRuntimeException.class);
             Assert.assertTrue(throwable.isPresent());
             Assert.assertEquals(
-                    CheckpointFailureManager.EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_EXCEPTION,
-                    throwable.get());
+                    CheckpointFailureManager.EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE,
+                    throwable.get().getMessage());
         }
         // assert that the job only failed once.
         Assert.assertEquals(1, StringGeneratingSourceFunction.INITIALIZE_TIMES.get());
@@ -198,7 +198,7 @@ public class CheckpointFailureManagerITCase extends TestLogger {
 
                             return new FutureTask<>(
                                     () -> {
-                                        throw new Exception("Async part snapshot exception.");
+                                        throw new Exception("Excepted async snapshot exception.");
                                     });
                         }
                     };

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -198,7 +198,7 @@ public class CheckpointFailureManagerITCase extends TestLogger {
 
                             return new FutureTask<>(
                                     () -> {
-                                        throw new Exception("Excepted async snapshot exception.");
+                                        throw new Exception("Expected async snapshot exception.");
                                     });
                         }
                     };


### PR DESCRIPTION
## What is the purpose of the change

Compared with https://github.com/apache/flink/pull/14656, this PR add another commit to refactor interfaces to decline checkpoint with `CheckpointException` instead of previous `Throwable`.

Currently, no mater how many times of async checkpoint failure, job would not trigger failover. This PR ensure the mechanism of failing the job by default when async phase of checkpoint failed, which was broken in FLINK-12364.

## Brief change log

  - Let `CHECKPOINT_ASYNC_EXCEPTION` could also be treated to fail the job.
  - Ensure decline checkpoint with specific `CheckpointException` instead of previous `throwable`.
  - If task is not running, never decline the checkpoint on task side to avoid unexpected failover again.
  - refactor interfaces to decline checkpoint with `CheckpointException` instead of previous `Throwable`.


## Verifying this change

This change added tests and can be verified as follows:

  - Added `CheckpointFailureManagerITCase#testAsyncCheckpointFailureTriggerJobFailed` to ensure job would failed once async checkpoint failed.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
