### PR TITLE
[FLINK-20997][tests] Generate yarn classpath before test phase

### DIFF
--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -416,7 +416,7 @@ under the License.
 					-->
 					<execution>
 						<id>store-classpath-in-target-for-tests</id>
-						<phase>package</phase>
+						<phase>process-test-resources</phase>
 						<goals>
 							<goal>build-classpath</goal>
 						</goals>


### PR DESCRIPTION
## What is the purpose of the change

YarnTestBase depends on classpaths generated by Maven dependency plugin in `package` phase, but YarnTestBaseTest is a unit test that executed in `test` phase (which is before `package`), so it's unable to find `yarn.classpath` and causes NPE.

## Brief change log

Make the classpath generated in `process-test-resources` phase.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
