### PR TITLE
[FLINK-20918][FileSystem] Avoid excessive flush of Hadoop output stream

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -121,7 +121,6 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 
     @Override
     public void sync() throws IOException {
-        out.hflush();
         out.hsync();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

HadoopRecoverableFsDataOutputStream#sync calls both `hflush` and `hsync`, whereas `hsync` is an enhanced version of `hflush`. We should remove the `hflush` call to avoid the excessive flush.

## Brief change log

Remove `hflush` in HadoopRecoverableFsDataOutputStream#sync.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
