### PR TITLE
[FLINK-20500][upsert-kafka] Fix temporal join test

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -497,16 +497,31 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
                                 LocalDateTime.parse("2020-08-16T00:01:05")),
                         changelogRow(
                                 "+U",
-                                103L,
-                                "Richard",
-                                "London",
-                                LocalDateTime.parse("2020-08-16T01:01:05")),
-                        changelogRow(
-                                "+U",
                                 101L,
                                 "Alice",
                                 "Wuhan",
                                 LocalDateTime.parse("2020-08-16T00:02:00")),
+                        changelogRow(
+                                "+U",
+                                104L,
+                                "Tomato",
+                                "Hongkong",
+                                LocalDateTime.parse("2020-08-16T00:05:05")),
+                        changelogRow(
+                                "+U",
+                                105L,
+                                "Tim",
+                                "Shenzhen",
+                                LocalDateTime.parse("2020-08-16T00:06:00")),
+                        // Keep the timestamp in the records are in the ascending order.
+                        // It will keep the records in the kafka partition are in the order.
+                        // It has the same effects by adjusting the watermark strategy.
+                        changelogRow(
+                                "+U",
+                                103L,
+                                "Richard",
+                                "London",
+                                LocalDateTime.parse("2020-08-16T01:01:05")),
                         changelogRow(
                                 "+U",
                                 101L,
@@ -517,20 +532,8 @@ public class UpsertKafkaTableITCase extends KafkaTestBaseWithFlink {
                                 "+U",
                                 104L,
                                 "Tomato",
-                                "Hongkong",
-                                LocalDateTime.parse("2020-08-16T00:05:05")),
-                        changelogRow(
-                                "+U",
-                                104L,
-                                "Tomato",
                                 "Shenzhen",
                                 LocalDateTime.parse("2020-08-16T01:05:05")),
-                        changelogRow(
-                                "+U",
-                                105L,
-                                "Tim",
-                                "Shenzhen",
-                                LocalDateTime.parse("2020-08-16T00:06:00")),
                         changelogRow(
                                 "+U",
                                 105L,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The reason why the test fails is the records in the same partition are out-of-order. I print the partition-id and offset in the partition.* 

```
partition-0
<102,Greg,Berlin,BERLIN,2020-08-15T00:00:03,0,0>
<103,Richard,Berlin,BERLIN,2020-08-16T00:01:05,0,1>
<103,Richard,London,LONDON,2020-08-16T01:01:05,0,2>
<105,Tim,Shenzhen,SHENZHEN,2020-08-16T00:06,0,3>
<105,Tim,Hongkong,HONGKONG,2020-08-16T01:06,0,4>

partition-1
<100,Bob,Beijing,BEIJING,2020-08-15T00:00:01,1,0>
<101,Alice,Shanghai,SHANGHAI,2020-08-15T00:00:02,1,1>
<101,Alice,Wuhan,WUHAN,2020-08-16T00:02,1,2>
<101,Alice,Hangzhou,HANGZHOU,2020-08-16T01:04:05,1,3>
<104,Tomato,Hongkong,HONGKONG,2020-08-16T00:05:05,1,4>
<104,Tomato,Shenzhen,SHENZHEN,2020-08-16T01:05:05,1,5>
```

In the test, the expected record is `<10004,104,2020-08-16T00:05:06,Tomato,HONGKONG,2020-08-16T00:05:05>
` but the actual record is `<10004,104,2020-08-16T00:05:06,null,null,null>`. 

It may be the left stream record `<10004,104,2020-08-16T00:05:06>` arrives before the record `<104,Tomato,Hongkong,HONGKONG,2020-08-16T00:05:05,1,4>
` in the right stream. When the left stream arrives, it finds the watermark is at timestamp `2020-08-16T01:04:05` in the right stream, which means the records before `2020-08-16T01:04:05` have arrived and emits itself.

Therefore, we should adjust the order in the partition or watermark strategy. Here we just adjust order for convenience. The new order in the partition follows.

```
<102,Greg,Berlin,BERLIN,2020-08-15T00:00:03,0,0>
<103,Richard,Berlin,BERLIN,2020-08-16T00:01:05,0,1>
<105,Tim,Shenzhen,SHENZHEN,2020-08-16T00:06,0,2>
<103,Richard,London,LONDON,2020-08-16T01:01:05,0,3>
<105,Tim,Hongkong,HONGKONG,2020-08-16T01:06,0,4>

<100,Bob,Beijing,BEIJING,2020-08-15T00:00:01,1,0>
<101,Alice,Shanghai,SHANGHAI,2020-08-15T00:00:02,1,1>
<101,Alice,Wuhan,WUHAN,2020-08-16T00:02,1,2>
<104,Tomato,Hongkong,HONGKONG,2020-08-16T00:05:05,1,3>
<101,Alice,Hangzhou,HANGZHOU,2020-08-16T01:04:05,1,4>
<104,Tomato,Shenzhen,SHENZHEN,2020-08-16T01:05:05,1,5>
```


## Brief change log

  - *Reorder the records in the partition*

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
