### PR TITLE
[FLINK-20645][network] Fix corrupted unaligned checkpoints. [1.12]

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequest.java
@@ -59,7 +59,8 @@ interface ChannelStateWriteRequest {
             long checkpointId, InputChannelInfo info, CloseableIterator<Buffer> iterator) {
         return buildWriteRequest(
                 checkpointId,
-                "writeInput",
+                "ChannelStateWriteRequest#writeInput",
+                info,
                 iterator,
                 (writer, buffer) -> writer.writeInput(info, buffer));
     }
@@ -68,7 +69,8 @@ interface ChannelStateWriteRequest {
             long checkpointId, ResultSubpartitionInfo info, Buffer... buffers) {
         return buildWriteRequest(
                 checkpointId,
-                "writeOutput",
+                "ChannelStateWriteRequest#writeOutput",
+                info,
                 ofElements(Buffer::recycleBuffer, buffers),
                 (writer, buffer) -> writer.writeOutput(info, buffer));
     }
@@ -76,6 +78,7 @@ interface ChannelStateWriteRequest {
     static ChannelStateWriteRequest buildWriteRequest(
             long checkpointId,
             String name,
+            Object channelInfo,
             CloseableIterator<Buffer> iterator,
             BiConsumerWithException<ChannelStateCheckpointWriter, Buffer, Exception>
                     bufferConsumer) {
@@ -85,7 +88,7 @@ interface ChannelStateWriteRequest {
                 writer -> {
                     while (iterator.hasNext()) {
                         Buffer buffer = iterator.next();
-                        NetworkActionsLogger.log(ChannelStateWriteRequest.class, name, buffer);
+                        NetworkActionsLogger.tracePersist(name, buffer, channelInfo, checkpointId);
                         try {
                             checkArgument(buffer.isBuffer());
                         } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -67,7 +67,8 @@ class InputChannelRecoveredStateHandler
     @Override
     public void recover(InputChannelInfo channelInfo, Buffer buffer) {
         if (buffer.readableBytes() > 0) {
-            NetworkActionsLogger.log(getClass(), "recover", buffer);
+            NetworkActionsLogger.traceRecover(
+                    "InputChannelRecoveredStateHandler#recover", buffer, channelInfo);
             getChannel(channelInfo).onRecoveredStateBuffer(buffer);
         } else {
             buffer.recycleBuffer();
@@ -118,7 +119,10 @@ class ResultSubpartitionRecoveredStateHandler
             throws IOException {
         bufferBuilderAndConsumer.f0.finish();
         if (bufferBuilderAndConsumer.f1.isDataAvailable()) {
-            NetworkActionsLogger.log(getClass(), "recover", bufferBuilderAndConsumer.f1);
+            NetworkActionsLogger.traceRecover(
+                    "ResultSubpartitionRecoveredStateHandler#recover",
+                    bufferBuilderAndConsumer.f1,
+                    subpartitionInfo);
             boolean added =
                     getSubpartition(subpartitionInfo)
                             .add(bufferBuilderAndConsumer.f1, Integer.MIN_VALUE);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -52,7 +53,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  * and {@link #setSize(int)}.
  */
 public interface Buffer {
-
     /**
      * Returns whether this buffer represents a buffer or an event.
      *
@@ -226,6 +226,16 @@ public interface Buffer {
 
     /** Sets the type of data this buffer represents. */
     void setDataType(DataType dataType);
+
+    default String toDebugString(boolean includeHash) {
+        StringBuilder prettyString = new StringBuilder("Buffer{size=").append(getSize());
+        if (includeHash) {
+            byte[] bytes = new byte[getSize()];
+            readOnlySlice().asByteBuf().readBytes(bytes);
+            prettyString.append(", hash=").append(Arrays.hashCode(bytes));
+        }
+        return prettyString.append("}").toString();
+    }
 
     /**
      * Used to identify the type of data contained in the {@link Buffer} so that we can get the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -197,6 +197,19 @@ public class BufferConsumer implements Closeable {
         return currentReaderPosition < writerPosition.getLatest();
     }
 
+    public String toDebugString(boolean includeHash) {
+        Buffer buffer = null;
+        try (BufferConsumer copiedBufferConsumer = copy()) {
+            buffer = copiedBufferConsumer.build();
+            checkState(copiedBufferConsumer.isFinished());
+            return buffer.toDebugString(includeHash);
+        } finally {
+            if (buffer != null) {
+                buffer.recycleBuffer();
+            }
+        }
+    }
+
     /**
      * Cached reading wrapper around {@link PositionMarker}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumerWithPartialRecordLength;
+import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
@@ -323,6 +324,8 @@ public class PipelinedSubpartition extends ResultSubpartition
             // It will be reported for reading either on flush or when the number of buffers in the
             // queue
             // will be 2 or more.
+            NetworkActionsLogger.traceOutput(
+                    "PipelinedSubpartition#pollBuffer", buffer, subpartitionInfo);
             return new BufferAndBacklog(
                     buffer,
                     getBuffersInBacklog(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Helper class for persisting channel state via {@link ChannelStateWriter}. */
 @NotThreadSafe
@@ -70,6 +71,10 @@ public final class ChannelStatePersister {
         if (checkpointStatus != CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier < barrierId) {
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
+        } else if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED) {
+            checkState(
+                    lastSeenBarrier >= barrierId,
+                    "Internal error, #stopPersisting for last checkpoint has not been called.");
         }
         if (knownBuffers.size() > 0) {
             channelStateWriter.addInputData(
@@ -102,7 +107,11 @@ public final class ChannelStatePersister {
         final AbstractEvent priorityEvent = parsePriorityEvent(buffer);
         if (priorityEvent instanceof CheckpointBarrier) {
             final long barrierId = ((CheckpointBarrier) priorityEvent).getId();
-            if (barrierId >= lastSeenBarrier) {
+            long expectedBarrierId =
+                    checkpointStatus == CheckpointStatus.COMPLETED
+                            ? lastSeenBarrier + 1
+                            : lastSeenBarrier;
+            if (barrierId >= expectedBarrierId) {
                 logEvent("found barrier", barrierId);
                 checkpointStatus = CheckpointStatus.BARRIER_RECEIVED;
                 lastSeenBarrier = barrierId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -258,6 +259,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         } else {
             channelStatePersister.maybePersist(buffer);
         }
+        NetworkActionsLogger.traceInput(
+                "LocalInputChannel#getNextBuffer",
+                buffer,
+                channelInfo,
+                channelStatePersister,
+                next.getSequenceNumber());
         return Optional.of(
                 new BufferAndAvailability(
                         buffer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -445,7 +445,12 @@ public class RemoteInputChannel extends InputChannel {
             final boolean wasEmpty;
             boolean firstPriorityEvent = false;
             synchronized (receivedBuffers) {
-                NetworkActionsLogger.log(getClass(), "onBuffer", buffer);
+                NetworkActionsLogger.traceInput(
+                        "RemoteInputChannel#onBuffer",
+                        buffer,
+                        channelInfo,
+                        channelStatePersister,
+                        sequenceNumber);
                 // Similar to notifyBufferAvailable(), make sure that we never add a buffer
                 // after releaseAllResources() released all buffers from receivedBuffers
                 // (see above for details).

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
-import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.PrioritizedDeque;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -653,8 +652,6 @@ public class SingleInputGate extends IndexedInputGate {
                     checkUnavailability();
                     continue;
                 }
-                NetworkActionsLogger.log(
-                        getClass(), "waitAndGetNextData", bufferAndAvailabilityOpt.get().buffer());
 
                 final BufferAndAvailability bufferAndAvailability = bufferAndAvailabilityOpt.get();
                 if (bufferAndAvailability.moreAvailable()) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -94,6 +94,9 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
     protected static final String NUM_LOST = "lost";
     public static final int BUFFER_PER_CHANNEL = 1;
 
+    private static final long HEADER = 0xABCDEAFCL << 32;
+    private static final long HEADER_MASK = 0xFFFFFFFFL << 32;
+
     @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
     @Rule public ErrorCollector collector = new ErrorCollector();
@@ -193,7 +196,6 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         }
 
         private static class LongSourceReader implements SourceReader<Long, LongSplit> {
-
             private final long minCheckpoints;
             private final int expectedRestarts;
             private final LongCounter numInputsCounter = new LongCounter();
@@ -216,7 +218,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                     return InputStatus.NOTHING_AVAILABLE;
                 }
 
-                output.collect(split.nextNumber, split.nextNumber);
+                output.collect(withHeader(split.nextNumber), split.nextNumber);
                 split.nextNumber += split.increment;
 
                 if (throttle) {
@@ -657,7 +659,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 
         @Override
         public Long map(Long value) throws Exception {
-            lastValue = value;
+            lastValue = withoutHeader(value);
             checkFail(failDuringMap, "map");
             return value;
         }
@@ -831,6 +833,21 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                     getRuntimeContext().getIndexOfThisSubtask(),
                     getRuntimeContext().getAttemptNumber());
             super.close();
+        }
+    }
+
+    protected static long withHeader(long value) {
+        return value ^ HEADER;
+    }
+
+    protected static long withoutHeader(long value) {
+        checkHeader(value);
+        return value ^ HEADER;
+    }
+
+    protected static void checkHeader(long value) {
+        if ((value & HEADER_MASK) != HEADER) {
+            throw new IllegalArgumentException("Stream corrupted");
         }
     }
 }


### PR DESCRIPTION
Backport of #14721.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

With unusual barrier flow, checkpoints may miss certain buffers and become unrecoverable.

## Brief change log

- Fix ChannelStatePersister. 
- Improve UnalignedCheckpointITCase to detect data corruption faster.
- Adding more trace output for network and checkpoint buffers as shown in the following

```
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - LocalInputChannel#getNextBuffer Buffer{size=1996, hash=-1568575630}, seq 4, ChannelStatePersister(1 (COMPLETED)} @ InputChannelInfo{gateIdx=0, inputChannelIdx=0}
9996 [Channel state writer Source: source (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - ChannelStateWriteRequest#writeOutput Buffer{size=20, hash=1432560496}, checkpoint 2 @ ResultSubpartitionInfo{partitionIdx=0, subPartitionIdx=0}
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - PipelinedSubpartition#pollBuffer Buffer{size=38, hash=-1801242596} @ ResultSubpartitionInfo{partitionIdx=0, subPartitionIdx=0}
9996 [forward (1/1)#0] TRACE org.apache.flink.runtime.io.network.logger.NetworkActionsLogger [] - LocalInputChannel#getNextBuffer Buffer{size=38, hash=-1801242596}, seq 5, ChannelStatePersister(2 (BARRIER_RECEIVED)} @ InputChannelInfo{gateIdx=0, inputChannelIdx=0}
9996 [Source: source (1/1)#0] INFO  org.apache.flink.test.checkpointing.UnalignedCheckpointTestBase [] - Snapshotted LongSplit{increment=1, nextNumber=199, numCompletedCheckpoints=1} @ 0 subtask (0 attempt)
```

## Verifying this change

Already covered by existing UnalignedControllerTest when assertion is added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
