### PR TITLE
[FLINK-21067][runtime][checkpoint] Modify the logic of computing which tasks to trigger/ack/commit to support finished tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlan.java
@@ -19,16 +19,15 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.executiongraph.Execution;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The brief of one checkpoint, indicating which tasks to trigger, waiting for acknowledge or commit
+ * The plan of one checkpoint, indicating which tasks to trigger, waiting for acknowledge or commit
  * for one specific checkpoint.
  */
 class CheckpointPlan {
@@ -37,7 +36,7 @@ class CheckpointPlan {
     private final List<Execution> tasksToTrigger;
 
     /** Tasks who need to acknowledge a checkpoint before it succeeds. */
-    private final Map<ExecutionAttemptID, ExecutionVertex> tasksToWaitFor;
+    private final List<Execution> tasksToWaitFor;
 
     /**
      * Tasks that are still running when taking the checkpoint, these need to be sent a message when
@@ -45,25 +44,43 @@ class CheckpointPlan {
      */
     private final List<ExecutionVertex> tasksToCommitTo;
 
+    /** Tasks that have already been finished when taking the checkpoint. */
+    private final List<Execution> finishedTasks;
+
+    /** The job vertices whose tasks are all finished when taking the checkpoint. */
+    private final List<ExecutionJobVertex> fullyFinishedJobVertex;
+
     CheckpointPlan(
             List<Execution> tasksToTrigger,
-            Map<ExecutionAttemptID, ExecutionVertex> tasksToWaitFor,
-            List<ExecutionVertex> tasksToCommitTo) {
+            List<Execution> tasksToWaitFor,
+            List<ExecutionVertex> tasksToCommitTo,
+            List<Execution> finishedTasks,
+            List<ExecutionJobVertex> fullyFinishedJobVertex) {
 
         this.tasksToTrigger = checkNotNull(tasksToTrigger);
         this.tasksToWaitFor = checkNotNull(tasksToWaitFor);
         this.tasksToCommitTo = checkNotNull(tasksToCommitTo);
+        this.finishedTasks = checkNotNull(finishedTasks);
+        this.fullyFinishedJobVertex = checkNotNull(fullyFinishedJobVertex);
     }
 
     List<Execution> getTasksToTrigger() {
         return tasksToTrigger;
     }
 
-    Map<ExecutionAttemptID, ExecutionVertex> getTasksToWaitFor() {
+    List<Execution> getTasksToWaitFor() {
         return tasksToWaitFor;
     }
 
     List<ExecutionVertex> getTasksToCommitTo() {
         return tasksToCommitTo;
+    }
+
+    public List<Execution> getFinishedTasks() {
+        return finishedTasks;
+    }
+
+    public List<ExecutionJobVertex> getFullyFinishedJobVertex() {
+        return fullyFinishedJobVertex;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlanCalculatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointPlanCalculatorContext.java
@@ -18,18 +18,25 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import java.util.concurrent.CompletableFuture;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
 /**
- * Calculates the plan of the next checkpoint, including the tasks to trigger, wait or commit for
- * each checkpoint.
+ * Provides the context for {@link DefaultCheckpointPlanCalculator} to compute the plan of
+ * checkpoints.
  */
-public interface CheckpointPlanCalculator {
+public interface CheckpointPlanCalculatorContext {
 
     /**
-     * Calculates the plan of the next checkpoint.
+     * Acquires the main thread executor for this job.
      *
-     * @return The result plan.
+     * @return The main thread executor.
      */
-    CompletableFuture<CheckpointPlan> calculateCheckpointPlan();
+    ScheduledExecutor getMainExecutor();
+
+    /**
+     * Detects whether there are already some tasks finished.
+     *
+     * @return Whether there are finished tasks.
+     */
+    boolean hasFinishedTasks();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionEdge;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Default implementation for {@link CheckpointPlanCalculator}. If all tasks are running, it
+ * directly marks all the sources as tasks to trigger, otherwise it would try to find the running
+ * tasks without running processors as tasks to trigger.
+ */
+public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator {
+
+    private final JobID jobId;
+
+    private final CheckpointPlanCalculatorContext context;
+
+    private final List<ExecutionJobVertex> jobVerticesInTopologyOrder = new ArrayList<>();
+
+    private final List<ExecutionVertex> allTasks = new ArrayList<>();
+
+    private final List<ExecutionVertex> sourceTasks = new ArrayList<>();
+
+    /**
+     * TODO Temporary flag to allow checkpoints after tasks finished. This is disabled for regular
+     * jobs to keep the current behavior but we want to allow it in tests. This should be removed
+     * once all parts of the stack support checkpoints after some tasks finished.
+     */
+    private boolean allowCheckpointsAfterTasksFinished;
+
+    public DefaultCheckpointPlanCalculator(
+            JobID jobId,
+            CheckpointPlanCalculatorContext context,
+            Iterable<ExecutionJobVertex> jobVerticesInTopologyOrderIterable) {
+
+        this.jobId = checkNotNull(jobId);
+        this.context = checkNotNull(context);
+
+        checkNotNull(jobVerticesInTopologyOrderIterable);
+        jobVerticesInTopologyOrderIterable.forEach(
+                jobVertex -> {
+                    jobVerticesInTopologyOrder.add(jobVertex);
+                    allTasks.addAll(Arrays.asList(jobVertex.getTaskVertices()));
+
+                    if (jobVertex.getJobVertex().isInputVertex()) {
+                        sourceTasks.addAll(Arrays.asList(jobVertex.getTaskVertices()));
+                    }
+                });
+    }
+
+    public void setAllowCheckpointsAfterTasksFinished(boolean allowCheckpointsAfterTasksFinished) {
+        this.allowCheckpointsAfterTasksFinished = allowCheckpointsAfterTasksFinished;
+    }
+
+    @Override
+    public CompletableFuture<CheckpointPlan> calculateCheckpointPlan() {
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    try {
+                        if (context.hasFinishedTasks() && !allowCheckpointsAfterTasksFinished) {
+                            throw new CheckpointException(
+                                    String.format(
+                                            "some tasks of job %s has been finished, abort the checkpoint",
+                                            jobId),
+                                    CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+                        }
+
+                        checkAllTasksInitiated();
+
+                        CheckpointPlan result =
+                                context.hasFinishedTasks()
+                                        ? calculateAfterTasksFinished()
+                                        : calculateWithAllTasksRunning();
+
+                        checkTasksStarted(result.getTasksToTrigger());
+
+                        return result;
+                    } catch (Throwable throwable) {
+                        throw new CompletionException(throwable);
+                    }
+                },
+                context.getMainExecutor());
+    }
+
+    /**
+     * Checks if all tasks are attached with the current Execution already. This method should be
+     * called from JobMaster main thread executor.
+     *
+     * @throws CheckpointException if some tasks do not have attached Execution.
+     */
+    private void checkAllTasksInitiated() throws CheckpointException {
+        for (ExecutionVertex task : allTasks) {
+            if (task.getCurrentExecutionAttempt() == null) {
+                throw new CheckpointException(
+                        String.format(
+                                "task %s of job %s is not being executed at the moment. Aborting checkpoint.",
+                                task.getTaskNameWithSubtaskIndex(), jobId),
+                        CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+            }
+        }
+    }
+
+    /**
+     * Checks if all tasks to trigger have already been in RUNNING state. This method should be
+     * called from JobMaster main thread executor.
+     *
+     * @throws CheckpointException if some tasks to trigger have not turned into RUNNING yet.
+     */
+    private void checkTasksStarted(List<Execution> toTrigger) throws CheckpointException {
+        for (Execution execution : toTrigger) {
+            if (execution.getState() == ExecutionState.CREATED
+                    || execution.getState() == ExecutionState.SCHEDULED
+                    || execution.getState() == ExecutionState.DEPLOYING) {
+
+                throw new CheckpointException(
+                        String.format(
+                                "Checkpoint triggering task %s of job %s has not being executed at the moment. "
+                                        + "Aborting checkpoint.",
+                                execution.getVertex().getTaskNameWithSubtaskIndex(), jobId),
+                        CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING);
+            }
+        }
+    }
+
+    /**
+     * Computes the checkpoint plan when all tasks are running. It would simply marks all the source
+     * tasks as need to trigger and all the tasks as need to wait and commit.
+     *
+     * @return The plan of this checkpoint.
+     */
+    private CheckpointPlan calculateWithAllTasksRunning() {
+        List<Execution> executionsToTrigger =
+                sourceTasks.stream()
+                        .map(ExecutionVertex::getCurrentExecutionAttempt)
+                        .collect(Collectors.toList());
+
+        List<Execution> tasksToWaitFor = createTaskToWaitFor(allTasks);
+
+        return new CheckpointPlan(
+                Collections.unmodifiableList(executionsToTrigger),
+                Collections.unmodifiableList(tasksToWaitFor),
+                Collections.unmodifiableList(allTasks),
+                Collections.emptyList(),
+                Collections.emptyList());
+    }
+
+    /**
+     * Calculates the checkpoint plan after some tasks have finished. We iterate the job graph to
+     * find the task that is still running, but do not has precedent running tasks.
+     *
+     * @return The plan of this checkpoint.
+     */
+    private CheckpointPlan calculateAfterTasksFinished() {
+        // First collect the task running status into BitSet so that we could
+        // do JobVertex level judgement for some vertices and avoid time-consuming
+        // access to volatile isFinished flag of Execution.
+        Map<JobVertexID, BitSet> taskRunningStatusByVertex = collectTaskRunningStatus();
+
+        List<Execution> tasksToTrigger = new ArrayList<>();
+        List<Execution> tasksToWaitFor = new ArrayList<>();
+        List<ExecutionVertex> tasksToCommitTo = new ArrayList<>();
+        List<Execution> finishedTasks = new ArrayList<>();
+        List<ExecutionJobVertex> fullyFinishedJobVertex = new ArrayList<>();
+
+        for (ExecutionJobVertex jobVertex : jobVerticesInTopologyOrder) {
+            BitSet taskRunningStatus = taskRunningStatusByVertex.get(jobVertex.getJobVertexId());
+
+            if (taskRunningStatus.cardinality() == 0) {
+                fullyFinishedJobVertex.add(jobVertex);
+
+                for (ExecutionVertex task : jobVertex.getTaskVertices()) {
+                    finishedTasks.add(task.getCurrentExecutionAttempt());
+                }
+
+                continue;
+            }
+
+            List<JobEdge> prevJobEdges = jobVertex.getJobVertex().getInputs();
+
+            // this is an optimization: we determine at the JobVertex level if some tasks can even
+            // be eligible for being in the "triggerTo" set.
+            boolean someTasksMustBeTriggered =
+                    someTasksMustBeTriggered(taskRunningStatusByVertex, prevJobEdges);
+
+            for (int i = 0; i < jobVertex.getTaskVertices().length; ++i) {
+                ExecutionVertex task = jobVertex.getTaskVertices()[i];
+                if (taskRunningStatus.get(task.getParallelSubtaskIndex())) {
+                    tasksToWaitFor.add(task.getCurrentExecutionAttempt());
+                    tasksToCommitTo.add(task);
+
+                    if (someTasksMustBeTriggered) {
+                        boolean hasRunningPrecedentTasks =
+                                hasRunningPrecedentTasks(
+                                        task, prevJobEdges, taskRunningStatusByVertex);
+
+                        if (!hasRunningPrecedentTasks) {
+                            tasksToTrigger.add(task.getCurrentExecutionAttempt());
+                        }
+                    }
+                } else {
+                    finishedTasks.add(task.getCurrentExecutionAttempt());
+                }
+            }
+        }
+
+        return new CheckpointPlan(
+                Collections.unmodifiableList(tasksToTrigger),
+                Collections.unmodifiableList(tasksToWaitFor),
+                Collections.unmodifiableList(tasksToCommitTo),
+                Collections.unmodifiableList(finishedTasks),
+                Collections.unmodifiableList(fullyFinishedJobVertex));
+    }
+
+    private boolean someTasksMustBeTriggered(
+            Map<JobVertexID, BitSet> runningTasksByVertex, List<JobEdge> prevJobEdges) {
+
+        for (JobEdge jobEdge : prevJobEdges) {
+            DistributionPattern distributionPattern = jobEdge.getDistributionPattern();
+            BitSet upstreamRunningStatus =
+                    runningTasksByVertex.get(jobEdge.getSource().getProducer().getID());
+
+            if (hasActiveUpstreamVertex(distributionPattern, upstreamRunningStatus)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Every task must have active upstream tasks if
+     *
+     * <ol>
+     *   <li>ALL_TO_ALL connection and some predecessors are still running.
+     *   <li>POINTWISE connection and all predecessors are still running.
+     * </ol>
+     *
+     * @param distribution The distribution pattern between the upstream vertex and the current
+     *     vertex.
+     * @param upstreamRunningTasks The running tasks of the upstream vertex.
+     * @return Whether every task of the current vertex is connected to some active predecessors.
+     */
+    private boolean hasActiveUpstreamVertex(
+            DistributionPattern distribution, BitSet upstreamRunningTasks) {
+        return (distribution == DistributionPattern.ALL_TO_ALL
+                        && upstreamRunningTasks.cardinality() > 0)
+                || (distribution == DistributionPattern.POINTWISE
+                        && upstreamRunningTasks.cardinality() == upstreamRunningTasks.size());
+    }
+
+    private boolean hasRunningPrecedentTasks(
+            ExecutionVertex vertex,
+            List<JobEdge> prevJobEdges,
+            Map<JobVertexID, BitSet> taskRunningStatusByVertex) {
+        for (int i = 0; i < prevJobEdges.size(); ++i) {
+            if (prevJobEdges.get(i).getDistributionPattern() == DistributionPattern.POINTWISE) {
+                for (ExecutionEdge executionEdge : vertex.getInputEdges(i)) {
+                    ExecutionVertex precedentTask = executionEdge.getSource().getProducer();
+                    BitSet precedentVertexRunningStatus =
+                            taskRunningStatusByVertex.get(precedentTask.getJobvertexId());
+
+                    if (precedentVertexRunningStatus.get(precedentTask.getParallelSubtaskIndex())) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Collects the task running status for each job vertex.
+     *
+     * @return The task running status for each job vertex.
+     */
+    @VisibleForTesting
+    Map<JobVertexID, BitSet> collectTaskRunningStatus() {
+        Map<JobVertexID, BitSet> runningStatusByVertex = new HashMap<>();
+
+        for (ExecutionJobVertex vertex : jobVerticesInTopologyOrder) {
+            BitSet runningTasks = new BitSet(vertex.getTaskVertices().length);
+
+            for (int i = 0; i < vertex.getTaskVertices().length; ++i) {
+                if (!vertex.getTaskVertices()[i].getCurrentExecutionAttempt().isFinished()) {
+                    runningTasks.set(i);
+                }
+            }
+
+            runningStatusByVertex.put(vertex.getJobVertexId(), runningTasks);
+        }
+
+        return runningStatusByVertex;
+    }
+
+    private List<Execution> createTaskToWaitFor(List<ExecutionVertex> tasks) {
+        List<Execution> tasksToAck = new ArrayList<>(tasks.size());
+        for (ExecutionVertex task : tasks) {
+            tasksToAck.add(task.getCurrentExecutionAttempt());
+        }
+
+        return tasksToAck;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ExecutionAttemptMappingProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ExecutionAttemptMappingProvider.java
@@ -21,13 +21,12 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Provides a mapping from {@link ExecutionAttemptID} to {@link ExecutionVertex} for currently
@@ -41,8 +40,9 @@ public class ExecutionAttemptMappingProvider {
     /** The cached mapping, which would only be updated on miss. */
     private final LinkedHashMap<ExecutionAttemptID, ExecutionVertex> cachedTasksById;
 
-    public ExecutionAttemptMappingProvider(List<ExecutionVertex> tasks) {
-        this.tasks = checkNotNull(tasks);
+    public ExecutionAttemptMappingProvider(Iterable<ExecutionVertex> tasksIterable) {
+        this.tasks = new ArrayList<>();
+        tasksIterable.forEach(this.tasks::add);
 
         this.cachedTasksById =
                 new LinkedHashMap<ExecutionAttemptID, ExecutionVertex>(tasks.size()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
+import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -141,7 +142,12 @@ public class PendingCheckpoint implements Checkpoint {
         this.checkpointId = checkpointId;
         this.checkpointTimestamp = checkpointTimestamp;
         this.checkpointPlan = checkNotNull(checkpointPlan);
-        this.notYetAcknowledgedTasks = new HashMap<>(checkpointPlan.getTasksToWaitFor());
+
+        this.notYetAcknowledgedTasks = new HashMap<>(checkpointPlan.getTasksToWaitFor().size());
+        for (Execution execution : checkpointPlan.getTasksToWaitFor()) {
+            notYetAcknowledgedTasks.put(execution.getAttemptId(), execution.getVertex());
+        }
+
         this.props = checkNotNull(props);
         this.targetLocation = checkNotNull(targetLocation);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -64,6 +64,10 @@ public class SubtaskStateStats implements Serializable {
     /** Is the checkpoint completed by this subtask. */
     private final boolean completed;
 
+    SubtaskStateStats(int subtaskIndex, long ackTimestamp) {
+        this(subtaskIndex, ackTimestamp, 0, 0, 0, 0, 0, 0, 0, false, true);
+    }
+
     SubtaskStateStats(
             int subtaskIndex,
             long ackTimestamp,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -896,7 +896,7 @@ public class Execution
     }
 
     @VisibleForTesting
-    void markFinished() {
+    public void markFinished() {
         markFinished(null, null);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCheckpointPlanCalculatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCheckpointPlanCalculatorContext.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.checkpoint.CheckpointPlanCalculatorContext;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link CheckpointPlanCalculatorContext} implementation based on the information from an {@link
+ * ExecutionGraph}.
+ */
+public class ExecutionGraphCheckpointPlanCalculatorContext
+        implements CheckpointPlanCalculatorContext {
+
+    private final ExecutionGraph executionGraph;
+
+    public ExecutionGraphCheckpointPlanCalculatorContext(ExecutionGraph executionGraph) {
+        this.executionGraph = checkNotNull(executionGraph);
+    }
+
+    @Override
+    public ScheduledExecutor getMainExecutor() {
+        return executionGraph.getJobMasterMainThreadExecutor();
+    }
+
+    @Override
+    public boolean hasFinishedTasks() {
+        return executionGraph.getNumFinishedVertices() > 0;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -24,7 +24,9 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
@@ -39,7 +41,6 @@ import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,7 +49,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
-import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.mockExecutionVertex;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -73,8 +73,12 @@ public class CheckpointCoordinatorMasterHooksTest {
 
     /** This method tests that hooks with the same identifier are not registered multiple times. */
     @Test
-    public void testDeduplicateOnRegister() {
-        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(new JobID());
+    public void testDeduplicateOnRegister() throws Exception {
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
+        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         MasterTriggerRestoreHook<?> hook1 = mock(MasterTriggerRestoreHook.class);
         when(hook1.getIdentifier()).thenReturn("test id");
@@ -92,8 +96,12 @@ public class CheckpointCoordinatorMasterHooksTest {
 
     /** Test that validates correct exceptions when supplying hooks with invalid IDs. */
     @Test
-    public void testNullOrInvalidId() {
-        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(new JobID());
+    public void testNullOrInvalidId() throws Exception {
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
+        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         try {
             cc.addMasterHook(null);
@@ -128,10 +136,11 @@ public class CheckpointCoordinatorMasterHooksTest {
         when(hook2.getIdentifier()).thenReturn(id2);
 
         // create the checkpoint coordinator
-        final JobID jid = new JobID();
-        final ExecutionAttemptID execId = new ExecutionAttemptID();
-        final ExecutionVertex ackVertex = mockExecutionVertex(execId);
-        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(jid, ackVertex);
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
+        CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(hook1);
         cc.addMasterHook(hook2);
@@ -181,14 +190,15 @@ public class CheckpointCoordinatorMasterHooksTest {
         when(statelessHook.getIdentifier()).thenReturn("some-id");
 
         // create the checkpoint coordinator
-        final JobID jid = new JobID();
-        final ExecutionAttemptID execId = new ExecutionAttemptID();
-        final ExecutionVertex ackVertex = mockExecutionVertex(execId);
+        JobVertexID jobVertexId = new JobVertexID();
+        final ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexId)
+                        .build();
         final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
         final CheckpointCoordinator cc =
-                instantiateCheckpointCoordinator(
-                        jid, manuallyTriggeredScheduledExecutor, ackVertex);
+                instantiateCheckpointCoordinator(graph, manuallyTriggeredScheduledExecutor);
 
         cc.addMasterHook(statefulHook1);
         cc.addMasterHook(statelessHook);
@@ -207,10 +217,17 @@ public class CheckpointCoordinatorMasterHooksTest {
         verify(statelessHook, times(1))
                 .triggerCheckpoint(anyLong(), anyLong(), any(Executor.class));
 
+        ExecutionAttemptID attemptID =
+                graph.getJobVertex(jobVertexId)
+                        .getTaskVertices()[0]
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+
         final long checkpointId =
                 cc.getPendingCheckpoints().values().iterator().next().getCheckpointId();
         cc.receiveAcknowledgeMessage(
-                new AcknowledgeCheckpoint(jid, execId, checkpointId), "Unknown location");
+                new AcknowledgeCheckpoint(graph.getJobID(), attemptID, checkpointId),
+                "Unknown location");
         assertEquals(0, cc.getNumberOfPendingCheckpoints());
 
         assertEquals(1, cc.getNumberOfRetainedSuccessfulCheckpoints());
@@ -280,9 +297,11 @@ public class CheckpointCoordinatorMasterHooksTest {
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         new TestCompletedCheckpointStorageLocation());
-        final ExecutionAttemptID execId = new ExecutionAttemptID();
-        final ExecutionVertex ackVertex = mockExecutionVertex(execId);
-        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(jid, ackVertex);
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
+        CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(statefulHook1);
         cc.addMasterHook(statelessHook);
@@ -338,9 +357,11 @@ public class CheckpointCoordinatorMasterHooksTest {
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         new TestCompletedCheckpointStorageLocation());
 
-        final ExecutionAttemptID execId = new ExecutionAttemptID();
-        final ExecutionVertex ackVertex = mockExecutionVertex(execId);
-        final CheckpointCoordinator cc = instantiateCheckpointCoordinator(jid, ackVertex);
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
+        CheckpointCoordinator cc = instantiateCheckpointCoordinator(graph);
 
         cc.addMasterHook(statefulHook);
         cc.addMasterHook(statelessHook);
@@ -374,14 +395,14 @@ public class CheckpointCoordinatorMasterHooksTest {
         final String id = "id";
 
         // create the checkpoint coordinator
-        final JobID jid = new JobID();
-        final ExecutionAttemptID execId = new ExecutionAttemptID();
-        final ExecutionVertex ackVertex = mockExecutionVertex(execId);
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .build();
         final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
                 new ManuallyTriggeredScheduledExecutor();
-        final CheckpointCoordinator cc =
-                instantiateCheckpointCoordinator(
-                        jid, manuallyTriggeredScheduledExecutor, ackVertex);
+        CheckpointCoordinator cc =
+                instantiateCheckpointCoordinator(graph, manuallyTriggeredScheduledExecutor);
 
         final MasterTriggerRestoreHook<Void> hook = mockGeneric(MasterTriggerRestoreHook.class);
         when(hook.getIdentifier()).thenReturn(id);
@@ -434,15 +455,14 @@ public class CheckpointCoordinatorMasterHooksTest {
     //  utilities
     // ------------------------------------------------------------------------
 
-    private CheckpointCoordinator instantiateCheckpointCoordinator(
-            JobID jid, ExecutionVertex... ackVertices) {
+    private CheckpointCoordinator instantiateCheckpointCoordinator(ExecutionGraph executionGraph) {
 
         return instantiateCheckpointCoordinator(
-                jid, new ManuallyTriggeredScheduledExecutor(), ackVertices);
+                executionGraph, new ManuallyTriggeredScheduledExecutor());
     }
 
     private CheckpointCoordinator instantiateCheckpointCoordinator(
-            JobID jid, ScheduledExecutor testingScheduledExecutor, ExecutionVertex... ackVertices) {
+            ExecutionGraph graph, ScheduledExecutor testingScheduledExecutor) {
 
         CheckpointCoordinatorConfiguration chkConfig =
                 new CheckpointCoordinatorConfiguration(
@@ -457,7 +477,7 @@ public class CheckpointCoordinatorMasterHooksTest {
                         0);
         Executor executor = Executors.directExecutor();
         return new CheckpointCoordinator(
-                jid,
+                graph.getJobID(),
                 chkConfig,
                 Collections.emptyList(),
                 new StandaloneCheckpointIDCounter(),
@@ -468,9 +488,11 @@ public class CheckpointCoordinatorMasterHooksTest {
                 testingScheduledExecutor,
                 SharedStateRegistry.DEFAULT_FACTORY,
                 new CheckpointFailureManager(0, NoOpFailJobCall.INSTANCE),
-                new CheckpointPlanCalculator(
-                        jid, new ArrayList<>(), Arrays.asList(ackVertices), new ArrayList<>()),
-                new ExecutionAttemptMappingProvider(Arrays.asList(ackVertices)));
+                new DefaultCheckpointPlanCalculator(
+                        graph.getJobID(),
+                        new ExecutionGraphCheckpointPlanCalculatorContext(graph),
+                        graph.getVerticesTopologically()),
+                new ExecutionAttemptMappingProvider(graph.getAllExecutionVertices()));
     }
 
     private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -19,24 +19,25 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.mock.Whitebox;
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway.CheckpointConsumer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -56,12 +57,12 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Assert;
-import org.mockito.invocation.InvocationOnMock;
 
 import javax.annotation.Nullable;
 
@@ -69,7 +70,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,12 +84,7 @@ import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /** Testing utils for checkpoint coordinator. */
 public class CheckpointCoordinatorTestingUtils {
@@ -356,154 +351,6 @@ public class CheckpointCoordinatorTestingUtils {
         }
     }
 
-    static ExecutionJobVertex mockExecutionJobVertex(
-            JobVertexID jobVertexID, int parallelism, int maxParallelism) throws Exception {
-
-        return mockExecutionJobVertex(
-                jobVertexID,
-                Collections.singletonList(OperatorID.fromJobVertexID(jobVertexID)),
-                parallelism,
-                maxParallelism);
-    }
-
-    static ExecutionJobVertex mockExecutionJobVertex(
-            JobVertexID jobVertexID,
-            List<OperatorID> jobVertexIDs,
-            int parallelism,
-            int maxParallelism)
-            throws Exception {
-        final ExecutionJobVertex executionJobVertex = mock(ExecutionJobVertex.class);
-
-        ExecutionVertex[] executionVertices = new ExecutionVertex[parallelism];
-
-        for (int i = 0; i < parallelism; i++) {
-            executionVertices[i] =
-                    mockExecutionVertex(
-                            new ExecutionAttemptID(),
-                            jobVertexID,
-                            jobVertexIDs,
-                            parallelism,
-                            maxParallelism,
-                            ExecutionState.RUNNING);
-
-            when(executionVertices[i].getParallelSubtaskIndex()).thenReturn(i);
-            when(executionVertices[i].getJobVertex()).thenReturn(executionJobVertex);
-        }
-
-        when(executionJobVertex.getJobVertexId()).thenReturn(jobVertexID);
-        when(executionJobVertex.getTaskVertices()).thenReturn(executionVertices);
-        when(executionJobVertex.getParallelism()).thenReturn(parallelism);
-        when(executionJobVertex.getMaxParallelism()).thenReturn(maxParallelism);
-        when(executionJobVertex.isMaxParallelismConfigured()).thenReturn(true);
-        List<OperatorIDPair> operatorIDPairs = new ArrayList<>();
-        for (OperatorID operatorID : jobVertexIDs) {
-            operatorIDPairs.add(OperatorIDPair.generatedIDOnly(operatorID));
-        }
-        when(executionJobVertex.getOperatorIDs()).thenReturn(operatorIDPairs);
-        when(executionJobVertex.getProducedDataSets()).thenReturn(new IntermediateResult[0]);
-
-        return executionJobVertex;
-    }
-
-    static ExecutionVertex mockExecutionVertex(ExecutionAttemptID attemptID) {
-        return mockExecutionVertex(attemptID, (LogicalSlot) null);
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            ExecutionAttemptID attemptID, CheckpointConsumer checkpointConsumer) {
-
-        final SimpleAckingTaskManagerGateway taskManagerGateway =
-                new SimpleAckingTaskManagerGateway();
-        taskManagerGateway.setCheckpointConsumer(checkpointConsumer);
-        return mockExecutionVertex(attemptID, taskManagerGateway);
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            ExecutionAttemptID attemptID, TaskManagerGateway taskManagerGateway) {
-
-        TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
-        slotBuilder.setTaskManagerGateway(taskManagerGateway);
-        LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
-        return mockExecutionVertex(attemptID, slot);
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            ExecutionAttemptID attemptID, @Nullable LogicalSlot slot) {
-
-        JobVertexID jobVertexID = new JobVertexID();
-        return mockExecutionVertex(
-                attemptID,
-                jobVertexID,
-                Collections.singletonList(OperatorID.fromJobVertexID(jobVertexID)),
-                slot,
-                1,
-                1,
-                ExecutionState.RUNNING);
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            ExecutionAttemptID attemptID,
-            JobVertexID jobVertexID,
-            List<OperatorID> jobVertexIDs,
-            int parallelism,
-            int maxParallelism,
-            ExecutionState state,
-            ExecutionState... successiveStates) {
-
-        return mockExecutionVertex(
-                attemptID,
-                jobVertexID,
-                jobVertexIDs,
-                null,
-                parallelism,
-                maxParallelism,
-                state,
-                successiveStates);
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            ExecutionAttemptID attemptID,
-            JobVertexID jobVertexID,
-            List<OperatorID> jobVertexIDs,
-            @Nullable LogicalSlot slot,
-            int parallelism,
-            int maxParallelism,
-            ExecutionState state,
-            ExecutionState... successiveStates) {
-
-        ExecutionVertex vertex = mock(ExecutionVertex.class);
-        when(vertex.getID()).thenReturn(ExecutionGraphTestUtils.createRandomExecutionVertexId());
-        when(vertex.getJobId()).thenReturn(new JobID());
-
-        final Execution exec =
-                spy(new Execution(mock(Executor.class), vertex, 1, 1L, Time.milliseconds(500L)));
-        if (slot != null) {
-            // is there a better way to do this?
-            Whitebox.setInternalState(exec, "assignedResource", slot);
-        }
-
-        when(exec.getAttemptId()).thenReturn(attemptID);
-        when(exec.getState()).thenReturn(state, successiveStates);
-
-        when(vertex.getJobvertexId()).thenReturn(jobVertexID);
-        when(vertex.getCurrentExecutionAttempt()).thenReturn(exec);
-        when(vertex.getTotalNumberOfParallelSubtasks()).thenReturn(parallelism);
-        when(vertex.getMaxParallelism()).thenReturn(maxParallelism);
-
-        ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-        List<OperatorIDPair> operatorIDPairs = new ArrayList<>();
-        for (OperatorID operatorID : jobVertexIDs) {
-            operatorIDPairs.add(OperatorIDPair.generatedIDOnly(operatorID));
-        }
-        when(jobVertex.getOperatorIDs()).thenReturn(operatorIDPairs);
-        when(jobVertex.getJobVertexId()).thenReturn(jobVertexID);
-        when(jobVertex.getParallelism()).thenReturn(parallelism);
-
-        when(vertex.getJobVertex()).thenReturn(jobVertex);
-
-        return vertex;
-    }
-
     static TaskStateSnapshot mockSubtaskState(
             JobVertexID jobVertexID, int index, KeyGroupRange keyGroupRange) throws IOException {
 
@@ -563,81 +410,249 @@ public class CheckpointCoordinatorTestingUtils {
         return new KeyGroupsStateHandle(keyGroupRangeOffsets, allSerializedStatesHandle);
     }
 
-    static Execution mockExecution() {
-        Execution mock = mock(Execution.class);
-        when(mock.getAttemptId()).thenReturn(new ExecutionAttemptID());
-        when(mock.getState()).thenReturn(ExecutionState.RUNNING);
-        return mock;
-    }
+    static class TriggeredCheckpoint {
+        final JobID jobId;
+        final long checkpointId;
+        final long timestamp;
+        final CheckpointOptions checkpointOptions;
 
-    static Execution mockExecution(CheckpointConsumer checkpointConsumer) {
-        ExecutionVertex executionVertex = mock(ExecutionVertex.class);
-        final JobID jobId = new JobID();
-        when(executionVertex.getJobId()).thenReturn(jobId);
-        Execution mock = mock(Execution.class);
-        ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
-        when(mock.getAttemptId()).thenReturn(executionAttemptID);
-        when(mock.getState()).thenReturn(ExecutionState.RUNNING);
-        when(mock.getVertex()).thenReturn(executionVertex);
-        doAnswer(
-                        (InvocationOnMock invocation) -> {
-                            final Object[] args = invocation.getArguments();
-                            checkpointConsumer.accept(
-                                    executionAttemptID,
-                                    jobId,
-                                    (long) args[0],
-                                    (long) args[1],
-                                    (CheckpointOptions) args[2]);
-                            return null;
-                        })
-                .when(mock)
-                .triggerCheckpoint(anyLong(), anyLong(), any(CheckpointOptions.class));
-        return mock;
-    }
-
-    static ExecutionVertex mockExecutionVertex(
-            Execution execution, JobVertexID vertexId, int subtask, int parallelism) {
-        ExecutionVertex mock = mock(ExecutionVertex.class);
-        when(mock.getJobvertexId()).thenReturn(vertexId);
-        when(mock.getParallelSubtaskIndex()).thenReturn(subtask);
-        when(mock.getCurrentExecutionAttempt()).thenReturn(execution);
-        when(mock.getTotalNumberOfParallelSubtasks()).thenReturn(parallelism);
-        when(mock.getMaxParallelism()).thenReturn(parallelism);
-        return mock;
-    }
-
-    static ExecutionJobVertex mockExecutionJobVertex(JobVertexID id, ExecutionVertex[] vertices) {
-        ExecutionJobVertex vertex = mock(ExecutionJobVertex.class);
-        when(vertex.getParallelism()).thenReturn(vertices.length);
-        when(vertex.getMaxParallelism()).thenReturn(vertices.length);
-        when(vertex.getJobVertexId()).thenReturn(id);
-        when(vertex.getTaskVertices()).thenReturn(vertices);
-        when(vertex.getOperatorIDs())
-                .thenReturn(
-                        Collections.singletonList(
-                                OperatorIDPair.generatedIDOnly(OperatorID.fromJobVertexID(id))));
-        when(vertex.getProducedDataSets()).thenReturn(new IntermediateResult[0]);
-
-        for (ExecutionVertex v : vertices) {
-            when(v.getJobVertex()).thenReturn(vertex);
+        public TriggeredCheckpoint(
+                JobID jobId,
+                long checkpointId,
+                long timestamp,
+                CheckpointOptions checkpointOptions) {
+            this.jobId = jobId;
+            this.checkpointId = checkpointId;
+            this.timestamp = timestamp;
+            this.checkpointOptions = checkpointOptions;
         }
-        return vertex;
+    }
+
+    static class NotifiedCheckpoint {
+        final JobID jobId;
+        final long checkpointId;
+        final long timestamp;
+
+        public NotifiedCheckpoint(JobID jobId, long checkpointId, long timestamp) {
+            this.jobId = jobId;
+            this.checkpointId = checkpointId;
+            this.timestamp = timestamp;
+        }
+    }
+
+    static class CheckpointRecorderTaskManagerGateway extends SimpleAckingTaskManagerGateway {
+
+        private final Map<ExecutionAttemptID, List<TriggeredCheckpoint>> triggeredCheckpoints =
+                new HashMap<>();
+
+        private final Map<ExecutionAttemptID, List<NotifiedCheckpoint>>
+                notifiedCompletedCheckpoints = new HashMap<>();
+
+        private final Map<ExecutionAttemptID, List<NotifiedCheckpoint>> notifiedAbortCheckpoints =
+                new HashMap<>();
+
+        @Override
+        public void triggerCheckpoint(
+                ExecutionAttemptID attemptId,
+                JobID jobId,
+                long checkpointId,
+                long timestamp,
+                CheckpointOptions checkpointOptions) {
+            triggeredCheckpoints
+                    .computeIfAbsent(attemptId, k -> new ArrayList<>())
+                    .add(
+                            new TriggeredCheckpoint(
+                                    jobId, checkpointId, timestamp, checkpointOptions));
+        }
+
+        @Override
+        public void notifyCheckpointComplete(
+                ExecutionAttemptID attemptId, JobID jobId, long checkpointId, long timestamp) {
+            notifiedCompletedCheckpoints
+                    .computeIfAbsent(attemptId, k -> new ArrayList<>())
+                    .add(new NotifiedCheckpoint(jobId, checkpointId, timestamp));
+        }
+
+        @Override
+        public void notifyCheckpointAborted(
+                ExecutionAttemptID attemptId, JobID jobId, long checkpointId, long timestamp) {
+            notifiedAbortCheckpoints
+                    .computeIfAbsent(attemptId, k -> new ArrayList<>())
+                    .add(new NotifiedCheckpoint(jobId, checkpointId, timestamp));
+        }
+
+        public void resetCount() {
+            triggeredCheckpoints.clear();
+            notifiedAbortCheckpoints.clear();
+            notifiedCompletedCheckpoints.clear();
+        }
+
+        public List<TriggeredCheckpoint> getTriggeredCheckpoints(ExecutionAttemptID attemptId) {
+            return triggeredCheckpoints.getOrDefault(attemptId, Collections.emptyList());
+        }
+
+        public TriggeredCheckpoint getOnlyTriggeredCheckpoint(ExecutionAttemptID attemptId) {
+            List<TriggeredCheckpoint> triggeredCheckpoints = getTriggeredCheckpoints(attemptId);
+            assertEquals(
+                    "There should be exactly one checkpoint triggered for " + attemptId,
+                    1,
+                    triggeredCheckpoints.size());
+            return triggeredCheckpoints.get(0);
+        }
+
+        public List<NotifiedCheckpoint> getNotifiedCompletedCheckpoints(
+                ExecutionAttemptID attemptId) {
+            return notifiedCompletedCheckpoints.getOrDefault(attemptId, Collections.emptyList());
+        }
+
+        public NotifiedCheckpoint getOnlyNotifiedCompletedCheckpoint(ExecutionAttemptID attemptId) {
+            List<NotifiedCheckpoint> completedCheckpoints =
+                    getNotifiedCompletedCheckpoints(attemptId);
+            assertEquals(
+                    "There should be exactly one checkpoint notified completed for " + attemptId,
+                    1,
+                    completedCheckpoints.size());
+            return completedCheckpoints.get(0);
+        }
+
+        public List<NotifiedCheckpoint> getNotifiedAbortedCheckpoints(
+                ExecutionAttemptID attemptId) {
+            return notifiedAbortCheckpoints.getOrDefault(attemptId, Collections.emptyList());
+        }
+
+        public NotifiedCheckpoint getOnlyNotifiedAbortedCheckpoint(ExecutionAttemptID attemptId) {
+            List<NotifiedCheckpoint> abortedCheckpoints = getNotifiedAbortedCheckpoints(attemptId);
+            assertEquals(
+                    "There should be exactly one checkpoint notified aborted for " + attemptId,
+                    1,
+                    abortedCheckpoints.size());
+            return abortedCheckpoints.get(0);
+        }
+    }
+
+    static class CheckpointExecutionGraphBuilder {
+        private final List<JobVertex> sourceVertices = new ArrayList<>();
+        private final List<JobVertex> nonSourceVertices = new ArrayList<>();
+        private boolean transitToRunning;
+        private TaskManagerGateway taskManagerGateway;
+        private ComponentMainThreadExecutor mainThreadExecutor;
+
+        CheckpointExecutionGraphBuilder() {
+            this.transitToRunning = true;
+            this.mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
+        }
+
+        public CheckpointExecutionGraphBuilder addJobVertex(JobVertexID id) {
+            return addJobVertex(id, true);
+        }
+
+        public CheckpointExecutionGraphBuilder addJobVertex(JobVertexID id, boolean isSource) {
+            return addJobVertex(id, 1, 32768, Collections.emptyList(), isSource);
+        }
+
+        public CheckpointExecutionGraphBuilder addJobVertex(
+                JobVertexID id, int parallelism, int maxParallelism) {
+            return addJobVertex(id, parallelism, maxParallelism, Collections.emptyList(), true);
+        }
+
+        public CheckpointExecutionGraphBuilder addJobVertex(
+                JobVertexID id,
+                int parallelism,
+                int maxParallelism,
+                List<OperatorIDPair> operators,
+                boolean isSource) {
+
+            JobVertex jobVertex =
+                    operators.size() == 0
+                            ? new JobVertex("anon", id)
+                            : new JobVertex("anon", id, operators);
+            jobVertex.setParallelism(parallelism);
+            jobVertex.setMaxParallelism(maxParallelism);
+            jobVertex.setInvokableClass(NoOpInvokable.class);
+
+            return addJobVertex(jobVertex, isSource);
+        }
+
+        public CheckpointExecutionGraphBuilder addJobVertex(JobVertex jobVertex, boolean isSource) {
+            if (isSource) {
+                sourceVertices.add(jobVertex);
+            } else {
+                nonSourceVertices.add(jobVertex);
+            }
+
+            return this;
+        }
+
+        public CheckpointExecutionGraphBuilder setTaskManagerGateway(
+                TaskManagerGateway taskManagerGateway) {
+            this.taskManagerGateway = taskManagerGateway;
+            return this;
+        }
+
+        public CheckpointExecutionGraphBuilder setTransitToRunning(boolean transitToRunning) {
+            this.transitToRunning = transitToRunning;
+            return this;
+        }
+
+        public CheckpointExecutionGraphBuilder setMainThreadExecutor(
+                ComponentMainThreadExecutor mainThreadExecutor) {
+            this.mainThreadExecutor = mainThreadExecutor;
+            return this;
+        }
+
+        ExecutionGraph build() throws Exception {
+            // Lets connect source vertices and non-source vertices
+            for (JobVertex source : sourceVertices) {
+                for (JobVertex nonSource : nonSourceVertices) {
+                    nonSource.connectNewDataSetAsInput(
+                            source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+                }
+            }
+
+            List<JobVertex> allVertices = new ArrayList<>();
+            allVertices.addAll(sourceVertices);
+            allVertices.addAll(nonSourceVertices);
+
+            ExecutionGraph executionGraph =
+                    ExecutionGraphTestUtils.createSimpleTestGraph(
+                            allVertices.toArray(new JobVertex[0]));
+            executionGraph.start(mainThreadExecutor);
+
+            if (taskManagerGateway != null) {
+                executionGraph
+                        .getAllExecutionVertices()
+                        .forEach(
+                                task -> {
+                                    LogicalSlot slot =
+                                            new TestingLogicalSlotBuilder()
+                                                    .setTaskManagerGateway(taskManagerGateway)
+                                                    .createTestingLogicalSlot();
+                                    task.tryAssignResource(slot);
+                                });
+            }
+
+            if (transitToRunning) {
+                executionGraph.transitionToRunning();
+                executionGraph
+                        .getAllExecutionVertices()
+                        .forEach(
+                                task ->
+                                        task.getCurrentExecutionAttempt()
+                                                .transitionState(ExecutionState.RUNNING));
+            }
+
+            return executionGraph;
+        }
     }
 
     /** A helper builder for {@link CheckpointCoordinator} to deduplicate test codes. */
     public static class CheckpointCoordinatorBuilder {
-        private JobID jobId = new JobID();
-
         private CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
                 new CheckpointCoordinatorConfigurationBuilder()
                         .setMaxConcurrentCheckpoints(Integer.MAX_VALUE)
                         .build();
 
-        private ExecutionVertex[] tasksToTrigger;
-
-        private ExecutionVertex[] tasksToWaitFor;
-
-        private ExecutionVertex[] tasksToCommitTo;
+        private ExecutionGraph executionGraph;
 
         private Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint =
                 Collections.emptyList();
@@ -661,18 +676,7 @@ public class CheckpointCoordinatorTestingUtils {
         private CheckpointFailureManager failureManager =
                 new CheckpointFailureManager(0, NoOpFailJobCall.INSTANCE);
 
-        public CheckpointCoordinatorBuilder() {
-            ExecutionVertex vertex = mockExecutionVertex(new ExecutionAttemptID());
-            ExecutionVertex[] defaultVertices = new ExecutionVertex[] {vertex};
-            tasksToTrigger = defaultVertices;
-            tasksToWaitFor = defaultVertices;
-            tasksToCommitTo = defaultVertices;
-        }
-
-        public CheckpointCoordinatorBuilder setJobId(JobID jobId) {
-            this.jobId = jobId;
-            return this;
-        }
+        private boolean allowCheckpointsAfterTasksFinished;
 
         public CheckpointCoordinatorBuilder setCheckpointCoordinatorConfiguration(
                 CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration) {
@@ -680,25 +684,8 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinatorBuilder setTasks(ExecutionVertex... tasks) {
-            this.tasksToTrigger = tasks;
-            this.tasksToWaitFor = tasks;
-            this.tasksToCommitTo = tasks;
-            return this;
-        }
-
-        public CheckpointCoordinatorBuilder setTasksToTrigger(ExecutionVertex[] tasksToTrigger) {
-            this.tasksToTrigger = tasksToTrigger;
-            return this;
-        }
-
-        public CheckpointCoordinatorBuilder setTasksToWaitFor(ExecutionVertex[] tasksToWaitFor) {
-            this.tasksToWaitFor = tasksToWaitFor;
-            return this;
-        }
-
-        public CheckpointCoordinatorBuilder setTasksToCommitTo(ExecutionVertex[] tasksToCommitTo) {
-            this.tasksToCommitTo = tasksToCommitTo;
+        public CheckpointCoordinatorBuilder setExecutionGraph(ExecutionGraph executionGraph) {
+            this.executionGraph = executionGraph;
             return this;
         }
 
@@ -753,9 +740,30 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
-        public CheckpointCoordinator build() {
+        public CheckpointCoordinatorBuilder setAllowCheckpointsAfterTasksFinished(
+                boolean allowCheckpointsAfterTasksFinished) {
+            this.allowCheckpointsAfterTasksFinished = allowCheckpointsAfterTasksFinished;
+            return this;
+        }
+
+        public CheckpointCoordinator build() throws Exception {
+            if (executionGraph == null) {
+                executionGraph =
+                        new CheckpointExecutionGraphBuilder()
+                                .addJobVertex(new JobVertexID())
+                                .build();
+            }
+
+            DefaultCheckpointPlanCalculator checkpointPlanCalculator =
+                    new DefaultCheckpointPlanCalculator(
+                            executionGraph.getJobID(),
+                            new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
+                            executionGraph.getVerticesTopologically());
+            checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(
+                    allowCheckpointsAfterTasksFinished);
+
             return new CheckpointCoordinator(
-                    jobId,
+                    executionGraph.getJobID(),
                     checkpointCoordinatorConfiguration,
                     coordinatorsToCheckpoint,
                     checkpointIDCounter,
@@ -766,12 +774,8 @@ public class CheckpointCoordinatorTestingUtils {
                     timer,
                     sharedStateRegistryFactory,
                     failureManager,
-                    new CheckpointPlanCalculator(
-                            jobId,
-                            Arrays.asList(tasksToTrigger),
-                            Arrays.asList(tasksToWaitFor),
-                            Arrays.asList(tasksToCommitTo)),
-                    new ExecutionAttemptMappingProvider(Arrays.asList(tasksToWaitFor)));
+                    checkpointPlanCalculator,
+                    new ExecutionAttemptMappingProvider(executionGraph.getAllExecutionVertices()));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
@@ -36,27 +37,22 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.util.SerializableObject;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.hamcrest.MockitoHamcrest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests concerning the restoring of state from a checkpoint to the task executions. */
@@ -68,7 +64,6 @@ public class CheckpointStateRestoreTest {
     @Test
     public void testSetState() {
         try {
-
             KeyGroupRange keyGroupRange = KeyGroupRange.of(0, 0);
             List<SerializableObject> testStates =
                     Collections.singletonList(new SerializableObject());
@@ -76,48 +71,36 @@ public class CheckpointStateRestoreTest {
                     CheckpointCoordinatorTestingUtils.generateKeyGroupState(
                             keyGroupRange, testStates);
 
-            final JobID jid = new JobID();
             final JobVertexID statefulId = new JobVertexID();
             final JobVertexID statelessId = new JobVertexID();
 
-            Execution statefulExec1 = mockExecution();
-            Execution statefulExec2 = mockExecution();
-            Execution statefulExec3 = mockExecution();
-            Execution statelessExec1 = mockExecution();
-            Execution statelessExec2 = mockExecution();
+            ExecutionGraph graph =
+                    new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                            .addJobVertex(statefulId, 3, 256)
+                            .addJobVertex(statelessId, 2, 256)
+                            .build();
 
-            ExecutionVertex stateful1 = mockExecutionVertex(statefulExec1, statefulId, 0, 3);
-            ExecutionVertex stateful2 = mockExecutionVertex(statefulExec2, statefulId, 1, 3);
-            ExecutionVertex stateful3 = mockExecutionVertex(statefulExec3, statefulId, 2, 3);
-            ExecutionVertex stateless1 = mockExecutionVertex(statelessExec1, statelessId, 0, 2);
-            ExecutionVertex stateless2 = mockExecutionVertex(statelessExec2, statelessId, 1, 2);
+            ExecutionJobVertex stateful = graph.getJobVertex(statefulId);
+            ExecutionJobVertex stateless = graph.getJobVertex(statelessId);
 
-            ExecutionJobVertex stateful =
-                    mockExecutionJobVertex(
-                            statefulId, new ExecutionVertex[] {stateful1, stateful2, stateful3});
-            ExecutionJobVertex stateless =
-                    mockExecutionJobVertex(
-                            statelessId, new ExecutionVertex[] {stateless1, stateless2});
+            ExecutionVertex stateful1 = stateful.getTaskVertices()[0];
+            ExecutionVertex stateful2 = stateful.getTaskVertices()[1];
+            ExecutionVertex stateful3 = stateful.getTaskVertices()[2];
+            ExecutionVertex stateless1 = stateless.getTaskVertices()[0];
+            ExecutionVertex stateless2 = stateless.getTaskVertices()[1];
 
-            Set<ExecutionJobVertex> tasks = new HashSet<>();
-            tasks.add(stateful);
-            tasks.add(stateless);
+            Execution statefulExec1 = stateful1.getCurrentExecutionAttempt();
+            Execution statefulExec2 = stateful2.getCurrentExecutionAttempt();
+            Execution statefulExec3 = stateful3.getCurrentExecutionAttempt();
+            Execution statelessExec1 = stateless1.getCurrentExecutionAttempt();
+            Execution statelessExec2 = stateless2.getCurrentExecutionAttempt();
 
             ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
                     new ManuallyTriggeredScheduledExecutor();
 
             CheckpointCoordinator coord =
                     new CheckpointCoordinatorBuilder()
-                            .setJobId(jid)
-                            .setTasksToTrigger(
-                                    new ExecutionVertex[] {
-                                        stateful1, stateful2, stateful3, stateless1, stateless2
-                                    })
-                            .setTasksToWaitFor(
-                                    new ExecutionVertex[] {
-                                        stateful1, stateful2, stateful3, stateless1, stateless2
-                                    })
-                            .setTasksToCommitTo(new ExecutionVertex[0])
+                            .setExecutionGraph(graph)
                             .setTimer(manuallyTriggeredScheduledExecutor)
                             .build();
 
@@ -138,7 +121,7 @@ public class CheckpointStateRestoreTest {
 
             coord.receiveAcknowledgeMessage(
                     new AcknowledgeCheckpoint(
-                            jid,
+                            graph.getJobID(),
                             statefulExec1.getAttemptId(),
                             checkpointId,
                             new CheckpointMetrics(),
@@ -146,7 +129,7 @@ public class CheckpointStateRestoreTest {
                     TASK_MANAGER_LOCATION_INFO);
             coord.receiveAcknowledgeMessage(
                     new AcknowledgeCheckpoint(
-                            jid,
+                            graph.getJobID(),
                             statefulExec2.getAttemptId(),
                             checkpointId,
                             new CheckpointMetrics(),
@@ -154,50 +137,35 @@ public class CheckpointStateRestoreTest {
                     TASK_MANAGER_LOCATION_INFO);
             coord.receiveAcknowledgeMessage(
                     new AcknowledgeCheckpoint(
-                            jid,
+                            graph.getJobID(),
                             statefulExec3.getAttemptId(),
                             checkpointId,
                             new CheckpointMetrics(),
                             subtaskStates),
                     TASK_MANAGER_LOCATION_INFO);
             coord.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId),
+                    new AcknowledgeCheckpoint(
+                            graph.getJobID(), statelessExec1.getAttemptId(), checkpointId),
                     TASK_MANAGER_LOCATION_INFO);
             coord.receiveAcknowledgeMessage(
-                    new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointId),
+                    new AcknowledgeCheckpoint(
+                            graph.getJobID(), statelessExec2.getAttemptId(), checkpointId),
                     TASK_MANAGER_LOCATION_INFO);
 
             assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
             assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
             // let the coordinator inject the state
-            assertTrue(coord.restoreLatestCheckpointedStateToAll(tasks, false));
+            assertTrue(
+                    coord.restoreLatestCheckpointedStateToAll(
+                            new HashSet<>(Arrays.asList(stateful, stateless)), false));
 
             // verify that each stateful vertex got the state
-
-            BaseMatcher<JobManagerTaskRestore> matcher =
-                    new BaseMatcher<JobManagerTaskRestore>() {
-                        @Override
-                        public boolean matches(Object o) {
-                            if (o instanceof JobManagerTaskRestore) {
-                                JobManagerTaskRestore taskRestore = (JobManagerTaskRestore) o;
-                                return Objects.equals(
-                                        taskRestore.getTaskStateSnapshot(), subtaskStates);
-                            }
-                            return false;
-                        }
-
-                        @Override
-                        public void describeTo(Description description) {
-                            description.appendValue(subtaskStates);
-                        }
-                    };
-
-            verify(statefulExec1, times(1)).setInitialState(MockitoHamcrest.argThat(matcher));
-            verify(statefulExec2, times(1)).setInitialState(MockitoHamcrest.argThat(matcher));
-            verify(statefulExec3, times(1)).setInitialState(MockitoHamcrest.argThat(matcher));
-            verify(statelessExec1, times(0)).setInitialState(Mockito.<JobManagerTaskRestore>any());
-            verify(statelessExec2, times(0)).setInitialState(Mockito.<JobManagerTaskRestore>any());
+            assertEquals(subtaskStates, statefulExec1.getTaskRestore().getTaskStateSnapshot());
+            assertEquals(subtaskStates, statefulExec2.getTaskRestore().getTaskStateSnapshot());
+            assertEquals(subtaskStates, statefulExec3.getTaskRestore().getTaskStateSnapshot());
+            assertNull(statelessExec1.getTaskRestore());
+            assertNull(statelessExec2.getTaskRestore());
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
@@ -75,9 +77,12 @@ public class CheckpointStatsTrackerTest {
     /** Tests that the number of remembered checkpoints configuration is respected. */
     @Test
     public void testTrackerWithoutHistory() throws Exception {
-        int numberOfSubtasks = 3;
-
-        JobVertexID vertexID = new JobVertexID();
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID, 3, 256)
+                        .build();
+        ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
 
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
@@ -91,11 +96,11 @@ public class CheckpointStatsTrackerTest {
                         1,
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        singletonMap(vertexID, numberOfSubtasks));
+                        singletonMap(jobVertexID, jobVertex.getParallelism()));
 
-        pending.reportSubtaskStats(vertexID, createSubtaskStats(0));
-        pending.reportSubtaskStats(vertexID, createSubtaskStats(1));
-        pending.reportSubtaskStats(vertexID, createSubtaskStats(2));
+        pending.reportSubtaskStats(jobVertexID, createSubtaskStats(0));
+        pending.reportSubtaskStats(jobVertexID, createSubtaskStats(1));
+        pending.reportSubtaskStats(jobVertexID, createSubtaskStats(2));
 
         pending.reportCompletedCheckpoint(null);
 
@@ -121,10 +126,14 @@ public class CheckpointStatsTrackerTest {
     /** Tests tracking of checkpoints. */
     @Test
     public void testCheckpointTracking() throws Exception {
-        int numberOfSubtasks = 3;
-
-        JobVertexID vertexID = new JobVertexID();
-        Map<JobVertexID, Integer> vertexToDop = singletonMap(vertexID, numberOfSubtasks);
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID, 3, 256)
+                        .build();
+        ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
+        Map<JobVertexID, Integer> vertexToDop =
+                singletonMap(jobVertexID, jobVertex.getParallelism());
 
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
@@ -141,9 +150,9 @@ public class CheckpointStatsTrackerTest {
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                         vertexToDop);
 
-        completed1.reportSubtaskStats(vertexID, createSubtaskStats(0));
-        completed1.reportSubtaskStats(vertexID, createSubtaskStats(1));
-        completed1.reportSubtaskStats(vertexID, createSubtaskStats(2));
+        completed1.reportSubtaskStats(jobVertexID, createSubtaskStats(0));
+        completed1.reportSubtaskStats(jobVertexID, createSubtaskStats(1));
+        completed1.reportSubtaskStats(jobVertexID, createSubtaskStats(2));
 
         completed1.reportCompletedCheckpoint(null);
 
@@ -163,9 +172,9 @@ public class CheckpointStatsTrackerTest {
                 tracker.reportPendingCheckpoint(
                         2, 1, CheckpointProperties.forSavepoint(true), vertexToDop);
 
-        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(0));
-        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(1));
-        savepoint.reportSubtaskStats(vertexID, createSubtaskStats(2));
+        savepoint.reportSubtaskStats(jobVertexID, createSubtaskStats(0));
+        savepoint.reportSubtaskStats(jobVertexID, createSubtaskStats(1));
+        savepoint.reportSubtaskStats(jobVertexID, createSubtaskStats(2));
 
         savepoint.reportCompletedCheckpoint(null);
 
@@ -243,8 +252,7 @@ public class CheckpointStatsTrackerTest {
     /** Tests that snapshots are only created if a new snapshot has been reported or updated. */
     @Test
     public void testCreateSnapshot() throws Exception {
-        JobVertexID jobVertexId = new JobVertexID();
-
+        JobVertexID jobVertexID = new JobVertexID();
         CheckpointStatsTracker tracker =
                 new CheckpointStatsTracker(
                         10,
@@ -260,9 +268,9 @@ public class CheckpointStatsTrackerTest {
                         1,
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        singletonMap(jobVertexId, 1));
+                        singletonMap(jobVertexID, 1));
 
-        pending.reportSubtaskStats(jobVertexId, createSubtaskStats(0));
+        pending.reportSubtaskStats(jobVertexID, createSubtaskStats(0));
 
         CheckpointStatsSnapshot snapshot2 = tracker.createSnapshot();
         assertNotEquals(snapshot1, snapshot2);
@@ -345,7 +353,12 @@ public class CheckpointStatsTrackerTest {
                     }
                 };
 
-        JobVertexID vertexID = new JobVertexID();
+        JobVertexID jobVertexID = new JobVertexID();
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID)
+                        .build();
+        ExecutionJobVertex jobVertex = graph.getJobVertex(jobVertexID);
 
         CheckpointStatsTracker stats =
                 new CheckpointStatsTracker(
@@ -415,7 +428,7 @@ public class CheckpointStatsTrackerTest {
                         0,
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        singletonMap(vertexID, 1));
+                        singletonMap(jobVertexID, 1));
 
         // Check counts
         assertEquals(Long.valueOf(1), numCheckpoints.getValue());
@@ -444,7 +457,7 @@ public class CheckpointStatsTrackerTest {
                         false,
                         true);
 
-        assertTrue(pending.reportSubtaskStats(vertexID, subtaskStats));
+        assertTrue(pending.reportSubtaskStats(jobVertexID, subtaskStats));
 
         pending.reportCompletedCheckpoint(externalPath);
 
@@ -467,7 +480,7 @@ public class CheckpointStatsTrackerTest {
                         11,
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        singletonMap(vertexID, 1));
+                        singletonMap(jobVertexID, 1));
 
         long failureTimestamp = 1230123L;
         nextPending.reportFailedCheckpoint(failureTimestamp, null);
@@ -503,9 +516,9 @@ public class CheckpointStatsTrackerTest {
                         5000,
                         CheckpointProperties.forCheckpoint(
                                 CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-                        singletonMap(vertexID, 1));
+                        singletonMap(jobVertexID, 1));
 
-        thirdPending.reportSubtaskStats(vertexID, subtaskStats);
+        thirdPending.reportSubtaskStats(jobVertexID, subtaskStats);
         thirdPending.reportCompletedCheckpoint(null);
 
         // Verify external path is "n/a", because internal checkpoint won't generate external path.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculatorTest.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Declarative tests for {@link DefaultCheckpointPlanCalculator}.
+ *
+ * <p>This test contains a framework for declaring vertex and edge states to then assert the
+ * calculator behavior.
+ */
+public class DefaultCheckpointPlanCalculatorTest {
+
+    @Test
+    public void testComputeAllRunningGraph() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(3, Collections.emptySet()),
+                        new VertexDeclaration(4, Collections.emptySet()),
+                        new VertexDeclaration(5, Collections.emptySet()),
+                        new VertexDeclaration(6, Collections.emptySet())),
+                Arrays.asList(
+                        new EdgeDeclaration(0, 2, DistributionPattern.ALL_TO_ALL),
+                        new EdgeDeclaration(1, 2, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(2, 3, DistributionPattern.ALL_TO_ALL)),
+                Arrays.asList(
+                        new TaskDeclaration(0, range(0, 3)), new TaskDeclaration(1, range(0, 4))));
+    }
+
+    @Test
+    public void testAllToAllEdgeWithSomeSourcesFinished() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(3, range(0, 2)),
+                        new VertexDeclaration(4, Collections.emptySet())),
+                Collections.singletonList(
+                        new EdgeDeclaration(0, 1, DistributionPattern.ALL_TO_ALL)),
+                Collections.singletonList(new TaskDeclaration(0, range(2, 3))));
+    }
+
+    @Test
+    public void testOneToOneEdgeWithSomeSourcesFinished() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(4, range(0, 2)),
+                        new VertexDeclaration(4, Collections.emptySet())),
+                Collections.singletonList(new EdgeDeclaration(0, 1, DistributionPattern.POINTWISE)),
+                Arrays.asList(
+                        new TaskDeclaration(0, range(2, 4)), new TaskDeclaration(1, range(0, 2))));
+    }
+
+    @Test
+    public void testOneToOnEdgeWithSomeSourcesAndTargetsFinished() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(4, range(0, 2)), new VertexDeclaration(4, of(0))),
+                Collections.singletonList(new EdgeDeclaration(0, 1, DistributionPattern.POINTWISE)),
+                Arrays.asList(
+                        new TaskDeclaration(0, range(2, 4)), new TaskDeclaration(1, range(1, 2))));
+    }
+
+    @Test
+    public void testComputeWithMultipleInputs() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(3, range(0, 3)),
+                        new VertexDeclaration(5, of(0, 2, 3)),
+                        new VertexDeclaration(5, of(2, 4)),
+                        new VertexDeclaration(5, of(2))),
+                Arrays.asList(
+                        new EdgeDeclaration(0, 3, DistributionPattern.ALL_TO_ALL),
+                        new EdgeDeclaration(1, 3, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(2, 3, DistributionPattern.POINTWISE)),
+                Arrays.asList(
+                        new TaskDeclaration(1, of(1, 4)), new TaskDeclaration(2, of(0, 1, 3))));
+    }
+
+    @Test
+    public void testComputeWithMultipleLevels() throws Exception {
+        runSingleTest(
+                Arrays.asList(
+                        new VertexDeclaration(16, range(0, 4)),
+                        new VertexDeclaration(16, range(0, 16)),
+                        new VertexDeclaration(16, range(0, 2)),
+                        new VertexDeclaration(16, Collections.emptySet()),
+                        new VertexDeclaration(16, Collections.emptySet())),
+                Arrays.asList(
+                        new EdgeDeclaration(0, 2, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(0, 3, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(1, 2, DistributionPattern.ALL_TO_ALL),
+                        new EdgeDeclaration(1, 3, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(2, 4, DistributionPattern.POINTWISE),
+                        new EdgeDeclaration(3, 4, DistributionPattern.ALL_TO_ALL)),
+                Arrays.asList(
+                        new TaskDeclaration(0, range(4, 16)),
+                        new TaskDeclaration(2, range(2, 4)),
+                        new TaskDeclaration(3, range(0, 4))));
+    }
+
+    @Test
+    public void testWithTriggeredTasksNotRunning() throws Exception {
+        ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(new JobVertexID())
+                        .setTransitToRunning(false)
+                        .build();
+        DefaultCheckpointPlanCalculator checkpointPlanCalculator =
+                createCheckpointPlanCalculator(graph);
+
+        try {
+            checkpointPlanCalculator.calculateCheckpointPlan().get();
+            fail("The computation should fail since not all tasks to trigger have start running");
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            assertThat(cause, instanceOf(CheckpointException.class));
+            assertEquals(
+                    CheckpointFailureReason.NOT_ALL_REQUIRED_TASKS_RUNNING,
+                    ((CheckpointException) cause).getCheckpointFailureReason());
+        }
+    }
+
+    // ------------------------- Utility methods ---------------------------------------
+
+    private void runSingleTest(
+            List<VertexDeclaration> vertexDeclarations,
+            List<EdgeDeclaration> edgeDeclarations,
+            List<TaskDeclaration> expectedToTriggerTaskDeclarations)
+            throws Exception {
+        runSingleTest(
+                vertexDeclarations,
+                edgeDeclarations,
+                expectedToTriggerTaskDeclarations,
+                IntStream.range(0, vertexDeclarations.size())
+                        .mapToObj(
+                                i ->
+                                        new TaskDeclaration(
+                                                i,
+                                                vertexDeclarations.get(i).finishedSubtaskIndices))
+                        .collect(Collectors.toList()));
+    }
+
+    private void runSingleTest(
+            List<VertexDeclaration> vertexDeclarations,
+            List<EdgeDeclaration> edgeDeclarations,
+            List<TaskDeclaration> expectedToTriggerTaskDeclarations,
+            List<TaskDeclaration> expectedFinishedTaskDeclarations)
+            throws Exception {
+
+        ExecutionGraph graph = createExecutionGraph(vertexDeclarations, edgeDeclarations);
+        DefaultCheckpointPlanCalculator planCalculator = createCheckpointPlanCalculator(graph);
+
+        List<TaskDeclaration> expectedRunningTaskDeclarations = new ArrayList<>();
+        List<ExecutionJobVertex> expectedFullyFinishedJobVertices = new ArrayList<>();
+
+        expectedFinishedTaskDeclarations.forEach(
+                finishedDeclaration -> {
+                    ExecutionJobVertex jobVertex =
+                            chooseJobVertex(graph, finishedDeclaration.vertexIndex);
+                    expectedRunningTaskDeclarations.add(
+                            new TaskDeclaration(
+                                    finishedDeclaration.vertexIndex,
+                                    minus(
+                                            range(0, jobVertex.getParallelism()),
+                                            finishedDeclaration.subtaskIndices)));
+                    if (finishedDeclaration.subtaskIndices.size() == jobVertex.getParallelism()) {
+                        expectedFullyFinishedJobVertices.add(jobVertex);
+                    }
+                });
+
+        List<ExecutionVertex> expectedRunningTasks =
+                chooseTasks(graph, expectedRunningTaskDeclarations.toArray(new TaskDeclaration[0]));
+        List<Execution> expectedFinishedTasks =
+                chooseTasks(graph, expectedFinishedTaskDeclarations.toArray(new TaskDeclaration[0]))
+                        .stream()
+                        .map(ExecutionVertex::getCurrentExecutionAttempt)
+                        .collect(Collectors.toList());
+        List<ExecutionVertex> expectedToTriggerTasks =
+                chooseTasks(
+                        graph, expectedToTriggerTaskDeclarations.toArray(new TaskDeclaration[0]));
+
+        // Tests computing checkpoint plan
+        CheckpointPlan checkpointPlan = planCalculator.calculateCheckpointPlan().get();
+        checkCheckpointPlan(
+                expectedToTriggerTasks,
+                expectedRunningTasks,
+                expectedFinishedTasks,
+                expectedFullyFinishedJobVertices,
+                checkpointPlan);
+    }
+
+    private ExecutionGraph createExecutionGraph(
+            List<VertexDeclaration> vertexDeclarations, List<EdgeDeclaration> edgeDeclarations)
+            throws Exception {
+
+        JobVertex[] jobVertices = new JobVertex[vertexDeclarations.size()];
+        for (int i = 0; i < vertexDeclarations.size(); ++i) {
+            jobVertices[i] =
+                    ExecutionGraphTestUtils.createJobVertex(
+                            vertexName(i),
+                            vertexDeclarations.get(i).parallelism,
+                            NoOpInvokable.class);
+        }
+
+        for (EdgeDeclaration edgeDeclaration : edgeDeclarations) {
+            jobVertices[edgeDeclaration.target].connectNewDataSetAsInput(
+                    jobVertices[edgeDeclaration.source],
+                    edgeDeclaration.distributionPattern,
+                    ResultPartitionType.PIPELINED);
+        }
+
+        ExecutionGraph graph = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertices);
+        graph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        graph.transitionToRunning();
+        graph.getAllExecutionVertices()
+                .forEach(
+                        task ->
+                                task.getCurrentExecutionAttempt()
+                                        .transitionState(ExecutionState.RUNNING));
+
+        for (int i = 0; i < vertexDeclarations.size(); ++i) {
+            JobVertexID jobVertexId = jobVertices[i].getID();
+            vertexDeclarations
+                    .get(i)
+                    .finishedSubtaskIndices
+                    .forEach(
+                            index -> {
+                                graph.getJobVertex(jobVertexId)
+                                        .getTaskVertices()[index]
+                                        .getCurrentExecutionAttempt()
+                                        .markFinished();
+                            });
+        }
+
+        return graph;
+    }
+
+    private DefaultCheckpointPlanCalculator createCheckpointPlanCalculator(ExecutionGraph graph) {
+        DefaultCheckpointPlanCalculator checkpointPlanCalculator =
+                new DefaultCheckpointPlanCalculator(
+                        graph.getJobID(),
+                        new ExecutionGraphCheckpointPlanCalculatorContext(graph),
+                        graph.getVerticesTopologically());
+        checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(true);
+        return checkpointPlanCalculator;
+    }
+
+    private void checkCheckpointPlan(
+            List<ExecutionVertex> expectedToTrigger,
+            List<ExecutionVertex> expectedRunning,
+            List<Execution> expectedFinished,
+            List<ExecutionJobVertex> expectedFullyFinished,
+            CheckpointPlan plan) {
+
+        // Compares tasks to trigger
+        List<Execution> expectedTriggeredExecutions =
+                expectedToTrigger.stream()
+                        .map(ExecutionVertex::getCurrentExecutionAttempt)
+                        .collect(Collectors.toList());
+        assertSameInstancesWithoutOrder(
+                "The computed tasks to trigger is different from expected",
+                expectedTriggeredExecutions,
+                plan.getTasksToTrigger());
+
+        // Compares running tasks
+        assertSameInstancesWithoutOrder(
+                "The computed running tasks is different from expected",
+                expectedRunning,
+                plan.getTasksToCommitTo());
+
+        // Compares finished tasks
+        assertSameInstancesWithoutOrder(
+                "The computed finished tasks is different from expected",
+                expectedFinished,
+                plan.getFinishedTasks());
+
+        // Compares fully finished job vertices
+        assertSameInstancesWithoutOrder(
+                "The computed fully finished JobVertex is different from expected",
+                expectedFullyFinished,
+                plan.getFullyFinishedJobVertex());
+
+        // Compares tasks to ack
+        assertSameInstancesWithoutOrder(
+                "The computed tasks to ack is different from expected",
+                expectedRunning.stream()
+                        .map(ExecutionVertex::getCurrentExecutionAttempt)
+                        .collect(Collectors.toList()),
+                plan.getTasksToWaitFor());
+    }
+
+    private <T> void assertSameInstancesWithoutOrder(
+            String comment, Collection<T> expected, Collection<T> actual) {
+        assertThat(
+                comment,
+                expected,
+                containsInAnyOrder(
+                        actual.stream()
+                                .map(CoreMatchers::sameInstance)
+                                .collect(Collectors.toList())));
+    }
+
+    private List<ExecutionVertex> chooseTasks(
+            ExecutionGraph graph, TaskDeclaration... chosenDeclarations) {
+        List<ExecutionVertex> tasks = new ArrayList<>();
+
+        for (TaskDeclaration chosenDeclaration : chosenDeclarations) {
+            ExecutionJobVertex jobVertex = chooseJobVertex(graph, chosenDeclaration.vertexIndex);
+            chosenDeclaration.subtaskIndices.forEach(
+                    index -> tasks.add(jobVertex.getTaskVertices()[index]));
+        }
+
+        return tasks;
+    }
+
+    private ExecutionJobVertex chooseJobVertex(ExecutionGraph graph, int vertexIndex) {
+        String name = vertexName(vertexIndex);
+        Optional<ExecutionJobVertex> foundVertex =
+                graph.getAllVertices().values().stream()
+                        .filter(jobVertex -> jobVertex.getName().equals(name))
+                        .findFirst();
+
+        if (!foundVertex.isPresent()) {
+            throw new RuntimeException("Vertex not found with index " + vertexIndex);
+        }
+
+        return foundVertex.get();
+    }
+
+    private String vertexName(int index) {
+        return "vertex_" + index;
+    }
+
+    private Set<Integer> range(int start, int end) {
+        return IntStream.range(start, end).boxed().collect(Collectors.toSet());
+    }
+
+    private Set<Integer> of(Integer... index) {
+        return new HashSet<>(Arrays.asList(index));
+    }
+
+    private Set<Integer> minus(Set<Integer> all, Set<Integer> toMinus) {
+        return all.stream().filter(e -> !toMinus.contains(e)).collect(Collectors.toSet());
+    }
+
+    // ------------------------- Utility helper classes ---------------------------------------
+
+    private static class VertexDeclaration {
+        final int parallelism;
+        final Set<Integer> finishedSubtaskIndices;
+
+        public VertexDeclaration(int parallelism, Set<Integer> finishedSubtaskIndices) {
+            this.parallelism = parallelism;
+            this.finishedSubtaskIndices = finishedSubtaskIndices;
+        }
+    }
+
+    private static class EdgeDeclaration {
+        final int source;
+        final int target;
+        final DistributionPattern distributionPattern;
+
+        public EdgeDeclaration(int source, int target, DistributionPattern distributionPattern) {
+            this.source = source;
+            this.target = target;
+            this.distributionPattern = distributionPattern;
+        }
+    }
+
+    private static class TaskDeclaration {
+        final int vertexIndex;
+
+        final Set<Integer> subtaskIndices;
+
+        public TaskDeclaration(int vertexIndex, Set<Integer> subtaskIndices) {
+            this.vertexIndex = vertexIndex;
+            this.subtaskIndices = subtaskIndices;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Modifies the logic of computation of checkpoint brief to support the case that have finished tasks. 

**Basic Algorithm**

The algorithm would search the graph from the source vertices to find those tasks that
1. Is still running.
2. Does not have running precedent tasks.

To reduce the overhead, the search is done in JobVertex level instead of task level. For the cases that
1. JobVertex `A` has running tasks and `A->B` via a `ALL_TO_ALL` edges
2. All tasks of JobVertex `A` are running and `A->B` via a `POINTWISE` edges

Then we could conclude that all the tasks of vertex B should not be triggered. It could be seen the time complexity for the whole algorithm would be linear to the number of tasks instead of execution edges.

**Considering the unordered finished report**

Another note about the algorithm is that since each tasks would report FINISHED to JM without coordination, thus for graph like `A -> B -> C`, it is possible that JobMaster first received the `FINISHED` report of `A` and `C` before `B`.  This might cause problem for the basic algorithm. Thus we would first iterates the graph reversely to find the accurate set of running tasks according to the observation that:
1. If one task is finished, all its precedent tasks are finished.

The iteration is also done in JobVertex level, like the basic algorithm

**Flag to disable checkpoints after tasks**

Checkpoints after tasks finished need to be enabled as a whole after we have finished all the work for JM, TM and failover, otherwise it may cause failed checkpoints or in-consistent checkpoint. To avoid this issue, we would introduce a temporary flag in `CheckpointCoordinator` to disable checkpoint after tasks finished in formal process for now and would remove the flags after the whole development is done.

## Brief change log

- f65290976eefdd70cc8b139cbf7b64ad31702499 modifies the formal process
- 5240cfd136ef88bfe8ab75242e8476b0898d2e25 fixed the existing tests
- 2ab49d334140ab47d7eb144964fac540e6f98444 added new tests for the changed logic.

## Verifying this change

- Added UT to verify the computation of checkpoint brief and checkpoint status tracker with finished tasks.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
