### PR TITLE
[FLINK-21070][table-runtime-blink] Fix invalid reuse of generated code

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/CompileUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/CompileUtils.java
@@ -62,7 +62,7 @@ public final class CompileUtils {
         try {
             Cache<ClassLoader, Class> compiledClasses =
                     COMPILED_CACHE.get(
-                            name,
+                            name + code,
                             () ->
                                     CacheBuilder.newBuilder()
                                             .maximumSize(5)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/CompileUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/generated/CompileUtils.java
@@ -62,7 +62,9 @@ public final class CompileUtils {
         try {
             Cache<ClassLoader, Class> compiledClasses =
                     COMPILED_CACHE.get(
-                            name + code,
+                            // "code" as a key should be sufficient as the class name
+                            // is part of the Java code
+                            code,
                             () ->
                                     CacheBuilder.newBuilder()
                                             .maximumSize(5)

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DataStructureConvertersTest.java
@@ -354,7 +354,13 @@ public class DataStructureConvertersTest {
                                         Arrays.asList(
                                                 Arrays.asList(1.0, null, 2.0, null),
                                                 Collections.emptyList(),
-                                                null))));
+                                                null))),
+                TestSpec.forDataType(DataTypes.STRUCTURED(GenericPojo.class, FIELD("value", INT())))
+                        .convertedTo(GenericPojo.class, new GenericPojo<>(12)),
+                TestSpec.forDataType(
+                                DataTypes.STRUCTURED(GenericPojo.class, FIELD("value", DATE())))
+                        .convertedTo(
+                                GenericPojo.class, new GenericPojo<>(LocalDate.ofEpochDay(123))));
     }
 
     @Parameter public TestSpec testSpec;
@@ -741,7 +747,7 @@ public class DataStructureConvertersTest {
         }
     }
 
-    /** Pojo with {@link List}. */
+    /** POJO with {@link List}. */
     public static class PojoWithList {
 
         public List<List<Double>> factors;
@@ -765,6 +771,32 @@ public class DataStructureConvertersTest {
         @Override
         public int hashCode() {
             return Objects.hash(factors);
+        }
+    }
+
+    /** POJO with a generic field. */
+    public static class GenericPojo<T> {
+        public T value;
+
+        public GenericPojo(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            GenericPojo<?> that = (GenericPojo<?>) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

`CompileUtils` reuses code based on only the class name. This could be error-prone as code that is slightly different would be ignored. The wrong behavior was visible during code generation of structured types. This PR fixes both the cache in `CompileUtils` as well as introduces a unique class name for `StructuredObjectConverter` for avoiding class name clashed.

## Brief change log

See above.

## Verifying this change

This change added tests and can be verified as follows: `DataStructureConverterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
