### PR TITLE
[FLINK-21071][docker][tests] Run docker tests against 1.12 images

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -48,7 +48,7 @@ function build_image() {
     local server_pid=$!
 
     echo "Preparing Dockeriles"
-    git clone https://github.com/apache/flink-docker.git --branch dev-master --single-branch
+    git clone https://github.com/apache/flink-docker.git --branch dev-1.12 --single-branch
     cd flink-docker
     ./add-custom.sh -u ${file_server_address}:9999/flink.tgz -n ${image_name}
 


### PR DESCRIPTION
Fixes an issue where the 1.12 docker tests were not running against the 1.12 docker code.