### PR TITLE
[FLINK-20645][network] Fix corrupted unaligned checkpoints.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
@@ -59,7 +59,8 @@ interface ChannelStateWriteRequest {
             long checkpointId, InputChannelInfo info, CloseableIterator<Buffer> iterator) {
         return buildWriteRequest(
                 checkpointId,
-                "writeInput",
+                "ChannelStateWriteRequest#writeInput",
+                info,
                 iterator,
                 (writer, buffer) -> writer.writeInput(info, buffer));
     }
@@ -68,7 +69,8 @@ interface ChannelStateWriteRequest {
             long checkpointId, ResultSubpartitionInfo info, Buffer... buffers) {
         return buildWriteRequest(
                 checkpointId,
-                "writeOutput",
+                "ChannelStateWriteRequest#writeOutput",
+                info,
                 ofElements(Buffer::recycleBuffer, buffers),
                 (writer, buffer) -> writer.writeOutput(info, buffer));
     }
@@ -76,6 +78,7 @@ interface ChannelStateWriteRequest {
     static ChannelStateWriteRequest buildWriteRequest(
             long checkpointId,
             String name,
+            Object channelInfo,
             CloseableIterator<Buffer> iterator,
             BiConsumerWithException<ChannelStateCheckpointWriter, Buffer, Exception>
                     bufferConsumer) {
@@ -85,7 +88,7 @@ interface ChannelStateWriteRequest {
                 writer -> {
                     while (iterator.hasNext()) {
                         Buffer buffer = iterator.next();
-                        NetworkActionsLogger.log(ChannelStateWriteRequest.class, name, buffer);
+                        NetworkActionsLogger.tracePersist(name, buffer, channelInfo, checkpointId);
                         try {
                             checkArgument(buffer.isBuffer());
                         } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -67,7 +67,8 @@ class InputChannelRecoveredStateHandler
     @Override
     public void recover(InputChannelInfo channelInfo, Buffer buffer) {
         if (buffer.readableBytes() > 0) {
-            NetworkActionsLogger.log(getClass(), "recover", buffer);
+            NetworkActionsLogger.traceRecover(
+                    "InputChannelRecoveredStateHandler#recover", buffer, channelInfo);
             getChannel(channelInfo).onRecoveredStateBuffer(buffer);
         } else {
             buffer.recycleBuffer();
@@ -118,7 +119,10 @@ class ResultSubpartitionRecoveredStateHandler
             throws IOException {
         bufferBuilderAndConsumer.f0.finish();
         if (bufferBuilderAndConsumer.f1.isDataAvailable()) {
-            NetworkActionsLogger.log(getClass(), "recover", bufferBuilderAndConsumer.f1);
+            NetworkActionsLogger.traceRecover(
+                    "ResultSubpartitionRecoveredStateHandler#recover",
+                    bufferBuilderAndConsumer.f1,
+                    subpartitionInfo);
             boolean added =
                     getSubpartition(subpartitionInfo)
                             .add(bufferBuilderAndConsumer.f1, Integer.MIN_VALUE);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -52,7 +53,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  * and {@link #setSize(int)}.
  */
 public interface Buffer {
-
     /**
      * Returns whether this buffer represents a buffer or an event.
      *
@@ -226,6 +226,16 @@ public interface Buffer {
 
     /** Sets the type of data this buffer represents. */
     void setDataType(DataType dataType);
+
+    default String toDebugString(boolean includeHash) {
+        StringBuilder prettyString = new StringBuilder("Buffer{size=").append(getSize());
+        if (includeHash) {
+            byte[] bytes = new byte[getSize()];
+            readOnlySlice().asByteBuf().readBytes(bytes);
+            prettyString.append(", hash=").append(Arrays.hashCode(bytes));
+        }
+        return prettyString.append("}").toString();
+    }
 
     /**
      * Used to identify the type of data contained in the {@link Buffer} so that we can get the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -197,6 +197,19 @@ public class BufferConsumer implements Closeable {
         return currentReaderPosition < writerPosition.getLatest();
     }
 
+    public String toDebugString(boolean includeHash) {
+        Buffer buffer = null;
+        try (BufferConsumer copiedBufferConsumer = copy()) {
+            buffer = copiedBufferConsumer.build();
+            checkState(copiedBufferConsumer.isFinished());
+            return buffer.toDebugString(includeHash);
+        } finally {
+            if (buffer != null) {
+                buffer.recycleBuffer();
+            }
+        }
+    }
+
     /**
      * Cached reading wrapper around {@link PositionMarker}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumerWithPartialRecordLength;
+import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
@@ -323,6 +324,8 @@ public class PipelinedSubpartition extends ResultSubpartition
             // It will be reported for reading either on flush or when the number of buffers in the
             // queue
             // will be 2 or more.
+            NetworkActionsLogger.traceOutput(
+                    "PipelinedSubpartition#pollBuffer", buffer, subpartitionInfo);
             return new BufferAndBacklog(
                     buffer,
                     getBuffersInBacklog(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -26,6 +26,9 @@ import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.util.CloseableIterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -37,7 +40,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Helper class for persisting channel state via {@link ChannelStateWriter}. */
 @NotThreadSafe
-final class ChannelStatePersister {
+public final class ChannelStatePersister {
+    private static final Logger LOG = LoggerFactory.getLogger(ChannelStatePersister.class);
+
     private final InputChannelInfo channelInfo;
 
     private enum CheckpointStatus {
@@ -62,6 +67,7 @@ final class ChannelStatePersister {
     }
 
     protected void startPersisting(long barrierId, List<Buffer> knownBuffers) {
+        logEvent("startPersisting", barrierId);
         if (checkpointStatus != CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier < barrierId) {
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
@@ -76,6 +82,7 @@ final class ChannelStatePersister {
     }
 
     protected void stopPersisting(long id) {
+        logEvent("stopPersisting", id);
         if (id >= lastSeenBarrier) {
             checkpointStatus = CheckpointStatus.COMPLETED;
             lastSeenBarrier = id;
@@ -95,19 +102,38 @@ final class ChannelStatePersister {
     protected Optional<Long> checkForBarrier(Buffer buffer) throws IOException {
         final AbstractEvent event = parseEvent(buffer);
         if (event instanceof CheckpointBarrier) {
-            if (((CheckpointBarrier) event).getId() >= lastSeenBarrier) {
+            final long barrierId = ((CheckpointBarrier) event).getId();
+            if (barrierId >= lastSeenBarrier) {
+                logEvent("found barrier", barrierId);
                 checkpointStatus = CheckpointStatus.BARRIER_RECEIVED;
-                lastSeenBarrier = ((CheckpointBarrier) event).getId();
+                lastSeenBarrier = barrierId;
                 return Optional.of(lastSeenBarrier);
+            } else {
+                logEvent("ignoring barrier", barrierId);
             }
         }
         if (event instanceof EventAnnouncement) { // NOTE: only remote channels
             EventAnnouncement announcement = (EventAnnouncement) event;
             if (announcement.getAnnouncedEvent() instanceof CheckpointBarrier) {
-                return Optional.of(((CheckpointBarrier) announcement.getAnnouncedEvent()).getId());
+                final long barrierId =
+                        ((CheckpointBarrier) announcement.getAnnouncedEvent()).getId();
+                logEvent("found announcement for barrier", barrierId);
+                return Optional.of(barrierId);
             }
         }
         return Optional.empty();
+    }
+
+    private void logEvent(String event, long barrierId) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "{} {}, lastSeenBarrier = {} ({}) @ {}",
+                    event,
+                    barrierId,
+                    lastSeenBarrier,
+                    checkpointStatus,
+                    channelInfo);
+        }
     }
 
     /**
@@ -130,5 +156,14 @@ final class ChannelStatePersister {
 
     protected boolean hasBarrierReceived() {
         return checkpointStatus == CheckpointStatus.BARRIER_RECEIVED;
+    }
+
+    @Override
+    public String toString() {
+        return "ChannelStatePersister(lastSeenBarrier="
+                + lastSeenBarrier
+                + " ("
+                + checkpointStatus
+                + ")}";
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -255,6 +256,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         numBuffersIn.inc();
         channelStatePersister.checkForBarrier(buffer);
         channelStatePersister.maybePersist(buffer);
+        NetworkActionsLogger.traceInput(
+                "LocalInputChannel#getNextBuffer",
+                buffer,
+                channelInfo,
+                channelStatePersister,
+                next.getSequenceNumber());
         return Optional.of(
                 new BufferAndAvailability(
                         buffer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -445,7 +445,12 @@ public class RemoteInputChannel extends InputChannel {
             final boolean wasEmpty;
             boolean firstPriorityEvent = false;
             synchronized (receivedBuffers) {
-                NetworkActionsLogger.log(getClass(), "onBuffer", buffer);
+                NetworkActionsLogger.traceInput(
+                        "RemoteInputChannel#onBuffer",
+                        buffer,
+                        channelInfo,
+                        channelStatePersister,
+                        sequenceNumber);
                 // Similar to notifyBufferAvailable(), make sure that we never add a buffer
                 // after releaseAllResources() released all buffers from receivedBuffers
                 // (see above for details).

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
-import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -653,8 +652,6 @@ public class SingleInputGate extends IndexedInputGate {
                     checkUnavailability();
                     continue;
                 }
-                NetworkActionsLogger.log(
-                        getClass(), "waitAndGetNextData", bufferAndAvailabilityOpt.get().buffer());
 
                 final BufferAndAvailability bufferAndAvailability = bufferAndAvailabilityOpt.get();
                 if (bufferAndAvailability.moreAvailable()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -213,7 +213,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         long barrierId = barrier.getId();
         if (currentCheckpointId < barrierId) {
             if (isCheckpointPending()) {
-                cancelSubsumedCheckpoint(currentCheckpointId);
+                cancelSubsumedCheckpoint(barrierId);
             }
             currentCheckpointId = barrierId;
             numBarriersReceived = 0;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -269,7 +269,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
         final SingleOutputStreamOperator<Long> deduplicated =
                 combinedSource
                         .partitionCustom(
-                                (key, numPartitions) -> (int) (key % numPartitions), l -> l)
+                                (key, numPartitions) -> (int) (withoutHeader(key) % numPartitions),
+                                l -> l)
                         .flatMap(new CountingMapFunction(numSources));
         addFailingPipeline(minCheckpoints, slotSharing, deduplicated);
     }
@@ -306,7 +307,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
     protected static class ShiftingPartitioner implements Partitioner<Long> {
         @Override
         public int partition(Long key, int numPartitions) {
-            return (int) ((key + 1) % numPartitions);
+            return (int) ((withoutHeader(key) + 1) % numPartitions);
         }
     }
 
@@ -314,7 +315,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
     protected static class ChunkDistributingPartitioner implements Partitioner<Long> {
         @Override
         public int partition(Long key, int numPartitions) {
-            return (int) ((key / numPartitions) % numPartitions);
+            return (int) ((withoutHeader(key) / numPartitions) % numPartitions);
         }
     }
 
@@ -351,6 +352,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
         @Override
         public void invoke(Long value, Context context) throws Exception {
+            value = withoutHeader(value);
             int parallelism = state.lastRecordInPartitions.length;
             int partition = (int) (value % parallelism);
             long lastRecord = state.lastRecordInPartitions[partition];
@@ -433,16 +435,18 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
         @Override
         public void flatMap1(Long value, Collector<Long> out) {
-            state.lastLeft = value;
-            if (state.lastRight >= value) {
+            long baseValue = withoutHeader(value);
+            state.lastLeft = baseValue;
+            if (state.lastRight >= baseValue) {
                 out.collect(value);
             }
         }
 
         @Override
         public void flatMap2(Long value, Collector<Long> out) {
-            state.lastRight = value;
-            if (state.lastLeft >= value) {
+            long baseValue = withoutHeader(value);
+            state.lastRight = baseValue;
+            if (state.lastLeft >= baseValue) {
                 out.collect(value);
             }
         }
@@ -468,6 +472,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
         @Override
         public void processElement(Long value, Context ctx, Collector<Long> out) {
+            checkHeader(value);
             out.collect(value);
         }
     }
@@ -486,7 +491,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
 
         @Override
         public void flatMap(Long value, Collector<Long> out) throws Exception {
-            final int offset = StrictMath.toIntExact(value * withdrawnCount);
+            long baseValue = withoutHeader(value);
+            final int offset = StrictMath.toIntExact(baseValue * withdrawnCount);
             for (int index = 0; index < withdrawnCount; index++) {
                 if (!seenRecords.get(index + offset)) {
                     seenRecords.set(index + offset);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

With unusual barrier flow, checkpoints may miss certain buffers and become unrecoverable.

## Brief change log

- Fix ChannelStatePersister. 
- Improve UnalignedCheckpointITCase to detect data corruption faster.
- Adding more trace output for network and checkpoint buffers as shown in the following

```
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - LocalInputChannel#getNextBuffer Buffer{size=1996, hash=-1568575630}, seq 4, ChannelStatePersister(1 (COMPLETED)} @ InputChannelInfo{gateIdx=0, inputChannelIdx=0}
9996 [Channel state writer Source: source (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - ChannelStateWriteRequest#writeOutput Buffer{size=20, hash=1432560496}, checkpoint 2 @ ResultSubpartitionInfo{partitionIdx=0, subPartitionIdx=0}
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - PipelinedSubpartition#pollBuffer Buffer{size=38, hash=-1801242596} @ ResultSubpartitionInfo{partitionIdx=0, subPartitionIdx=0}
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - LocalInputChannel#getNextBuffer Buffer{size=38, hash=-1801242596}, seq 5, ChannelStatePersister(2 (BARRIER_RECEIVED)} @ InputChannelInfo{gateIdx=0, inputChannelIdx=0}
9996 [Source: source (1/1)#0] INFO  org.apache.flink.test.checkpointing.UnalignedCheckpointTestBase [] - Snapshotted LongSplit{increment=1, nextNumber=199, numCompletedCheckpoints=1} @ 0 subtask (0 attempt)
```

## Verifying this change

Already covered by existing UnalignedControllerTest when assertion is added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
