### PR TITLE
[FLINK-20989][table-planner-blink] Functions in ExplodeFunctionUtil should handle null data to avoid NPE

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ExplodeFunctionUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ExplodeFunctionUtil.scala
@@ -31,7 +31,9 @@ import scala.collection.JavaConverters._
 @SerialVersionUID(1L)
 class ObjectExplodeTableFunc(componentType: TypeInformation[_]) extends TableFunction[Object] {
   def eval(arr: Array[Object]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Object, Integer]): Unit = {
@@ -50,7 +52,9 @@ class ObjectExplodeTableFunc(componentType: TypeInformation[_]) extends TableFun
 @SerialVersionUID(1L)
 class FloatExplodeTableFunc extends TableFunction[Float] {
   def eval(arr: Array[Float]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Float, Integer]): Unit = {
@@ -61,7 +65,9 @@ class FloatExplodeTableFunc extends TableFunction[Float] {
 @SerialVersionUID(1L)
 class ShortExplodeTableFunc extends TableFunction[Short] {
   def eval(arr: Array[Short]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Short, Integer]): Unit = {
@@ -72,7 +78,9 @@ class ShortExplodeTableFunc extends TableFunction[Short] {
 @SerialVersionUID(1L)
 class IntExplodeTableFunc extends TableFunction[Int] {
   def eval(arr: Array[Int]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Int, Integer]): Unit = {
@@ -83,7 +91,9 @@ class IntExplodeTableFunc extends TableFunction[Int] {
 @SerialVersionUID(1L)
 class LongExplodeTableFunc extends TableFunction[Long] {
   def eval(arr: Array[Long]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Long, Integer]): Unit = {
@@ -94,7 +104,9 @@ class LongExplodeTableFunc extends TableFunction[Long] {
 @SerialVersionUID(1L)
 class DoubleExplodeTableFunc extends TableFunction[Double] {
   def eval(arr: Array[Double]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Double, Integer]): Unit = {
@@ -105,7 +117,9 @@ class DoubleExplodeTableFunc extends TableFunction[Double] {
 @SerialVersionUID(1L)
 class ByteExplodeTableFunc extends TableFunction[Byte] {
   def eval(arr: Array[Byte]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Byte, Integer]): Unit = {
@@ -116,7 +130,9 @@ class ByteExplodeTableFunc extends TableFunction[Byte] {
 @SerialVersionUID(1L)
 class BooleanExplodeTableFunc extends TableFunction[Boolean] {
   def eval(arr: Array[Boolean]): Unit = {
-    arr.foreach(collect)
+    if (arr != null) {
+      arr.foreach(collect)
+    }
   }
 
   def eval(map: util.Map[Boolean, Integer]): Unit = {
@@ -127,6 +143,9 @@ class BooleanExplodeTableFunc extends TableFunction[Boolean] {
 @SerialVersionUID(1L)
 class MapExplodeTableFunc extends TableFunction[Row] {
   def eval(map: util.Map[Object, Object]): Unit = {
+    if (map == null) {
+      return
+    }
     map.asScala.foreach { case (key, value) =>
       collect(Row.of(key, value))
     }
@@ -135,6 +154,9 @@ class MapExplodeTableFunc extends TableFunction[Row] {
 
 object CommonCollect {
   def collect[T](map: util.Map[T, Integer], collectFunc: (T) => Unit): Unit = {
+    if (map == null) {
+      return
+    }
     map.asScala.foreach { e =>
       for (i <- 0 until e._2) {
         collectFunc(e._1)
@@ -170,7 +192,6 @@ object ExplodeFunctionUtil {
       case BasicTypeInfo.FLOAT_TYPE_INFO => new FloatExplodeTableFunc
       case BasicTypeInfo.DOUBLE_TYPE_INFO => new DoubleExplodeTableFunc
       case BasicTypeInfo.BYTE_TYPE_INFO => new ByteExplodeTableFunc
-      case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
       case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
       case _ => new ObjectExplodeTableFunc(typeInfo)
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/ExploadFuntionUtilTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/ExploadFuntionUtilTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.utils
+
+import org.apache.flink.api.common.functions.util.ListCollector
+import org.apache.flink.api.common.typeinfo.Types
+import org.apache.flink.types.Row
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+import java.util
+
+/**
+ * Test for functions in [[ExploadFuntionUti]].
+ */
+class ExploadFuntionUtilTest {
+
+  @Test
+  def testObjectExplodeTableFunc(): Unit = {
+    val func = new ObjectExplodeTableFunc(Types.STRING)
+    val list = new util.ArrayList[Object]()
+    func.setCollector(new ListCollector[Object](list))
+    func.eval(null.asInstanceOf[Array[Object]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Object, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testFloatExplodeTableFunc(): Unit = {
+    val func = new FloatExplodeTableFunc()
+    val list = new util.ArrayList[Float]()
+    func.setCollector(new ListCollector[Float](list))
+    func.eval(null.asInstanceOf[Array[Float]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Float, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testShortExplodeTableFunc(): Unit = {
+    val func = new ShortExplodeTableFunc()
+    val list = new util.ArrayList[Short]()
+    func.setCollector(new ListCollector[Short](list))
+    func.eval(null.asInstanceOf[Array[Short]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Short, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testIntExplodeTableFunc(): Unit = {
+    val func = new IntExplodeTableFunc()
+    val list = new util.ArrayList[Int]()
+    func.setCollector(new ListCollector[Int](list))
+    func.eval(null.asInstanceOf[Array[Int]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Int, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testLongExplodeTableFunc(): Unit = {
+    val func = new LongExplodeTableFunc()
+    val list = new util.ArrayList[Long]()
+    func.setCollector(new ListCollector[Long](list))
+    func.eval(null.asInstanceOf[Array[Long]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Long, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testDoubleExplodeTableFunc(): Unit = {
+    val func = new DoubleExplodeTableFunc()
+    val list = new util.ArrayList[Double]()
+    func.setCollector(new ListCollector[Double](list))
+    func.eval(null.asInstanceOf[Array[Double]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Double, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testByteExplodeTableFunc(): Unit = {
+    val func = new ByteExplodeTableFunc()
+    val list = new util.ArrayList[Byte]()
+    func.setCollector(new ListCollector[Byte](list))
+    func.eval(null.asInstanceOf[Array[Byte]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Byte, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testBooleanExplodeTableFunc(): Unit = {
+    val func = new BooleanExplodeTableFunc()
+    val list = new util.ArrayList[Boolean]()
+    func.setCollector(new ListCollector[Boolean](list))
+    func.eval(null.asInstanceOf[Array[Boolean]])
+    assertTrue(list.isEmpty)
+    func.eval(null.asInstanceOf[util.Map[Boolean, Integer]])
+    assertTrue(list.isEmpty)
+  }
+
+  @Test
+  def testMapExplodeTableFunc(): Unit = {
+    val func = new MapExplodeTableFunc()
+    val list = new util.ArrayList[Row]()
+    func.setCollector(new ListCollector[Row](list))
+    func.eval(null.asInstanceOf[util.Map[Object, Object]])
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*The following test case will encounter NPE:

    val t = tEnv.fromValues(
      DataTypes.ROW(
        DataTypes.FIELD("a", DataTypes.INT()),
        DataTypes.FIELD("b", DataTypes.ARRAY(DataTypes.STRING()))
      ),
      row(1, Array("aa", "bb", "cc")),
      row(2, null),
      row(3, Array("dd"))
    )
    tEnv.registerTable("T", t)
    tEnv.executeSql("SELECT a, s FROM T, UNNEST(T.b) as A (s)").print()

The reason is functions in ExplodeFunctionUtil do not handle null data, this pr aims to fix the bug. Since 1.12, the bug is fixed, see https://issues.apache.org/jira/browse/FLINK-18528*


## Brief change log

  - *Handle null data in ExplodeFunctionUtil*


## Verifying this change


This change added tests and can be verified as follows:

*(example:)*
  - *Added ExploadFuntionUtilTest to verify each function*
  - *Extended UnnestITCase to verify the bug via e2e*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
