### PR TITLE
[FLINK-21077] Introduce SlotPoolService to abstract SlotPool from JobMaster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerFactory.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
@@ -56,7 +56,8 @@ public enum DefaultJobManagerRunnerFactory implements JobManagerRunnerFactory {
         final JobMasterConfiguration jobMasterConfiguration =
                 JobMasterConfiguration.fromConfiguration(configuration);
 
-        final SlotPoolFactory slotPoolFactory = SlotPoolFactory.fromConfiguration(configuration);
+        final SlotPoolServiceFactory slotPoolFactory =
+                SlotPoolServiceFactory.fromConfiguration(configuration);
         final SchedulerNGFactory schedulerNGFactory =
                 SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration);
         final ShuffleMaster<?> shuffleMaster =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -52,8 +52,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -154,7 +154,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
     private final ClassLoader userCodeLoader;
 
-    private final SlotPool slotPool;
+    private final SlotPoolService slotPoolService;
 
     private final SchedulerNGFactory schedulerNGFactory;
 
@@ -212,7 +212,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
             ResourceID resourceId,
             JobGraph jobGraph,
             HighAvailabilityServices highAvailabilityService,
-            SlotPoolFactory slotPoolFactory,
+            SlotPoolServiceFactory slotPoolFactory,
             JobManagerSharedServices jobManagerSharedServices,
             HeartbeatServices heartbeatServices,
             JobManagerJobMetricGroupFactory jobMetricGroupFactory,
@@ -297,7 +297,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         resourceManagerLeaderRetriever =
                 highAvailabilityServices.getResourceManagerLeaderRetriever();
 
-        this.slotPool = checkNotNull(slotPoolFactory).createSlotPool(jid);
+        this.slotPoolService = checkNotNull(slotPoolFactory).createSlotPoolService(jid);
 
         this.registeredTaskManagers = new HashMap<>(4);
         this.partitionTracker =
@@ -343,7 +343,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         jobGraph,
                         scheduledExecutorService,
                         jobMasterConfiguration.getConfiguration(),
-                        slotPool,
+                        slotPoolService,
                         scheduledExecutorService,
                         userCodeLoader,
                         highAvailabilityServices.getCheckpointRecoveryFactory(),
@@ -486,7 +486,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                 cause.getMessage());
 
         taskManagerHeartbeatManager.unmonitorTarget(resourceID);
-        slotPool.releaseTaskManager(resourceID, cause);
+        slotPoolService.releaseTaskManager(resourceID, cause);
         partitionTracker.stopTrackingPartitionsFor(resourceID);
 
         Tuple2<TaskManagerLocation, TaskExecutorGateway> taskManagerConnection =
@@ -604,7 +604,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                 new RpcTaskManagerGateway(taskExecutorGateway, getFencingToken());
 
         return CompletableFuture.completedFuture(
-                slotPool.offerSlots(taskManagerLocation, rpcTaskManagerGateway, slots));
+                slotPoolService.offerSlots(taskManagerLocation, rpcTaskManagerGateway, slots));
     }
 
     @Override
