### PR TITLE
[FLINK-21041][table-planner-blink] Introduce ExecNodeGraph to wrap the ExecNode topology

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -483,10 +483,11 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
             int expected, Table table, TableEnvironment tEnv) {
         PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
         RelNode relNode = planner.optimize(TableTestUtil.toRelNode(table));
-        ExecNode execNode =
-                planner.translateToExecNodePlan(toScala(Collections.singletonList(relNode))).get(0);
-        @SuppressWarnings("unchecked")
-        Transformation transformation = execNode.translateToPlan(planner);
+        ExecNode<?> execNode =
+                planner.translateToExecNodeGraph(toScala(Collections.singletonList(relNode)))
+                        .getRootNodes()
+                        .get(0);
+        Transformation<?> transformation = execNode.translateToPlan(planner);
         Assert.assertEquals(expected, transformation.getParallelism());
     }
 
@@ -518,7 +519,9 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
         RelNode relNode = planner.optimize(TableTestUtil.toRelNode(table));
         ExecNode<?> execNode =
-                planner.translateToExecNodePlan(toScala(Collections.singletonList(relNode))).get(0);
+                planner.translateToExecNodeGraph(toScala(Collections.singletonList(relNode)))
+                        .getRootNodes()
+                        .get(0);
         Transformation<?> transformation =
                 (execNode.translateToPlan(planner).getInputs().get(0)).getInputs().get(0);
         Assert.assertEquals(1, transformation.getParallelism());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraph.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraph.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.plan.nodes.exec.processor;
+package org.apache.flink.table.planner.plan.nodes.exec;
 
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import java.util.List;
 
