### PR TITLE
[FLINK-21104][network] Ensure that converted input channels start in the correct persisting state.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -75,7 +75,8 @@ public final class ChannelStatePersister {
         } else if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED) {
             checkState(
                     lastSeenBarrier >= barrierId,
-                    "Internal error, #stopPersisting for last checkpoint has not been called.");
+                    "Internal error, #stopPersisting for last checkpoint has not been called for "
+                            + channelInfo);
         }
         if (knownBuffers.size() > 0) {
             channelStateWriter.addInputData(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -69,6 +69,8 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     protected final int networkBuffersPerChannel;
     private boolean exclusiveBuffersAssigned;
 
+    private long lastStoppedCheckpointId = -1;
+
     RecoveredInputChannel(
             SingleInputGate inputGate,
             int channelIndex,
@@ -100,7 +102,14 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     public final InputChannel toInputChannel() throws IOException {
         Preconditions.checkState(
                 stateConsumedFuture.isDone(), "recovered state is not fully consumed");
-        return toInputChannelInternal();
+        final InputChannel inputChannel = toInputChannelInternal();
+        inputChannel.checkpointStopped(lastStoppedCheckpointId);
+        return inputChannel;
+    }
+
+    @Override
+    public void checkpointStopped(long checkpointId) {
+        this.lastStoppedCheckpointId = checkpointId;
     }
 
     protected abstract InputChannel toInputChannelInternal() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -296,6 +296,7 @@ public class SingleInputGate extends IndexedInputGate {
 
     @VisibleForTesting
     void convertRecoveredInputChannels() {
+        LOG.info("Converting recovered input channels ({} channels)", getNumberOfInputChannels());
         for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry :
                 inputChannels.entrySet()) {
             InputChannel inputChannel = entry.getValue();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -145,6 +145,10 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 }
                 numBarriersReceived = 0;
                 lastCancelledOrCompletedCheckpointId = currentCheckpointId;
+                LOG.debug(
+                        "{}: Received all barriers for checkpoint {}.",
+                        taskName,
+                        currentCheckpointId);
                 handleBarrier(
                         barrier,
                         channelInfo,
@@ -179,6 +183,11 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             }
             return true;
         } catch (CheckpointException e) {
+            LOG.debug(
+                    "{}: Aborting checkpoint {} after exception {}.",
+                    taskName,
+                    currentCheckpointId,
+                    e);
             abortInternal(barrier.getId(), e);
             return false;
         } catch (RuntimeException | IOException e) {
@@ -227,6 +236,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         final long cancelledId = cancelBarrier.getCheckpointId();
         if (cancelledId > currentCheckpointId
                 || (cancelledId == currentCheckpointId && numBarriersReceived > 0)) {
+            LOG.debug("{}: Received cancellation {}.", taskName, cancelledId);
             abortInternal(
                     cancelledId,
                     new CheckpointException(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When a checkpoint is aborted, the ChannelStatePersister of an input channel is stopped for that checkpoint.
A barrier that arrives after that is simply ignored.
However, if a channel is still being recovered during the abortion, the information that the checkpoint is stopped is lost for that particular channel.

## Brief change log

- This commit initializes converted channels with that state correctly.
- Additionally, this commit includes test that helped to verify that the ChannelStatePersister is actually working correctly now.


## Verifying this change

Stabilizes the UnalignedCheckpointITCase and added 2 unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
