### PR TITLE
[hotfix][docs] Removes link formatting of anchors

### DIFF
--- a/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/deployment/resource-providers/standalone/docker.md
@@ -478,7 +478,7 @@ The next sections show examples of configuration files to run Flink.
     $ docker exec -t -i "${JM_CONTAINER}" flink run -d -c ${JOB_CLASS_NAME} /job.jar
     ```
 
-Here, we provide the <a id="app-cluster-yml">docker-compose.yml</a> for *Application Cluster*.
+Here, we provide the <a id="app-cluster-yml">`docker-compose.yml`</a> for *Application Cluster*.
 
 Note: For the Application Mode cluster, the artifacts must be available in the Flink containers, check details [here](#application-mode-on-docker).
 See also [how to specify the JobManager arguments](#jobmanager-additional-command-line-arguments)
@@ -517,7 +517,7 @@ services:
 {% endhighlight %}
 
 
-As well as the <a id="session-cluster-yml">configuration file</a> for *Session Cluster*:
+As well as the <a id="session-cluster-yml">`docker-compose.yml`</a> for *Session Cluster*:
 
 
 {% highlight yaml %}


### PR DESCRIPTION
## What is the purpose of the change

The anchors for the docker-compose.yml were formatted like actual links which
might be confusing to readers. A click wouldn't have had any impact.

## Brief change log

I added the code formatting to the link text to overwrite the link formatting (see the `docker-compose.yml` text in the attached screenshot).

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
<img width="995" alt="Screenshot 2021-01-21 at 08 59 29" src="https://user-images.githubusercontent.com/1101012/105321009-2e662e00-5bc7-11eb-90b6-9512e2d6b233.png">