-/** DAGProcess plugin, use it can set resource of dag or change other node info. */
-public interface DAGProcessor {
+/** The {@link ExecNodeGraph} representing the {@link ExecNode} topology. */
+public class ExecNodeGraph {
+    private final List<ExecNode<?>> rootNodes;
 
-    /** Given an {@link ExecNodeGraph}, process it and return the result {@link ExecNodeGraph}. */
-    ExecNodeGraph process(ExecNodeGraph execGraph, DAGProcessContext context);
+    public ExecNodeGraph(List<ExecNode<?>> rootNodes) {
+        this.rootNodes = rootNodes;
+    }
+
+    public List<ExecNode<?>> getRootNodes() {
+        return rootNodes;
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraphGenerator.java
@@ -40,20 +40,20 @@ import java.util.Map;
  * once all ExecNodes' implementation are separated from physical rel, we will use {@link ExecEdge}
  * to replace them.
  */
-public class ExecGraphGenerator {
+public class ExecNodeGraphGenerator {
 
     private final Map<FlinkPhysicalRel, ExecNode<?>> visitedRels;
 
-    public ExecGraphGenerator() {
+    public ExecNodeGraphGenerator() {
         this.visitedRels = new IdentityHashMap<>();
     }
 
-    public List<ExecNode<?>> generate(List<FlinkPhysicalRel> relNodes) {
-        List<ExecNode<?>> execNodes = new ArrayList<>(relNodes.size());
+    public ExecNodeGraph generate(List<FlinkPhysicalRel> relNodes) {
+        List<ExecNode<?>> rootNodes = new ArrayList<>(relNodes.size());
         for (FlinkPhysicalRel relNode : relNodes) {
-            execNodes.add(generate(relNode));
+            rootNodes.add(generate(relNode));
         }
-        return execNodes;
+        return new ExecNodeGraph(rootNodes);
     }
 
     private ExecNode<?> generate(FlinkPhysicalRel rel) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.utils;
 
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLegacySink;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecSink;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
@@ -91,6 +92,14 @@ public class ExecNodePlanDumper {
                 new ArrayList<>(checkNotNull(borders, "borders should not be null."));
         TreeReuseInfo reuseInfo = new TreeReuseInfo(node, borderList);
         return doConvertTreeToString(node, reuseInfo, true, borderList, includingBorders);
+    }
+
+    /**
+     * Converts an {@link ExecNodeGraph} to a string as a tree style. see {@link
+     * #dagToString(List)}.
+     */
+    public static String dagToString(ExecNodeGraph execGraph) {
+        return dagToString(execGraph.getRootNodes());
     }
 
     /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.processor.{DAGProcessContext, DAGProcessor, DeadlockBreakupProcessor, MultipleInputNodeCreationProcessor}
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, LegacyBatchExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNodeGraph, LegacyBatchExecNode}
 import org.apache.flink.table.planner.plan.optimize.{BatchCommonSubGraphBasedOptimizer, Optimizer}
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.sinks.{BatchSelectTableSink, SelectTableSinkBase}
@@ -60,9 +60,9 @@ class BatchPlanner(
 
   override protected def getOptimizer: Optimizer = new BatchCommonSubGraphBasedOptimizer(this)
 
-  override private[flink] def translateToExecNodePlan(
-      optimizedRelNodes: Seq[RelNode]): util.List[ExecNode[_]] = {
-    val execNodePlan = super.translateToExecNodePlan(optimizedRelNodes)
+  override private[flink] def translateToExecNodeGraph(
+      optimizedRelNodes: Seq[RelNode]): ExecNodeGraph = {
+    val execGraph = super.translateToExecNodeGraph(optimizedRelNodes)
     val context = new DAGProcessContext(this)
 
     val processors = new util.ArrayList[DAGProcessor]()
@@ -74,16 +74,14 @@ class BatchPlanner(
       processors.add(new MultipleInputNodeCreationProcessor(false))
     }
 
-    processors.foldLeft(execNodePlan)(
-      (sinkNodes, processor) => processor.process(sinkNodes, context))
+    processors.foldLeft(execGraph)((graph, processor) => processor.process(graph, context))
   }
 
-  override protected def translateToPlan(
-      execNodes: util.List[ExecNode[_]]): util.List[Transformation[_]] = {
+  override protected def translateToPlan(execGraph: ExecNodeGraph): util.List[Transformation[_]] = {
     val planner = createDummyPlanner()
     planner.overrideEnvParallelism()
 
-    execNodes.map {
+    execGraph.getRootNodes.map {
       case legacyNode: LegacyBatchExecNode[_] => legacyNode.translateToPlan(planner)
       case node: BatchExecNode[_] => node.translateToPlan(planner)
       case _ =>
@@ -120,9 +118,9 @@ class BatchPlanner(
       case o => throw new TableException(s"Unsupported operation: ${o.getClass.getCanonicalName}")
     }
     val optimizedRelNodes = optimize(sinkRelNodes)
-    val execNodes = translateToExecNodePlan(optimizedRelNodes)
+    val execGraph = translateToExecNodeGraph(optimizedRelNodes)
 
-    val transformations = translateToPlan(execNodes)
+    val transformations = translateToPlan(execGraph)
 
     val execEnv = getExecEnv
     ExecutorUtils.setBatchProperties(execEnv)
@@ -151,7 +149,7 @@ class BatchPlanner(
 
     sb.append("== Optimized Execution Plan ==")
     sb.append(System.lineSeparator)
-    sb.append(ExecNodePlanDumper.dagToString(execNodes))
+    sb.append(ExecNodePlanDumper.dagToString(execGraph))
 
     if (extraDetails.contains(ExplainDetail.JSON_EXECUTION_PLAN)) {
       sb.append(System.lineSeparator)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -27,8 +27,9 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.Expression;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecGraphGenerator;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraphGenerator;
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
 import org.apache.flink.table.planner.utils.BatchTableTestUtil;
 import org.apache.flink.table.planner.utils.StreamTableTestUtil;
@@ -43,7 +44,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 
 /** Tests for {@link MultipleInputNodeCreationProcessor}. */
 public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
@@ -103,9 +103,9 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
         Table table = util.tableEnv().sqlQuery(sql);
         RelNode relNode = TableTestUtil.toRelNode(table);
         FlinkPhysicalRel optimizedRel = (FlinkPhysicalRel) util.getPlanner().optimize(relNode);
-        ExecGraphGenerator generator = new ExecGraphGenerator();
-        List<ExecNode<?>> execNodes = generator.generate(Collections.singletonList(optimizedRel));
-        ExecNode<?> execNode = execNodes.get(0);
+        ExecNodeGraphGenerator generator = new ExecNodeGraphGenerator();
+        ExecNodeGraph execGraph = generator.generate(Collections.singletonList(optimizedRel));
+        ExecNode<?> execNode = execGraph.getRootNodes().get(0);
         while (!execNode.getInputNodes().isEmpty()) {
             execNode = execNode.getInputNodes().get(0);
         }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -860,8 +860,8 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
 
     // build optimized exec plan if `expectedPlans` contains OPT_EXEC
     val optimizedExecPlan = if (expectedPlans.contains(PlanKind.OPT_EXEC)) {
-      val optimizedExecs = getPlanner.translateToExecNodePlan(optimizedRels)
-      System.lineSeparator + ExecNodePlanDumper.dagToString(optimizedExecs)
+      val execGraph = getPlanner.translateToExecNodeGraph(optimizedRels)
+      System.lineSeparator + ExecNodePlanDumper.dagToString(execGraph)
     } else {
       ""
     }


### PR DESCRIPTION


## What is the purpose of the change

*Currently, we use List<ExecNode<?> to represent the ExecNode topology, as we will introduce more features (such as serialize/deserialize ExecNodes), It's better we can introduce an unified class to represent the topology.*


## Brief change log

  - *Introduce ExecNodeGraph to wrap the ExecNode topology*


## Verifying this change

This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
