### PR TITLE
[FLINK-20831][table/sql runtime] Introduce the in-memory topN buffer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/HeapSort.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/HeapSort.java
@@ -16,19 +16,26 @@
  * limitations under the License.
  */
 
+package org.apache.flink.runtime.operators.sort;
+
 /**
  * This file is based on source code from the Hadoop Project (http://hadoop.apache.org/), licensed
  * by the Apache Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE
  * file distributed with this work for additional information regarding copyright ownership.
  */
-package org.apache.flink.runtime.operators.sort;
-
 public final class HeapSort implements IndexedSorter {
     public HeapSort() {}
 
-    private static void downHeap(final IndexedSortable s, final int b, int i, final int N) {
-        for (int idx = i << 1; idx < N; idx = i << 1) {
-            if (idx + 1 < N && s.compare(b + idx, b + idx + 1) < 0) {
+    /**
+     * @param s the record array to adjust the heap.
+     * @param b offset of the index. If the origin index in the array is 0 and it's logical location
+     *     is 1, it should set -1 to adjust the logical index to physical index.
+     * @param i logical index in the heap
+     * @param boundary boundary of the heap in logical
+     */
+    public void downHeap(final IndexedSortable s, final int b, int i, final int boundary) {
+        for (int idx = i << 1; idx < boundary; idx = i << 1) {
+            if (idx + 1 < boundary && s.compare(b + idx, b + idx + 1) < 0) {
                 if (s.compare(b + i, b + idx + 1) < 0) {
                     s.swap(b + i, b + idx + 1);
                 } else {
@@ -44,15 +51,31 @@ public final class HeapSort implements IndexedSorter {
         }
     }
 
-    public void sort(final IndexedSortable s, final int p, final int r) {
-        final int N = r - p;
+    /**
+     * Make the buffer as a heap.
+     *
+     * @param p the index of the first element to sort in physical.
+     * @param r the last element index to sort (not included) in physical.
+     */
+    public void heapify(final IndexedSortable s, final int p, final int r) {
+        final int recordNum = r - p;
         // build heap w/ reverse comparator, then write in-place from end
-        final int t = Integer.highestOneBit(N);
+        final int t = Integer.highestOneBit(recordNum);
         for (int i = t; i > 1; i >>>= 1) {
             for (int j = i >>> 1; j < i; ++j) {
-                downHeap(s, p - 1, j, N + 1);
+                downHeap(s, p - 1, j, recordNum + 1);
             }
         }
+    }
+
+    /**
+     * Bottom-up heap sort. After building the heap, sort the data in memory.
+     *
+     * @param p the index of the first element to sort.
+     * @param r the last element index to sort (not included)
+     */
+    public void sort(final IndexedSortable s, final int p, final int r) {
+        heapify(s, p, r);
         for (int i = r - 1; i > p; --i) {
             s.swap(p, i);
             downHeap(s, p - 1, 1, i - p + 1);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesLinkedMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesLinkedMultiMap.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+import org.apache.flink.table.runtime.util.KeyValueIterator;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/**
+ * A binary map in the structure like {@code Map<K, LinkedList<V>>}, where there are multiple values
+ * under a single key, and they are all bytes based. It can be used for performing aggregations
+ * where the accumulator of aggregations are unfixed-width. The memory is divided into three areas:
+ *
+ * <p>Bucket area: pointer + hashcode
+ *
+ * <pre>
+ *   |---- 4 Bytes (pointer to key entry) ----|
+ *   |----- 4 Bytes (key hashcode) ----------|
+ * </pre>
+ *
+ * <p>Key area: a key entry contains key data, pointer to the tail value, and the head value entry.
+ *
+ * <pre>
+ *   |--- 4 + len(K) Bytes  (key data) ------|
+ *   |--- 4 Bytes (pointer to tail value) ---|
+ *   |--- 4 Bytes (pointer to next value) ---|
+ *   |--- 4 + len(V) Bytes (value data) -----|
+ * </pre>
+ *
+ * <p>Value area: a value entry contains a pointer to the next value and the value data. Pointer is
+ * -1 if this is the last entry.
+ *
+ * <pre>
+ *   |--- 4 Bytes (pointer to next value) ---|
+ *   |--- 4 + len(V) Bytes (value data) -----|
+ * </pre>
+ */
+public class AbstractBytesLinkedMultiMap<K> extends AbstractBytesMultiMap<K> {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBytesLinkedMultiMap.class);
+
+    /** Pointer to the tail value under a key. */
+    private int endPtr;
+
+    /** Offset of `endPtr` in key area. */
+    private int endPtrOffset;
+
+    public AbstractBytesLinkedMultiMap(
+            Object owner,
+            MemoryManager memoryManager,
+            long memorySize,
+            PagedTypeSerializer<K> keySerializer,
+            LogicalType[] valueTypes) {
+        super(owner, memoryManager, memorySize, keySerializer, valueTypes);
+        this.recordArea = new RecordArea();
+        this.reusedValue = ((RecordArea) this.recordArea).valueIterator(-1);
+    }
+
+    @Override
+    public KeyValueIterator<K, Iterator<RowData>> getEntryIterator() {
+        return ((RecordArea) recordArea).entryIterator();
+    }
+
+    @Override
+    protected void appendRecordWhenFoundKey(
+            LookupInfo<K, Iterator<RowData>> info, BinaryRowData value) throws IOException {
+        // append value only if there exits key-value pair.
+        int newPointer = ((RecordArea) recordArea).appendValue(value);
+        if (pointerToSecondValue == -1) {
+            // this is the second value
+            ((RecordArea) recordArea).updateValuePointerInKeyArea(newPointer, endPtr);
+        } else {
+            ((RecordArea) recordArea).updateValuePointerInValueArea(newPointer, endPtr);
+        }
+        // update pointer of the tail value under a key
+        endPtr = newPointer;
+        ((RecordArea) recordArea).updateValuePointerInKeyArea(newPointer, endPtrOffset);
+    }
+
+    // ----------------------- Record Area -----------------------
+
+    private final class RecordArea implements BytesMap.RecordArea<K, Iterator<RowData>> {
+        private final ArrayList<MemorySegment> keySegments = new ArrayList<>();
+        private final ArrayList<MemorySegment> valSegments = new ArrayList<>();
+
+        private final RandomAccessInputView keyInView;
+        private final RandomAccessInputView valInView;
+        private final SimpleCollectingOutputView keyOutView;
+        private final SimpleCollectingOutputView valOutView;
+
+        private final ValueIterator reusedValueIterator = new ValueIterator(0);
+
+        RecordArea() {
+            this.keyOutView = new SimpleCollectingOutputView(keySegments, memoryPool, segmentSize);
+            this.valOutView = new SimpleCollectingOutputView(valSegments, memoryPool, segmentSize);
+            this.keyInView = new RandomAccessInputView(keySegments, segmentSize);
+            this.valInView = new RandomAccessInputView(valSegments, segmentSize);
+        }
+
+        public void release() {
+            returnSegments(valSegments);
+            returnSegments(keySegments);
+            valSegments.clear();
+            keySegments.clear();
+        }
+
+        public void reset() {
+            release();
+            // request a new memory segment from freeMemorySegments
+            // reset segmentNum and positionInSegment
+            keyOutView.reset();
+            valOutView.reset();
+            valInView.setReadPosition(0);
+            keyInView.setReadPosition(0);
+        }
+
+        // ----------------------- Append -----------------------
+        private int appendValue(BinaryRowData value) throws IOException {
+            final long offsetOfPointer = writePointer(valOutView, -1);
+            valueSerializer.serializeToPages(value, valOutView);
+            if (offsetOfPointer > Integer.MAX_VALUE) {
+                LOG.warn(
+                        "We can't handle key area with more than Integer.MAX_VALUE bytes,"
+                                + " because the pointer is a integer.");
+                throw new EOFException();
+            }
+            return (int) offsetOfPointer;
+        }
+
+        // ----------------------- Read -----------------------
+        @Override
+        public void setReadPosition(int position) {
+            keyInView.setReadPosition(position);
+        }
+
+        public boolean readKeyAndEquals(K lookupKey) throws IOException {
+            reusedKey = keySerializer.mapFromPages(reusedKey, keyInView);
+            return lookupKey.equals(reusedKey);
+        }
+
+        @Override
+        public Iterator<RowData> readValue(Iterator<RowData> reuse) throws IOException {
+            endPtr = readPointer(keyInView);
+            endPtrOffset = (int) keyInView.getReadPosition() - ELEMENT_POINT_LENGTH;
+            pointerToSecondValue = readPointer(keyInView);
+            return reuse;
+        }
+
+        /** The key is not exist before. Add key and first value to key area. */
+        @Override
+        public int appendRecord(
+                BytesMap.LookupInfo<K, Iterator<RowData>> lookupInfo, BinaryRowData value)
+                throws IOException {
+            int keyOffset = (int) writeKey(keyOutView, lookupInfo.key);
+
+            // skip the pointer to the tail value.
+            endPtrOffset = skipPointer(keyOutView);
+
+            // write a value entry: a next-pointer and value data
+            long pointerOfEndValue = writePointer(keyOutView, -1);
+            // write first value to keyOutView.
+            valueSerializer.serializeToPages(value, keyOutView);
+
+            if (pointerOfEndValue > Integer.MAX_VALUE) {
+                LOG.warn(
+                        "We can't handle key area with more than Integer.MAX_VALUE bytes,"
+                                + " because the pointer is a integer.");
+                throw new EOFException();
+            }
+            endPtr = (int) pointerOfEndValue;
+            // update pointer to the tail value
+            updateValuePointerInKeyArea(endPtr, endPtrOffset);
+
+            return keyOffset;
+        }
+
+        @Override
+        public long getSegmentsSize() {
+            return (valSegments.size() + keySegments.size()) * ((long) segmentSize);
+        }
+
+        void updateValuePointerInKeyArea(int newPointer, int ptrOffset) {
+            updateValuePointer(keyInView, newPointer, ptrOffset);
+        }
+
+        void updateValuePointerInValueArea(int newPointer, int ptrOffset) {
+            updateValuePointer(valInView, newPointer, ptrOffset);
+        }
+
+        KeyValueIterator<K, Iterator<RowData>> entryIterator() {
+            return new EntryIterator();
+        }
+
+        final class EntryIterator implements KeyValueIterator<K, Iterator<RowData>> {
+            private int count;
+
+            public EntryIterator() {
+                count = 0;
+                if (numKeys > 0) {
+                    recordArea.setReadPosition(0);
+                }
+            }
+
+            @Override
+            public boolean advanceNext() throws IOException {
+                if (count < numKeys) {
+                    count++;
+                    keySerializer.mapFromPages(reusedKey, keyInView);
+                    // skip end pointer of value
+                    skipPointer(keyInView);
+                    // read pointer to second value
+                    pointerToSecondValue = readPointer(keyInView);
+                    reusedRecord = valueSerializer.mapFromPages(reusedRecord, keyInView);
+                    reusedValueIterator.setOffset(pointerToSecondValue);
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public K getKey() {
+                return reusedKey;
+            }
+
+            @Override
+            public Iterator<RowData> getValue() {
+                return reusedValue;
+            }
+
+            public boolean hasNext() {
+                return count < numKeys;
+            }
+        }
+
+        Iterator<RowData> valueIterator(int valueOffset) {
+            reusedValueIterator.setOffset(valueOffset);
+            return reusedValueIterator;
+        }
+
+        final class ValueIterator implements Iterator<RowData> {
+            private int offset;
+            private boolean isFirstRead;
+
+            public ValueIterator(int offset) {
+                this.offset = offset;
+                this.isFirstRead = true;
+            }
+
+            public void setOffset(int offset) {
+                this.offset = offset;
+                this.isFirstRead = true;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return isFirstRead || offset != -1;
+            }
+
+            @Override
+            public RowData next() {
+                if (isFirstRead) {
+                    isFirstRead = false;
+                    return reusedRecord;
+                }
+                if (hasNext()) {
+                    valInView.setReadPosition(offset);
+                    try {
+                        this.offset = readPointer(valInView);
+                        // reuse first value data row
+                        valueSerializer.mapFromPages(reusedRecord, valInView);
+                    } catch (IOException e) {
+                        throw new RuntimeException(
+                                "Exception happened while iterating"
+                                        + " value list of a key in BytesMultiMap");
+                    }
+                    return reusedRecord;
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMap.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.runtime.util.collections.binary;
 
-import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.RandomAccessInputView;
 import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
@@ -37,15 +36,16 @@ import org.slf4j.LoggerFactory;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
- * A binary map in the structure like {@code Map<K, List<V>>}, where there are multiple values under
- * a single key, and they are all bytes based. It can be used for performing aggregations where the
- * accumulator of aggregations are unfixed-width. The memory is divided into three areas:
+ * A binary map in the structure like {@code Map<K, ArrayList<V>>}, where there are multiple values
+ * under a single key, and they are all bytes based. The design of the value of the binary map
+ * changes. It may works like the <@code LinkedList> or <@code ArrayList>. The purpose of the binary
+ * map is that can be used for performing aggregations where the accumulator of aggregations are
+ * unfixed-width. The memory is divided into three areas:
  *
  * <p>Bucket area: pointer + hashcode
  *
@@ -54,22 +54,9 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  *   |----- 4 Bytes (key hashcode) ----------|
  * </pre>
  *
- * <p>Key area: a key entry contains key data, pointer to the tail value, and the head value entry.
+ * <p>Key area: a key entry contains key data and other information.
  *
- * <pre>
- *   |--- 4 + len(K) Bytes  (key data) ------|
- *   |--- 4 Bytes (pointer to tail value) ---|
- *   |--- 4 Bytes (pointer to next value) ---|
- *   |--- 4 + len(V) Bytes (value data) -----|
- * </pre>
- *
- * <p>Value area: a value entry contains a pointer to the next value and the value data. Pointer is
- * -1 if this is the last entry.
- *
- * <pre>
- *   |--- 4 Bytes (pointer to next value) ---|
- *   |--- 4 + len(V) Bytes (value data) -----|
- * </pre>
+ * <p>Value area: a value entry the value data and other information.
  */
 public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowData>> {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBytesMultiMap.class);
@@ -78,20 +65,14 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
     protected final PagedTypeSerializer<K> keySerializer;
 
     /** Used to serialize hash map key and value into RecordArea's MemorySegments. */
-    private final BinaryRowDataSerializer valueSerializer;
-
-    /** Pointer to the tail value under a key. */
-    private int endPtr;
-
-    /** Offset of `endPtr` in key area. */
-    private int endPtrOffset;
+    protected final BinaryRowDataSerializer valueSerializer;
 
     /** Pointer to the second value under a key. */
-    private int pointerToSecondValue;
+    protected int pointerToSecondValue;
 
-    private BinaryRowData reusedRecord;
+    protected BinaryRowData reusedRecord;
 
-    private long numKeys = 0;
+    protected long numKeys = 0;
 
     public AbstractBytesMultiMap(
             final Object owner,
@@ -102,10 +83,8 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         super(owner, memoryManager, memorySize, keySerializer);
         checkArgument(valueTypes.length > 0);
 
-        this.recordArea = new RecordArea();
         this.keySerializer = keySerializer;
         this.valueSerializer = new BinaryRowDataSerializer(valueTypes.length);
-        this.reusedValue = ((RecordArea) this.recordArea).valueIterator(-1);
         this.reusedRecord = valueSerializer.createInstance();
 
         checkArgument(
@@ -137,17 +116,7 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
             throws IOException {
         try {
             if (lookupInfo.found) {
-                // append value only if there exits key-value pair.
-                int newPointer = ((RecordArea) recordArea).appendValue(value);
-                if (pointerToSecondValue == -1) {
-                    // this is the second value
-                    ((RecordArea) recordArea).updateValuePointerInKeyArea(newPointer, endPtr);
-                } else {
-                    ((RecordArea) recordArea).updateValuePointerInValueArea(newPointer, endPtr);
-                }
-                // update pointer of the tail value under a key
-                endPtr = newPointer;
-                ((RecordArea) recordArea).updateValuePointerInKeyArea(newPointer, endPtrOffset);
+                appendRecordWhenFoundKey(lookupInfo, value);
             } else {
                 if (numKeys >= growthThreshold) {
                     growAndRehash();
@@ -174,9 +143,10 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         }
     }
 
-    public KeyValueIterator<K, Iterator<RowData>> getEntryIterator() {
-        return ((RecordArea) recordArea).entryIterator();
-    }
+    protected abstract void appendRecordWhenFoundKey(
+            LookupInfo<K, Iterator<RowData>> info, BinaryRowData value) throws IOException;
+
+    public abstract KeyValueIterator<K, Iterator<RowData>> getEntryIterator();
 
     /** release the map's record and bucket area's memory segments. */
     public void free() {
@@ -200,221 +170,16 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         numKeys = 0;
     }
 
-    // ----------------------- Record Area -----------------------
-
-    private final class RecordArea implements BytesMap.RecordArea<K, Iterator<RowData>> {
-        private final ArrayList<MemorySegment> keySegments = new ArrayList<>();
-        private final ArrayList<MemorySegment> valSegments = new ArrayList<>();
-
-        private final RandomAccessInputView keyInView;
-        private final RandomAccessInputView valInView;
-        private final SimpleCollectingOutputView keyOutView;
-        private final SimpleCollectingOutputView valOutView;
-
-        private ValueIterator reusedValueIterator = new ValueIterator(0);
-
-        RecordArea() {
-            this.keyOutView = new SimpleCollectingOutputView(keySegments, memoryPool, segmentSize);
-            this.valOutView = new SimpleCollectingOutputView(valSegments, memoryPool, segmentSize);
-            this.keyInView = new RandomAccessInputView(keySegments, segmentSize);
-            this.valInView = new RandomAccessInputView(valSegments, segmentSize);
-        }
-
-        public void release() {
-            returnSegments(valSegments);
-            returnSegments(keySegments);
-            valSegments.clear();
-            keySegments.clear();
-        }
-
-        public void reset() {
-            release();
-            // request a new memory segment from freeMemorySegments
-            // reset segmentNum and positionInSegment
-            keyOutView.reset();
-            valOutView.reset();
-            valInView.setReadPosition(0);
-            keyInView.setReadPosition(0);
-        }
-
-        // ----------------------- Append -----------------------
-        private int appendValue(BinaryRowData value) throws IOException {
-            final long offsetOfPointer = writePointer(valOutView, -1);
-            valueSerializer.serializeToPages(value, valOutView);
-            if (offsetOfPointer > Integer.MAX_VALUE) {
-                LOG.warn(
-                        "We can't handle key area with more than Integer.MAX_VALUE bytes,"
-                                + " because the pointer is a integer.");
-                throw new EOFException();
-            }
-            return (int) offsetOfPointer;
-        }
-
-        // ----------------------- Read -----------------------
-        @Override
-        public void setReadPosition(int position) {
-            keyInView.setReadPosition(position);
-        }
-
-        public boolean readKeyAndEquals(K lookupKey) throws IOException {
-            reusedKey = keySerializer.mapFromPages(reusedKey, keyInView);
-            return lookupKey.equals(reusedKey);
-        }
-
-        @Override
-        public Iterator<RowData> readValue(Iterator<RowData> reuse) throws IOException {
-            endPtr = readPointer(keyInView);
-            endPtrOffset = (int) keyInView.getReadPosition() - ELEMENT_POINT_LENGTH;
-            pointerToSecondValue = readPointer(keyInView);
-            return reuse;
-        }
-
-        /** The key is not exist before. Add key and first value to key area. */
-        @Override
-        public int appendRecord(LookupInfo<K, Iterator<RowData>> lookupInfo, BinaryRowData value)
-                throws IOException {
-            int lastPosition = (int) keyOutView.getCurrentOffset();
-            // write key to keyOutView
-            int skip = keySerializer.serializeToPages(lookupInfo.key, keyOutView);
-            int keyOffset = lastPosition + skip;
-
-            // skip the pointer to the tail value.
-            endPtrOffset = skipPointer(keyOutView);
-
-            // write a value entry: a next-pointer and value data
-            long pointerOfEndValue = writePointer(keyOutView, -1);
-            // write first value to keyOutView.
-            valueSerializer.serializeToPages(value, keyOutView);
-
-            if (pointerOfEndValue > Integer.MAX_VALUE) {
-                LOG.warn(
-                        "We can't handle key area with more than Integer.MAX_VALUE bytes,"
-                                + " because the pointer is a integer.");
-                throw new EOFException();
-            }
-            endPtr = (int) pointerOfEndValue;
-            // update pointer to the tail value
-            updateValuePointerInKeyArea(endPtr, endPtrOffset);
-
-            return keyOffset;
-        }
-
-        @Override
-        public long getSegmentsSize() {
-            return (valSegments.size() + keySegments.size()) * ((long) segmentSize);
-        }
-
-        void updateValuePointerInKeyArea(int newPointer, int ptrOffset) throws IOException {
-            updateValuePointer(keyInView, newPointer, ptrOffset);
-        }
-
-        void updateValuePointerInValueArea(int newPointer, int ptrOffset) throws IOException {
-            updateValuePointer(valInView, newPointer, ptrOffset);
-        }
-
-        /** Update the content from specific offset. */
-        private void updateValuePointer(RandomAccessInputView view, int newPointer, int ptrOffset)
-                throws IOException {
-            view.setReadPosition(ptrOffset);
-            int currPosInSeg = view.getCurrentPositionInSegment();
-            view.getCurrentSegment().putInt(currPosInSeg, newPointer);
-        }
-
-        KeyValueIterator<K, Iterator<RowData>> entryIterator() {
-            return new EntryIterator();
-        }
-
-        final class EntryIterator implements KeyValueIterator<K, Iterator<RowData>> {
-            private int count;
-
-            public EntryIterator() {
-                count = 0;
-                if (numKeys > 0) {
-                    recordArea.setReadPosition(0);
-                }
-            }
-
-            @Override
-            public boolean advanceNext() throws IOException {
-                if (count < numKeys) {
-                    count++;
-                    keySerializer.mapFromPages(reusedKey, keyInView);
-                    // skip end pointer of value
-                    skipPointer(keyInView);
-                    // read pointer to second value
-                    pointerToSecondValue = readPointer(keyInView);
-                    reusedRecord = valueSerializer.mapFromPages(reusedRecord, keyInView);
-                    reusedValueIterator.setOffset(pointerToSecondValue);
-                    return true;
-                }
-                return false;
-            }
-
-            @Override
-            public K getKey() {
-                return reusedKey;
-            }
-
-            @Override
-            public Iterator<RowData> getValue() {
-                return reusedValue;
-            }
-
-            public boolean hasNext() {
-                return count < numKeys;
-            }
-        }
-
-        Iterator<RowData> valueIterator(int valueOffset) {
-            reusedValueIterator.setOffset(valueOffset);
-            return reusedValueIterator;
-        }
-
-        final class ValueIterator implements Iterator<RowData> {
-            private int offset;
-            private boolean isFirstRead;
-
-            public ValueIterator(int offset) {
-                this.offset = offset;
-                this.isFirstRead = true;
-            }
-
-            public void setOffset(int offset) {
-                this.offset = offset;
-                this.isFirstRead = true;
-            }
-
-            @Override
-            public boolean hasNext() {
-                return isFirstRead || offset != -1;
-            }
-
-            @Override
-            public RowData next() {
-                if (isFirstRead) {
-                    isFirstRead = false;
-                    return reusedRecord;
-                }
-                if (hasNext()) {
-                    valInView.setReadPosition(offset);
-                    try {
-                        this.offset = readPointer(valInView);
-                        // reuse first value data row
-                        valueSerializer.mapFromPages(reusedRecord, valInView);
-                    } catch (IOException e) {
-                        throw new RuntimeException(
-                                "Exception happened while iterating"
-                                        + " value list of a key in BytesMultiMap");
-                    }
-                    return reusedRecord;
-                }
-                return null;
-            }
-        }
+    protected long writeKey(SimpleCollectingOutputView keyOutView, K key) throws IOException {
+        int lastPosition = (int) keyOutView.getCurrentOffset();
+        // write key to keyOutView
+        int skip = keySerializer.serializeToPages(key, keyOutView);
+        return lastPosition + skip;
     }
 
     /** Write value into the output view, and return offset of the value. */
-    private long writePointer(SimpleCollectingOutputView outputView, int value) throws IOException {
+    protected long writePointer(SimpleCollectingOutputView outputView, int value)
+            throws IOException {
         int oldPosition = (int) outputView.getCurrentOffset();
         int skip = checkSkipWriteForPointer(outputView);
         outputView.getCurrentSegment().putInt(outputView.getCurrentPositionInSegment(), value);
@@ -423,7 +188,7 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         return oldPosition + skip;
     }
 
-    private int readPointer(AbstractPagedInputView inputView) throws IOException {
+    protected int readPointer(AbstractPagedInputView inputView) throws IOException {
         checkSkipReadForPointer(inputView);
         int value = inputView.getCurrentSegment().getInt(inputView.getCurrentPositionInSegment());
         // advance position in segment
@@ -431,7 +196,7 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         return value;
     }
 
-    private int skipPointer(SimpleCollectingOutputView outputView) throws IOException {
+    protected int skipPointer(SimpleCollectingOutputView outputView) throws IOException {
         int oldPosition = (int) outputView.getCurrentOffset();
         // skip 4 bytes for pointer to the tail value
         int skip = checkSkipWriteForPointer(outputView);
@@ -439,9 +204,16 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
         return oldPosition + skip;
     }
 
-    private void skipPointer(AbstractPagedInputView inputView) throws IOException {
+    protected void skipPointer(AbstractPagedInputView inputView) throws IOException {
         checkSkipReadForPointer(inputView);
         inputView.skipBytesToRead(ELEMENT_POINT_LENGTH);
+    }
+
+    /** Update the content from specific offset. */
+    protected void updateValuePointer(RandomAccessInputView view, int newPointer, int ptrOffset) {
+        view.setReadPosition(ptrOffset);
+        int currPosInSeg = view.getCurrentPositionInSegment();
+        view.getCurrentSegment().putInt(currPosInSeg, newPointer);
     }
 
     /** For pointer needing update, skip unaligned part (4 bytes) for convenient updating. */

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMap.java
@@ -30,7 +30,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  *
  * @see AbstractBytesMultiMap for more information about the binary layout.
  */
-public final class BytesMultiMap extends AbstractBytesMultiMap<BinaryRowData> {
+public final class BytesMultiMap extends AbstractBytesLinkedMultiMap<BinaryRowData> {
 
     public BytesMultiMap(
             Object owner,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMap.java
@@ -30,7 +30,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  *
  * @see AbstractBytesMultiMap for more information about the binary layout.
  */
-public final class WindowBytesMultiMap extends AbstractBytesMultiMap<WindowKey> {
+public final class WindowBytesMultiMap extends AbstractBytesLinkedMultiMap<WindowKey> {
 
     public WindowBytesMultiMap(
             Object owner,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesSortedArrayMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesSortedArrayMultiMap.java
@@ -1,0 +1,504 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.io.disk.RandomAccessInputView;
+import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.operators.sort.HeapSort;
+import org.apache.flink.runtime.operators.sort.IndexedSortable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
+import org.apache.flink.table.runtime.util.KeyValueIterator;
+import org.apache.flink.table.runtime.util.WindowKey;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.MathUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A binary map in the structure like {@code Map<K, ArrayList<V>>}, where there are multiple values
+ * under a single key, and they are all bytes based. The memory is divided into three areas:
+ *
+ * <p>Bucket area: pointer + hashcode
+ *
+ * <pre>
+ *   |---- 4 Bytes (pointer to key entry) ----|
+ *   |----- 4 Bytes (key hashcode) ----------|
+ * </pre>
+ *
+ * <p>Key area: a key entry contains key data, array size and pre-allocated pointer array.
+ *
+ * <pre>
+ *   |--- 4 + len(K) Bytes (key data) -----------|
+ *   |--- 4 Bytes (array size) ------------------|
+ *   |--- 4 x (array capacity) Bytes (array)-----|
+ * </pre>
+ *
+ * <p>Value area: a value entry contains the value data.
+ *
+ * <pre>
+ *   |--- 4 + len(V) Bytes (value data) -----|
+ * </pre>
+ *
+ * <p>The binary map is mainly designed for topN operator. When the array is full and the new
+ * records satisfies the topN condition, it will replace the pointer in the array with the pointer
+ * of the new records. When it's time to emit, the binary map will also sort the records under the
+ * key.
+ */
+public class WindowBytesSortedArrayMultiMap extends AbstractBytesMultiMap<WindowKey> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WindowBytesSortedArrayMultiMap.class);
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /** The address of the array size under the specified key. */
+    private int arraySizeAddress;
+
+    /** The size of the array under the specified key. */
+    private int arraySize;
+
+    /** The address of the array under the specified key. */
+    private int arrayAddress;
+
+    // --------------------------------------------------------------------------------------------
+    // Sorter && comparator
+    // --------------------------------------------------------------------------------------------
+
+    /** The sorter to sort the data. */
+    private final HeapSort innerSorter;
+
+    /** The comparator to determine the order of the data. */
+    private final RecordComparator comparator;
+
+    // --------------------------------------------------------------------------------------------
+    // Value serializer
+    // --------------------------------------------------------------------------------------------
+
+    /** The value used in comparision. */
+    private final BinaryRowData reusedLeftValue;
+
+    /** The serializer to serialize the value. */
+    private final BinaryRowDataSerializer valueSerializerForComparison;
+
+    /** The value used in comparision. */
+    private final BinaryRowData reusedRightValue;
+
+    // --------------------------------------------------------------------------------------------
+    // Array attribute
+    // --------------------------------------------------------------------------------------------
+
+    private final int arrayCapacity;
+
+    public WindowBytesSortedArrayMultiMap(
+            Object owner,
+            MemoryManager memoryManager,
+            int memorySize,
+            LogicalType[] keyTypes,
+            LogicalType[] valueTypes,
+            int arrayCapacity,
+            RecordComparator comparator) {
+        super(
+                owner,
+                memoryManager,
+                memorySize,
+                new WindowKeySerializer(keyTypes.length),
+                valueTypes);
+        checkArgument(
+                memorySize > INIT_BUCKET_MEMORY_IN_BYTES, "The minBucketMemorySize is not valid!");
+        checkArgument(keyTypes.length > 0);
+        checkArgument(
+                memoryManager.getPageSize() > arrayCapacity * ELEMENT_POINT_LENGTH,
+                "The size of array should not large than the page size.");
+
+        this.valueSerializerForComparison = new BinaryRowDataSerializer(valueTypes.length);
+        this.reusedLeftValue = valueSerializer.createInstance();
+        this.reusedRightValue = valueSerializerForComparison.createInstance();
+
+        this.arrayCapacity = arrayCapacity;
+        this.comparator = comparator;
+        this.innerSorter = new HeapSort();
+        this.recordArea = new ArrayRecordArea();
+
+        this.reusedValue = ((ArrayRecordArea) recordArea).valueIterator();
+
+        int initBucketSegmentNum =
+                MathUtils.roundDownToPowerOf2((int) (INIT_BUCKET_MEMORY_IN_BYTES / segmentSize));
+        // allocate and initialize MemorySegments for bucket area
+        initBucketSegments(initBucketSegmentNum);
+    }
+
+    @Override
+    protected void appendRecordWhenFoundKey(
+            LookupInfo<WindowKey, Iterator<RowData>> info, BinaryRowData value) throws IOException {
+        if (arraySize == arrayCapacity) {
+            if (comparator.compare(value, reusedRecord) >= 0) {
+                return;
+            }
+            int valueOffset = ((ArrayRecordArea) recordArea).appendValue(value);
+            ((ArrayRecordArea) recordArea).updatePointerAtHead(valueOffset);
+            innerSorter.downHeap(((ArrayRecordArea) recordArea), -1, 1, arraySize + 1);
+        } else {
+            int valueOffset = ((ArrayRecordArea) recordArea).appendValue(value);
+            ((ArrayRecordArea) recordArea).appendPointerAtTail(valueOffset);
+
+            if (arraySize == arrayCapacity) {
+                this.innerSorter.heapify(((ArrayRecordArea) recordArea), 0, arrayCapacity);
+            }
+        }
+    }
+
+    public KeyValueIterator<WindowKey, Iterator<RowData>> getEntryIterator() {
+        return ((ArrayRecordArea) recordArea).entryIterator();
+    }
+
+    private class ArrayRecordArea
+            implements BytesMap.RecordArea<WindowKey, Iterator<RowData>>, IndexedSortable {
+
+        private final ArrayList<MemorySegment> keySegments = new ArrayList<>();
+        private final ArrayList<MemorySegment> valSegments = new ArrayList<>();
+
+        private final RandomAccessInputView keyInView;
+        private final RandomAccessInputView valInView;
+        private final RandomAccessInputView valInViewForComparison;
+
+        private final SimpleCollectingOutputView keyOutView;
+        private final SimpleCollectingOutputView valOutView;
+
+        private final ValueIterator reusedValueIterator = new ValueIterator();
+
+        public ArrayRecordArea() {
+            this.keyOutView = new SimpleCollectingOutputView(keySegments, memoryPool, segmentSize);
+            this.valOutView = new SimpleCollectingOutputView(valSegments, memoryPool, segmentSize);
+            this.keyInView = new RandomAccessInputView(keySegments, segmentSize);
+            this.valInView = new RandomAccessInputView(valSegments, segmentSize);
+            this.valInViewForComparison = new RandomAccessInputView(valSegments, segmentSize);
+        }
+
+        // ----------------------- IndexedSortable -----------------------
+
+        @Override
+        public int compare(int i, int j) {
+            int addressI = calculateAddress(i);
+            int addressJ = calculateAddress(j);
+
+            int pointerI, pointerJ, pos;
+            keyInView.setReadPosition(addressI);
+            pos = keyInView.getCurrentPositionInSegment();
+            pointerI = keyInView.getCurrentSegment().getInt(pos);
+
+            keyInView.setReadPosition(addressJ);
+            pos = keyInView.getCurrentPositionInSegment();
+            pointerJ = keyInView.getCurrentSegment().getInt(pos);
+
+            valInView.setReadPosition(pointerI);
+            valInViewForComparison.setReadPosition(pointerJ);
+            try {
+                return comparator.compare(
+                        valueSerializer.mapFromPages(reusedLeftValue, valInView),
+                        valueSerializerForComparison.mapFromPages(
+                                reusedRightValue, valInViewForComparison));
+            } catch (IOException ioex) {
+                throw new RuntimeException("Error comparing two records.", ioex);
+            }
+        }
+
+        @Override
+        public int compare(
+                int segmentNumberI, int segmentOffsetI, int segmentNumberJ, int segmentOffsetJ) {
+            throw new UnsupportedOperationException(
+                    "Unsupported Operation. Please use index to locate the element");
+        }
+
+        @Override
+        public void swap(int i, int j) {
+            int addressI = calculateAddress(i);
+            int addressJ = calculateAddress(j);
+
+            keyInView.setReadPosition(addressI);
+            MemorySegment segmentI = keyInView.getCurrentSegment();
+            int posI = keyInView.getCurrentPositionInSegment();
+            int pointerI = segmentI.getInt(posI);
+
+            keyInView.setReadPosition(addressJ);
+            MemorySegment segmentJ = keyInView.getCurrentSegment();
+            int posJ = keyInView.getCurrentPositionInSegment();
+            int pointerJ = segmentJ.getInt(posJ);
+
+            segmentJ.putInt(posJ, pointerI);
+            segmentI.putInt(posI, pointerJ);
+        }
+
+        @Override
+        public void swap(
+                int segmentNumberI, int segmentOffsetI, int segmentNumberJ, int segmentOffsetJ) {
+            throw new UnsupportedOperationException(
+                    "Unsupported Operation. Please use index to locate the element");
+        }
+
+        @Override
+        public int size() {
+            return arraySize;
+        }
+
+        @Override
+        public int recordSize() {
+            // return the size of the pointer
+            return ELEMENT_POINT_LENGTH;
+        }
+
+        @Override
+        public int recordsPerSegment() {
+            // store the key in key area which cause it's difficult to measure.
+            throw new UnsupportedOperationException(
+                    "Unsupported Operation. ArrayRecordArea will also "
+                            + "store the key part of the records whose size is out-of-control.");
+        }
+
+        // ----------------------- RecordArea -----------------------
+
+        @Override
+        public void setReadPosition(int position) {
+            keyInView.setReadPosition(position);
+        }
+
+        @Override
+        public boolean readKeyAndEquals(WindowKey lookupKey) throws IOException {
+            reusedKey = keySerializer.mapFromPages(reusedKey, keyInView);
+            return lookupKey.equals(reusedKey);
+        }
+
+        @Override
+        public Iterator<RowData> readValue(Iterator<RowData> reuse) throws IOException {
+            // set up the address of the array size and array
+            arraySize = readPointer(keyInView);
+            arraySizeAddress = (int) keyInView.getReadPosition() - ELEMENT_POINT_LENGTH;
+            arrayAddress = (int) keyInView.getReadPosition();
+            // read head of the array (it may be the head of the heap)
+            int head = readPointer(keyInView);
+            valInView.setReadPosition(head);
+            valueSerializer.mapFromPages(reusedRecord, valInView);
+            return reuse;
+        }
+
+        @Override
+        public int appendRecord(
+                LookupInfo<WindowKey, Iterator<RowData>> lookupInfo, BinaryRowData value)
+                throws IOException {
+            int keyOffset = (int) writeKey(keyOutView, lookupInfo.key);
+
+            // write the array size into key area
+            arraySizeAddress = (int) writePointer(keyOutView, 1);
+
+            // skip to the size
+            arrayAddress = arraySizeAddress + ELEMENT_POINT_LENGTH;
+
+            // pre-allocate the array in the key area
+            preAllocateArray();
+
+            int recordOffset = appendValue(value);
+            updatePointerAtHead(recordOffset);
+            return keyOffset;
+        }
+
+        private int appendValue(BinaryRowData value) throws IOException {
+            long recordOffset = valOutView.getCurrentOffset();
+            recordOffset += valueSerializer.serializeToPages(value, valOutView);
+            if (recordOffset > Integer.MAX_VALUE) {
+                LOG.warn(
+                        "We can't handle key area with more than Integer.MAX_VALUE bytes,"
+                                + " because the pointer is a integer.");
+                throw new EOFException();
+            }
+            return (int) recordOffset;
+        }
+
+        @Override
+        public long getSegmentsSize() {
+            return (valSegments.size() + keySegments.size()) * ((long) segmentSize);
+        }
+
+        @Override
+        public void release() {
+            returnSegments(keySegments);
+            returnSegments(valSegments);
+
+            valSegments.clear();
+            keySegments.clear();
+        }
+
+        @Override
+        public void reset() {
+            release();
+
+            keyOutView.reset();
+            valOutView.reset();
+            keyInView.setReadPosition(0);
+            valInView.setReadPosition(0);
+            valInViewForComparison.setReadPosition(0);
+        }
+
+        // ----------------------- Iterator -----------------------
+
+        public EntryIterator entryIterator() {
+            return new EntryIterator();
+        }
+
+        public ValueIterator valueIterator() {
+            return reusedValueIterator;
+        }
+
+        final class EntryIterator implements KeyValueIterator<WindowKey, Iterator<RowData>> {
+            private int count;
+            private int nextKeyAreaAddress;
+
+            public EntryIterator() {
+                count = 0;
+                nextKeyAreaAddress = 0;
+                if (numKeys > 0) {
+                    recordArea.setReadPosition(0);
+                }
+            }
+
+            @Override
+            public boolean advanceNext() throws IOException {
+                if (count < numKeys) {
+                    count++;
+                    keyInView.setReadPosition(nextKeyAreaAddress);
+                    keySerializer.mapFromPages(reusedKey, keyInView);
+                    // set up the array size && address
+                    // TODO: readValue should only read the head of the array when the array is
+                    // sorted.
+                    readValue(reusedValue);
+                    // sort array
+                    innerSorter.sort(ArrayRecordArea.this);
+                    nextKeyAreaAddress = calculateAddress(arrayCapacity);
+                    // If the size of the array < the capacity of the array, the array is unsorted.
+                    // Therefore, we need to re-read the first value.
+                    reusedValueIterator.reset();
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public WindowKey getKey() {
+                return reusedKey;
+            }
+
+            @Override
+            public Iterator<RowData> getValue() {
+                return reusedValue;
+            }
+
+            public boolean hasNext() {
+                return count < numKeys;
+            }
+        }
+
+        final class ValueIterator implements Iterator<RowData> {
+            private int readCount;
+            long offset = 0;
+
+            public void reset() {
+                setReadPosition(calculateAddress(0));
+                readCount = 0;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return readCount < arraySize;
+            }
+
+            @Override
+            public RowData next() {
+                if (hasNext()) {
+                    try {
+                        // reuse first value data row
+                        offset = readPointer(keyInView);
+                        valInView.setReadPosition(offset);
+                        valueSerializer.mapFromPages(reusedRecord, valInView);
+                    } catch (IOException e) {
+                        throw new RuntimeException(
+                                "Exception happened while iterating"
+                                        + " value list of a key in WindowBytesSortedMultiMap");
+                    }
+                    readCount++;
+                    return reusedRecord;
+                }
+                return null;
+            }
+        }
+
+        // ----------------------- Utils -----------------------
+
+        /** Calculate the address of the element index under the key. */
+        private int calculateAddress(int elementIndex) {
+            long lastPos = keyInView.getReadPosition();
+            keyInView.setReadPosition(arrayAddress);
+            int remainSize =
+                    keyInView.getCurrentSegment().size() - keyInView.getCurrentPositionInSegment();
+
+            // keep the read pos unchanged.
+            keyInView.setReadPosition(lastPos);
+            if (remainSize >= (elementIndex + 1) * ELEMENT_POINT_LENGTH) {
+                return arrayAddress + elementIndex * ELEMENT_POINT_LENGTH;
+            } else {
+                return arrayAddress
+                        + remainSize
+                        + (elementIndex - remainSize / ELEMENT_POINT_LENGTH) * ELEMENT_POINT_LENGTH;
+            }
+        }
+
+        private void preAllocateArray() throws IOException {
+            // the array is in the new segment
+            if (keyOutView.getCurrentPositionInSegment() >= keyOutView.getCurrentSegment().size()) {
+                keyOutView.advance();
+            }
+            int newKeyAddress = calculateAddress(arrayCapacity);
+            keyOutView.skipBytesToWrite(newKeyAddress - arrayAddress);
+        }
+
+        private void updatePointerAtHead(int pointer) {
+            // update pointer at head
+            updateValuePointer(keyInView, pointer, calculateAddress(0));
+        }
+
+        private void appendPointerAtTail(int pointer) {
+            // write pointer into the array
+            updateValuePointer(keyInView, pointer, calculateAddress(arraySize));
+            // update array size
+            updateValuePointer(keyInView, ++arraySize, arraySizeAddress);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/IntRecordComparator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/IntRecordComparator.java
@@ -26,6 +26,16 @@ public class IntRecordComparator implements RecordComparator {
 
     public static final IntRecordComparator INSTANCE = new IntRecordComparator();
 
+    private final boolean isDescendingOrder;
+
+    public IntRecordComparator() {
+        this(false);
+    }
+
+    public IntRecordComparator(boolean isDescendingOrder) {
+        this.isDescendingOrder = isDescendingOrder;
+    }
+
     @Override
     public int compare(RowData o1, RowData o2) {
 
@@ -37,14 +47,19 @@ public class IntRecordComparator implements RecordComparator {
                         : (null0At1
                                 ? -1
                                 : (null0At2 ? 1 : Integer.compare(o1.getInt(0), o2.getInt(0))));
-        if (cmp0 != 0) {
+        if (isDescendingOrder) {
+            return -cmp0;
+        } else {
             return cmp0;
         }
-        return 0;
     }
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof IntRecordComparator;
+        if (!(obj instanceof IntRecordComparator)) {
+            return false;
+        }
+        IntRecordComparator other = (IntRecordComparator) obj;
+        return isDescendingOrder == other.isDescendingOrder;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesHashMapTest.java
@@ -27,7 +27,9 @@ import org.apache.flink.table.types.logical.LogicalType;
 public class BytesHashMapTest extends BytesHashMapTestBase<BinaryRowData> {
 
     public BytesHashMapTest() {
-        super(new BinaryRowDataSerializer(KEY_TYPES.length));
+        super(
+                new BinaryRowDataSerializer(KEY_TYPES.length),
+                RandomKeyGeneratorFactory.createBinaryRowDataKeyGenerator());
     }
 
     @Override
@@ -37,10 +39,5 @@ public class BytesHashMapTest extends BytesHashMapTestBase<BinaryRowData> {
             LogicalType[] keyTypes,
             LogicalType[] valueTypes) {
         return new BytesHashMap(this, memoryManager, memorySize, keyTypes, valueTypes);
-    }
-
-    @Override
-    public BinaryRowData[] generateRandomKeys(int num) {
-        return getRandomizedInputs(num);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMapTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMapTestBase.java
@@ -18,13 +18,16 @@
 
 package org.apache.flink.table.runtime.util.collections.binary;
 
-import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-
-import java.util.Random;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 /** Test case for {@link BytesMap}. */
 public class BytesMapTestBase {
@@ -32,71 +35,16 @@ public class BytesMapTestBase {
     protected static final int PAGE_SIZE = 32 * 1024;
     protected static final int NUM_ENTRIES = 10000;
 
-    protected BinaryRowData[] getRandomizedInputs(int num) {
-        final Random rnd = new Random(RANDOM_SEED);
-        return getRandomizedInputs(num, rnd, true);
-    }
-
-    protected BinaryRowData[] getRandomizedInputs(int num, Random rnd, boolean nullable) {
-        BinaryRowData[] lists = new BinaryRowData[num];
-        for (int i = 0; i < num; i++) {
-            int intVal = rnd.nextInt(Integer.MAX_VALUE);
-            long longVal = -rnd.nextLong();
-            boolean boolVal = longVal % 2 == 0;
-            String strVal = nullable && boolVal ? null : getString(intVal, intVal % 1024) + i;
-            Double doubleVal = rnd.nextDouble();
-            Short shotVal = (short) intVal;
-            Float floatVal = nullable && boolVal ? null : rnd.nextFloat();
-            lists[i] = createRow(intVal, strVal, doubleVal, longVal, boolVal, floatVal, shotVal);
-        }
-        return lists;
-    }
-
-    protected BinaryRowData createRow(
-            Integer f0, String f1, Double f2, Long f3, Boolean f4, Float f5, Short f6) {
-
-        BinaryRowData row = new BinaryRowData(7);
-        BinaryRowWriter writer = new BinaryRowWriter(row);
-
-        // int, string, double, long, boolean
-        if (f0 == null) {
-            writer.setNullAt(0);
-        } else {
-            writer.writeInt(0, f0);
-        }
-        if (f1 == null) {
-            writer.setNullAt(1);
-        } else {
-            writer.writeString(1, StringData.fromString(f1));
-        }
-        if (f2 == null) {
-            writer.setNullAt(2);
-        } else {
-            writer.writeDouble(2, f2);
-        }
-        if (f3 == null) {
-            writer.setNullAt(3);
-        } else {
-            writer.writeLong(3, f3);
-        }
-        if (f4 == null) {
-            writer.setNullAt(4);
-        } else {
-            writer.writeBoolean(4, f4);
-        }
-        if (f5 == null) {
-            writer.setNullAt(5);
-        } else {
-            writer.writeFloat(5, f5);
-        }
-        if (f6 == null) {
-            writer.setNullAt(6);
-        } else {
-            writer.writeShort(6, f6);
-        }
-        writer.complete();
-        return row;
-    }
+    protected static final LogicalType[] KEY_TYPES =
+            new LogicalType[] {
+                new IntType(),
+                new VarCharType(VarCharType.MAX_LENGTH),
+                new DoubleType(),
+                new BigIntType(),
+                new BooleanType(),
+                new FloatType(),
+                new SmallIntType()
+            };
 
     protected int needNumMemSegments(int numEntries, int valLen, int keyLen, int pageSize) {
         return 2 * (valLen + keyLen + 1024 * 3 + 4 + 8 + 8) * numEntries / pageSize;
@@ -105,13 +53,5 @@ public class BytesMapTestBase {
     protected int rowLength(RowType tpe) {
         return BinaryRowData.calculateFixPartSizeInBytes(tpe.getFieldCount())
                 + BytesHashMap.getVariableLength(tpe.getChildren().toArray(new LogicalType[0]));
-    }
-
-    private String getString(int count, int length) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < length; i++) {
-            builder.append(count);
-        }
-        return builder.toString();
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiLinkedMapTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiLinkedMapTestBase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.Random;
+
+/** Base test class for {@link BytesMultiMap} and {@link WindowBytesMultiMap}. */
+public abstract class BytesMultiLinkedMapTestBase<K> extends BytesMultiMapTestBase<K> {
+
+    protected static final LogicalType[] VALUE_TYPES =
+            new LogicalType[] {new VarCharType(), new IntType()};
+
+    public BytesMultiLinkedMapTestBase(
+            PagedTypeSerializer<K> keySerializer, RandomKeyGenerator<K> generator) {
+        super(keySerializer, generator);
+    }
+
+    @Override
+    BinaryRowData[] genValues(int num) {
+        BinaryRowData[] values = new BinaryRowData[num];
+        final Random rnd = new Random(RANDOM_SEED);
+        for (int i = 0; i < num; i++) {
+            values[i] = new BinaryRowData(2);
+            BinaryRowWriter writer = new BinaryRowWriter(values[i]);
+            writer.writeString(0, StringData.fromString("string" + rnd.nextInt()));
+            writer.writeInt(1, rnd.nextInt());
+            writer.complete();
+        }
+        return values;
+    }
+
+    abstract MapCreator<K> buildCreator();
+
+    // ------------------------------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------------------------------
+
+    @Test
+    public void buildAndRetrieve() throws Exception {
+        innerBuildAndRetrieve(
+                buildCreator(),
+                (keys, values, actual) -> {
+                    while (actual.advanceNext()) {
+                        int i = 0;
+                        Iterator<RowData> valueIter = actual.getValue();
+                        while (valueIter.hasNext()) {
+                            Assert.assertEquals(valueIter.next(), values[i++]);
+                        }
+                    }
+                });
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTest.java
@@ -18,29 +18,21 @@
 
 package org.apache.flink.table.runtime.util.collections.binary;
 
-import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
-import org.apache.flink.table.types.logical.LogicalType;
 
 /** Verify the correctness of {@link BytesMultiMap}. */
-public class BytesMultiMapTest extends BytesMultiMapTestBase<BinaryRowData> {
+public class BytesMultiMapTest extends BytesMultiLinkedMapTestBase<BinaryRowData> {
 
     public BytesMultiMapTest() {
-        super(new BinaryRowDataSerializer(KEY_TYPES.length));
+        super(
+                new BinaryRowDataSerializer(KEY_TYPES.length),
+                RandomKeyGeneratorFactory.createBinaryRowDataKeyGenerator());
     }
 
     @Override
-    public AbstractBytesMultiMap<BinaryRowData> createBytesMultiMap(
-            MemoryManager memoryManager,
-            int memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes) {
-        return new BytesMultiMap(this, memoryManager, memorySize, keyTypes, valueTypes);
-    }
-
-    @Override
-    public BinaryRowData[] generateRandomKeys(int num) {
-        return getRandomizedInputs(num);
+    MapCreator<BinaryRowData> buildCreator() {
+        return (memoryManager, memorySize) ->
+                new BytesMultiMap(this, memoryManager, memorySize, KEY_TYPES, VALUE_TYPES);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/BytesMultiMapTestBase.java
@@ -21,77 +21,40 @@ package org.apache.flink.table.runtime.util.collections.binary;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.binary.BinaryRowData;
-import org.apache.flink.table.data.writer.BinaryRowWriter;
 import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.util.KeyValueIterator;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BooleanType;
-import org.apache.flink.table.types.logical.DoubleType;
-import org.apache.flink.table.types.logical.FloatType;
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.SmallIntType;
-import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.Assert;
-import org.junit.Test;
-
+import java.io.IOException;
 import java.util.Iterator;
-import java.util.Random;
 
-/** Base test class for {@link BytesMultiMap} and {@link WindowBytesMultiMap}. */
+import static org.apache.flink.table.runtime.util.collections.binary.BytesHashMapTestBase.VALUE_TYPES;
+
+/** Base test class for binary multi-map. */
 public abstract class BytesMultiMapTestBase<K> extends BytesMapTestBase {
     protected static final int NUM_VALUE_PER_KEY = 50;
-
-    static final LogicalType[] KEY_TYPES =
-            new LogicalType[] {
-                new IntType(),
-                new VarCharType(VarCharType.MAX_LENGTH),
-                new DoubleType(),
-                new BigIntType(),
-                new BooleanType(),
-                new FloatType(),
-                new SmallIntType()
-            };
-
-    static final LogicalType[] VALUE_TYPES =
-            new LogicalType[] {
-                new VarCharType(VarCharType.MAX_LENGTH), new IntType(),
-            };
+    protected final RandomKeyGenerator<K> generator;
 
     protected final PagedTypeSerializer<K> keySerializer;
     protected final BinaryRowDataSerializer valueSerializer;
 
-    public BytesMultiMapTestBase(PagedTypeSerializer<K> keySerializer) {
+    public BytesMultiMapTestBase(
+            PagedTypeSerializer<K> keySerializer, RandomKeyGenerator<K> generator) {
         this.keySerializer = keySerializer;
         this.valueSerializer = new BinaryRowDataSerializer(VALUE_TYPES.length);
+        this.generator = generator;
     }
 
-    /**
-     * Creates the specific BytesHashMap, either {@link BytesMultiMap} or {@link
-     * WindowBytesMultiMap}.
-     */
-    public abstract AbstractBytesMultiMap<K> createBytesMultiMap(
-            MemoryManager memoryManager,
-            int memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes);
-
-    /**
-     * Generates {@code num} random keys, the types of key fields are defined in {@link #KEY_TYPES}.
-     */
-    public abstract K[] generateRandomKeys(int num);
+    abstract BinaryRowData[] genValues(int num);
 
     // ------------------------------------------------------------------------------------------
-    // Tests
+    // Utils
     // ------------------------------------------------------------------------------------------
 
-    @Test
-    public void testBuildAndRetrieve() throws Exception {
+    protected void innerBuildAndRetrieve(MapCreator<K> creator, MapValidator<K> validator)
+            throws Exception {
         final int numMemSegments =
                 needNumMemSegments(
                         NUM_ENTRIES,
@@ -102,10 +65,9 @@ public abstract class BytesMultiMapTestBase<K> extends BytesMapTestBase {
         MemoryManager memoryManager =
                 MemoryManagerBuilder.newBuilder().setMemorySize(numMemSegments * PAGE_SIZE).build();
 
-        AbstractBytesMultiMap<K> table =
-                createBytesMultiMap(memoryManager, memorySize, KEY_TYPES, VALUE_TYPES);
+        AbstractBytesMultiMap<K> table = creator.createMap(memoryManager, memorySize);
 
-        K[] keys = generateRandomKeys(NUM_ENTRIES / 10);
+        K[] keys = generator.createKeys(KEY_TYPES, NUM_ENTRIES / 10);
         BinaryRowData[] values = genValues(NUM_VALUE_PER_KEY);
 
         for (K key : keys) {
@@ -117,25 +79,17 @@ public abstract class BytesMultiMapTestBase<K> extends BytesMapTestBase {
         }
 
         KeyValueIterator<K, Iterator<RowData>> iter = table.getEntryIterator();
-        while (iter.advanceNext()) {
-            int i = 0;
-            Iterator<RowData> valueIter = iter.getValue();
-            while (valueIter.hasNext()) {
-                Assert.assertEquals(valueIter.next(), values[i++]);
-            }
-        }
+        validator.validate(keys, values, iter);
     }
 
-    private BinaryRowData[] genValues(int num) {
-        BinaryRowData[] values = new BinaryRowData[num];
-        final Random rnd = new Random(RANDOM_SEED);
-        for (int i = 0; i < num; i++) {
-            values[i] = new BinaryRowData(2);
-            BinaryRowWriter writer = new BinaryRowWriter(values[i]);
-            writer.writeString(0, StringData.fromString("string" + rnd.nextInt()));
-            writer.writeInt(1, rnd.nextInt());
-            writer.complete();
-        }
-        return values;
+    /** Creates the specific multi-map. */
+    interface MapCreator<K> {
+        AbstractBytesMultiMap<K> createMap(MemoryManager memoryManager, int memorySize);
+    }
+
+    interface MapValidator<K> {
+        void validate(
+                K[] keys, BinaryRowData[] values, KeyValueIterator<K, Iterator<RowData>> actual)
+                throws IOException;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/RandomKeyGenerator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/RandomKeyGenerator.java
@@ -18,26 +18,10 @@
 
 package org.apache.flink.table.runtime.util.collections.binary;
 
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
-import org.apache.flink.table.runtime.util.WindowKey;
 import org.apache.flink.table.types.logical.LogicalType;
 
-/** Test case for {@link WindowBytesHashMap}. */
-public class WindowBytesHashMapTest extends BytesHashMapTestBase<WindowKey> {
+/** Generator to generate keys. */
+interface RandomKeyGenerator<K> {
 
-    public WindowBytesHashMapTest() {
-        super(
-                new WindowKeySerializer(KEY_TYPES.length),
-                RandomKeyGeneratorFactory.createWindowKeyGenerator());
-    }
-
-    @Override
-    public AbstractBytesHashMap<WindowKey> createBytesHashMap(
-            MemoryManager memoryManager,
-            int memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes) {
-        return new WindowBytesHashMap(this, memoryManager, memorySize, keyTypes, valueTypes);
-    }
+    K[] createKeys(LogicalType[] fieldTypes, int num);
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/RandomKeyGeneratorFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/RandomKeyGeneratorFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.util.WindowKey;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import java.util.Random;
+
+/** Generate random keys. */
+class RandomKeyGeneratorFactory {
+
+    private static final Random rnd = new Random();
+
+    private static final double NULL_PROBABILITY = 0.1;
+
+    static RandomKeyGenerator<BinaryRowData> createBinaryRowDataKeyGenerator() {
+        return (fieldTypes, num) -> {
+            BinaryRowData[] rows = new BinaryRowData[num];
+            for (int i = 0; i < num; i++) {
+                rows[i] = createRow(fieldTypes);
+            }
+            return rows;
+        };
+    }
+
+    static RandomKeyGenerator<WindowKey> createWindowKeyGenerator() {
+        return (fieldTypes, num) -> {
+            WindowKey[] windowKeys = new WindowKey[num];
+            for (int i = 0; i < num; i++) {
+                windowKeys[i] = new WindowKey(rnd.nextLong(), createRow(fieldTypes));
+            }
+            return windowKeys;
+        };
+    }
+
+    private static BinaryRowData createRow(LogicalType[] types) {
+
+        BinaryRowData row = new BinaryRowData(types.length);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+
+        int intVal = rnd.nextInt(Integer.MAX_VALUE);
+
+        for (int i = 0; i < types.length; i++) {
+            if (rnd.nextDouble() < NULL_PROBABILITY) {
+                writer.setNullAt(i);
+                continue;
+            }
+
+            if (types[i] instanceof IntType) {
+                writer.writeInt(i, rnd.nextInt());
+            } else if (types[i] instanceof VarCharType) {
+                writer.writeString(i, StringData.fromString(getString(intVal, intVal % 1024)));
+            } else if (types[i] instanceof DoubleType) {
+                writer.writeDouble(i, rnd.nextDouble());
+            } else if (types[i] instanceof BigIntType) {
+                writer.writeLong(i, rnd.nextLong());
+            } else if (types[i] instanceof BooleanType) {
+                writer.writeBoolean(i, rnd.nextBoolean());
+            } else if (types[i] instanceof FloatType) {
+                writer.writeFloat(i, rnd.nextFloat());
+            } else if (types[i] instanceof SmallIntType) {
+                writer.writeShort(i, (short) rnd.nextInt());
+            } else {
+                throw new UnsupportedOperationException("Unsupported type: " + types[i]);
+            }
+        }
+        return row;
+    }
+
+    private static String getString(int count, int length) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            builder.append(count);
+        }
+        return builder.toString();
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMapTest.java
@@ -18,38 +18,21 @@
 
 package org.apache.flink.table.runtime.util.collections.binary;
 
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
-import org.apache.flink.table.types.logical.LogicalType;
-
-import java.util.Random;
 
 /** Verify the correctness of {@link WindowBytesMultiMap}. */
-public class WindowBytesMultiMapTest extends BytesMultiMapTestBase<WindowKey> {
+public class WindowBytesMultiMapTest extends BytesMultiLinkedMapTestBase<WindowKey> {
 
     public WindowBytesMultiMapTest() {
-        super(new WindowKeySerializer(KEY_TYPES.length));
+        super(
+                new WindowKeySerializer(KEY_TYPES.length),
+                RandomKeyGeneratorFactory.createWindowKeyGenerator());
     }
 
     @Override
-    public AbstractBytesMultiMap<WindowKey> createBytesMultiMap(
-            MemoryManager memoryManager,
-            int memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes) {
-        return new WindowBytesMultiMap(this, memoryManager, memorySize, keyTypes, valueTypes);
-    }
-
-    @Override
-    public WindowKey[] generateRandomKeys(int num) {
-        final Random rnd = new Random(RANDOM_SEED);
-        BinaryRowData[] keys = getRandomizedInputs(num, rnd, true);
-        WindowKey[] windowKeys = new WindowKey[num];
-        for (int i = 0; i < num; i++) {
-            windowKeys[i] = new WindowKey(rnd.nextLong(), keys[i]);
-        }
-        return windowKeys;
+    MapCreator<WindowKey> buildCreator() {
+        return (memoryManager, memorySize) ->
+                new WindowBytesMultiMap(this, memoryManager, memorySize, KEY_TYPES, VALUE_TYPES);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesSortedArrayMultiMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesSortedArrayMultiMapTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util.collections.binary;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.runtime.operators.sort.IntRecordComparator;
+import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
+import org.apache.flink.table.runtime.util.WindowKey;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+/** Tests for {@link WindowBytesSortedArrayMultiMap}. */
+public class WindowBytesSortedArrayMultiMapTest extends BytesMultiMapTestBase<WindowKey> {
+
+    private static final LogicalType[] VALUE_TYPES =
+            new LogicalType[] {new IntType(), new VarCharType(VarCharType.MAX_LENGTH)};
+
+    private final MapValidator<WindowKey> validator =
+            (keys, values, actual) -> {
+                while (actual.advanceNext()) {
+                    int i = 0;
+                    Iterator<RowData> valueIter = actual.getValue();
+                    while (valueIter.hasNext()) {
+                        Assert.assertEquals(valueIter.next(), values[i++]);
+                    }
+                }
+            };
+
+    private final MapValidator<WindowKey> validatorInDescendingOrder =
+            (keys, values, actual) -> {
+                while (actual.advanceNext()) {
+                    int i = 0;
+                    Iterator<RowData> valueIter = actual.getValue();
+                    while (valueIter.hasNext()) {
+                        Assert.assertEquals(valueIter.next(), values[NUM_VALUE_PER_KEY - 1 - i++]);
+                    }
+                }
+            };
+
+    public WindowBytesSortedArrayMultiMapTest() {
+        super(
+                new WindowKeySerializer(KEY_TYPES.length),
+                RandomKeyGeneratorFactory.createWindowKeyGenerator());
+    }
+
+    @Test
+    public void testBuildAndRetrieve() throws Exception {
+        int heapCapacity = NUM_VALUE_PER_KEY - 10;
+        MapCreator<WindowKey> creator =
+                (memoryManager, memorySize) ->
+                        new WindowBytesSortedArrayMultiMap(
+                                this,
+                                memoryManager,
+                                memorySize,
+                                KEY_TYPES,
+                                VALUE_TYPES,
+                                heapCapacity,
+                                IntRecordComparator.INSTANCE);
+
+        innerBuildAndRetrieve(creator, validator);
+    }
+
+    @Test
+    public void testBuildAndRetrieveWithLargeCapacity() throws Exception {
+        int heapCapacity = NUM_VALUE_PER_KEY + 10;
+        MapCreator<WindowKey> creator =
+                (memoryManager, memorySize) ->
+                        new WindowBytesSortedArrayMultiMap(
+                                this,
+                                memoryManager,
+                                memorySize,
+                                KEY_TYPES,
+                                VALUE_TYPES,
+                                heapCapacity,
+                                IntRecordComparator.INSTANCE);
+
+        innerBuildAndRetrieve(creator, validator);
+    }
+
+    @Test
+    public void testBuildAndRetrieveDescendingOrder() throws Exception {
+        int heapCapacity = NUM_VALUE_PER_KEY - 10;
+        MapCreator<WindowKey> creator =
+                (memoryManager, memorySize) ->
+                        new WindowBytesSortedArrayMultiMap(
+                                this,
+                                memoryManager,
+                                memorySize,
+                                KEY_TYPES,
+                                VALUE_TYPES,
+                                heapCapacity,
+                                new IntRecordComparator(true));
+
+        innerBuildAndRetrieve(creator, validatorInDescendingOrder);
+    }
+
+    @Test
+    public void testBuildAndRetrieveDescendingOrderWithLargeCapacity() throws Exception {
+        int heapCapacity = NUM_VALUE_PER_KEY + 10;
+        MapCreator<WindowKey> creator =
+                (memoryManager, memorySize) ->
+                        new WindowBytesSortedArrayMultiMap(
+                                this,
+                                memoryManager,
+                                memorySize,
+                                KEY_TYPES,
+                                VALUE_TYPES,
+                                heapCapacity,
+                                new IntRecordComparator(true));
+
+        innerBuildAndRetrieve(creator, validatorInDescendingOrder);
+    }
+
+    @Override
+    BinaryRowData[] genValues(int num) {
+        BinaryRowData[] values = new BinaryRowData[num];
+        for (int i = 0; i < num; i++) {
+            values[i] = new BinaryRowData(2);
+            BinaryRowWriter writer = new BinaryRowWriter(values[i]);
+            writer.writeInt(0, i);
+            writer.writeString(1, StringData.fromString("String " + i));
+            writer.complete();
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The buffer is used to cache the record and only keep the topN records. When the invoker decide to emit or snapshot, it can get the sorted records from the buffer. The main benfit of the buffer is that it can reduce the per-record state visit.*


## Brief change log

  - *`BytesMultiMap` has two types of subclass: `AbstractBytesLinkedMultiMap` and `AbstractBytesArrayMultiMap`, which is like `LinkedList` and `ArrayList` to `List`*
  - *Introduce the `WindowBytesSortedArrayMultiMap`, which will only keep the topN element under the specified key.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test to sort data with asecending order*
  - *Added test to sort data with desecending order*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