@@ -628,7 +628,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     private void internalFailAllocation(
             @Nullable ResourceID resourceId, AllocationID allocationId, Exception cause) {
         final Optional<ResourceID> resourceIdOptional =
-                slotPool.failAllocation(resourceId, allocationId, cause);
+                slotPoolService.failAllocation(resourceId, allocationId, cause);
         resourceIdOptional.ifPresent(
                 taskManagerId -> {
                     if (!partitionTracker.isTrackingPartitionsFor(taskManagerId)) {
@@ -687,7 +687,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                                     return new RegistrationResponse.Decline(throwable.getMessage());
                                 }
 
-                                slotPool.registerTaskManager(taskManagerId);
+                                slotPoolService.registerTaskManager(taskManagerId);
                                 registeredTaskManagers.put(
                                         taskManagerId,
                                         Tuple2.of(taskManagerLocation, taskExecutorGateway));
@@ -783,7 +783,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     @Override
     public void notifyNotEnoughResourcesAvailable(
             Collection<ResourceRequirement> acquiredResources) {
-        slotPool.notifyNotEnoughResourcesAvailable(acquiredResources);
+        slotPoolService.notifyNotEnoughResourcesAvailable(acquiredResources);
     }
 
     @Override
@@ -850,7 +850,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                     createResourceManagerHeartbeatManager(heartbeatServices);
 
             // start the slot pool make sure the slot pool now accepts messages for this leader
-            slotPool.start(getFencingToken(), getAddress(), getMainThreadExecutor());
+            slotPoolService.start(getFencingToken(), getAddress(), getMainThreadExecutor());
 
             // job is ready to go, try to establish connection with resource manager
             //   - activate leader retrieval for the resource manager
@@ -883,7 +883,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
         // TODO: Distinguish between job termination which should free all slots and a loss of
         // leadership which should keep the slots
-        slotPool.close();
+        slotPoolService.close();
 
         stopHeartbeatServices();
 
@@ -1050,7 +1050,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                     new EstablishedResourceManagerConnection(
                             resourceManagerGateway, resourceManagerResourceId);
 
-            slotPool.connectToResourceManager(resourceManagerGateway);
+            slotPoolService.connectToResourceManager(resourceManagerGateway);
 
             resourceManagerHeartbeatManager.monitorTarget(
                     resourceManagerResourceId,
@@ -1108,7 +1108,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         ResourceManagerGateway resourceManagerGateway =
                 establishedResourceManagerConnection.getResourceManagerGateway();
         resourceManagerGateway.disconnectJobManager(jobGraph.getJobID(), cause);
-        slotPool.disconnectResourceManager();
+        slotPoolService.disconnectResourceManager();
     }
 
     // ----------------------------------------------------------------------------------------------
@@ -1276,7 +1276,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         @Override
         public AllocatedSlotReport retrievePayload(ResourceID resourceID) {
             validateRunsInMainThread();
-            return slotPool.createAllocatedSlotReport(resourceID);
+            return slotPoolService.createAllocatedSlotReport(resourceID);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
@@ -41,7 +41,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
     private final JobMasterConfiguration jobMasterConfiguration;
 
-    private final SlotPoolFactory slotPoolFactory;
+    private final SlotPoolServiceFactory slotPoolFactory;
 
     private final RpcService rpcService;
 
@@ -61,7 +61,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 
     public DefaultJobMasterServiceFactory(
             JobMasterConfiguration jobMasterConfiguration,
-            SlotPoolFactory slotPoolFactory,
+            SlotPoolServiceFactory slotPoolFactory,
             RpcService rpcService,
             HighAvailabilityServices haServices,
             JobManagerSharedServices jobManagerSharedServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AbstractSlotPoolServiceFactory.java
@@ -23,8 +23,8 @@ import org.apache.flink.util.clock.Clock;
 
 import javax.annotation.Nonnull;
 
-/** Abstract SlotPoolFactory. */
-public abstract class AbstractSlotPoolFactory implements SlotPoolFactory {
+/** Abstract SlotPoolServiceFactory. */
+public abstract class AbstractSlotPoolServiceFactory implements SlotPoolServiceFactory {
 
     @Nonnull protected final Clock clock;
 
@@ -34,7 +34,7 @@ public abstract class AbstractSlotPoolFactory implements SlotPoolFactory {
 
     @Nonnull protected final Time batchSlotTimeout;
 
-    protected AbstractSlotPoolFactory(
+    protected AbstractSlotPoolServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** {@link SlotPool} implementation which uses the {@link DeclarativeSlotPool} to allocate slots. */
-public class DeclarativeSlotPoolBridge implements SlotPool {
+public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSlotPoolBridge.class);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeServiceFactory.java
@@ -25,9 +25,9 @@ import org.apache.flink.util.clock.Clock;
 import javax.annotation.Nonnull;
 
 /** Factory for {@link DeclarativeSlotPoolBridge}. */
-public class DeclarativeSlotPoolBridgeFactory extends AbstractSlotPoolFactory {
+public class DeclarativeSlotPoolBridgeServiceFactory extends AbstractSlotPoolServiceFactory {
 
-    public DeclarativeSlotPoolBridgeFactory(
+    public DeclarativeSlotPoolBridgeServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,
@@ -37,7 +37,7 @@ public class DeclarativeSlotPoolBridgeFactory extends AbstractSlotPoolFactory {
 
     @Nonnull
     @Override
-    public SlotPool createSlotPool(@Nonnull JobID jobId) {
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
         return new DeclarativeSlotPoolBridge(
                 jobId,
                 new DefaultDeclarativeSlotPoolFactory(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultSlotPoolServiceFactory.java
@@ -25,9 +25,9 @@ import org.apache.flink.util.clock.Clock;
 import javax.annotation.Nonnull;
 
 /** Default slot pool factory. */
-public class DefaultSlotPoolFactory extends AbstractSlotPoolFactory {
+public class DefaultSlotPoolServiceFactory extends AbstractSlotPoolServiceFactory {
 
-    public DefaultSlotPoolFactory(
+    public DefaultSlotPoolServiceFactory(
             @Nonnull Clock clock,
             @Nonnull Time rpcTimeout,
             @Nonnull Time slotIdleTimeout,
@@ -37,7 +37,7 @@ public class DefaultSlotPoolFactory extends AbstractSlotPoolFactory {
 
     @Override
     @Nonnull
-    public SlotPool createSlotPool(@Nonnull JobID jobId) {
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
         return new SlotPoolImpl(jobId, clock, rpcTimeout, slotIdleTimeout, batchSlotTimeout);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -123,11 +122,6 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
      */
     Optional<ResourceID> failAllocation(AllocationID allocationID, Exception cause);
 
-    default Optional<ResourceID> failAllocation(
-            @Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
-        return failAllocation(allocationID, cause);
-    }
-
     // ------------------------------------------------------------------------
     //  allocating and disposing slots
     // ------------------------------------------------------------------------
@@ -197,14 +191,6 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
     @Nonnull
     CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
             @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile);
-
-    /**
-     * Notifies that not enough resources are available to fulfill the resource requirements.
-     *
-     * @param acquiredResources the resources that have been acquired
-     */
-    default void notifyNotEnoughResourcesAvailable(
-            Collection<ResourceRequirement> acquiredResources) {}
 
     /**
      * Disables batch slot request timeout check. Invoked when someone else wants to take over the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -90,7 +90,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>TODO : Make pending requests location preference aware TODO : Make pass location preferences
  * to ResourceManager when sending a slot request
  */
-public class SlotPoolImpl implements SlotPool {
+public class SlotPoolImpl implements SlotPool, SlotPoolService {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -827,6 +827,12 @@ public class SlotPoolImpl implements SlotPool {
 
         // TODO: add some unit tests when the previous two are ready, the allocation may failed at
         // any phase
+    }
+
+    @Override
+    public Optional<ResourceID> failAllocation(
+            @Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
+        return failAllocation(allocationID, cause);
     }
 
     private Optional<ResourceID> tryFailingAllocatedSlot(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolService.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/** Service used by the {@link JobMaster} to manage a slot pool. */
+public interface SlotPoolService extends AutoCloseable {
+
+    /**
+     * Tries to cast this slot pool service into the given clazz.
+     *
+     * @param clazz to cast the slot pool service into
+     * @param <T> type of clazz
+     * @return {@link Optional#of} the target type if it can be cast; otherwise {@link
+     *     Optional#empty()}
+     */
+    default <T> Optional<T> castInto(Class<T> clazz) {
+        if (clazz.isAssignableFrom(this.getClass())) {
+            return Optional.of(clazz.cast(this));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Start the encapsulated slot pool implementation.
+     *
+     * @param jobMasterId jobMasterId to start the service with
+     * @param address address of the owner
+     * @param mainThreadExecutor mainThreadExecutor to run actions in the main thread
+     * @throws Exception if the the service cannot be started
+     */
+    void start(
+            JobMasterId jobMasterId, String address, ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception;
+
+    /** Suspend the slot pool service. */
+    void suspend();
+
+    /** Close the slot pool service. */
+    void close();
+
+    /**
+     * Offers multiple slots to the {@link SlotPoolService}. The slot offerings can be individually
+     * accepted or rejected by returning the collection of accepted slot offers.
+     *
+     * @param taskManagerLocation from which the slot offers originate
+     * @param taskManagerGateway to talk to the slot offerer
+     * @param offers slot offers which are offered to the {@link SlotPoolService}
+     * @return A collection of accepted slot offers. The remaining slot offers are implicitly
+     *     rejected.
+     */
+    Collection<SlotOffer> offerSlots(
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            Collection<SlotOffer> offers);
+
+    /**
+     * Fails the allocation with the given allocationId.
+     *
+     * @param taskManagerId taskManagerId is non-null if the signal comes from a TaskManager; if the
+     *     signal comes from the ResourceManager, then it is null
+     * @param allocationId allocationId identifies which allocation to fail
+     * @param cause cause why the allocation failed
+     * @return Optional task executor if it has no more slots registered
+     */
+    Optional<ResourceID> failAllocation(
+            @Nullable ResourceID taskManagerId, AllocationID allocationId, Exception cause);
+
+    /**
+     * Registers a TaskExecutor with the given {@link ResourceID} at {@link SlotPoolService}.
+     *
+     * @param taskManagerId identifying the TaskExecutor to register
+     * @return true iff a new resource id was registered
+     */
+    boolean registerTaskManager(ResourceID taskManagerId);
+
+    /**
+     * Releases a TaskExecutor with the given {@link ResourceID} from the {@link SlotPoolService}.
+     *
+     * @param taskManagerId identifying the TaskExecutor which shall be released from the SlotPool
+     * @param cause for the releasing of the TaskManager
+     * @return true iff a given registered resource id was removed
+     */
+    boolean releaseTaskManager(ResourceID taskManagerId, Exception cause);
+
+    /**
+     * Connects the SlotPool to the given ResourceManager. After this method is called, the SlotPool
+     * will be able to request resources from the given ResourceManager.
+     *
+     * @param resourceManagerGateway The RPC gateway for the resource manager.
+     */
+    void connectToResourceManager(ResourceManagerGateway resourceManagerGateway);
+
+    /**
+     * Disconnects the slot pool from its current Resource Manager. After this call, the pool will
+     * not be able to request further slots from the Resource Manager, and all currently pending
+     * requests to the resource manager will be canceled.
+     *
+     * <p>The slot pool will still be able to serve slots from its internal pool.
+     */
+    void disconnectResourceManager();
+
+    /**
+     * Create report about the allocated slots belonging to the specified task manager.
+     *
+     * @param taskManagerId identifies the task manager
+     * @return the allocated slots on the task manager
+     */
+    AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId);
+
+    /**
+     * Notifies that not enough resources are available to fulfill the resource requirements.
+     *
+     * @param acquiredResources the resources that have been acquired
+     */
+    default void notifyNotEnoughResourcesAvailable(
+            Collection<ResourceRequirement> acquiredResources) {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolServiceFactory.java
@@ -28,13 +28,13 @@ import org.apache.flink.util.clock.SystemClock;
 
 import javax.annotation.Nonnull;
 
-/** Factory interface for {@link SlotPool}. */
-public interface SlotPoolFactory {
+/** Factory interface for {@link SlotPoolService}. */
+public interface SlotPoolServiceFactory {
 
     @Nonnull
-    SlotPool createSlotPool(@Nonnull JobID jobId);
+    SlotPoolService createSlotPoolService(@Nonnull JobID jobId);
 
-    static SlotPoolFactory fromConfiguration(Configuration configuration) {
+    static SlotPoolServiceFactory fromConfiguration(Configuration configuration) {
         final Time rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
         final Time slotIdleTimeout =
                 Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
@@ -43,10 +43,10 @@ public interface SlotPoolFactory {
 
         if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
 
-            return new DeclarativeSlotPoolBridgeFactory(
+            return new DeclarativeSlotPoolBridgeServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
         } else {
-            return new DefaultSlotPoolFactory(
+            return new DefaultSlotPoolServiceFactory(
                     SystemClock.getInstance(), rpcTimeout, slotIdleTimeout, batchSlotTimeout);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -52,7 +53,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final JobGraph jobGraph,
             final Executor ioExecutor,
             final Configuration jobMasterConfiguration,
-            final SlotPool slotPool,
+            final SlotPoolService slotPoolService,
             final ScheduledExecutorService futureExecutor,
             final ClassLoader userCodeLoader,
             final CheckpointRecoveryFactory checkpointRecoveryFactory,
@@ -67,6 +68,14 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
             final ComponentMainThreadExecutor mainThreadExecutor,
             final JobStatusListener jobStatusListener)
             throws Exception {
+
+        final SlotPool slotPool =
+                slotPoolService
+                        .castInto(SlotPool.class)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "The DefaultScheduler requires a SlotPool."));
 
         final DefaultSchedulerComponents schedulerComponents =
                 createSchedulerComponents(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -45,7 +45,7 @@ public interface SchedulerNGFactory {
             JobGraph jobGraph,
             Executor ioExecutor,
             Configuration jobMasterConfiguration,
-            SlotPool slotPool,
+            SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
@@ -90,7 +90,7 @@ public class JobMasterSchedulerTest extends TestLogger {
                 JobGraph jobGraph,
                 Executor ioExecutor,
                 Configuration jobMasterConfiguration,
-                SlotPool slotPool,
+                SlotPoolService slotPoolService,
                 ScheduledExecutorService futureExecutor,
                 ClassLoader userCodeLoader,
                 CheckpointRecoveryFactory checkpointRecoveryFactory,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -39,7 +39,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerSharedServicesBuilder;
 import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -73,7 +73,7 @@ public class JobMasterBuilder {
 
     private HeartbeatServices heartbeatServices = DEFAULT_HEARTBEAT_SERVICES;
 
-    private SlotPoolFactory slotPoolFactory = null;
+    private SlotPoolServiceFactory slotPoolFactory = null;
 
     private OnCompletionActions onCompletionActions = new TestingOnCompletionActions();
 
@@ -129,7 +129,7 @@ public class JobMasterBuilder {
         return this;
     }
 
-    public JobMasterBuilder withSlotPoolFactory(SlotPoolFactory slotPoolFactory) {
+    public JobMasterBuilder withSlotPoolFactory(SlotPoolServiceFactory slotPoolFactory) {
         this.slotPoolFactory = slotPoolFactory;
         return this;
     }
@@ -195,7 +195,7 @@ public class JobMasterBuilder {
                 highAvailabilityServices,
                 slotPoolFactory != null
                         ? slotPoolFactory
-                        : SlotPoolFactory.fromConfiguration(configuration),
+                        : SlotPoolServiceFactory.fromConfiguration(configuration),
                 jobManagerSharedServices,
                 heartbeatServices,
                 UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.ExecutionDeploymentTracker;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolService;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 
@@ -53,7 +53,7 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             JobGraph jobGraph,
             Executor ioExecutor,
             Configuration jobMasterConfiguration,
-            SlotPool slotPool,
+            SlotPoolService slotPoolService,
             ScheduledExecutorService futureExecutor,
             ClassLoader userCodeLoader,
             CheckpointRecoveryFactory checkpointRecoveryFactory,


### PR DESCRIPTION
## What is the purpose of the change

This commit allows to support different SlotPoolService implementations which can
accommodate different slot pool implementations (e.g. SlotPool, DeclarativeSlotPool, etc.).

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
