### PR TITLE
[FLINK-17085][kubernetes] Remove FlinkKubeClient.handleException

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -118,7 +118,6 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
                                         HighAvailabilityServicesUtils.AddressResolution
                                                 .TRY_ADDRESS_RESOLUTION)));
             } catch (Exception e) {
-                client.handleException(e);
                 throw new RuntimeException(
                         new ClusterRetrieveException("Could not create the RestClusterClient.", e));
             }
@@ -275,7 +274,6 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
         try {
             client.stopAndCleanupCluster(clusterId);
         } catch (Exception e) {
-            client.handleException(e);
             throw new FlinkException("Could not kill Kubernetes cluster " + clusterId);
         }
     }
@@ -285,7 +283,6 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
         try {
             client.close();
         } catch (Exception e) {
-            client.handleException(e);
             LOG.error("failed to close client, exception {}", e.toString());
         }
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -195,11 +195,6 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public void handleException(Exception e) {
-        LOG.error("A Kubernetes exception occurred.", e);
-    }
-
-    @Override
     public Optional<KubernetesService> getRestService(String clusterId) {
         final String serviceName = ExternalServiceDecorator.getExternalServiceName(clusterId);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -96,9 +96,6 @@ public interface FlinkKubeClient extends AutoCloseable {
      */
     List<KubernetesPod> getPodsWithLabels(Map<String, String> labels);
 
-    /** Log exceptions. */
-    void handleException(Exception e);
-
     /**
      * Watch the pods selected by labels and do the {@link WatchCallbackHandler}.
      *

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -147,11 +147,6 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public void handleException(Exception e) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public KubernetesWatch watchPodsAndDoCallback(
             Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler) {
         return watchPodsAndDoCallbackFunction.apply(labels, podCallbackHandler);


### PR DESCRIPTION
## What is the purpose of the change

Code cleanup removing `FlinkKubeClient.handleException` as it doesn't add any value.

## Brief change log

`handleException` was removed from `FlinkKubeClient` interface. The occurrences of this method were replaced by a more meaningful log message where necessary.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
