### PR TITLE
[FLINK-21017][docs] Fix missing backquote in table connectors docs

### DIFF
--- a/docs/dev/table/connectors/index.md
+++ b/docs/dev/table/connectors/index.md
@@ -116,7 +116,7 @@ CREATE TABLE MyUserTable (
   `user` BIGINT,
   `message` STRING,
   `rowtime` TIMESTAMP(3) METADATA FROM 'timestamp',    -- use a metadata column to access Kafka's record timestamp
-  `proctime AS PROCTIME(),    -- use a computed column to define a proctime attribute
+  `proctime` AS PROCTIME(),    -- use a computed column to define a proctime attribute
   WATERMARK FOR `rowtime` AS `rowtime` - INTERVAL '5' SECOND    -- use a WATERMARK statement to define a rowtime attribute
 ) WITH (
   -- declare the external system to connect to

--- a/docs/dev/table/connectors/index.zh.md
+++ b/docs/dev/table/connectors/index.zh.md
@@ -116,7 +116,7 @@ CREATE TABLE MyUserTable (
   `user` BIGINT,
   `message` STRING,
   `rowtime` TIMESTAMP(3) METADATA FROM 'timestamp',    -- use a metadata column to access Kafka's record timestamp
-  `proctime AS PROCTIME(),    -- use a computed column to define a proctime attribute
+  `proctime` AS PROCTIME(),    -- use a computed column to define a proctime attribute
   WATERMARK FOR `rowtime` AS `rowtime` - INTERVAL '5' SECOND    -- use a WATERMARK statement to define a rowtime attribute
 ) WITH (
   -- declare the external system to connect to


### PR DESCRIPTION
## What is the purpose of the change

Fix missing backquote in table connectors docs.


## Brief change log

* Fix missing backquote in `dev/table/connectors/index.md`
* Fix missing backquote in `dev/table/connectors/index.zh.md`


## Verifying this change

This change is a doc fix without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
