### PR TITLE
[FLINK-20933][python] Config Python Operator Use Managed Memory In Python DataStream

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1730,6 +1730,11 @@ class StreamTableEnvironment(TableEnvironment):
         .. versionadded:: 1.12.0
         """
         j_data_stream = data_stream._j_data_stream
+        get_gateway().jvm \
+            .org.apache.flink.python.util.PythonConfigUtil.setManagedMemory(
+            j_data_stream.getTransformation(),
+            self._get_j_env(),
+            self._j_tenv.getConfig())
         if len(fields) == 0:
             return Table(j_table=self._j_tenv.fromDataStream(j_data_stream), t_env=self)
         elif all(isinstance(f, Expression) for f in fields):

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -416,6 +416,7 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
         expected = ['1,Hi,Hello', '2,Hello,Hi']
         self.assert_equals(result, expected)
 
+        ds = ds.map(lambda x: x, Types.ROW([Types.INT(), Types.STRING(), Types.STRING()]))
         table = t_env.from_data_stream(ds, col('a'), col('b'), col('c'))
         t_env.register_table_sink("ExprSink",
                                   source_sink_utils.TestAppendSink(field_names, field_types))

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -18,8 +18,11 @@
 package org.apache.flink.python.util;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
@@ -44,6 +47,8 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -128,6 +133,27 @@ public class PythonConfigUtil {
         firstStream.setSlotSharingGroup(secondStream.getSlotSharingGroup());
     }
 
+    /** Set Python Operator Use Managed Memory. */
+    public static void setManagedMemory(
+            Transformation<?> transformation,
+            StreamExecutionEnvironment env,
+            TableConfig tableConfig) {
+        Configuration config = getMergedConfig(env, tableConfig);
+        if (config.getBoolean(PythonOptions.USE_MANAGED_MEMORY)) {
+            setManagedMemory(transformation);
+        }
+    }
+
+    private static void setManagedMemory(Transformation<?> transformation) {
+        if (isPythonOperator(transformation)) {
+            transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
+        }
+        List<Transformation<?>> inputTransformations = transformation.getInputs();
+        for (Transformation inputTransformation : inputTransformations) {
+            setManagedMemory(inputTransformation);
+        }
+    }
+
     /**
      * Generate a {@link StreamGraph} for transformations maintained by current {@link
      * StreamExecutionEnvironment}, and reset the merged env configurations with dependencies to
@@ -153,18 +179,7 @@ public class PythonConfigUtil {
             transformationsField.setAccessible(true);
             for (Transformation transform :
                     (List<Transformation<?>>) transformationsField.get(env)) {
-                if (transform instanceof OneInputTransformation
-                        && isPythonOperator(
-                                ((OneInputTransformation) transform).getOperatorFactory())) {
-                    transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
-                } else if (transform instanceof TwoInputTransformation
-                        && isPythonOperator(
-                                ((TwoInputTransformation) transform).getOperatorFactory())) {
-                    transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
-                } else if (transform instanceof AbstractMultipleInputTransformation
-                        && isPythonOperator(
-                                ((AbstractMultipleInputTransformation) transform)
-                                        .getOperatorFactory())) {
+                if (isPythonOperator(transform)) {
                     transform.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
                 }
             }
@@ -210,6 +225,19 @@ public class PythonConfigUtil {
         if (streamOperatorFactory instanceof SimpleOperatorFactory) {
             return ((SimpleOperatorFactory) streamOperatorFactory).getOperator()
                     instanceof AbstractPythonFunctionOperator;
+        } else {
+            return false;
+        }
+    }
+
+    private static boolean isPythonOperator(Transformation<?> transform) {
+        if (transform instanceof OneInputTransformation) {
+            return isPythonOperator(((OneInputTransformation) transform).getOperatorFactory());
+        } else if (transform instanceof TwoInputTransformation) {
+            return isPythonOperator(((TwoInputTransformation) transform).getOperatorFactory());
+        } else if (transform instanceof AbstractMultipleInputTransformation) {
+            return isPythonOperator(
+                    ((AbstractMultipleInputTransformation) transform).getOperatorFactory());
         } else {
             return false;
         }
@@ -269,5 +297,38 @@ public class PythonConfigUtil {
                                             != Boundedness.BOUNDED);
         }
         return !existsUnboundedSource;
+    }
+
+    public static Configuration getMergedConfig(
+            StreamExecutionEnvironment env, TableConfig tableConfig) {
+        try {
+            Configuration config = new Configuration(getEnvironmentConfig(env));
+            config.addAll(tableConfig.getConfiguration());
+            Configuration mergedConfig =
+                    PythonDependencyUtils.configurePythonDependencies(env.getCachedFiles(), config);
+            mergedConfig.setString("table.exec.timezone", tableConfig.getLocalTimeZone().getId());
+            return mergedConfig;
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new TableException("Method getMergedConfig failed.", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Configuration getMergedConfig(ExecutionEnvironment env, TableConfig tableConfig) {
+        try {
+            Field field = ExecutionEnvironment.class.getDeclaredField("cacheFile");
+            field.setAccessible(true);
+            Configuration config = new Configuration(env.getConfiguration());
+            config.addAll(tableConfig.getConfiguration());
+            Configuration mergedConfig =
+                    PythonDependencyUtils.configurePythonDependencies(
+                            (List<Tuple2<String, DistributedCache.DistributedCacheEntry>>)
+                                    field.get(env),
+                            config);
+            mergedConfig.setString("table.exec.timezone", tableConfig.getLocalTimeZone().getId());
+            return mergedConfig;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new TableException("Method getMergedConfig failed.", e);
+        }
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
@@ -91,31 +91,14 @@ trait CommonPythonBase {
     }
   }
 
-  protected def getConfig(
+  protected def getMergedConfig(
       env: StreamExecutionEnvironment,
       tableConfig: TableConfig): Configuration = {
-    val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
+    val clazz = loadClass(CommonPythonBase.PythonConfigUtil)
     val realEnv = getRealEnvironment(env)
     val method = clazz.getDeclaredMethod(
-      "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(
-      null, realEnv.getCachedFiles, getMergedConfiguration(realEnv, tableConfig))
-      .asInstanceOf[Configuration]
-    config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
-    config
-  }
-
-  private def getMergedConfiguration(
-      env: StreamExecutionEnvironment,
-      tableConfig: TableConfig): Configuration = {
-    // As the python dependency configurations may appear in both
-    // `StreamExecutionEnvironment#getConfiguration` (e.g. parsed from flink-conf.yaml and command
-    // line) and `TableConfig#getConfiguration` (e.g. user specified), we need to merge them and
-    // ensure the user specified configuration has priority over others.
-    val method = classOf[StreamExecutionEnvironment].getDeclaredMethod("getConfiguration")
-    method.setAccessible(true)
-    val config = new Configuration(method.invoke(env).asInstanceOf[Configuration])
-    config.addAll(tableConfig.getConfiguration)
+      "getMergedConfig", classOf[StreamExecutionEnvironment], classOf[TableConfig])
+    val config = method.invoke(null, realEnv, tableConfig).asInstanceOf[Configuration]
     config
   }
 
@@ -137,5 +120,5 @@ trait CommonPythonBase {
 }
 
 object CommonPythonBase {
-  val PYTHON_DEPENDENCY_UTILS_CLASS = "org.apache.flink.python.util.PythonDependencyUtils"
+  val PythonConfigUtil = "org.apache.flink.python.util.PythonConfigUtil"
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
@@ -54,13 +54,14 @@ class BatchExecPythonCalc(
   override protected def translateToPlanInternal(planner: BatchPlanner): Transformation[RowData] = {
     val inputTransform = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       inputTransform,
       calcProgram,
       "BatchExecPythonCalc",
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -72,14 +72,15 @@ class BatchExecPythonCorrelate(
       planner: BatchPlanner): Transformation[RowData] = {
     val inputTransformation = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       inputTransformation,
       scan,
       "BatchExecPythonCorrelate",
       outputRowType,
-      getConfig(planner.getExecEnv, planner.getTableConfig),
+      config,
       joinType)
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupAggregate.scala
@@ -185,12 +185,13 @@ class BatchExecPythonGroupAggregate(
     val outputType = FlinkTypeFactory.toLogicalRowType(getRowType)
     val inputType = FlinkTypeFactory.toLogicalRowType(inputRowType)
 
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       input,
       inputType,
       outputType,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+      config)
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonGroupWindowAggregate.scala
@@ -144,6 +144,7 @@ class BatchExecPythonGroupWindowAggregate(
     val groupBufferLimitSize = planner.getTableConfig.getConfiguration.getInteger(
       ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT)
 
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       input,
       inputType,
@@ -152,9 +153,9 @@ class BatchExecPythonGroupWindowAggregate(
       groupBufferLimitSize,
       windowSize,
       slideSize,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonOverAggregate.scala
@@ -123,6 +123,7 @@ class BatchExecPythonOverAggregate(
         windowBoundary.append(boundary)
         aggCallToAggFunction.map((_, index))
     }
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       input,
       aggFunctions,
@@ -130,9 +131,9 @@ class BatchExecPythonOverAggregate(
       inputType,
       outputType,
       grouping,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -54,17 +54,18 @@ class StreamExecPythonCalc(
       planner: StreamPlanner): Transformation[RowData] = {
     val inputTransform = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       inputTransform,
       calcProgram,
       "StreamExecPythonCalc",
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      config)
 
     if (inputsContainSingleton()) {
       ret.setParallelism(1)
       ret.setMaxParallelism(1)
     }
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -77,12 +77,13 @@ class StreamExecPythonCorrelate(
       planner: StreamPlanner): Transformation[RowData] = {
     val inputTransformation = getInputNodes.get(0).translateToPlan(planner)
       .asInstanceOf[Transformation[RowData]]
+    val config = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonOneInputTransformation(
       inputTransformation,
       scan,
       "StreamExecPythonCorrelate",
       outputRowType,
-      getConfig(planner.getExecEnv, planner.getTableConfig),
+      config,
       joinType)
     if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupAggregate.scala
@@ -130,8 +130,9 @@ class StreamExecPythonGroupAggregate(
       dataViewSpecs = Array()
     }
 
+    val config = getMergedConfig(planner.getExecEnv, tableConfig)
     val operator = getPythonAggregateFunctionOperator(
-      getConfig(planner.getExecEnv, tableConfig),
+      config,
       inputRowType,
       outRowType,
       pythonFunctionInfos,
@@ -160,7 +161,7 @@ class StreamExecPythonGroupAggregate(
       ret.setMaxParallelism(1)
     }
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonGroupWindowAggregate.scala
@@ -128,6 +128,7 @@ class StreamExecPythonGroupWindowAggregate(
     }
 
     val (windowAssigner, trigger) = generateWindowAssignerAndTrigger()
+    val mergedConfig = getMergedConfig(planner.getExecEnv, planner.getTableConfig)
     val ret = createPythonStreamWindowGroupOneInputTransformation(
       inputTransform,
       inputType,
@@ -136,7 +137,7 @@ class StreamExecPythonGroupWindowAggregate(
       windowAssigner,
       trigger,
       emitStrategy.getAllowLateness,
-      getConfig(planner.getExecEnv, planner.getTableConfig))
+      mergedConfig)
 
     if (inputsContainSingleton()) {
       ret.setParallelism(1)
@@ -149,7 +150,7 @@ class StreamExecPythonGroupWindowAggregate(
     ret.setStateKeySelector(selector)
     ret.setStateKeyType(selector.getProducedType)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getTableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(mergedConfig)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonOverAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonOverAggregate.scala
@@ -156,6 +156,7 @@ class StreamExecPythonOverAggregate(
     }
     // bounded OVER window
     val precedingOffset = -1 * boundValue.asInstanceOf[Long]
+    val config = getMergedConfig(planner.getExecEnv, tableConfig)
     val ret = createPythonOneInputTransformation(
       inputDS,
       inRowType,
@@ -167,9 +168,9 @@ class StreamExecPythonOverAggregate(
       partitionKeys,
       tableConfig.getMinIdleStateRetentionTime,
       tableConfig.getMaxIdleStateRetentionTime,
-      getConfig(planner.getExecEnv, tableConfig))
+      config)
 
-    if (isPythonWorkerUsingManagedMemory(tableConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -80,7 +80,7 @@ class DataSetPythonCalc(
     val flatMapFunctionOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       flatMapFunctionResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val flatMapFunction = getPythonScalarFunctionFlatMap(
-      getConfig(tableEnv.execEnv, tableEnv.getConfig),
+      getMergedConfig(tableEnv.execEnv, tableEnv.getConfig),
       flatMapFunctionInputRowType,
       flatMapFunctionOutputRowType,
       calcProgram)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCorrelate.scala
@@ -87,7 +87,7 @@ class DataSetPythonCorrelate(
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
     val flatMapFunction = getPythonTableFunctionFlatMap(
-      getConfig(tableEnv.execEnv, tableEnv.getConfig),
+      getMergedConfig(tableEnv.execEnv, tableEnv.getConfig),
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -81,8 +81,9 @@ class DataStreamPythonCalc(
       inputSchema.typeInfo).getLogicalType.asInstanceOf[RowType]
     val pythonOperatorOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       pythonOperatorResultTypeInfo).getLogicalType.asInstanceOf[RowType]
+    val config = getMergedConfig(planner.getExecutionEnvironment, planner.getConfig)
     val pythonOperator = getPythonScalarFunctionOperator(
-      getConfig(planner.getExecutionEnvironment, planner.getConfig),
+      config,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       calcProgram)
@@ -95,7 +96,7 @@ class DataStreamPythonCalc(
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputParallelism)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.getTransformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -93,8 +93,9 @@ class DataStreamPythonCorrelate(
 
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
+    val config = getMergedConfig(planner.getExecutionEnvironment, planner.getConfig)
     val pythonOperator = getPythonTableFunctionOperator(
-      getConfig(planner.getExecutionEnvironment, planner.getConfig),
+      config,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,
@@ -114,7 +115,7 @@ class DataStreamPythonCorrelate(
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputDataStream.getParallelism)
 
-    if (isPythonWorkerUsingManagedMemory(planner.getConfig.getConfiguration)) {
+    if (isPythonWorkerUsingManagedMemory(config)) {
       ret.getTransformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON)
     }
     ret


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Config Python Operator Use Managed Memory In Python DataStream*


## Brief change log

  - *Add method `setManagedMemory` to set all Python Operator to use Managed Memory*

## Verifying this change

This change added tests and can be verified as follows:

  - *Correct original test `test_from_data_stream` to cover this feature*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
