### PR TITLE
[FLINK-21059][kafka] KafkaSourceEnumerator does not honor consumer properties

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -61,7 +61,7 @@ import java.util.function.Supplier;
  *     .setGroupId("MyGroup")
  *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
  *     .setDeserializer(new TestingKafkaRecordDeserializer())
- *     .setStartingOffsetInitializer(OffsetsInitializer.earliest())
+ *     .setStartingOffsets(OffsetsInitializer.earliest())
  *     .build();
  * }</pre>
  *

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -290,7 +290,7 @@ public class KafkaSourceEnumerator
 
     private KafkaConsumer<byte[], byte[]> getKafkaConsumer() {
         Properties consumerProps = new Properties();
-        copyProperty(properties, consumerProps, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+        deepCopyProperties(properties, consumerProps);
         // set client id prefix
         String clientIdPrefix =
                 consumerProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
@@ -309,7 +309,7 @@ public class KafkaSourceEnumerator
 
     private AdminClient getKafkaAdminClient() {
         Properties adminClientProps = new Properties();
-        copyProperty(properties, adminClientProps, ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+        deepCopyProperties(properties, adminClientProps);
         // set client id prefix
         String clientIdPrefix =
                 adminClientProps.getProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key());
@@ -351,8 +351,11 @@ public class KafkaSourceEnumerator
         return (startIndex + tp.partition()) % numReaders;
     }
 
-    private static void copyProperty(Properties from, Properties to, String key) {
-        to.setProperty(key, from.getProperty(key));
+    @VisibleForTesting
+    static void deepCopyProperties(Properties from, Properties to) {
+        for (String key : from.stringPropertyNames()) {
+            to.setProperty(key, from.getProperty(key));
+        }
     }
 
     // --------------- private class ---------------


### PR DESCRIPTION
## What is the purpose of the change

*Ensure that KafkaSourceEnumerator honors the user provided consumer properties*

## Verifying this change

I tested this change on an internal Kafka cluster, we should probably also add unit test coverage. Putting this up for discussion.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
