### PR TITLE
[FLINK-6042][runtime] Adds exception history

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -270,9 +270,22 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         delayExecutor.schedule(
                 () ->
                         FutureUtils.assertNoException(
-                                cancelFuture.thenRunAsync(
-                                        restartTasks(executionVertexVersions, globalRecovery),
-                                        getMainThreadExecutor())),
+                                cancelFuture
+                                        .thenRunAsync(
+                                                restartTasks(
+                                                        executionVertexVersions, globalRecovery),
+                                                getMainThreadExecutor())
+                                        .thenRunAsync(
+                                                () ->
+                                                        archiveExceptions(
+                                                                failureHandlingResult.getError(),
+                                                                executionVertexVersions.stream()
+                                                                        .map(
+                                                                                ExecutionVertexVersion
+                                                                                        ::getExecutionVertexId)
+                                                                        .collect(
+                                                                                Collectors
+                                                                                        .toList())))),
                 failureHandlingResult.getRestartDelayMS(),
                 TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
## What is the purpose of the change

❗ This PR contains work in progress. ❗ 

The goal is to expose a history of caught exceptions through the web UI.

## Brief change log

- added exception history to `DefaultScheduler`
- `[...]`

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
