### PR TITLE
[FLINK-20992][checkpointing] Tolerate checkpoint cleanup failures

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1278,7 +1278,14 @@ public class CheckpointCoordinator {
     }
 
     void scheduleTriggerRequest() {
-        timer.execute(this::executeQueuedRequest);
+        synchronized (lock) {
+            if (isShutdown()) {
+                LOG.debug(
+                        "Skip scheduling trigger request because the CheckpointCoordinator is shut down");
+            } else {
+                timer.execute(this::executeQueuedRequest);
+            }
+        }
     }
 
     private void sendAcknowledgeMessages(long checkpointId, long timestamp) {


### PR DESCRIPTION
## What is the purpose of the change

Cleaning checkpoints may try to schedule new checkpoint trigger requests.
This will fail (throw `RejectedExecutionException`) if ThreadPool is shutting down. This in turn will fail the JM.

This PR directly address this. More general approaches are discussed in FLINK-20992.

## Brief change log

- Tolerate checkpoint cleanup failures
- Skip scheduling checkpoint triggering if checkpoint coordinator is shutting down

## Verifying this change

Added `CheckpointCleanerTest` with `testTolerateFailureInPostCleanupSubmit` and `testTolerateFailureInPostCleanup`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
