### PR TITLE
[FLINK-21009] Can not disable certain options in Elasticsearch 7 connector

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
@@ -109,31 +109,45 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevel
         }
 
         /**
-         * Sets the maximum number of actions to buffer for each bulk request.
+         * Sets the maximum number of actions to buffer for each bulk request. You can pass -1 to
+         * disable it.
          *
          * @param numMaxActions the maximum number of actions to buffer per bulk request.
          */
         public void setBulkFlushMaxActions(int numMaxActions) {
+            Preconditions.checkArgument(
+                    numMaxActions == -1 || numMaxActions > 0,
+                    "Max number of buffered actions must be larger than 0.");
+
             this.bulkRequestsConfig.put(
                     CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, String.valueOf(numMaxActions));
         }
 
         /**
-         * Sets the maximum size of buffered actions, in mb, per bulk request.
+         * Sets the maximum size of buffered actions, in mb, per bulk request. You can pass -1 to
+         * disable it.
          *
          * @param maxSizeMb the maximum size of buffered actions, in mb.
          */
         public void setBulkFlushMaxSizeMb(int maxSizeMb) {
+            Preconditions.checkArgument(
+                    maxSizeMb == -1 || maxSizeMb > 0,
+                    "Max size of buffered actions must be larger than 0.");
+
             this.bulkRequestsConfig.put(
                     CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB, String.valueOf(maxSizeMb));
         }
 
         /**
-         * Sets the bulk flush interval, in milliseconds.
+         * Sets the bulk flush interval, in milliseconds. You can pass -1 to disable it.
          *
          * @param intervalMillis the bulk flush interval, in milliseconds.
          */
         public void setBulkFlushInterval(long intervalMillis) {
+            Preconditions.checkArgument(
+                    intervalMillis == -1 || intervalMillis >= 0,
+                    "Interval (in milliseconds) between each flush must be larger than or equal to 0.");
+
             this.bulkRequestsConfig.put(
                     CONFIG_KEY_BULK_FLUSH_INTERVAL_MS, String.valueOf(intervalMillis));
         }

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSink.java
@@ -109,39 +109,43 @@ public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T, RestHighLevel
         }
 
         /**
-         * Sets the maximum number of actions to buffer for each bulk request.
+         * Sets the maximum number of actions to buffer for each bulk request. You can pass -1 to
+         * disable it.
          *
          * @param numMaxActions the maximum number of actions to buffer per bulk request.
          */
         public void setBulkFlushMaxActions(int numMaxActions) {
             Preconditions.checkArgument(
-                    numMaxActions > 0, "Max number of buffered actions must be larger than 0.");
+                    numMaxActions == -1 || numMaxActions > 0,
+                    "Max number of buffered actions must be larger than 0.");
 
             this.bulkRequestsConfig.put(
                     CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, String.valueOf(numMaxActions));
         }
 
         /**
-         * Sets the maximum size of buffered actions, in mb, per bulk request.
+         * Sets the maximum size of buffered actions, in mb, per bulk request. You can pass -1 to
+         * disable it.
          *
          * @param maxSizeMb the maximum size of buffered actions, in mb.
          */
         public void setBulkFlushMaxSizeMb(int maxSizeMb) {
             Preconditions.checkArgument(
-                    maxSizeMb > 0, "Max size of buffered actions must be larger than 0.");
+                    maxSizeMb == -1 || maxSizeMb > 0,
+                    "Max size of buffered actions must be larger than 0.");
 
             this.bulkRequestsConfig.put(
                     CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB, String.valueOf(maxSizeMb));
         }
 
         /**
-         * Sets the bulk flush interval, in milliseconds.
+         * Sets the bulk flush interval, in milliseconds. You can pass -1 to disable it.
          *
          * @param intervalMillis the bulk flush interval, in milliseconds.
          */
         public void setBulkFlushInterval(long intervalMillis) {
             Preconditions.checkArgument(
-                    intervalMillis >= 0,
+                    intervalMillis == -1 || intervalMillis >= 0,
                     "Interval (in milliseconds) between each flush must be larger than or equal to 0.");
 
             this.bulkRequestsConfig.put(


### PR DESCRIPTION
## What is the purpose of the change

It makes it possible to disable options:

    bulk flush max actions
    bulk flush max size
    bulk flush interval


## Verifying this change

I did not add tests, as I could not find a good way to assert these settings. Any suggestions are welcome.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
