### PR TITLE
[FLINK-21054][table-runtime-blink] Implement mini-batch optimized slicing window aggregate operator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -218,7 +218,7 @@ public class MemoryManager {
         Preconditions.checkState(!isShutDown, "Memory manager has been shut down.");
         Preconditions.checkArgument(
                 numberOfPages <= totalNumberOfPages,
-                "Cannot allocate more segments %d than the max number %d",
+                "Cannot allocate more segments %s than the max number %s",
                 numberOfPages,
                 totalNumberOfPages);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -118,7 +118,7 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
     @Override
     public CheckpointStorageLocation initializeLocationForCheckpoint(long checkpointId)
             throws IOException {
-        checkArgument(checkpointId >= 0, "Illegal negative checkpoint id: %d.", checkpointId);
+        checkArgument(checkpointId >= 0, "Illegal negative checkpoint id: %s.", checkpointId);
         checkArgument(
                 baseLocationsInitialized, "The base checkpoint location has not been initialized.");
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -255,6 +255,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
         this.config.setStateBackendUsesManagedMemory(true);
         this.config.setManagedMemoryFractionOperatorOfUseCase(
                 ManagedMemoryUseCase.STATE_BACKEND, 1.0);
+        this.config.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.OPERATOR, 1.0);
         this.executionConfig = env.getExecutionConfig();
         this.checkpointLock = new Object();
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/StateConfigUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/StateConfigUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link StateConfigUtil}. */
+public class StateConfigUtilTest {
+
+    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testRocksDBWithHeapTimer() throws Exception {
+        File tempDir = tempFolder.newFolder().getAbsoluteFile();
+        Configuration conf = new Configuration();
+        conf.setString("state.backend", "rocksdb");
+        conf.setString("state.backend.rocksdb.timer-service.factory", "HEAP");
+        conf.setString("state.checkpoints.dir", "file://" + tempDir.toString());
+        assertIsStateImmutable(false, conf);
+    }
+
+    @Test
+    public void testRocksDBWithDefaultTimer() throws Exception {
+        File tempDir = tempFolder.newFolder().getAbsoluteFile();
+        Configuration conf = new Configuration();
+        conf.setString("state.backend", "rocksdb");
+        conf.setString("state.checkpoints.dir", "file://" + tempDir.toString());
+        assertIsStateImmutable(true, conf);
+    }
+
+    @Test
+    public void testHeapState() throws Exception {
+        Configuration conf = new Configuration();
+        assertIsStateImmutable(false, conf);
+    }
+
+    private void assertIsStateImmutable(boolean result, Configuration conf) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
+        env.setParallelism(1);
+        env.fromElements("a", "b", "c")
+                .keyBy(s -> s)
+                .transform(
+                        "testing",
+                        BasicTypeInfo.BOOLEAN_TYPE_INFO,
+                        new TestingStateBackendOperator())
+                .addSink(new VerifyingSink());
+        env.execute();
+        assertEquals(Arrays.asList(result, result, result), VerifyingSink.RESULT);
+    }
+
+    @After
+    public void before() {
+        VerifyingSink.RESULT.clear();
+    }
+
+    private static final class TestingStateBackendOperator extends AbstractStreamOperator<Boolean>
+            implements OneInputStreamOperator<String, Boolean> {
+
+        private static final long serialVersionUID = 6355892847620434528L;
+
+        private transient Boolean result = null;
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            this.result = StateConfigUtil.isStateImmutableInStateBackend(getKeyedStateBackend());
+        }
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {
+            if (result != null) {
+                output.collect(new StreamRecord<>(result));
+            }
+        }
+    }
+
+    private static final class VerifyingSink implements SinkFunction<Boolean> {
+        private static final long serialVersionUID = 4572915858888093394L;
+
+        private static final List<Boolean> RESULT = new ArrayList<>();
+
+        @Override
+        public void invoke(Boolean value, Context context) throws Exception {
+            synchronized (RESULT) {
+                RESULT.add(value);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/StateConfigUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/StateConfigUtilTest.java
@@ -91,7 +91,7 @@ public class StateConfigUtilTest {
     private static final class TestingStateBackendOperator extends AbstractStreamOperator<Boolean>
             implements OneInputStreamOperator<String, Boolean> {
 
-        private static final long serialVersionUID = 6355892847620434528L;
+        private static final long serialVersionUID = 1L;
 
         private transient Boolean result = null;
 
@@ -110,7 +110,7 @@ public class StateConfigUtilTest {
     }
 
     private static final class VerifyingSink implements SinkFunction<Boolean> {
-        private static final long serialVersionUID = 4572915858888093394L;
+        private static final long serialVersionUID = 1L;
 
         private static final List<Boolean> RESULT = new ArrayList<>();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupAggFunction.java
@@ -37,7 +37,7 @@ import org.apache.flink.util.Collector;
 
 import static org.apache.flink.table.data.util.RowDataUtil.isAccumulateMsg;
 import static org.apache.flink.table.data.util.RowDataUtil.isRetractMsg;
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /** Aggregate Function used for the groupby (without window) aggregate. */
 public class GroupAggFunction extends KeyedProcessFunction<RowData, RowData, RowData> {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupTableAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/GroupTableAggFunction.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Collector;
 
 import static org.apache.flink.table.data.util.RowDataUtil.isAccumulateMsg;
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /** Aggregate Function used for the groupby (without window) table aggregate. */
 public class GroupTableAggFunction extends KeyedProcessFunction<RowData, RowData, RowData> {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGlobalGroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGlobalGroupAggFunction.java
@@ -39,7 +39,7 @@ import javax.annotation.Nullable;
 
 import java.util.Map;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /** Aggregate Function used for the global groupby (without window) aggregate in miniBatch mode. */
 public class MiniBatchGlobalGroupAggFunction

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGroupAggFunction.java
@@ -47,7 +47,7 @@ import java.util.Map;
 
 import static org.apache.flink.table.data.util.RowDataUtil.isAccumulateMsg;
 import static org.apache.flink.table.data.util.RowDataUtil.isRetractMsg;
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /**
  * Aggregate Function used for the groupby (without window) aggregate in miniBatch mode.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchIncrementalGroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchIncrementalGroupAggFunction.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /**
  * Aggregate Function used for the incremental groupby (without window) aggregate in miniBatch mode.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.CombineRecordsFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
+import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceUnsharedWindowAggProcessor;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners.HoppingSliceAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link SlicingWindowAggOperatorBuilder} is used to build a {@link SlicingWindowOperator} for
+ * window aggregate.
+ *
+ * <pre>
+ * SlicingWindowAggOperatorBuilder.builder()
+ *   .inputType(inputType)
+ *   .keyTypes(keyFieldTypes)
+ *   .assigner(SliceAssigners.tumbling(rowtimeIndex, Duration.ofSeconds(5)))
+ *   .aggregate(genAggsFunction), accTypes)
+ *   .build();
+ * </pre>
+ */
+public class SlicingWindowAggOperatorBuilder {
+
+    public static SlicingWindowAggOperatorBuilder builder() {
+        return new SlicingWindowAggOperatorBuilder();
+    }
+
+    private SliceAssigner assigner;
+    private RowType inputType;
+    private LogicalType[] keyTypes;
+    private LogicalType[] accumulatorTypes;
+    private GeneratedNamespaceAggsHandleFunction<Long> generatedAggregateFunction;
+    private int indexOfCountStart = -1;
+
+    public SlicingWindowAggOperatorBuilder inputType(RowType rowType) {
+        this.inputType = rowType;
+        return this;
+    }
+
+    public SlicingWindowAggOperatorBuilder keyTypes(LogicalType[] keyTypes) {
+        this.keyTypes = keyTypes;
+        return this;
+    }
+
+    public SlicingWindowAggOperatorBuilder assigner(SliceAssigner assigner) {
+        this.assigner = assigner;
+        return this;
+    }
+
+    public SlicingWindowAggOperatorBuilder aggregate(
+            GeneratedNamespaceAggsHandleFunction<Long> generatedAggregateFunction,
+            LogicalType[] accumulatorTypes) {
+        this.generatedAggregateFunction = generatedAggregateFunction;
+        this.accumulatorTypes = accumulatorTypes;
+        return this;
+    }
+
+    /**
+     * Specify the index position of the COUNT(*) value in the accumulator buffer. This is only
+     * required for Hopping windows which uses this to determine whether the window is empty and
+     * then decide whether to register timer for the next window.
+     *
+     * @see HoppingSliceAssigner#nextTriggerWindow(long, Supplier)
+     */
+    public SlicingWindowAggOperatorBuilder countStarIndex(int indexOfCountStart) {
+        this.indexOfCountStart = indexOfCountStart;
+        return this;
+    }
+
+    public SlicingWindowOperator<RowData, ?> build() {
+        checkNotNull(assigner);
+        checkNotNull(inputType);
+        checkNotNull(keyTypes);
+        checkNotNull(accumulatorTypes);
+        checkNotNull(generatedAggregateFunction);
+        final WindowBuffer.Factory bufferFactory =
+                new RecordsWindowBuffer.Factory(keyTypes, inputType);
+        final WindowCombineFunction.Factory combinerFactory =
+                new CombineRecordsFunction.Factory(generatedAggregateFunction);
+        final SlicingWindowProcessor<Long> windowProcessor;
+        if (assigner instanceof SliceSharedAssigner) {
+            windowProcessor =
+                    new SliceSharedWindowAggProcessor(
+                            generatedAggregateFunction,
+                            bufferFactory,
+                            combinerFactory,
+                            (SliceSharedAssigner) assigner,
+                            accumulatorTypes,
+                            indexOfCountStart);
+        } else if (assigner instanceof SliceUnsharedAssigner) {
+            windowProcessor =
+                    new SliceUnsharedWindowAggProcessor(
+                            generatedAggregateFunction,
+                            bufferFactory,
+                            combinerFactory,
+                            (SliceUnsharedAssigner) assigner,
+                            accumulatorTypes);
+        } else {
+            throw new IllegalArgumentException(
+                    "assigner must be instance of SliceUnsharedAssigner or SliceSharedAssigner.");
+        }
+        return new SlicingWindowOperator<>(windowProcessor);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -68,7 +68,9 @@ public final class RecordsWindowBuffer implements WindowBuffer {
 
     @Override
     public void addElement(BinaryRowData key, long sliceEnd, RowData element) throws Exception {
-        // track the lowest trigger time, if watermark exceeds the trigger time, it means there
+        // track the lowest trigger time, if watermark exceeds the trigger time,
+        // it means there are some elements in the buffer belong to a window going to be fired,
+        // and we need to flush the buffer into state for firing.
         minTriggerTime = Math.min(sliceEnd - 1, minTriggerTime);
 
         reuseWindowKey.replace(sliceEnd, key);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
+
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
+import org.apache.flink.table.runtime.util.KeyValueIterator;
+import org.apache.flink.table.runtime.util.WindowKey;
+import org.apache.flink.table.runtime.util.collections.binary.BytesMap.LookupInfo;
+import org.apache.flink.table.runtime.util.collections.binary.WindowBytesMultiMap;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.io.EOFException;
+import java.util.Iterator;
+
+/**
+ * An implementation of {@link WindowBuffer} that buffers input elements in a {@link
+ * WindowBytesMultiMap} and combines buffered elements into state when flushing.
+ */
+public final class RecordsWindowBuffer implements WindowBuffer {
+
+    private final WindowCombineFunction combineFunction;
+    private final WindowBytesMultiMap recordsBuffer;
+    private final WindowKey reuseWindowKey;
+    private final RowDataSerializer recordSerializer;
+
+    private long minTriggerTime = Long.MAX_VALUE;
+
+    public RecordsWindowBuffer(
+            Object operatorOwner,
+            MemoryManager memoryManager,
+            long memorySize,
+            WindowCombineFunction combineFunction,
+            LogicalType[] keyTypes,
+            RowType inputType) {
+        this.combineFunction = combineFunction;
+        LogicalType[] inputFieldTypes =
+                inputType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .toArray(LogicalType[]::new);
+        this.recordsBuffer =
+                new WindowBytesMultiMap(
+                        operatorOwner, memoryManager, memorySize, keyTypes, inputFieldTypes);
+        this.recordSerializer = new RowDataSerializer(inputFieldTypes);
+        this.reuseWindowKey = new WindowKeySerializer(keyTypes.length).createInstance();
+    }
+
+    @Override
+    public void addElement(BinaryRowData key, long sliceEnd, RowData element) throws Exception {
+        // track the lowest trigger time, if watermark exceeds the trigger time, it means there
+        minTriggerTime = Math.min(sliceEnd - 1, minTriggerTime);
+
+        reuseWindowKey.replace(sliceEnd, key);
+        LookupInfo<WindowKey, Iterator<RowData>> lookup = recordsBuffer.lookup(reuseWindowKey);
+        try {
+            recordsBuffer.append(lookup, recordSerializer.toBinaryRow(element));
+        } catch (EOFException e) {
+            // buffer is full, flush it to state
+            flush();
+            // remember to add the input element again
+            addElement(key, sliceEnd, element);
+        }
+    }
+
+    @Override
+    public void advanceProgress(long progress) throws Exception {
+        if (progress >= minTriggerTime) {
+            // there should be some window to be fired, flush buffer to state first
+            flush();
+        }
+    }
+
+    @Override
+    public void flush() throws Exception {
+        if (recordsBuffer.getNumKeys() > 0) {
+            KeyValueIterator<WindowKey, Iterator<RowData>> entryIterator =
+                    recordsBuffer.getEntryIterator();
+            while (entryIterator.advanceNext()) {
+                combineFunction.combine(entryIterator.getKey(), entryIterator.getValue());
+            }
+            recordsBuffer.reset();
+            // reset trigger time
+            minTriggerTime = Long.MAX_VALUE;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        recordsBuffer.free();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Factory
+    // ------------------------------------------------------------------------------------------
+
+    public static final class Factory implements WindowBuffer.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        private final LogicalType[] keyTypes;
+        private final RowType inputType;
+
+        public Factory(LogicalType[] keyTypes, RowType inputType) {
+            this.keyTypes = keyTypes;
+            this.inputType = inputType;
+        }
+
+        @Override
+        public WindowBuffer create(
+                Object operatorOwner,
+                MemoryManager memoryManager,
+                long memorySize,
+                WindowCombineFunction combineFunction) {
+            return new RecordsWindowBuffer(
+                    operatorOwner, memoryManager, memorySize, combineFunction, keyTypes, inputType);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -114,6 +114,7 @@ public final class RecordsWindowBuffer implements WindowBuffer {
     // Factory
     // ------------------------------------------------------------------------------------------
 
+    /** Factory to create {@link RecordsWindowBuffer}. */
     public static final class Factory implements WindowBuffer.Factory {
 
         private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * A buffer that buffers data in memory and flushes many values to state together at a time to avoid
+ * frequently accessing state.
+ */
+@Internal
+public interface WindowBuffer {
+
+    /**
+     * Adds an element with associated key into the buffer. The buffer may temporarily buffer the
+     * element, or immediately write it to the stream.
+     *
+     * <p>It may be that adding this element fills up an internal buffer and causes the buffer
+     * flushing of a batch of internally buffered elements.
+     *
+     * @param key the key associated with the element
+     * @param element The element to add.
+     * @throws Exception Thrown, if the element cannot be added to the buffer, or if the flushing
+     *     throws an exception.
+     */
+    void addElement(BinaryRowData key, long window, RowData element) throws Exception;
+
+    /**
+     * Advances the progress time, the progress time is watermark if working in event-time mode, or
+     * current processing time if working in processing-time mode.
+     *
+     * <p>This will potentially flush buffered data into states, because the watermark advancement
+     * may be in a very small step, but we don't need to flush buffered data for every watermark
+     * advancement.
+     *
+     * @param progress the current progress time
+     */
+    void advanceProgress(long progress) throws Exception;
+
+    /**
+     * Flushes all intermediate buffered data to the underlying backend or output stream.
+     *
+     * @throws Exception Thrown if the buffer cannot be flushed, or if the output stream throws an
+     *     exception.
+     */
+    void flush() throws Exception;
+
+    /** Release resources allocated by this buffer. */
+    void close() throws Exception;
+
+    // ------------------------------------------------------------------------
+
+    /** A factory that creates a {@link WindowBuffer}. */
+    @FunctionalInterface
+    interface Factory extends Serializable {
+
+        /**
+         * Creates a {@link WindowBuffer} that buffers elements in memory before flushing.
+         *
+         * @param operatorOwner the owner of the operator
+         * @param memoryManager the manager that governs memory by Flink framework
+         * @param memorySize the managed memory size can be used by this operator
+         * @param combineFunction the combine function used to combine buffered data into state
+         * @throws IOException thrown if the buffer can't be opened
+         */
+        WindowBuffer create(
+                Object operatorOwner,
+                MemoryManager memoryManager,
+                long memorySize,
+                WindowCombineFunction combineFunction)
+                throws IOException;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
@@ -114,9 +114,9 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
         // step 5: register timer for current window
         if (isEventTime) {
             timerService.registerEventTimeTimer(window, window - 1);
-        } else {
-            timerService.registerProcessingTimeTimer(window, window - 1);
         }
+        // we don't need register processing-time timer, because we already register them
+        // per-record in AbstractWindowAggProcessor.processElement()
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.combines;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.dataview.PerWindowStateDataViewStore;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.window.state.StateKeyContext;
+import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
+import org.apache.flink.table.runtime.util.WindowKey;
+
+import java.util.Iterator;
+
+import static org.apache.flink.table.data.util.RowDataUtil.isAccumulateMsg;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.isStateImmutableInStateBackend;
+
+/**
+ * An implementation of {@link WindowCombineFunction} that accumulates input records into the window
+ * accumulator state.
+ */
+public final class CombineRecordsFunction implements WindowCombineFunction {
+
+    /** The service to register event-time or processing-time timers. */
+    private final InternalTimerService<Long> timerService;
+
+    /** Context to switch current key for states. */
+    private final StateKeyContext keyContext;
+
+    /** The state stores window accumulators. */
+    private final WindowValueState<Long> accState;
+
+    /** Function used to handle all aggregates. */
+    private final NamespaceAggsHandleFunction<Long> aggregator;
+
+    /** Whether to copy input key, because key is reused. */
+    private final boolean requiresCopyKey;
+
+    /** Whether the operator works in event-time mode, used to indicate registering which timer. */
+    private final boolean isEventTime;
+
+    public CombineRecordsFunction(
+            InternalTimerService<Long> timerService,
+            StateKeyContext keyContext,
+            WindowValueState<Long> accState,
+            NamespaceAggsHandleFunction<Long> aggregator,
+            boolean requiresCopyKey,
+            boolean isEventTime) {
+        this.timerService = timerService;
+        this.keyContext = keyContext;
+        this.accState = accState;
+        this.aggregator = aggregator;
+        this.requiresCopyKey = requiresCopyKey;
+        this.isEventTime = isEventTime;
+    }
+
+    @Override
+    public void combine(WindowKey windowKey, Iterator<RowData> records) throws Exception {
+        // step 0: set current key for states and timers
+        final BinaryRowData key;
+        if (requiresCopyKey) {
+            // the incoming key is reused, we should copy it if state backend doesn't copy it
+            key = windowKey.getKey().copy();
+        } else {
+            key = windowKey.getKey();
+        }
+        keyContext.setCurrentKey(key);
+
+        // step 1: get the accumulator for the current key and window
+        Long window = windowKey.getWindow();
+        RowData acc = accState.value(window);
+        if (acc == null) {
+            acc = aggregator.createAccumulators();
+        }
+
+        // step 2: set accumulator to function
+        aggregator.setAccumulators(window, acc);
+
+        // step 3: do accumulate
+        while (records.hasNext()) {
+            RowData record = records.next();
+            if (isAccumulateMsg(record)) {
+                aggregator.accumulate(record);
+            } else {
+                aggregator.retract(record);
+            }
+        }
+
+        // step 4: update accumulator into state
+        acc = aggregator.getAccumulators();
+        accState.update(window, acc);
+
+        // step 5: register timer for current window
+        if (isEventTime) {
+            timerService.registerEventTimeTimer(window, window - 1);
+        } else {
+            timerService.registerProcessingTimeTimer(window, window - 1);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        aggregator.close();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Factory
+    // ----------------------------------------------------------------------------------------
+
+    public static final class Factory implements WindowCombineFunction.Factory {
+
+        private static final long serialVersionUID = 1L;
+
+        private final GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler;
+
+        public Factory(GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler) {
+            this.genAggsHandler = genAggsHandler;
+        }
+
+        @Override
+        public WindowCombineFunction create(
+                RuntimeContext runtimeContext,
+                InternalTimerService<Long> timerService,
+                KeyedStateBackend<RowData> stateBackend,
+                WindowValueState<Long> windowState,
+                boolean isEventTime)
+                throws Exception {
+            final NamespaceAggsHandleFunction<Long> aggregator =
+                    genAggsHandler.newInstance(runtimeContext.getUserCodeClassLoader());
+            aggregator.open(
+                    new PerWindowStateDataViewStore(
+                            stateBackend, LongSerializer.INSTANCE, runtimeContext));
+            boolean requiresCopyKey = !isStateImmutableInStateBackend(stateBackend);
+            return new CombineRecordsFunction(
+                    timerService,
+                    stateBackend::setCurrentKey,
+                    windowState,
+                    aggregator,
+                    requiresCopyKey,
+                    isEventTime);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
@@ -128,6 +128,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     // Factory
     // ----------------------------------------------------------------------------------------
 
+    /** Factory to create {@link CombineRecordsFunction}. */
     public static final class Factory implements WindowCombineFunction.Factory {
 
         private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/WindowCombineFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/WindowCombineFunction.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.combines;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
+import org.apache.flink.table.runtime.util.WindowKey;
+
+import java.io.Serializable;
+import java.util.Iterator;
+
+/** The {@link WindowCombineFunction} is used to combine buffered data into state. */
+@Internal
+public interface WindowCombineFunction {
+
+    /**
+     * Combines the buffered data into state based on the given window-key pair.
+     *
+     * @param windowKey the window-key pair that the buffered data belong to, the window-key object
+     *     is reused.
+     * @param value the buffered data, the iterator and {@link RowData} objects are reused
+     */
+    void combine(WindowKey windowKey, Iterator<RowData> value) throws Exception;
+
+    /** Release resources allocated by this combine function. */
+    void close() throws Exception;
+
+    // ------------------------------------------------------------------------
+
+    /** A factory that creates a {@link WindowCombineFunction}. */
+    @FunctionalInterface
+    interface Factory extends Serializable {
+
+        /**
+         * Creates a {@link WindowCombineFunction} that can combine buffered data into states.
+         *
+         * @param runtimeContext the current {@link RuntimeContext}
+         * @param timerService the service to register event-time and processing-time timers
+         * @param stateBackend the state backend to accessing states
+         * @param windowState the window state to flush buffered data into.
+         * @param isEventTime indicates whether the operator works in event-time or processing-time
+         *     mode, used for register corresponding timers.
+         */
+        WindowCombineFunction create(
+                RuntimeContext runtimeContext,
+                InternalTimerService<Long> timerService,
+                KeyedStateBackend<RowData> stateBackend,
+                WindowValueState<Long> windowState,
+                boolean isEventTime)
+                throws Exception;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.processors;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.table.runtime.dataview.PerWindowStateDataViewStore;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.ClockService;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
+import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.LogicalType;
+
+/** A base implementation of {@link SlicingWindowProcessor} for window aggregate. */
+public abstract class AbstractWindowAggProcessor implements SlicingWindowProcessor<Long> {
+    private static final long serialVersionUID = 1L;
+
+    protected final GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler;
+    protected final WindowBuffer.Factory windowBufferFactory;
+    protected final WindowCombineFunction.Factory combineFactory;
+    protected final SliceAssigner sliceAssigner;
+    protected final LogicalType[] accumulatorTypes;
+    protected final boolean isEventTime;
+
+    // ----------------------------------------------------------------------------------------
+
+    protected transient long currentProgress;
+
+    protected transient Context<Long> ctx;
+
+    protected transient ClockService clockService;
+
+    protected transient InternalTimerService<Long> timerService;
+
+    protected transient NamespaceAggsHandleFunction<Long> aggregator;
+
+    protected transient WindowBuffer windowBuffer;
+
+    /** state schema: [key, window_end, accumulator]. */
+    protected transient WindowValueState<Long> windowState;
+
+    protected transient JoinedRowData reuseOutput;
+
+    public AbstractWindowAggProcessor(
+            GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler,
+            WindowBuffer.Factory bufferFactory,
+            WindowCombineFunction.Factory combinerFactory,
+            SliceAssigner sliceAssigner,
+            LogicalType[] accumulatorTypes) {
+        this.genAggsHandler = genAggsHandler;
+        this.windowBufferFactory = bufferFactory;
+        this.combineFactory = combinerFactory;
+        this.sliceAssigner = sliceAssigner;
+        this.accumulatorTypes = accumulatorTypes;
+        this.isEventTime = sliceAssigner.isEventTime();
+    }
+
+    @Override
+    public void open(Context<Long> context) throws Exception {
+        this.ctx = context;
+        final LongSerializer namespaceSerializer = LongSerializer.INSTANCE;
+        ValueState<RowData> state =
+                ctx.getKeyedStateBackend()
+                        .getOrCreateKeyedState(
+                                namespaceSerializer,
+                                new ValueStateDescriptor<>(
+                                        "window-aggs", new RowDataSerializer(accumulatorTypes)));
+        this.windowState =
+                new WindowValueState<>((InternalValueState<RowData, Long, RowData>) state);
+        this.clockService = ClockService.of(ctx.getTimerService());
+        this.timerService = ctx.getTimerService();
+        this.aggregator =
+                genAggsHandler.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+        this.aggregator.open(
+                new PerWindowStateDataViewStore(
+                        ctx.getKeyedStateBackend(), namespaceSerializer, ctx.getRuntimeContext()));
+        final WindowCombineFunction combineFunction =
+                combineFactory.create(
+                        ctx.getRuntimeContext(),
+                        ctx.getTimerService(),
+                        ctx.getKeyedStateBackend(),
+                        windowState,
+                        isEventTime);
+        this.windowBuffer =
+                windowBufferFactory.create(
+                        ctx.getOperatorOwner(),
+                        ctx.getMemoryManager(),
+                        ctx.getMemorySize(),
+                        combineFunction);
+
+        this.reuseOutput = new JoinedRowData();
+        this.currentProgress = Long.MIN_VALUE;
+    }
+
+    @Override
+    public boolean processElement(BinaryRowData key, RowData element) throws Exception {
+        long sliceEnd = sliceAssigner.assignSliceEnd(element, clockService);
+        if (!isEventTime) {
+            // always register processing time for every element when processing time mode
+            timerService.registerProcessingTimeTimer(sliceEnd, sliceEnd - 1);
+        }
+        if (isEventTime && sliceEnd - 1 <= currentProgress) {
+            // element is late and should be dropped
+            return true;
+        }
+        windowBuffer.addElement(key, sliceEnd, element);
+        return false;
+    }
+
+    @Override
+    public void advanceProgress(long progress) throws Exception {
+        if (progress > currentProgress) {
+            currentProgress = progress;
+            windowBuffer.advanceProgress(currentProgress);
+        }
+    }
+
+    @Override
+    public void prepareCheckpoint() throws Exception {
+        windowBuffer.flush();
+    }
+
+    @Override
+    public void clearWindow(Long windowEnd) throws Exception {
+        Iterable<Long> expires = sliceAssigner.expiredSlices(windowEnd);
+        for (Long slice : expires) {
+            windowState.clear(slice);
+            aggregator.cleanup(slice);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (aggregator != null) {
+            aggregator.close();
+        }
+        if (windowBuffer != null) {
+            windowBuffer.close();
+        }
+    }
+
+    @Override
+    public TypeSerializer<Long> createWindowSerializer() {
+        return LongSerializer.INSTANCE;
+    }
+
+    protected void collect(RowData aggResult) {
+        reuseOutput.replace(ctx.getKeyedStateBackend().getCurrentKey(), aggResult);
+        ctx.output(reuseOutput);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.processors;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * An window aggregate processor implementation which works for {@link SliceSharedAssigner}, e.g.
+ * hopping windows and cumulative windows.
+ */
+public final class SliceSharedWindowAggProcessor extends AbstractWindowAggProcessor
+        implements SliceSharedAssigner.MergeCallback {
+    private static final long serialVersionUID = 1L;
+
+    private final SliceSharedAssigner sliceSharedAssigner;
+    private final WindowIsEmptySupplier emptySupplier;
+
+    public SliceSharedWindowAggProcessor(
+            GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler,
+            WindowBuffer.Factory bufferFactory,
+            WindowCombineFunction.Factory combinerFactory,
+            SliceSharedAssigner sliceAssigner,
+            LogicalType[] accumulatorTypes,
+            int indexOfCountStar) {
+        super(genAggsHandler, bufferFactory, combinerFactory, sliceAssigner, accumulatorTypes);
+        this.sliceSharedAssigner = sliceAssigner;
+        this.emptySupplier = new WindowIsEmptySupplier(indexOfCountStar, sliceAssigner);
+    }
+
+    @Override
+    public void fireWindow(Long windowEnd) throws Exception {
+        sliceSharedAssigner.mergeSlices(windowEnd, this);
+        // we have set accumulator in the merge() method
+        RowData aggResult = aggregator.getValue(windowEnd);
+        if (!isWindowEmpty()) {
+            // for hopping windows, the triggered window may be an empty window
+            // (see register next window below), for such window, we shouldn't emit it
+            collect(aggResult);
+        }
+
+        // we should register next window timer here,
+        // because slices are shared, maybe no elements arrived for the next slices
+        Optional<Long> nextWindowEndOptional =
+                sliceSharedAssigner.nextTriggerWindow(windowEnd, emptySupplier);
+        if (nextWindowEndOptional.isPresent()) {
+            long nextWindowEnd = nextWindowEndOptional.get();
+            if (sliceSharedAssigner.isEventTime()) {
+                timerService.registerEventTimeTimer(nextWindowEnd, nextWindowEnd - 1);
+            } else {
+                timerService.registerProcessingTimeTimer(nextWindowEnd, nextWindowEnd - 1);
+            }
+        }
+    }
+
+    @Override
+    public void merge(@Nullable Long mergeResult, Iterable<Long> toBeMerged) throws Exception {
+        // get base accumulator
+        final RowData acc;
+        if (mergeResult == null) {
+            // null means the merged is not on state, create a new acc
+            acc = aggregator.createAccumulators();
+        } else {
+            RowData stateAcc = windowState.value(mergeResult);
+            if (stateAcc == null) {
+                acc = aggregator.createAccumulators();
+            } else {
+                acc = stateAcc;
+            }
+        }
+        // set base accumulator
+        aggregator.setAccumulators(mergeResult, acc);
+
+        // merge slice accumulators
+        for (Long slice : toBeMerged) {
+            RowData sliceAcc = windowState.value(slice);
+            if (sliceAcc != null) {
+                aggregator.merge(slice, sliceAcc);
+            }
+        }
+
+        // set merged acc into state if the merged acc is on state
+        if (mergeResult != null) {
+            windowState.update(mergeResult, aggregator.getAccumulators());
+        }
+    }
+
+    private boolean isWindowEmpty() {
+        if (emptySupplier.indexOfCountStar < 0) {
+            // for non-hopping windows, the window is never empty
+            return false;
+        } else {
+            return emptySupplier.get();
+        }
+    }
+
+    private final class WindowIsEmptySupplier implements Supplier<Boolean> {
+
+        private final int indexOfCountStar;
+
+        private WindowIsEmptySupplier(int indexOfCountStar, SliceAssigner assigner) {
+            if (assigner instanceof SliceAssigners.HoppingSliceAssigner) {
+                checkArgument(
+                        indexOfCountStar >= 0,
+                        "Hopping window requires a COUNT(*) in the aggregate functions.");
+            }
+            this.indexOfCountStar = indexOfCountStar;
+        }
+
+        @Override
+        public Boolean get() {
+            if (indexOfCountStar < 0) {
+                return false;
+            }
+            try {
+                RowData acc = aggregator.getAccumulators();
+                return acc == null || acc.getLong(indexOfCountStar) == 0;
+            } catch (Exception e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window.processors;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssigner;
+import org.apache.flink.table.types.logical.LogicalType;
+
+/**
+ * An window aggregate processor implementation which works for {@link SliceUnsharedAssigner}, e.g.
+ * tumbling windows.
+ */
+public final class SliceUnsharedWindowAggProcessor extends AbstractWindowAggProcessor {
+    private static final long serialVersionUID = 1L;
+
+    public SliceUnsharedWindowAggProcessor(
+            GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler,
+            WindowBuffer.Factory windowBufferFactory,
+            WindowCombineFunction.Factory combineFactory,
+            SliceUnsharedAssigner sliceAssigner,
+            LogicalType[] accumulatorTypes) {
+        super(genAggsHandler, windowBufferFactory, combineFactory, sliceAssigner, accumulatorTypes);
+    }
+
+    @Override
+    public void fireWindow(Long windowEnd) throws Exception {
+        RowData acc = windowState.value(windowEnd);
+        if (acc == null) {
+            acc = aggregator.createAccumulators();
+        }
+        aggregator.setAccumulators(windowEnd, acc);
+        RowData aggResult = aggregator.getValue(windowEnd);
+        collect(aggResult);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionBase.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /**
  * Base class for deduplicate function.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateFunctionBase.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateFunctionBase.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.runtime.context.ExecutionContext;
 import org.apache.flink.table.runtime.operators.bundle.MapBundleFunction;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 
 /**
  * Base class for miniBatch deduplicate function.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utility to create a {@link JoinRecordStateView} depends on {@link JoinInputSideSpec}. */

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utility to create a {@link OuterJoinRecordStateViews} depends on {@link JoinInputSideSpec}. */

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/ClockService.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/ClockService.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+
+/**
+ * A clock service which can get current processing time. This can help to mock processing time in
+ * tests.
+ */
+@Internal
+public interface ClockService {
+
+    /** Returns the current processing time. */
+    long currentProcessingTime();
+
+    /** Creates a {@link ClockService} from the given {@link InternalTimerService}. */
+    static ClockService of(InternalTimerService<?> timerService) {
+        return timerService::currentProcessingTime;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigner.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+
+import java.io.Serializable;
+
+/**
+ * A {@link SliceAssigner} assigns element into a single slice. Note that we use the slice end
+ * timestamp to identify a slice.
+ *
+ * <p>Note: {@link SliceAssigner} servers as a base interface. Concrete assigners should implement
+ * interface {@link SliceSharedAssigner} or {@link SliceUnsharedAssigner}.
+ *
+ * @see SlicingWindowOperator for more definition of slice.
+ */
+@Internal
+public interface SliceAssigner extends Serializable {
+
+    /**
+     * Returns the end timestamp of a slice that the given element should belong.
+     *
+     * @param element the element to which slice should belong to.
+     * @param clock the service to get current processing time.
+     */
+    long assignSliceEnd(RowData element, ClockService clock);
+
+    /** Returns the corresponding window start timestamp of the given window end timestamp. */
+    long getWindowStart(long windowEnd);
+
+    /**
+     * Returns an iterator of slices to expire when the given window is emitted. The window and
+     * slices are both identified by the end timestamp.
+     *
+     * @param windowEnd the end timestamp of window emitted.
+     */
+    Iterable<Long> expiredSlices(long windowEnd);
+
+    /**
+     * Returns {@code true} if elements are assigned to windows based on event time, {@code false}
+     * based on processing time.
+     */
+    boolean isEventTime();
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -99,7 +99,7 @@ public final class SliceAssigners {
     // Slice Assigners
     // ------—------—------—------—------—------—------—------—------—------—------—------—------—
 
-    /** The {@link SliceAssigner} for tumbling windows */
+    /** The {@link SliceAssigner} for tumbling windows. */
     public static final class TumblingSliceAssigner extends AbstractSliceAssigner
             implements SliceUnsharedAssigner {
         private static final long serialVersionUID = 1L;
@@ -146,7 +146,7 @@ public final class SliceAssigners {
         }
     }
 
-    /** The {@link SliceAssigner} for hopping windows */
+    /** The {@link SliceAssigner} for hopping windows. */
     public static final class HoppingSliceAssigner extends AbstractSliceAssigner
             implements SliceSharedAssigner {
         private static final long serialVersionUID = 1L;
@@ -217,7 +217,7 @@ public final class SliceAssigners {
         }
     }
 
-    /** The {@link SliceAssigner} for cumulative windows */
+    /** The {@link SliceAssigner} for cumulative windows. */
     public static final class CumulativeSliceAssigner extends AbstractSliceAssigner
             implements SliceSharedAssigner {
         private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -174,7 +174,7 @@ public final class SliceAssigners {
             if (size % slide != 0) {
                 throw new IllegalArgumentException(
                         String.format(
-                                "Hopping Window requires size must be an integral multiple of slide, but got size %dms and slide %dms.",
+                                "Slicing Hopping Window requires size must be an integral multiple of slide, but got size %dms and slide %dms.",
                                 size, slide));
             }
             this.size = size;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -171,6 +171,12 @@ public final class SliceAssigners {
                                 "Hopping Window must satisfy slide > 0 and size > 0, but got slide %dms and size %dms.",
                                 slide, size));
             }
+            if (size % slide != 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Hopping Window requires size must be an integral multiple of slide, but got size %dms and slide %dms.",
+                                size, slide));
+            }
             this.size = size;
             this.slide = slide;
             this.offset = offset;
@@ -337,7 +343,7 @@ public final class SliceAssigners {
 
         @Override
         public long getWindowStart(long windowEnd) {
-            return windowEnd - windowSize;
+            return TimeWindow.getWindowStartWithOffset(windowEnd - 1, 0L, windowSize);
         }
 
         @Override
@@ -389,7 +395,6 @@ public final class SliceAssigners {
     // Private Utilities
     // ------------------------------------------------------------------------------------------
 
-    /** A lazy Iterable which transform {@code List<OuterReocord>} to {@code Iterable<RowData>}. */
     private static final class ReusableListIterable implements IterableIterator<Long> {
         private final List<Long> values = new ArrayList<>();
         private int index = 0;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -1,0 +1,467 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.window.TimeWindow;
+import org.apache.flink.util.IterableIterator;
+import org.apache.flink.util.MathUtils;
+
+import org.apache.commons.math3.util.ArithmeticUtils;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Utilities to create {@link SliceAssigner}s. */
+@Internal
+public final class SliceAssigners {
+
+    // ------—------—------—------—------—------—------—------—------—------—------—------—------—
+    // Utilities
+    // ------—------—------—------—------—------—------—------—------—------—------—------—------—
+
+    /**
+     * Creates a tumbling window {@link SliceAssigner} that assigns elements to slices of tumbling
+     * windows.
+     *
+     * @param rowtimeIndex the index of rowtime field in the input row, {@code -1} if based on
+     *     processing time.
+     * @param size the size of the generated windows.
+     */
+    public static TumblingSliceAssigner tumbling(int rowtimeIndex, Duration size) {
+        return new TumblingSliceAssigner(rowtimeIndex, size.toMillis(), 0);
+    }
+
+    /**
+     * Creates a hopping window {@link SliceAssigner} that assigns elements to slices of hopping
+     * windows.
+     *
+     * @param rowtimeIndex the index of rowtime field in the input row, {@code -1} if based on *
+     *     processing time.
+     * @param size the size of the generated windows.
+     * @param slide the slide interval of the generated windows.
+     */
+    public static HoppingSliceAssigner hopping(int rowtimeIndex, Duration size, Duration slide) {
+        return new HoppingSliceAssigner(rowtimeIndex, size.toMillis(), slide.toMillis(), 0);
+    }
+
+    /**
+     * Creates a cumulative window {@link SliceAssigner} that assigns elements to slices of
+     * cumulative windows.
+     *
+     * @param rowtimeIndex the index of rowtime field in the input row, {@code -1} if based on *
+     *     processing time.
+     * @param maxSize the max size of the generated windows.
+     * @param step the step interval of the generated windows.
+     */
+    public static CumulativeSliceAssigner cumulative(
+            int rowtimeIndex, Duration maxSize, Duration step) {
+        return new CumulativeSliceAssigner(rowtimeIndex, maxSize.toMillis(), step.toMillis(), 0);
+    }
+
+    /**
+     * Creates a {@link SliceAssigner} that assigns elements which has been attached window start
+     * and window end timestamp to slices. The assigned slice is equal to the given window.
+     *
+     * @param windowEndIndex the index of window end field in the input row, mustn't be a negative
+     *     value.
+     * @param windowSize the size of the generated window.
+     */
+    public static WindowedSliceAssigner windowed(int windowEndIndex, Duration windowSize) {
+        return new WindowedSliceAssigner(windowEndIndex, windowSize.toMillis());
+    }
+
+    // ------—------—------—------—------—------—------—------—------—------—------—------—------—
+    // Slice Assigners
+    // ------—------—------—------—------—------—------—------—------—------—------—------—------—
+
+    /** The {@link SliceAssigner} for tumbling windows */
+    public static final class TumblingSliceAssigner extends AbstractSliceAssigner
+            implements SliceUnsharedAssigner {
+        private static final long serialVersionUID = 1L;
+
+        /** Creates a new {@link TumblingSliceAssigner} with a new specified offset. */
+        public TumblingSliceAssigner withOffset(Duration offset) {
+            return new TumblingSliceAssigner(rowtimeIndex, size, offset.toMillis());
+        }
+
+        private final long size;
+        private final long offset;
+        private final ReusableListIterable reuseList = new ReusableListIterable();
+
+        private TumblingSliceAssigner(int rowtimeIndex, long size, long offset) {
+            super(rowtimeIndex);
+            checkArgument(
+                    size > 0,
+                    String.format(
+                            "Tumbling Window parameters must satisfy size > 0, but got size %dms.",
+                            size));
+            checkArgument(
+                    Math.abs(offset) < size,
+                    String.format(
+                            "Tumbling Window parameters must satisfy abs(offset) < size, bot got size %dms and offset %dms.",
+                            size, offset));
+            this.size = size;
+            this.offset = offset;
+        }
+
+        @Override
+        public long assignSliceEnd(long timestamp) {
+            long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, size);
+            return start + size;
+        }
+
+        public long getWindowStart(long windowEnd) {
+            return windowEnd - size;
+        }
+
+        @Override
+        public Iterable<Long> expiredSlices(long windowEnd) {
+            reuseList.reset(windowEnd);
+            return reuseList;
+        }
+    }
+
+    /** The {@link SliceAssigner} for hopping windows */
+    public static final class HoppingSliceAssigner extends AbstractSliceAssigner
+            implements SliceSharedAssigner {
+        private static final long serialVersionUID = 1L;
+
+        /** Creates a new {@link HoppingSliceAssigner} with a new specified offset. */
+        public HoppingSliceAssigner withOffset(Duration offset) {
+            return new HoppingSliceAssigner(rowtimeIndex, size, slide, offset.toMillis());
+        }
+
+        private final long size;
+        private final long slide;
+        private final long offset;
+        private final long sliceSize;
+        private final int numSlicesPerWindow;
+        private final ReusableListIterable reuseList = new ReusableListIterable();
+
+        protected HoppingSliceAssigner(int rowtimeIndex, long size, long slide, long offset) {
+            super(rowtimeIndex);
+            if (size <= 0 || slide <= 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Hopping Window must satisfy slide > 0 and size > 0, but got slide %dms and size %dms.",
+                                slide, size));
+            }
+            this.size = size;
+            this.slide = slide;
+            this.offset = offset;
+            this.sliceSize = ArithmeticUtils.gcd(size, slide);
+            this.numSlicesPerWindow = MathUtils.checkedDownCast(size / sliceSize);
+        }
+
+        @Override
+        public long assignSliceEnd(long timestamp) {
+            long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, sliceSize);
+            return start + sliceSize;
+        }
+
+        @Override
+        public long getWindowStart(long windowEnd) {
+            return windowEnd - size;
+        }
+
+        @Override
+        public Iterable<Long> expiredSlices(long windowEnd) {
+            // we need to cleanup the first slice of the window
+            long windowStart = getWindowStart(windowEnd);
+            long firstSliceEnd = windowStart + sliceSize;
+            reuseList.reset(firstSliceEnd);
+            return reuseList;
+        }
+
+        @Override
+        public void mergeSlices(long sliceEnd, MergeCallback callback) throws Exception {
+            // the iterable to list all the slices of the triggered window
+            Iterable<Long> toBeMerged =
+                    new HoppingSlicesIterable(sliceEnd, sliceSize, numSlicesPerWindow);
+            // null namespace means use heap data views, instead of state state views
+            callback.merge(null, toBeMerged);
+        }
+
+        @Override
+        public Optional<Long> nextTriggerWindow(long windowEnd, Supplier<Boolean> isWindowEmpty) {
+            if (isWindowEmpty.get()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(windowEnd + sliceSize);
+            }
+        }
+    }
+
+    /** The {@link SliceAssigner} for cumulative windows */
+    public static final class CumulativeSliceAssigner extends AbstractSliceAssigner
+            implements SliceSharedAssigner {
+        private static final long serialVersionUID = 1L;
+
+        /** Creates a new {@link CumulativeSliceAssigner} with a new specified offset. */
+        public CumulativeSliceAssigner withOffset(Duration offset) {
+            return new CumulativeSliceAssigner(rowtimeIndex, maxSize, step, offset.toMillis());
+        }
+
+        private final long maxSize;
+        private final long step;
+        private final long offset;
+        private final ReusableListIterable reuseList = new ReusableListIterable();
+
+        protected CumulativeSliceAssigner(int rowtimeIndex, long maxSize, long step, long offset) {
+            super(rowtimeIndex);
+            if (maxSize <= 0 || step <= 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Cumulative Window parameters must satisfy maxSize > 0 and step > 0, but got maxSize %dms and step %dms.",
+                                maxSize, step));
+            }
+            if (maxSize % step != 0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Cumulative Window requires maxSize must be an integral multiple of step, but got maxSize %dms and step %dms.",
+                                maxSize, step));
+            }
+
+            this.maxSize = maxSize;
+            this.step = step;
+            this.offset = offset;
+        }
+
+        @Override
+        public long assignSliceEnd(long timestamp) {
+            long start = TimeWindow.getWindowStartWithOffset(timestamp, offset, step);
+            return start + step;
+        }
+
+        @Override
+        public long getWindowStart(long windowEnd) {
+            return TimeWindow.getWindowStartWithOffset(windowEnd - 1, offset, maxSize);
+        }
+
+        @Override
+        public Iterable<Long> expiredSlices(long windowEnd) {
+            long windowStart = getWindowStart(windowEnd);
+            long firstSliceEnd = windowStart + step;
+            long lastSliceEnd = windowStart + maxSize;
+            if (windowEnd == firstSliceEnd) {
+                // we reuse state in the first slice, skip cleanup for the first slice
+                return Collections.emptyList();
+            } else if (windowEnd == lastSliceEnd) {
+                // when this is the last slice,
+                // we need to cleanup the shared state which is the first slice
+                reuseList.reset(windowEnd, firstSliceEnd);
+            } else {
+                reuseList.reset(windowEnd);
+            }
+            return reuseList;
+        }
+
+        @Override
+        public void mergeSlices(long sliceEnd, MergeCallback callback) throws Exception {
+            long windowStart = getWindowStart(sliceEnd);
+            long firstSliceEnd = windowStart + step;
+            if (sliceEnd == firstSliceEnd) {
+                // if this is the first slice, there is nothing to merge
+                reuseList.clear();
+            } else {
+                // otherwise, merge the current slice state into the first slice state
+                reuseList.reset(sliceEnd);
+            }
+            callback.merge(firstSliceEnd, reuseList);
+        }
+
+        @Override
+        public Optional<Long> nextTriggerWindow(long windowEnd, Supplier<Boolean> isWindowEmpty) {
+            long nextWindowEnd = windowEnd + step;
+            long maxWindowEnd = getWindowStart(windowEnd) + maxSize;
+            if (nextWindowEnd > maxWindowEnd) {
+                return Optional.empty();
+            } else {
+                return Optional.of(nextWindowEnd);
+            }
+        }
+    }
+
+    /**
+     * The {@link SliceAssigner} for elements have been attached window start and end timestamps.
+     */
+    public static final class WindowedSliceAssigner implements SliceUnsharedAssigner {
+        private static final long serialVersionUID = 1L;
+
+        private final int windowEndIndex;
+        private final long windowSize;
+        private final ReusableListIterable reuseList = new ReusableListIterable();
+
+        public WindowedSliceAssigner(int windowEndIndex, long windowSize) {
+            checkArgument(
+                    windowEndIndex >= 0,
+                    "Windowed slice assigner must have a positive window end index.");
+            checkArgument(
+                    windowSize > 0,
+                    String.format(
+                            "Windowed Window parameters must satisfy size > 0, but got size %dms.",
+                            windowSize));
+            this.windowEndIndex = windowEndIndex;
+            this.windowSize = windowSize;
+        }
+
+        @Override
+        public long assignSliceEnd(RowData element, ClockService clock) {
+            return element.getLong(windowEndIndex);
+        }
+
+        @Override
+        public long getWindowStart(long windowEnd) {
+            return windowEnd - windowSize;
+        }
+
+        @Override
+        public Iterable<Long> expiredSlices(long windowEnd) {
+            reuseList.reset(windowEnd);
+            return reuseList;
+        }
+
+        @Override
+        public boolean isEventTime() {
+            // it always works in event-time mode if input row has been attached windows
+            return true;
+        }
+    }
+
+    /** A base implementation for {@link SliceAssigner}. */
+    private abstract static class AbstractSliceAssigner implements SliceAssigner {
+        private static final long serialVersionUID = 1L;
+
+        protected final int rowtimeIndex;
+        protected final boolean isEventTime;
+
+        protected AbstractSliceAssigner(int rowtimeIndex) {
+            this.rowtimeIndex = rowtimeIndex;
+            this.isEventTime = rowtimeIndex >= 0;
+        }
+
+        public abstract long assignSliceEnd(long timestamp);
+
+        @Override
+        public final long assignSliceEnd(RowData element, ClockService clock) {
+            final long timestamp;
+            if (rowtimeIndex >= 0) {
+                timestamp = element.getLong(rowtimeIndex);
+            } else {
+                // in processing time mode
+                timestamp = clock.currentProcessingTime();
+            }
+            return assignSliceEnd(timestamp);
+        }
+
+        @Override
+        public final boolean isEventTime() {
+            return isEventTime;
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Private Utilities
+    // ------------------------------------------------------------------------------------------
+
+    /** A lazy Iterable which transform {@code List<OuterReocord>} to {@code Iterable<RowData>}. */
+    private static final class ReusableListIterable implements IterableIterator<Long> {
+        private final List<Long> values = new ArrayList<>();
+        private int index = 0;
+
+        public void clear() {
+            values.clear();
+            index = 0;
+        }
+
+        public void reset(Long slice) {
+            values.clear();
+            values.add(slice);
+            index = 0;
+        }
+
+        public void reset(Long slice1, Long slice2) {
+            values.clear();
+            values.add(slice1);
+            values.add(slice2);
+            index = 0;
+        }
+
+        @Override
+        public Iterator<Long> iterator() {
+            index = 0;
+            return this;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index < values.size();
+        }
+
+        @Override
+        public Long next() {
+            Long value = values.get(index);
+            index++;
+            return value;
+        }
+    }
+
+    private static final class HoppingSlicesIterable implements IterableIterator<Long> {
+
+        private final long sliceSize;
+        private long lastSliceEnd;
+        private int numSlicesRemaining;
+
+        HoppingSlicesIterable(long lastSliceEnd, long sliceSize, int numSlicesPerWindow) {
+            this.lastSliceEnd = lastSliceEnd;
+            this.sliceSize = sliceSize;
+            this.numSlicesRemaining = numSlicesPerWindow;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return numSlicesRemaining > 0;
+        }
+
+        @Override
+        public Long next() {
+            long slice = lastSliceEnd;
+            numSlicesRemaining--;
+            lastSliceEnd -= sliceSize;
+            return slice;
+        }
+
+        @Override
+        public Iterator<Long> iterator() {
+            return this;
+        }
+    }
+
+    // avoid to initialize the util
+    private SliceAssigners() {}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceSharedAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceSharedAssigner.java
@@ -48,7 +48,7 @@ public interface SliceSharedAssigner extends SliceAssigner {
      * following window to trigger for now.
      *
      * <p>The purpose of this method is avoid register too many timers for each hopping and
-     * cumulative slice, e.g. HOP(1day, 10s) needs register 4300 timers for every slice. In order to
+     * cumulative slice, e.g. HOP(1day, 10s) needs register 8640 timers for every slice. In order to
      * improve this, we only register one timer for the next window. For hopping windows we don't
      * register next window if current window is empty (i.e. no records in current window). That
      * means we will have one more unnecessary window triggered for hopping windows if no elements

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceSharedAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceSharedAssigner.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A {@link SliceAssigner} which shares slices for windows, which means a window is divided into
+ * multiple slices and need to merge the slices into windows when emitting windows.
+ *
+ * <p>Classical window of {@link SliceSharedAssigner} is hopping window.
+ */
+@Internal
+public interface SliceSharedAssigner extends SliceAssigner {
+
+    /**
+     * Determines which slices (if any) should be merged.
+     *
+     * @param sliceEnd the triggered slice, identified by end timestamp
+     * @param callback a callback that can be invoked to signal which slices should be merged.
+     */
+    void mergeSlices(long sliceEnd, MergeCallback callback) throws Exception;
+
+    /**
+     * Returns the optional end timestamp of next window which should be triggered. Empty if no
+     * following window to trigger for now.
+     *
+     * <p>The purpose of this method is avoid register too many timers for each hopping and
+     * cumulative slice, e.g. HOP(1day, 10s) needs register 4300 timers for every slice. In order to
+     * improve this, we only register one timer for the next window. For hopping windows we don't
+     * register next window if current window is empty (i.e. no records in current window). That
+     * means we will have one more unnecessary window triggered for hopping windows if no elements
+     * arrives for a key for a long time. We will skip to emit window result for the triggered empty
+     * window, see {@link SliceSharedWindowAggProcessor#fireWindow(Long)}.
+     *
+     * @param windowEnd the current triggered window, identified by end timestamp
+     * @param isWindowEmpty a supplier that can be invoked to get whether the triggered window is
+     *     empty (i.e. no records in the window).
+     */
+    Optional<Long> nextTriggerWindow(long windowEnd, Supplier<Boolean> isWindowEmpty);
+
+    // ------------------------------------------------------------------------
+
+    /**
+     * Callback to be used in {@link #mergeSlices(long, MergeCallback)} for specifying which slices
+     * should be merged.
+     */
+    interface MergeCallback {
+
+        /**
+         * Specifies that states of the given slices should be merged into the result slice.
+         *
+         * @param mergeResult The resulting merged slice, {@code null} if it represents a non-state
+         *     namespace.
+         * @param toBeMerged The list of slices that should be merged into one slice.
+         */
+        void merge(@Nullable Long mergeResult, Iterable<Long> toBeMerged) throws Exception;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceUnsharedAssigner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceUnsharedAssigner.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A {@link SliceAssigner} which doesn't share slices for windows, which means a window is divided
+ * into only one slice and doesn't need to merge the slices when emitting windows.
+ *
+ * <p>Classical window of {@link SliceUnsharedAssigner} is tumbling window.
+ */
+@Internal
+public interface SliceUnsharedAssigner extends SliceAssigner {}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
@@ -223,10 +223,8 @@ public final class SlicingWindowOperator<K, W> extends TableStreamOperator<RowDa
             // we need to notify WindowProcessor first to flush buffer into state
             lastTriggeredProcessingTime = timestamp;
             windowProcessor.advanceProgress(timestamp);
-            // register timer again, because we need to skip current timer to avoid duplicate output
-            setCurrentKey(timer.getKey());
-            internalTimerService.registerProcessingTimeTimer(timer.getNamespace(), timestamp);
-            return;
+            // timers registered in advanceProgress() should always be smaller than current timer
+            // so, it should be safe to trigger current timer straightforwards.
         }
         onTimer(timer);
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.KeyContext;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.operators.TableStreamOperator;
+import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link SlicingWindowOperator} implements an optimized processing for aligned windows which
+ * can apply the slicing optimization. The core idea of slicing optimization is to divide all
+ * elements from a data stream into a finite number of non-overlapping chunks (a.k.a. slices).
+ *
+ * <p>
+ *
+ * <h3>Concept of Aligned Window and Unaligned Window</h3>
+ *
+ * <p>We divide windows into 2 categories: Aligned Windows and Unaligned Windows.
+ *
+ * <p>Aligned Windows are windows have predetermined window boundaries and windows can be divided
+ * into finite number of non-overlapping chunks. The boundary of an aligned window is determined
+ * independently from the time characteristic of the data stream, or messages it receives. For
+ * example, hopping (sliding) window is an aligned window as the window boundaries are predetermined
+ * based on the window size and slide. Aligned windows include tumbling, hopping, cumulative
+ * windows.
+ *
+ * <p>Unaligned Windows are windows determined dynamically based on elements. For example, session
+ * window is an unaligned window as the window boundaries are determined based on the messages
+ * timestamps and their correlations. Currently, unaligned windows include session window only.
+ *
+ * <p>Because aligned windows can be divided into finite number of non-overlapping chunks (a.k.a.
+ * slices), which can apply efficient processing to share intermediate results.
+ *
+ * <p>
+ *
+ * <h3>Concept of Slice</h3>
+ *
+ * <p>Dividing a window of aligned windows into a finite number of non-overlapping chunks, where the
+ * chunks are slices. It has the following properties:
+ *
+ * <ul>
+ *   <li>An element must only belong to a single slice.
+ *   <li>Slices are non-overlapping, i.e. S_i and S_j should not have any shared elements if i != j.
+ *   <li>A window is consist of a finite number of slices.
+ * </ul>
+ *
+ * <p>
+ *
+ * <h3>Abstraction of Slicing Window Operator</h3>
+ *
+ * A slicing window operator is a simple wrap of {@link SlicingWindowProcessor}. It delegates all
+ * the important methods to the underlying processor, where the processor can have different
+ * implementation for aggregate and topk or others.
+ *
+ * <p>A {@link SlicingWindowProcessor} usually leverages the {@link SliceAssigner} to assign slices
+ * and calculate based on the slices. See {@link SliceSharedWindowAggProcessor} as an example.
+ *
+ * <p>Note: since {@link SlicingWindowProcessor} leverages slicing optimization for aligned windows,
+ * therefore, it doesn't support unaligned windows, e.g. session window.
+ *
+ * <p>Note: currently, {@link SlicingWindowOperator} doesn't support early-fire and late-arrival.
+ * Thus late elements (elements belong to emitted windows) will be simply dropped.
+ */
+@Internal
+public final class SlicingWindowOperator<K, W> extends TableStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData>, Triggerable<K, W>, KeyContext {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String LATE_ELEMENTS_DROPPED_METRIC_NAME = "numLateRecordsDropped";
+    private static final String LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME = "lateRecordsDroppedRate";
+    private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
+
+    /** The concrete window operator implementation. */
+    private final SlicingWindowProcessor<W> windowProcessor;
+
+    // ------------------------------------------------------------------------
+
+    /** This is used for emitting elements with a given timestamp. */
+    protected transient TimestampedCollector<RowData> collector;
+
+    /** Flag to prevent duplicate function.close() calls in close() and dispose(). */
+    private transient boolean functionsClosed = false;
+
+    /** The service to register timers. */
+    private transient InternalTimerService<W> internalTimerService;
+
+    /** The tracked processing time triggered last time. */
+    private transient long lastTriggeredProcessingTime;
+
+    // ------------------------------------------------------------------------
+    // Metrics
+    // ------------------------------------------------------------------------
+
+    private transient Counter numLateRecordsDropped;
+    private transient Meter lateRecordsDroppedRate;
+    private transient Gauge<Long> watermarkLatency;
+
+    public SlicingWindowOperator(SlicingWindowProcessor<W> windowProcessor) {
+        this.windowProcessor = windowProcessor;
+        setChainingStrategy(ChainingStrategy.ALWAYS);
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        functionsClosed = false;
+
+        lastTriggeredProcessingTime = Long.MIN_VALUE;
+        collector = new TimestampedCollector<>(output);
+        collector.eraseTimestamp();
+
+        internalTimerService =
+                getInternalTimerService(
+                        "window-timers", windowProcessor.createWindowSerializer(), this);
+
+        windowProcessor.open(
+                new WindowProcessorContext<>(
+                        getContainingTask(),
+                        getContainingTask().getEnvironment().getMemoryManager(),
+                        computeMemorySize(),
+                        internalTimerService,
+                        getKeyedStateBackend(),
+                        collector,
+                        getRuntimeContext()));
+
+        // metrics
+        this.numLateRecordsDropped = metrics.counter(LATE_ELEMENTS_DROPPED_METRIC_NAME);
+        this.lateRecordsDroppedRate =
+                metrics.meter(
+                        LATE_ELEMENTS_DROPPED_RATE_METRIC_NAME,
+                        new MeterView(numLateRecordsDropped));
+        this.watermarkLatency =
+                metrics.gauge(
+                        WATERMARK_LATENCY_METRIC_NAME,
+                        () -> {
+                            long watermark = internalTimerService.currentWatermark();
+                            if (watermark < 0) {
+                                return 0L;
+                            } else {
+                                return internalTimerService.currentProcessingTime() - watermark;
+                            }
+                        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        collector = null;
+        functionsClosed = true;
+        windowProcessor.close();
+    }
+
+    @Override
+    public void dispose() throws Exception {
+        super.dispose();
+        collector = null;
+        if (!functionsClosed) {
+            functionsClosed = true;
+            windowProcessor.close();
+        }
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> element) throws Exception {
+        RowData inputRow = element.getValue();
+        BinaryRowData currentKey = (BinaryRowData) getCurrentKey();
+        boolean isElementDropped = windowProcessor.processElement(currentKey, inputRow);
+        if (isElementDropped) {
+            // markEvent will increase numLateRecordsDropped
+            lateRecordsDroppedRate.markEvent();
+        }
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        windowProcessor.advanceProgress(mark.getTimestamp());
+        super.processWatermark(mark);
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, W> timer) throws Exception {
+        onTimer(timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+        long timestamp = timer.getTimestamp();
+        if (timestamp > lastTriggeredProcessingTime) {
+            // similar to the watermark advance,
+            // we need to notify WindowProcessor first to flush buffer into state
+            lastTriggeredProcessingTime = timestamp;
+            windowProcessor.advanceProgress(timestamp);
+            // register timer again, because we need to skip current timer to avoid duplicate output
+            setCurrentKey(timer.getKey());
+            internalTimerService.registerProcessingTimeTimer(timer.getNamespace(), timestamp);
+            return;
+        }
+        onTimer(timer);
+    }
+
+    private void onTimer(InternalTimer<K, W> timer) throws Exception {
+        setCurrentKey(timer.getKey());
+        W window = timer.getNamespace();
+        windowProcessor.fireWindow(window);
+        windowProcessor.clearWindow(window);
+        // we don't need to clear window timers,
+        // because there should only be one timer for each window now, which is current timer.
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        windowProcessor.prepareCheckpoint();
+    }
+
+    /** Context implementation for {@link SlicingWindowProcessor.Context}. */
+    private static final class WindowProcessorContext<W>
+            implements SlicingWindowProcessor.Context<W> {
+
+        private final Object operatorOwner;
+        private final MemoryManager memoryManager;
+        private final long memorySize;
+        private final InternalTimerService<W> timerService;
+        private final KeyedStateBackend<RowData> keyedStateBackend;
+        private final Output<RowData> collector;
+        private final RuntimeContext runtimeContext;
+
+        private WindowProcessorContext(
+                Object operatorOwner,
+                MemoryManager memoryManager,
+                long memorySize,
+                InternalTimerService<W> timerService,
+                KeyedStateBackend<RowData> keyedStateBackend,
+                Output<RowData> collector,
+                RuntimeContext runtimeContext) {
+            this.operatorOwner = operatorOwner;
+            this.memoryManager = memoryManager;
+            this.memorySize = memorySize;
+            this.timerService = timerService;
+            this.keyedStateBackend = checkNotNull(keyedStateBackend);
+            this.collector = checkNotNull(collector);
+            this.runtimeContext = checkNotNull(runtimeContext);
+        }
+
+        @Override
+        public Object getOperatorOwner() {
+            return operatorOwner;
+        }
+
+        @Override
+        public MemoryManager getMemoryManager() {
+            return memoryManager;
+        }
+
+        @Override
+        public long getMemorySize() {
+            return memorySize;
+        }
+
+        @Override
+        public KeyedStateBackend<RowData> getKeyedStateBackend() {
+            return keyedStateBackend;
+        }
+
+        @Override
+        public InternalTimerService<W> getTimerService() {
+            return timerService;
+        }
+
+        @Override
+        public void output(RowData result) {
+            collector.collect(result);
+        }
+
+        @Override
+        public RuntimeContext getRuntimeContext() {
+            return runtimeContext;
+        }
+    }
+
+    // ------------------------------------------------------------------------------
+    // Visible For Testing
+    // ------------------------------------------------------------------------------
+
+    @VisibleForTesting
+    public Counter getNumLateRecordsDropped() {
+        return numLateRecordsDropped;
+    }
+
+    @VisibleForTesting
+    public Gauge<Long> getWatermarkLatency() {
+        return watermarkLatency;
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
@@ -49,8 +49,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * can apply the slicing optimization. The core idea of slicing optimization is to divide all
  * elements from a data stream into a finite number of non-overlapping chunks (a.k.a. slices).
  *
- * <p>
- *
  * <h3>Concept of Aligned Window and Unaligned Window</h3>
  *
  * <p>We divide windows into 2 categories: Aligned Windows and Unaligned Windows.
@@ -69,8 +67,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Because aligned windows can be divided into finite number of non-overlapping chunks (a.k.a.
  * slices), which can apply efficient processing to share intermediate results.
  *
- * <p>
- *
  * <h3>Concept of Slice</h3>
  *
  * <p>Dividing a window of aligned windows into a finite number of non-overlapping chunks, where the
@@ -82,11 +78,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   <li>A window is consist of a finite number of slices.
  * </ul>
  *
- * <p>
- *
  * <h3>Abstraction of Slicing Window Operator</h3>
  *
- * A slicing window operator is a simple wrap of {@link SlicingWindowProcessor}. It delegates all
+ * <p>A slicing window operator is a simple wrap of {@link SlicingWindowProcessor}. It delegates all
  * the important methods to the underlying processor, where the processor can have different
  * implementation for aggregate and topk or others.
  *

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowProcessor.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+
+import java.io.Serializable;
+
+/** A processor that processes elements for slicing windows. */
+@Internal
+public interface SlicingWindowProcessor<W> extends Serializable {
+
+    /** Initialization method for the function. It is called before the actual working methods. */
+    void open(Context<W> context) throws Exception;
+
+    /**
+     * Process an element with associated key from the input stream. Returns true if this element is
+     * dropped because of late arrival.
+     *
+     * @param key the key associated with the element
+     * @param element The element to process.
+     */
+    boolean processElement(BinaryRowData key, RowData element) throws Exception;
+
+    /**
+     * Advances the progress time, the progress time is watermark if working in event-time mode, or
+     * current processing time if working in processing-time mode.
+     *
+     * <p>This will potentially flush buffered data into states, because the watermark advancement
+     * may be in a very small step, but we don't need to flush buffered data for every watermark
+     * advancement.
+     *
+     * @param progress the current progress time
+     */
+    void advanceProgress(long progress) throws Exception;
+
+    /** Performs a preparation before checkpoint. This usually flushes buffered data into state. */
+    void prepareCheckpoint() throws Exception;
+
+    /**
+     * Emit results of the given window.
+     *
+     * <p>Note: the key context has been set.
+     *
+     * @param window the window to emit
+     */
+    void fireWindow(W window) throws Exception;
+
+    /**
+     * Clear state and resources associated with the given window namespace.
+     *
+     * <p>Note: the key context has been set.
+     *
+     * @param window the window to clear
+     */
+    void clearWindow(W window) throws Exception;
+
+    /**
+     * The tear-down method of the function. It is called after the last call to the main working
+     * methods.
+     */
+    void close() throws Exception;
+
+    /** Returns the serializer of the window type. */
+    TypeSerializer<W> createWindowSerializer();
+
+    // ------------------------------------------------------------------------------------------
+
+    /** Information available in an invocation of methods of {@link SlicingWindowProcessor}. */
+    interface Context<W> {
+
+        /**
+         * Returns the object instance of this operator which is used for tracking managed memories
+         * used by this operator.
+         */
+        Object getOperatorOwner();
+
+        /** Returns the current {@link MemoryManager}. */
+        MemoryManager getMemoryManager();
+
+        /** Returns the managed memory size can be used by this operator. */
+        long getMemorySize();
+
+        /** Returns the current {@link KeyedStateBackend}. */
+        KeyedStateBackend<RowData> getKeyedStateBackend();
+
+        /** Returns the current {@link InternalTimerService}. */
+        InternalTimerService<W> getTimerService();
+
+        /** Returns the current {@link RuntimeContext}. */
+        RuntimeContext getRuntimeContext();
+
+        /** Outputs results to downstream operators. */
+        void output(RowData result);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/StateKeyContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/StateKeyContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.data.RowData;
 
 /** Context to switch current key in state backend. */
 public interface StateKeyContext {
+
     /** Sets current state key to given value. */
     void setCurrentKey(RowData key);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/StateKeyContext.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/StateKeyContext.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.state;
+
+import org.apache.flink.table.data.RowData;
+
+/** Context to switch current key in state backend. */
+public interface StateKeyContext {
+    /** Sets current state key to given value. */
+    void setCurrentKey(RowData key);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowState.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowState.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.state;
+
+/** A base interface for manipulate state with window namespace. */
+public interface WindowState<W> {
+
+    /** Removes the value mapped under current key and the given window. */
+    void clear(W window);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowValueState.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowValueState.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.state;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.table.data.RowData;
+
+import java.io.IOException;
+
+/** A wrapper of {@link ValueState} which is easier to update based on window namespace. */
+public final class WindowValueState<W> implements WindowState<W> {
+
+    private final InternalValueState<RowData, W, RowData> windowState;
+
+    public WindowValueState(InternalValueState<RowData, W, RowData> windowState) {
+        this.windowState = windowState;
+    }
+
+    public void clear(W window) {
+        windowState.setCurrentNamespace(window);
+        windowState.clear();
+    }
+
+    /** Returns the current value for the state under current key and the given window. */
+    public RowData value(W window) throws IOException {
+        windowState.setCurrentNamespace(window);
+        return windowState.value();
+    }
+
+    /**
+     * Update the state with the given value under current key and the given window.
+     *
+     * @param window the window namespace.
+     * @param value the new value for the state.
+     */
+    public void update(W window, RowData value) throws IOException {
+        windowState.setCurrentNamespace(window);
+        windowState.update(value);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LazyMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LazyMemorySegmentPool.java
@@ -19,12 +19,9 @@
 package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.Preconditions;
-
-import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -37,22 +34,12 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
     private static final long PER_REQUEST_MEMORY_SIZE = 16 * 1024 * 1024;
 
     private final Object owner;
-    private final @Nullable MemoryManager memoryManager;
+    private final MemoryManager memoryManager;
     private final ArrayList<MemorySegment> cachePages;
     private final int maxPages;
     private final int perRequestPages;
 
     private int pageUsage;
-
-    public LazyMemorySegmentPool(Object owner, MemoryManager memoryManager, long memorySize) {
-        this(
-                owner,
-                memoryManager,
-                (int) memorySize
-                        / (memoryManager == null
-                                ? MemoryManager.DEFAULT_PAGE_SIZE
-                                : memoryManager.getPageSize()));
-    }
 
     public LazyMemorySegmentPool(Object owner, MemoryManager memoryManager, int maxPages) {
         this.owner = owner;
@@ -60,14 +47,13 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
         this.cachePages = new ArrayList<>();
         this.maxPages = maxPages;
         this.pageUsage = 0;
-        this.perRequestPages = Math.max(1, (int) (PER_REQUEST_MEMORY_SIZE / pageSize()));
+        this.perRequestPages =
+                Math.max(1, (int) (PER_REQUEST_MEMORY_SIZE / memoryManager.getPageSize()));
     }
 
     @Override
     public int pageSize() {
-        return memoryManager == null
-                ? MemoryManager.DEFAULT_PAGE_SIZE
-                : memoryManager.getPageSize();
+        return this.memoryManager.getPageSize();
     }
 
     @Override
@@ -92,19 +78,10 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
 
         if (this.cachePages.isEmpty()) {
             int numPages = Math.min(freePages, this.perRequestPages);
-            // allocate from non-managed heap memory
-            if (memoryManager == null) {
-                for (int i = 0; i < numPages; i++) {
-                    cachePages.add(
-                            MemorySegmentFactory.allocateUnpooledSegment(
-                                    MemoryManager.DEFAULT_PAGE_SIZE));
-                }
-            } else {
-                try {
-                    this.memoryManager.allocatePages(owner, this.cachePages, numPages);
-                } catch (MemoryAllocationException e) {
-                    throw new RuntimeException(e);
-                }
+            try {
+                this.memoryManager.allocatePages(owner, this.cachePages, numPages);
+            } catch (MemoryAllocationException e) {
+                throw new RuntimeException(e);
             }
         }
         this.pageUsage++;
@@ -148,10 +125,6 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
     }
 
     public void cleanCache() {
-        if (memoryManager == null) {
-            this.cachePages.clear();
-        } else {
-            this.memoryManager.release(this.cachePages);
-        }
+        this.memoryManager.release(this.cachePages);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
@@ -20,9 +20,13 @@ package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.state.KeyedStateBackend;
 
 /** Utility to create a {@link StateTtlConfig} object. */
-public class StateTtlConfigUtil {
+public class StateConfigUtil {
+
+    private static final String ROCKSDB_KEYED_STATE_BACKEDN =
+            "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend";
 
     /**
      * Creates a {@link StateTtlConfig} depends on retentionTime parameter.
@@ -38,5 +42,11 @@ public class StateTtlConfigUtil {
         } else {
             return StateTtlConfig.DISABLED;
         }
+    }
+
+    public static boolean isStateImmutableInStateBackend(KeyedStateBackend<?> stateBackend) {
+        // TODO: remove this once FLINK-21027 is supported
+        // state key and value is immutable only when using rocksdb state backend
+        return ROCKSDB_KEYED_STATE_BACKEDN.equals(stateBackend.getClass().getCanonicalName());
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMap.java
@@ -94,7 +94,8 @@ public abstract class BytesMap<K, V> {
             MemoryManager memoryManager,
             long memorySize,
             TypeSerializer<K> keySerializer) {
-        this.memoryPool = new LazyMemorySegmentPool(owner, memoryManager, memorySize);
+        int maxPages = (int) (memorySize / memoryManager.getPageSize());
+        this.memoryPool = new LazyMemorySegmentPool(owner, memoryManager, maxPages);
         this.segmentSize = memoryPool.pageSize();
         this.reservedNumBuffers = (int) (memorySize / segmentSize);
         this.numBucketsPerSegment = segmentSize / BUCKET_SIZE;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/BytesMap.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Base class for {@link BytesHashMap} and BytesMultiMap.
+ * Base class for {@link BytesHashMap} and {@link BytesMultiMap}.
  *
  * @param <K> type of the map key.
  * @param <V> type of the map value.

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -1,0 +1,784 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.aggregate.window;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.table.runtime.dataview.StateDataViewStore;
+import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
+import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
+import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/** Tests for window aggregate operators created by {@link SlicingWindowAggOperatorBuilder}. */
+public class SlicingWindowAggOperatorTest {
+
+    private static final RowType INPUT_ROW_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new RowType.RowField("f0", new VarCharType(Integer.MAX_VALUE)),
+                            new RowType.RowField("f1", new IntType()),
+                            new RowType.RowField("f2", new BigIntType())));
+
+    private static final LogicalType[] KEY_TYPES =
+            new LogicalType[] {new VarCharType(Integer.MAX_VALUE)};
+
+    private static final LogicalType[] ACC_TYPES =
+            new LogicalType[] {new BigIntType(), new BigIntType()};
+
+    private static final LogicalType[] OUTPUT_TYPES =
+            new LogicalType[] {
+                new VarCharType(Integer.MAX_VALUE),
+                new BigIntType(),
+                new BigIntType(),
+                new BigIntType(),
+                new BigIntType()
+            };
+
+    private static final BinaryRowDataKeySelector KEY_SELECTOR =
+            new BinaryRowDataKeySelector(
+                    new int[] {0}, INPUT_ROW_TYPE.getChildren().toArray(new LogicalType[0]));
+
+    private static final TypeSerializer<RowData> OUT_SERIALIZER =
+            new RowDataSerializer(OUTPUT_TYPES);
+
+    private static final RowDataHarnessAssertor ASSERTER =
+            new RowDataHarnessAssertor(
+                    OUTPUT_TYPES,
+                    new GenericRowRecordSortComparator(0, new VarCharType(VarCharType.MAX_LENGTH)));
+
+    @Test
+    public void testEventTimeHoppingWindows() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.hopping(2, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .countStarIndex(1)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 3999L));
+        testHarness.processElement(insertRecord("key2", 1, 3000L));
+
+        testHarness.processElement(insertRecord("key1", 1, 20L));
+        testHarness.processElement(insertRecord("key1", 1, 0L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+
+        testHarness.processElement(insertRecord("key2", 1, 1998L));
+        testHarness.processElement(insertRecord("key2", 1, 1999L));
+        testHarness.processElement(insertRecord("key2", 1, 1000L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, -2000L, 1000L));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, -1000L, 2000L));
+        expectedOutput.add(insertRecord("key2", 3L, 3L, -1000L, 2000L));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(2999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(new Watermark(2999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(insertRecord("key2", 5L, 5L, 1000L, 4000L));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key2", 1, 3500L));
+
+        testHarness.processWatermark(new Watermark(4999));
+        expectedOutput.add(insertRecord("key2", 2L, 2L, 2000L, 5000L));
+        expectedOutput.add(new Watermark(4999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key1", 1, 4999L));
+
+        testHarness.processWatermark(new Watermark(5999));
+        expectedOutput.add(insertRecord("key2", 2L, 2L, 3000L, 6000L));
+        expectedOutput.add(new Watermark(5999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // those don't have any effect...
+        testHarness.processWatermark(new Watermark(6999));
+        testHarness.processWatermark(new Watermark(7999));
+        expectedOutput.add(new Watermark(6999));
+        expectedOutput.add(new Watermark(7999));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        assertEquals(2, operator.getNumLateRecordsDropped().getCount());
+
+        testHarness.close();
+
+        // we close once in the rest...
+        assertEquals("Close was not called.", 2, aggsFunction.closeCalled.get());
+    }
+
+    @Test
+    public void testProcessingTimeHoppingWindows() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.hopping(-1, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .countStarIndex(1)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // timestamp is ignored in processing time
+        testHarness.setProcessingTime(3);
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(1000);
+
+        expectedOutput.add(insertRecord("key2", 1L, 1L, -2000L, 1000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(2000);
+
+        expectedOutput.add(insertRecord("key2", 3L, 3L, -1000L, 2000L));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(3000);
+
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 0L, 3000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(7000);
+
+        expectedOutput.add(insertRecord("key2", 2L, 2L, 1000L, 4000L));
+        expectedOutput.add(insertRecord("key1", 5L, 5L, 1000L, 4000L));
+        expectedOutput.add(insertRecord("key1", 5L, 5L, 2000L, 5000L));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 3000L, 6000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+        assertEquals("Close was not called.", 1, aggsFunction.closeCalled.get());
+    }
+
+    @Test
+    public void testEventTimeCumulativeWindows() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.cumulative(2, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 2999L));
+        testHarness.processElement(insertRecord("key2", 1, 3000L));
+
+        testHarness.processElement(insertRecord("key1", 1, 20L));
+        testHarness.processElement(insertRecord("key1", 1, 0L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+
+        testHarness.processElement(insertRecord("key2", 1, 1998L));
+        testHarness.processElement(insertRecord("key2", 1, 1999L));
+        testHarness.processElement(insertRecord("key2", 1, 1000L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 0L, 1000L));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 0L, 2000L));
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 2000L));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(2999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key2", 4L, 4L, 0L, 3000L));
+        expectedOutput.add(new Watermark(2999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup();
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 4000L));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key1", 2, 3500L));
+
+        testHarness.processWatermark(new Watermark(4999));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 5000L));
+        expectedOutput.add(new Watermark(4999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key1", 1, 4999L));
+
+        testHarness.processWatermark(new Watermark(5999));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 6000L));
+        expectedOutput.add(new Watermark(5999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // those don't have any effect...
+        testHarness.processWatermark(new Watermark(6999));
+        testHarness.processWatermark(new Watermark(7999));
+        expectedOutput.add(new Watermark(6999));
+        expectedOutput.add(new Watermark(7999));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        assertEquals(2, operator.getNumLateRecordsDropped().getCount());
+
+        testHarness.close();
+
+        // we close once in the rest...
+        assertEquals("Close was not called.", 2, aggsFunction.closeCalled.get());
+    }
+
+    @Test
+    public void testProcessingTimeCumulativeWindows() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.cumulative(-1, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // timestamp is ignored in processing time
+        testHarness.setProcessingTime(3);
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(1000);
+
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 0L, 1000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(2000);
+
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 2000L));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(3000);
+
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 0L, 3000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key1", 1, Long.MAX_VALUE));
+
+        testHarness.setProcessingTime(7000);
+
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 3000L, 4000L));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 4000L));
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 3000L, 5000L));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 5000L));
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 3000L, 6000L));
+        expectedOutput.add(insertRecord("key2", 1L, 1L, 3000L, 6000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+        assertEquals("Close was not called.", 1, aggsFunction.closeCalled.get());
+    }
+
+    @Test
+    public void testEventTimeTumblingWindows() throws Exception {
+        final SliceAssigner assigner = SliceAssigners.tumbling(2, Duration.ofSeconds(3));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 3999L));
+        testHarness.processElement(insertRecord("key2", 1, 3000L));
+
+        testHarness.processElement(insertRecord("key1", 1, 20L));
+        testHarness.processElement(insertRecord("key1", 1, 0L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+
+        testHarness.processElement(insertRecord("key2", 1, 1998L));
+        testHarness.processElement(insertRecord("key2", 1, 1999L));
+        testHarness.processElement(insertRecord("key2", 1, 1000L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup();
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(2999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(new Watermark(2999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key1", 1, 2500L));
+
+        testHarness.processWatermark(new Watermark(4999));
+        expectedOutput.add(new Watermark(4999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key2", 1, 2999L));
+
+        testHarness.processWatermark(new Watermark(5999));
+        expectedOutput.add(insertRecord("key2", 2L, 2L, 3000L, 6000L));
+        expectedOutput.add(new Watermark(5999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // those don't have any effect...
+        testHarness.processWatermark(new Watermark(6999));
+        testHarness.processWatermark(new Watermark(7999));
+        expectedOutput.add(new Watermark(6999));
+        expectedOutput.add(new Watermark(7999));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        assertEquals(2, operator.getNumLateRecordsDropped().getCount());
+
+        testHarness.close();
+
+        // we close once in the rest...
+        assertEquals("Close was not called.", 2, aggsFunction.closeCalled.get());
+    }
+
+    @Test
+    public void testProcessingTimeTumblingWindows() throws Exception {
+        final SliceAssigner assigner = SliceAssigners.tumbling(-1, Duration.ofSeconds(3));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+        SlicingWindowOperator<RowData, ?> operator =
+                SlicingWindowAggOperatorBuilder.builder()
+                        .inputType(INPUT_ROW_TYPE)
+                        .keyTypes(KEY_TYPES)
+                        .assigner(assigner)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        testHarness.setProcessingTime(3);
+
+        // timestamp is ignored in processing time
+        testHarness.processElement(insertRecord("key2", 1, Long.MAX_VALUE));
+        testHarness.processElement(insertRecord("key2", 1, 7000L));
+        testHarness.processElement(insertRecord("key2", 1, 7000L));
+
+        testHarness.processElement(insertRecord("key1", 1, 7000L));
+        testHarness.processElement(insertRecord("key1", 1, 7000L));
+
+        testHarness.setProcessingTime(5000);
+
+        expectedOutput.add(insertRecord("key2", 3L, 3L, 0L, 3000L));
+        expectedOutput.add(insertRecord("key1", 2L, 2L, 0L, 3000L));
+
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processElement(insertRecord("key1", 1, 7000L));
+        testHarness.processElement(insertRecord("key1", 1, 7000L));
+        testHarness.processElement(insertRecord("key1", 1, 7000L));
+
+        testHarness.setProcessingTime(7000);
+
+        expectedOutput.add(insertRecord("key1", 3L, 3L, 3000L, 6000L));
+
+        assertEquals(Long.valueOf(0L), operator.getWatermarkLatency().getValue());
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    @Test
+    public void testInvalidWindows() {
+        final SliceAssigner assigner =
+                SliceAssigners.hopping(2, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
+
+        try {
+            // hopping window without specifying count star index
+            SlicingWindowAggOperatorBuilder.builder()
+                    .inputType(INPUT_ROW_TYPE)
+                    .keyTypes(KEY_TYPES)
+                    .assigner(assigner)
+                    .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                    .build();
+            fail("should fail");
+        } catch (Exception e) {
+            assertThat(
+                    e,
+                    containsMessage(
+                            "Hopping window requires a COUNT(*) in the aggregate functions."));
+        }
+    }
+
+    private static OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+            SlicingWindowOperator<RowData, ?> operator) throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                operator, KEY_SELECTOR, KEY_SELECTOR.getProducedType());
+    }
+
+    private static GeneratedNamespaceAggsHandleFunction<Long> wrapGenerated(
+            NamespaceAggsHandleFunction<Long> aggsFunction) {
+        return new GeneratedNamespaceAggsHandleFunction<Long>("N/A", "N/A", new Object[0]) {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public NamespaceAggsHandleFunction<Long> newInstance(ClassLoader classLoader) {
+                return aggsFunction;
+            }
+        };
+    }
+
+    /**
+     * This performs a {@code SUM(f1), COUNT(f1)}, where f1 is BIGINT type. The return value
+     * contains {@code sum, count, window_start, window_end}.
+     */
+    private static class SumAndCountAggsFunction implements NamespaceAggsHandleFunction<Long> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final SliceAssigner assigner;
+
+        boolean openCalled;
+        final AtomicInteger closeCalled = new AtomicInteger(0);
+
+        long sum;
+        boolean sumIsNull;
+        long count;
+        boolean countIsNull;
+
+        protected transient JoinedRowData result;
+
+        private SumAndCountAggsFunction(SliceAssigner assigner) {
+            this.assigner = assigner;
+        }
+
+        public void open(StateDataViewStore store) throws Exception {
+            openCalled = true;
+            result = new JoinedRowData();
+        }
+
+        public void setAccumulators(Long window, RowData acc) throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            sumIsNull = acc.isNullAt(0);
+            if (!sumIsNull) {
+                sum = acc.getLong(0);
+            } else {
+                sum = 0L;
+            }
+
+            countIsNull = acc.isNullAt(1);
+            if (!countIsNull) {
+                count = acc.getLong(1);
+            } else {
+                count = 0L;
+            }
+        }
+
+        public void accumulate(RowData inputRow) throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            boolean inputIsNull = inputRow.isNullAt(1);
+            if (!inputIsNull) {
+                sum += inputRow.getInt(1);
+                count += 1;
+                sumIsNull = false;
+                countIsNull = false;
+            }
+        }
+
+        public void retract(RowData inputRow) throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            boolean inputIsNull = inputRow.isNullAt(1);
+            if (!inputIsNull) {
+                sum -= inputRow.getInt(1);
+                count -= 1;
+            }
+        }
+
+        public void merge(Long window, RowData otherAcc) throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            boolean sumIsNull2 = otherAcc.isNullAt(0);
+            if (!sumIsNull2) {
+                sum += otherAcc.getLong(0);
+                sumIsNull = false;
+            }
+            boolean countIsNull2 = otherAcc.isNullAt(1);
+            if (!countIsNull2) {
+                count += otherAcc.getLong(1);
+                countIsNull = false;
+            }
+        }
+
+        public RowData createAccumulators() {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            GenericRowData rowData = new GenericRowData(2);
+            ;
+            rowData.setField(1, 0L); // count has default 0 value
+            return rowData;
+        }
+
+        public RowData getAccumulators() throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            GenericRowData row = new GenericRowData(2);
+            if (!sumIsNull) {
+                row.setField(0, sum);
+            }
+            if (!countIsNull) {
+                row.setField(1, count);
+            }
+            return row;
+        }
+
+        public void cleanup(Long window) {}
+
+        public void close() {
+            closeCalled.incrementAndGet();
+        }
+
+        @Override
+        public RowData getValue(Long window) throws Exception {
+            if (!openCalled) {
+                fail("Open was not called");
+            }
+            GenericRowData row = new GenericRowData(4);
+            if (!sumIsNull) {
+                row.setField(0, sum);
+            }
+            if (!countIsNull) {
+                row.setField(1, count);
+            }
+            row.setField(1, count);
+            row.setField(2, assigner.getWindowStart(window));
+            row.setField(3, window);
+            return row;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -738,7 +738,6 @@ public class SlicingWindowAggOperatorTest {
                 fail("Open was not called");
             }
             GenericRowData rowData = new GenericRowData(2);
-            ;
             rowData.setField(1, 0L); // count has default 0 value
             return rowData;
         }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/CumulativeSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/CumulativeSliceAssignerTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/** Tests for {@link SliceAssigners.CumulativeSliceAssigner} */
+/** Tests for {@link SliceAssigners.CumulativeSliceAssigner}. */
 public class CumulativeSliceAssignerTest extends SliceAssignerTestBase {
 
     @Test

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/CumulativeSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/CumulativeSliceAssignerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link SliceAssigners.CumulativeSliceAssigner} */
+public class CumulativeSliceAssignerTest extends SliceAssignerTestBase {
+
+    @Test
+    public void testSliceAssignment() {
+        SliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(1000L, assignSliceEnd(assigner, 0L));
+        assertEquals(5000L, assignSliceEnd(assigner, 4999L));
+        assertEquals(6000L, assignSliceEnd(assigner, 5000L));
+    }
+
+    @Test
+    public void testSliceAssignmentWithOffset() {
+        SliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1))
+                        .withOffset(Duration.ofMillis(100));
+
+        assertEquals(1100L, assignSliceEnd(assigner, 100L));
+        assertEquals(5100L, assignSliceEnd(assigner, 5099L));
+        assertEquals(6100L, assignSliceEnd(assigner, 5100L));
+    }
+
+    @Test
+    public void testGetWindowStart() {
+        SliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(-5000L, assigner.getWindowStart(0L));
+        assertEquals(0L, assigner.getWindowStart(1000L));
+        assertEquals(0L, assigner.getWindowStart(2000L));
+        assertEquals(0L, assigner.getWindowStart(3000L));
+        assertEquals(0L, assigner.getWindowStart(4000L));
+        assertEquals(0L, assigner.getWindowStart(5000L));
+        assertEquals(5000L, assigner.getWindowStart(6000L));
+        assertEquals(5000L, assigner.getWindowStart(8000L));
+    }
+
+    @Test
+    public void testExpiredSlices() {
+        SliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        // reuse the first slice, skip to cleanup it
+        assertEquals(Collections.emptyList(), expiredSlices(assigner, 1000L));
+
+        assertEquals(Collections.singletonList(2000L), expiredSlices(assigner, 2000L));
+        assertEquals(Collections.singletonList(3000L), expiredSlices(assigner, 3000L));
+        assertEquals(Collections.singletonList(4000L), expiredSlices(assigner, 4000L));
+        assertEquals(Arrays.asList(5000L, 1000L), expiredSlices(assigner, 5000L));
+
+        // reuse the first slice, skip to cleanup it
+        assertEquals(Collections.emptyList(), expiredSlices(assigner, 6000L));
+
+        assertEquals(Arrays.asList(10000L, 6000L), expiredSlices(assigner, 10000L));
+        assertEquals(Arrays.asList(0L, -4000L), expiredSlices(assigner, 0L));
+    }
+
+    @Test
+    public void testMerge() throws Exception {
+        SliceAssigners.CumulativeSliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(Long.valueOf(1000L), mergeResultSlice(assigner, 1000L));
+        assertEquals(Collections.emptyList(), toBeMergedSlices(assigner, 1000L)); // the first slice
+
+        assertEquals(Long.valueOf(1000L), mergeResultSlice(assigner, 2000L));
+        assertEquals(Collections.singletonList(2000L), toBeMergedSlices(assigner, 2000L));
+
+        assertEquals(Long.valueOf(1000L), mergeResultSlice(assigner, 3000L));
+        assertEquals(Collections.singletonList(3000L), toBeMergedSlices(assigner, 3000L));
+
+        assertEquals(Long.valueOf(1000L), mergeResultSlice(assigner, 4000L));
+        assertEquals(Collections.singletonList(4000L), toBeMergedSlices(assigner, 4000L));
+
+        assertEquals(Long.valueOf(1000L), mergeResultSlice(assigner, 5000L));
+        assertEquals(Collections.singletonList(5000L), toBeMergedSlices(assigner, 5000L));
+
+        assertEquals(Long.valueOf(6000L), mergeResultSlice(assigner, 6000L));
+        assertEquals(Collections.emptyList(), toBeMergedSlices(assigner, 6000L)); // the first slice
+
+        assertEquals(Long.valueOf(6000L), mergeResultSlice(assigner, 8000L));
+        assertEquals(Collections.singletonList(8000L), toBeMergedSlices(assigner, 8000L));
+
+        assertEquals(Long.valueOf(6000L), mergeResultSlice(assigner, 10000L));
+        assertEquals(Collections.singletonList(10000L), toBeMergedSlices(assigner, 10000L));
+
+        assertEquals(Long.valueOf(-4000L), mergeResultSlice(assigner, 0L));
+        assertEquals(Collections.singletonList(0L), toBeMergedSlices(assigner, 0L));
+    }
+
+    @Test
+    public void testNextTriggerWindow() {
+        SliceAssigners.CumulativeSliceAssigner assigner =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(0L, () -> false));
+        assertEquals(Optional.of(2000L), assigner.nextTriggerWindow(1000L, () -> false));
+        assertEquals(Optional.of(3000L), assigner.nextTriggerWindow(2000L, () -> false));
+        assertEquals(Optional.of(4000L), assigner.nextTriggerWindow(3000L, () -> false));
+        assertEquals(Optional.of(5000L), assigner.nextTriggerWindow(4000L, () -> false));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(5000L, () -> false));
+        assertEquals(Optional.of(7000L), assigner.nextTriggerWindow(6000L, () -> false));
+
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(0L, () -> true));
+        assertEquals(Optional.of(2000L), assigner.nextTriggerWindow(1000L, () -> true));
+        assertEquals(Optional.of(3000L), assigner.nextTriggerWindow(2000L, () -> true));
+        assertEquals(Optional.of(4000L), assigner.nextTriggerWindow(3000L, () -> true));
+        assertEquals(Optional.of(5000L), assigner.nextTriggerWindow(4000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(5000L, () -> true));
+        assertEquals(Optional.of(7000L), assigner.nextTriggerWindow(6000L, () -> true));
+    }
+
+    @Test
+    public void testEventTime() {
+        SliceAssigner assigner1 =
+                SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        assertTrue(assigner1.isEventTime());
+
+        SliceAssigner assigner2 =
+                SliceAssigners.cumulative(-1, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        assertFalse(assigner2.isEventTime());
+    }
+
+    @Test
+    public void testInvalidParameters() {
+        assertErrorMessage(
+                () -> SliceAssigners.cumulative(0, Duration.ofSeconds(-5), Duration.ofSeconds(1)),
+                "Cumulative Window parameters must satisfy maxSize > 0 and step > 0, but got maxSize -5000ms and step 1000ms.");
+
+        assertErrorMessage(
+                () -> SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(-1)),
+                "Cumulative Window parameters must satisfy maxSize > 0 and step > 0, but got maxSize 5000ms and step -1000ms.");
+
+        assertErrorMessage(
+                () -> SliceAssigners.cumulative(0, Duration.ofSeconds(5), Duration.ofSeconds(2)),
+                "Cumulative Window requires maxSize must be an integral multiple of step, but got maxSize 5000ms and step 2000ms.");
+
+        // should pass
+        SliceAssigners.hopping(0, Duration.ofSeconds(10), Duration.ofSeconds(2))
+                .withOffset(Duration.ofSeconds(-1));
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
@@ -137,6 +137,10 @@ public class HoppingSliceAssignerTest extends SliceAssignerTestBase {
                 () -> SliceAssigners.hopping(0, Duration.ofSeconds(2), Duration.ofSeconds(-1)),
                 "Hopping Window must satisfy slide > 0 and size > 0, but got slide -1000ms and size 2000ms.");
 
+        assertErrorMessage(
+                () -> SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(2)),
+                "Hopping Window requires size must be an integral multiple of slide, but got size 5000ms and slide 2000ms.");
+
         // should pass
         SliceAssigners.hopping(0, Duration.ofSeconds(10), Duration.ofSeconds(5))
                 .withOffset(Duration.ofSeconds(-1));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link SliceAssigners.HoppingSliceAssigner} */
+public class HoppingSliceAssignerTest extends SliceAssignerTestBase {
+
+    @Test
+    public void testSliceAssignment() {
+        SliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(1000L, assignSliceEnd(assigner, 0L));
+        assertEquals(5000L, assignSliceEnd(assigner, 4999L));
+        assertEquals(6000L, assignSliceEnd(assigner, 5000L));
+    }
+
+    @Test
+    public void testSliceAssignmentWithOffset() {
+        SliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1))
+                        .withOffset(Duration.ofMillis(100));
+
+        assertEquals(1100L, assignSliceEnd(assigner, 100L));
+        assertEquals(5100L, assignSliceEnd(assigner, 5099L));
+        assertEquals(6100L, assignSliceEnd(assigner, 5100L));
+    }
+
+    @Test
+    public void testGetWindowStart() {
+        SliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(-5000L, assigner.getWindowStart(0L));
+        assertEquals(0L, assigner.getWindowStart(5000L));
+        assertEquals(1000L, assigner.getWindowStart(6000L));
+    }
+
+    @Test
+    public void testExpiredSlices() {
+        SliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(Collections.singletonList(-4000L), expiredSlices(assigner, 0L));
+        assertEquals(Collections.singletonList(1000L), expiredSlices(assigner, 5000L));
+        assertEquals(Collections.singletonList(6000L), expiredSlices(assigner, 10000L));
+    }
+
+    @Test
+    public void testMerge() throws Exception {
+        SliceAssigners.HoppingSliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertNull(mergeResultSlice(assigner, 0L));
+        assertEquals(
+                Arrays.asList(0L, -1000L, -2000L, -3000L, -4000L), toBeMergedSlices(assigner, 0L));
+
+        assertNull(mergeResultSlice(assigner, 5000L));
+        assertEquals(
+                Arrays.asList(5000L, 4000L, 3000L, 2000L, 1000L),
+                toBeMergedSlices(assigner, 5000L));
+
+        assertNull(mergeResultSlice(assigner, 6000L));
+        assertEquals(
+                Arrays.asList(6000L, 5000L, 4000L, 3000L, 2000L),
+                toBeMergedSlices(assigner, 6000L));
+    }
+
+    @Test
+    public void testNextTriggerWindow() {
+        SliceAssigners.HoppingSliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+        assertEquals(Optional.of(1000L), assigner.nextTriggerWindow(0L, () -> false));
+        assertEquals(Optional.of(2000L), assigner.nextTriggerWindow(1000L, () -> false));
+        assertEquals(Optional.of(3000L), assigner.nextTriggerWindow(2000L, () -> false));
+        assertEquals(Optional.of(4000L), assigner.nextTriggerWindow(3000L, () -> false));
+        assertEquals(Optional.of(5000L), assigner.nextTriggerWindow(4000L, () -> false));
+        assertEquals(Optional.of(6000L), assigner.nextTriggerWindow(5000L, () -> false));
+        assertEquals(Optional.of(7000L), assigner.nextTriggerWindow(6000L, () -> false));
+
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(0L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(1000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(2000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(3000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(4000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(5000L, () -> true));
+        assertEquals(Optional.empty(), assigner.nextTriggerWindow(6000L, () -> true));
+    }
+
+    @Test
+    public void testEventTime() {
+        SliceAssigner assigner1 =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        assertTrue(assigner1.isEventTime());
+
+        SliceAssigner assigner2 =
+                SliceAssigners.hopping(-1, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        assertFalse(assigner2.isEventTime());
+    }
+
+    @Test
+    public void testInvalidParameters() {
+        assertErrorMessage(
+                () -> SliceAssigners.hopping(0, Duration.ofSeconds(-2), Duration.ofSeconds(1)),
+                "Hopping Window must satisfy slide > 0 and size > 0, but got slide 1000ms and size -2000ms.");
+
+        assertErrorMessage(
+                () -> SliceAssigners.hopping(0, Duration.ofSeconds(2), Duration.ofSeconds(-1)),
+                "Hopping Window must satisfy slide > 0 and size > 0, but got slide -1000ms and size 2000ms.");
+
+        // should pass
+        SliceAssigners.hopping(0, Duration.ofSeconds(10), Duration.ofSeconds(5))
+                .withOffset(Duration.ofSeconds(-1));
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-/** Tests for {@link SliceAssigners.HoppingSliceAssigner} */
+/** Tests for {@link SliceAssigners.HoppingSliceAssigner}. */
 public class HoppingSliceAssignerTest extends SliceAssignerTestBase {
 
     @Test

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/HoppingSliceAssignerTest.java
@@ -139,7 +139,7 @@ public class HoppingSliceAssignerTest extends SliceAssignerTestBase {
 
         assertErrorMessage(
                 () -> SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(2)),
-                "Hopping Window requires size must be an integral multiple of slide, but got size 5000ms and slide 2000ms.");
+                "Slicing Hopping Window requires size must be an integral multiple of slide, but got size 5000ms and slide 2000ms.");
 
         // should pass
         SliceAssigners.hopping(0, Duration.ofSeconds(10), Duration.ofSeconds(5))

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssignerTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssignerTestBase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import java.util.List;
+
+import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/** Utilities for testing {@link SliceAssigner}s. */
+public abstract class SliceAssignerTestBase {
+
+    private static final ClockService CLOCK_SERVICE = System::currentTimeMillis;
+
+    protected static void assertErrorMessage(Runnable runnable, String errorMessage) {
+        try {
+            runnable.run();
+            fail("should fail.");
+        } catch (Exception e) {
+            assertThat(e, containsMessage(errorMessage));
+        }
+    }
+
+    protected static long assignSliceEnd(SliceAssigner assigner, long timestamp) {
+        return assigner.assignSliceEnd(row(timestamp), CLOCK_SERVICE);
+    }
+
+    protected static List<Long> expiredSlices(SliceAssigner assigner, long sliceEnd) {
+        return Lists.newArrayList(assigner.expiredSlices(sliceEnd));
+    }
+
+    protected static Long mergeResultSlice(SliceSharedAssigner assigner, long sliceEnd)
+            throws Exception {
+        TestingMergingCallBack callBack = new TestingMergingCallBack();
+        assigner.mergeSlices(sliceEnd, callBack);
+        return callBack.mergeResult;
+    }
+
+    protected static List<Long> toBeMergedSlices(SliceSharedAssigner assigner, long sliceEnd)
+            throws Exception {
+        TestingMergingCallBack callBack = new TestingMergingCallBack();
+        assigner.mergeSlices(sliceEnd, callBack);
+        return callBack.toBeMerged;
+    }
+
+    protected static RowData row(long timestamp) {
+        BinaryRowData binaryRowData = new BinaryRowData(1);
+        BinaryRowWriter writer = new BinaryRowWriter(binaryRowData);
+        writer.writeTimestamp(0, TimestampData.fromEpochMillis(timestamp), 3);
+        writer.complete();
+        return binaryRowData;
+    }
+
+    private static final class TestingMergingCallBack implements SliceSharedAssigner.MergeCallback {
+
+        private Long mergeResult;
+        private List<Long> toBeMerged;
+
+        @Override
+        public void merge(Long mergeResult, Iterable<Long> toBeMerged) throws Exception {
+            this.mergeResult = mergeResult;
+            this.toBeMerged = Lists.newArrayList(toBeMerged);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/TumblingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/TumblingSliceAssignerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link SliceAssigners.TumblingSliceAssigner} */
+public class TumblingSliceAssignerTest extends SliceAssignerTestBase {
+
+    @Test
+    public void testSliceAssignment() {
+        SliceAssigner assigner = SliceAssigners.tumbling(0, Duration.ofSeconds(5));
+
+        assertEquals(5000L, assignSliceEnd(assigner, 0L));
+        assertEquals(5000L, assignSliceEnd(assigner, 4999L));
+        assertEquals(10000L, assignSliceEnd(assigner, 5000L));
+    }
+
+    @Test
+    public void testSliceAssignmentWithOffset() {
+        SliceAssigner assigner =
+                SliceAssigners.tumbling(0, Duration.ofSeconds(5))
+                        .withOffset(Duration.ofMillis(100));
+
+        assertEquals(5100L, assignSliceEnd(assigner, 100L));
+        assertEquals(5100L, assignSliceEnd(assigner, 5099L));
+        assertEquals(10100L, assignSliceEnd(assigner, 5100L));
+    }
+
+    @Test
+    public void testGetWindowStart() {
+        SliceAssigner assigner = SliceAssigners.tumbling(0, Duration.ofSeconds(5));
+
+        assertEquals(-5000L, assigner.getWindowStart(0L));
+        assertEquals(0L, assigner.getWindowStart(5000L));
+        assertEquals(5000L, assigner.getWindowStart(10000L));
+    }
+
+    @Test
+    public void testExpiredSlices() {
+        SliceAssigner assigner = SliceAssigners.tumbling(0, Duration.ofSeconds(5));
+
+        assertEquals(Collections.singletonList(0L), expiredSlices(assigner, 0L));
+        assertEquals(Collections.singletonList(5000L), expiredSlices(assigner, 5000L));
+        assertEquals(Collections.singletonList(10000L), expiredSlices(assigner, 10000L));
+    }
+
+    @Test
+    public void testEventTime() {
+        SliceAssigner assigner1 = SliceAssigners.tumbling(0, Duration.ofSeconds(5));
+        assertTrue(assigner1.isEventTime());
+
+        SliceAssigner assigner2 = SliceAssigners.tumbling(-1, Duration.ofSeconds(5));
+        assertFalse(assigner2.isEventTime());
+    }
+
+    @Test
+    public void testInvalidParameters() {
+        assertErrorMessage(
+                () -> SliceAssigners.tumbling(0, Duration.ofSeconds(-1)),
+                "Tumbling Window parameters must satisfy size > 0, but got size -1000ms.");
+
+        assertErrorMessage(
+                () ->
+                        SliceAssigners.tumbling(0, Duration.ofSeconds(10))
+                                .withOffset(Duration.ofSeconds(20)),
+                "Tumbling Window parameters must satisfy abs(offset) < size, bot got size 10000ms and offset 20000ms.");
+
+        // should pass
+        SliceAssigners.tumbling(0, Duration.ofSeconds(10)).withOffset(Duration.ofSeconds(-1));
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/TumblingSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/TumblingSliceAssignerTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/** Tests for {@link SliceAssigners.TumblingSliceAssigner} */
+/** Tests for {@link SliceAssigners.TumblingSliceAssigner}. */
 public class TumblingSliceAssignerTest extends SliceAssignerTestBase {
 
     @Test

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-/** Tests for {@link SliceAssigners.WindowedSliceAssigner} */
+/** Tests for {@link SliceAssigners.WindowedSliceAssigner}. */
 public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
 
     @Test

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
@@ -43,7 +43,12 @@ public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
         SliceAssigner assigner = SliceAssigners.windowed(0, Duration.ofSeconds(5));
 
         assertEquals(-5000L, assigner.getWindowStart(0L));
+        assertEquals(0L, assigner.getWindowStart(1000L));
+        assertEquals(0L, assigner.getWindowStart(2000L));
+        assertEquals(0L, assigner.getWindowStart(3000L));
+        assertEquals(0L, assigner.getWindowStart(4000L));
         assertEquals(0L, assigner.getWindowStart(5000L));
+        assertEquals(5000L, assigner.getWindowStart(6000L));
         assertEquals(5000L, assigner.getWindowStart(10000L));
     }
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/slicing/WindowedSliceAssignerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.slicing;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link SliceAssigners.WindowedSliceAssigner} */
+public class WindowedSliceAssignerTest extends SliceAssignerTestBase {
+
+    @Test
+    public void testSliceAssignment() {
+        SliceAssigner assigner = SliceAssigners.windowed(0, Duration.ofSeconds(5));
+
+        assertEquals(0L, assignSliceEnd(assigner, 0L));
+        assertEquals(5000L, assignSliceEnd(assigner, 5000L));
+        assertEquals(10000L, assignSliceEnd(assigner, 10000L));
+    }
+
+    @Test
+    public void testGetWindowStart() {
+        SliceAssigner assigner = SliceAssigners.windowed(0, Duration.ofSeconds(5));
+
+        assertEquals(-5000L, assigner.getWindowStart(0L));
+        assertEquals(0L, assigner.getWindowStart(5000L));
+        assertEquals(5000L, assigner.getWindowStart(10000L));
+    }
+
+    @Test
+    public void testExpiredSlices() {
+        SliceAssigner assigner = SliceAssigners.windowed(0, Duration.ofSeconds(5));
+
+        assertEquals(Collections.singletonList(0L), expiredSlices(assigner, 0L));
+        assertEquals(Collections.singletonList(5000L), expiredSlices(assigner, 5000L));
+        assertEquals(Collections.singletonList(10000L), expiredSlices(assigner, 10000L));
+    }
+
+    @Test
+    public void testEventTime() {
+        SliceAssigner assigner =
+                SliceAssigners.hopping(0, Duration.ofSeconds(5), Duration.ofSeconds(1));
+        assertTrue(assigner.isEventTime());
+    }
+
+    @Test
+    public void testInvalidParameters() {
+        assertErrorMessage(
+                () -> SliceAssigners.windowed(-1, Duration.ofSeconds(5)),
+                "Windowed slice assigner must have a positive window end index.");
+
+        assertErrorMessage(
+                () -> SliceAssigners.windowed(0, Duration.ofSeconds(-5)),
+                "Windowed Window parameters must satisfy size > 0, but got size -5000ms.");
+
+        // should pass
+        SliceAssigners.tumbling(1, Duration.ofSeconds(10));
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We have supported cumulative windows in FLINK-19605. However, the current cumulative window is not efficient, because the slices are not shared.

We leverages the slicing ideas proposed in FLINK-7001 and this design doc [1]. The slicing is an optimized implementation for hopping, cumulative, tumbling windows. Besides of that, we introduced ManagedMemory based mini-batch optimization for the slicing window aggregate operator, this can tremendously reduce the accessing of state and get the higher throughtput without latency loss.

[1]: https://docs.google.com/document/d/1ziVsuW_HQnvJr_4a9yKwx_LEnhVkdlde2Z5l6sx5HlY/edit#

## Brief change log

For slicing window abstraction:

- Introduced a basic `SlicingWindowOperator` to support slicing window operators, for aggregate and topn in the future. 
- Introduce the abstraction of `SliceAssigner` and several implementations, e.g. tumbling, hopping, cumulative.

For window aggregate operators:

- Introduce the abstraction of `WindowBuffer` to support different strategies to buffer data. Currently we only support buffering raw records using `WindowBytesMultiMap`. In the future, we will support buffering accumulators using `WindowBytesHashMap`. 
- Introduce the abstraction of `WindowCombineFunction` to support different strategies to combine buffered data into state. Currently we only support combine and accumulate raw records into state. In the future, we will support combine accumulators into state.
- Implements `SliceSharedWindowAggProcessor` which aggregates data based on shared slices. 
- Implements `SliceUnsharedWindowAggProcessor` which aggregates data based on unshared slices.
- A `SlicingWindowAggOperatorBuilder` for fluently build a window aggregate operator.

## Verifying this change

- Added unit tests for every SliceAssigners for every methods
- Added unit tests for tumbling, hopping, cumulative windows for event-time and processing-time modes. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)