### PR TITLE
[FLINK-21069][table-planner-blink] Configuration "parallelism.default" doesn't take effect for TableEnvironment#explainSql

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -155,11 +155,6 @@ abstract class PlannerBase(
     if (modifyOperations.isEmpty) {
       return List.empty[Transformation[_]]
     }
-    // prepare the execEnv before translating
-    getExecEnv.configure(
-      getTableConfig.getConfiguration,
-      Thread.currentThread().getContextClassLoader)
-    overrideEnvParallelism()
 
     val relNodes = modifyOperations.map(translateToRel)
     val optimizedRelNodes = optimize(relNodes)
@@ -186,6 +181,12 @@ abstract class PlannerBase(
     */
   @VisibleForTesting
   private[flink] def translateToRel(modifyOperation: ModifyOperation): RelNode = {
+    // prepare the execEnv before translating
+    getExecEnv.configure(
+      getTableConfig.getConfiguration,
+      Thread.currentThread().getContextClassLoader)
+    overrideEnvParallelism()
+
     modifyOperation match {
       case s: UnregisteredSinkModifyOperation[_] =>
         val input = getRelBuilder.queryOperation(s.getChild).build()

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testStreamTableEnvironmentExecutionExplain.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testStreamTableEnvironmentExecutionExplain.out
@@ -24,10 +24,10 @@ LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
     "type" : "CsvTableSource(read fields: first)",
     "pact" : "Operator",
     "contents" : "CsvTableSource(read fields: first)",
-    "parallelism" : 1,
+    "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
-      "ship_strategy" : "FORWARD",
+      "ship_strategy" : "REBALANCE",
       "side" : "second"
     } ]
   }, {
@@ -35,7 +35,7 @@ LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
     "type" : "SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: first)]], fields=[first])",
     "pact" : "Operator",
     "contents" : "SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: first)]], fields=[first])",
-    "parallelism" : 1,
+    "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",
@@ -46,7 +46,7 @@ LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
     "type" : "SinkConversionToRow",
     "pact" : "Operator",
     "contents" : "SinkConversionToRow",
-    "parallelism" : 1,
+    "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",
@@ -57,7 +57,7 @@ LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
     "type" : "Map",
     "pact" : "Operator",
     "contents" : "Map",
-    "parallelism" : 1,
+    "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",
@@ -68,7 +68,7 @@ LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
     "type" : "Sink: CsvTableSink(first)",
     "pact" : "Data Sink",
     "contents" : "Sink: CsvTableSink(first)",
-    "parallelism" : 1,
+    "parallelism" : 4,
     "predecessors" : [ {
       "id" : ,
       "ship_strategy" : "FORWARD",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -105,25 +105,28 @@ class TableEnvironmentTest {
   }
 
   @Test
-  def testStreamTableEnvironmentExecutionExplain(): Unit = {
+  def testStreamTableEnvironmentExecutionExplainWithEnvParallelism(): Unit = {
     val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
     execEnv.setParallelism(4)
     val settings = EnvironmentSettings.newInstance().inStreamingMode().build()
-    var tEnv = StreamTableEnvironment.create(execEnv, settings)
+    val tEnv = StreamTableEnvironment.create(execEnv, settings)
 
-    testStreamTableEnvironmentExecutionExplain(tEnv)
-
-    tEnv = StreamTableEnvironment.create(
-      StreamExecutionEnvironment.getExecutionEnvironment,
-      settings)
-    val conf = new Configuration()
-    conf.setInteger("parallelism.default", 4)
-    tEnv.getConfig.addConfiguration(conf)
-
-    testStreamTableEnvironmentExecutionExplain(tEnv)
+    verifyTableEnvironmentExecutionExplain(tEnv)
   }
 
-  def testStreamTableEnvironmentExecutionExplain(tEnv: TableEnvironment): Unit = {
+  @Test
+  def testStreamTableEnvironmentExecutionExplainWithConfParallelism(): Unit = {
+    val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val settings = EnvironmentSettings.newInstance().inStreamingMode().build()
+    val tEnv = StreamTableEnvironment.create(execEnv, settings)
+    val configuration = new Configuration()
+    configuration.setInteger("parallelism.default", 4)
+    tEnv.getConfig.addConfiguration(configuration)
+
+    verifyTableEnvironmentExecutionExplain(tEnv)
+  }
+
+  private def verifyTableEnvironmentExecutionExplain(tEnv: TableEnvironment): Unit = {
     TestTableSourceSinks.createPersonCsvTemporaryTable(tEnv, "MyTable")
 
     TestTableSourceSinks.createCsvTemporarySinkTable(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.api
 
 import org.apache.flink.api.common.typeinfo.Types.STRING
 import org.apache.flink.api.scala._
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment, _}
@@ -106,10 +107,23 @@ class TableEnvironmentTest {
   @Test
   def testStreamTableEnvironmentExecutionExplain(): Unit = {
     val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
-    execEnv.setParallelism(1)
+    execEnv.setParallelism(4)
     val settings = EnvironmentSettings.newInstance().inStreamingMode().build()
-    val tEnv = StreamTableEnvironment.create(execEnv, settings)
+    var tEnv = StreamTableEnvironment.create(execEnv, settings)
 
+    testStreamTableEnvironmentExecutionExplain(tEnv)
+
+    tEnv = StreamTableEnvironment.create(
+      StreamExecutionEnvironment.getExecutionEnvironment,
+      settings)
+    val conf = new Configuration()
+    conf.setInteger("parallelism.default", 4)
+    tEnv.getConfig.addConfiguration(conf)
+
+    testStreamTableEnvironmentExecutionExplain(tEnv)
+  }
+
+  def testStreamTableEnvironmentExecutionExplain(tEnv: TableEnvironment): Unit = {
     TestTableSourceSinks.createPersonCsvTemporaryTable(tEnv, "MyTable")
 
     TestTableSourceSinks.createCsvTemporarySinkTable(


### PR DESCRIPTION
## What is the purpose of the change

*The configuration `parallelism.default` for table environment doesn't take effect for `TableEnvironment#explain`. Because `PlannerBase#translateToRel` doesn't invoke `overrideEnvParallelism` which configures the configuration into underlying `StreamExecutionEnvironment` and is invoked in `translate`. Method `overrideEnvParallelism` should be invoked in `translateToRel` and removed from `translate`.*

## Brief change log

  - *`PlannerBase#translateToRel` invokes the method `overrideEnvParallelism` which configures the configuration into underlying `StreamExecutionEnvironment`.*

## Verifying this change

  - *Modify `testStreamTableEnvironmentExecutionExplain` of `TableEnvironmentTest` to verify the test case whether the configuration `parallelism.default` takes effect in `TableEnvironment#explainSql` or not.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)