### PR TITLE
[FLINK-21026][flink-sql-parser] Align column list specification synta…

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -972,6 +972,9 @@ SqlNode RichSqlInsert() :
         }
     ]
     [
+        <PARTITION> PartitionSpecCommaList(partitionList)
+    ]
+    [
         LOOKAHEAD(2)
         { final Pair<SqlNodeList, SqlNodeList> p; }
         p = ParenthesizedCompoundIdentifierList() {
@@ -982,9 +985,6 @@ SqlNode RichSqlInsert() :
                 columnList = p.left;
             }
         }
-    ]
-    [
-        <PARTITION> PartitionSpecCommaList(partitionList)
     ]
     source = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
         return new RichSqlInsert(s.end(source), keywordList, extendedKeywordList, table, source,

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -122,15 +122,15 @@ public class RichSqlInsert extends SqlInsert {
         final int opLeft = getOperator().getLeftPrec();
         final int opRight = getOperator().getRightPrec();
         getTargetTable().unparse(writer, opLeft, opRight);
-        if (getTargetColumnList() != null) {
-            getTargetColumnList().unparse(writer, opLeft, opRight);
-        }
-        writer.newlineAndIndent();
         if (staticPartitions != null && staticPartitions.size() > 0) {
             writer.keyword("PARTITION");
             staticPartitions.unparse(writer, opLeft, opRight);
             writer.newlineAndIndent();
         }
+        if (getTargetColumnList() != null) {
+            getTargetColumnList().unparse(writer, opLeft, opRight);
+        }
+        writer.newlineAndIndent();
         getSource().unparse(writer, 0, 0);
     }
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -866,35 +866,40 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     public void testInsertPartitionSpecs() {
-        final String sql1 = "insert into emps(x,y) partition (x='ab', y='bc') select * from emps";
+        final String sql1 = "insert into emps partition (x='ab', y='bc') (x,y) select * from emps";
         final String expected =
-                "INSERT INTO `EMPS` (`X`, `Y`)\n"
+                "INSERT INTO `EMPS` "
                         + "PARTITION (`X` = 'ab', `Y` = 'bc')\n"
+                        + "(`X`, `Y`)\n"
                         + "(SELECT *\n"
                         + "FROM `EMPS`)";
         sql(sql1).ok(expected);
         final String sql2 =
-                "insert into emp (empno, ename, job, mgr, hiredate,\n"
-                        + "  sal, comm, deptno, slacker)\n"
+                "insert into emp\n"
                         + "partition(empno='1', job='job')\n"
+                        + "(empno, ename, job, mgr, hiredate,\n"
+                        + "  sal, comm, deptno, slacker)\n"
                         + "select 'nom', 0, timestamp '1970-01-01 00:00:00',\n"
                         + "  1, 1, 1, false\n"
                         + "from (values 'a')";
         sql(sql2)
                 .ok(
-                        "INSERT INTO `EMP` (`EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`,"
-                                + " `COMM`, `DEPTNO`, `SLACKER`)\n"
+                        "INSERT INTO `EMP` "
                                 + "PARTITION (`EMPNO` = '1', `JOB` = 'job')\n"
+                                + "(`EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`,"
+                                + " `COMM`, `DEPTNO`, `SLACKER`)\n"
                                 + "(SELECT 'nom', 0, TIMESTAMP '1970-01-01 00:00:00', 1, 1, 1, FALSE\n"
                                 + "FROM (VALUES (ROW('a'))))");
         final String sql3 =
-                "insert into empnullables (empno, ename)\n"
+                "insert into empnullables\n"
                         + "partition(ename='b')\n"
+                        + "(empno, ename)\n"
                         + "select 1 from (values 'a')";
         sql(sql3)
                 .ok(
-                        "INSERT INTO `EMPNULLABLES` (`EMPNO`, `ENAME`)\n"
+                        "INSERT INTO `EMPNULLABLES` "
                                 + "PARTITION (`ENAME` = 'b')\n"
+                                + "(`EMPNO`, `ENAME`)\n"
                                 + "(SELECT 1\n"
                                 + "FROM (VALUES (ROW('a'))))");
     }
@@ -902,23 +907,25 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     public void testInsertCaseSensitivePartitionSpecs() {
         final String expected =
-                "INSERT INTO `emps` (`x`, `y`)\n"
+                "INSERT INTO `emps` "
                         + "PARTITION (`x` = 'ab', `y` = 'bc')\n"
+                        + "(`x`, `y`)\n"
                         + "(SELECT *\n"
                         + "FROM `EMPS`)";
-        sql("insert into \"emps\"(\"x\",\"y\") "
-                        + "partition (\"x\"='ab', \"y\"='bc') select * from emps")
+        sql("insert into \"emps\" "
+                        + "partition (\"x\"='ab', \"y\"='bc')(\"x\",\"y\") select * from emps")
                 .ok(expected);
     }
 
     @Test
     public void testInsertExtendedColumnAsStaticPartition1() {
         final String expected =
-                "INSERT INTO `EMPS` EXTEND (`Z` BOOLEAN) (`X`, `Y`)\n"
+                "INSERT INTO `EMPS` EXTEND (`Z` BOOLEAN) "
                         + "PARTITION (`Z` = 'ab')\n"
+                        + "(`X`, `Y`)\n"
                         + "(SELECT *\n"
                         + "FROM `EMPS`)";
-        sql("insert into emps(z boolean)(x,y) partition (z='ab') select * from emps").ok(expected);
+        sql("insert into emps(z boolean) partition (z='ab') (x,y) select * from emps").ok(expected);
     }
 
     @Test(expected = SqlParseException.class)
@@ -940,8 +947,9 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
         // partitioned
         final String sql1 = "INSERT OVERWRITE myTbl PARTITION (p1='v1',p2='v2') SELECT * FROM src";
         final String expected1 =
-                "INSERT OVERWRITE `MYTBL`\n"
+                "INSERT OVERWRITE `MYTBL` "
                         + "PARTITION (`P1` = 'v1', `P2` = 'v2')\n"
+                        + "\n"
                         + "(SELECT *\n"
                         + "FROM `SRC`)";
         sql(sql1).ok(expected1);


### PR DESCRIPTION
…x with hive in INSERT statement

## What is the purpose of the change

HIVE-9481 allows column list specification in INSERT statement in Hive. And the column list specification appears after the partition clause. Whereas in Flink, the column list specification appears before the partition clause. This PR align the column list specification syntax with Hive.

## Brief change log
- 8b36c8a  Align column list specification syntax with hive in INSERT statement

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
