### PR TITLE
[FLINK-21020][build] Bump Jackson to 2.10.5.1

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.7.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0
 - commons-codec:commons-codec:1.10

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,12 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.8.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5
 - com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 - com.google.guava:guava:11.0.2
 - com.microsoft.azure:azure-keyvault-core:0.8.0
 - com.microsoft.azure:azure-storage:5.4.0

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -18,9 +18,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.3
 - com.google.guava:guava:11.0.2
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 
 This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.11.754
 - com.amazonaws:aws-java-sdk-sts:1.11.754
 - com.amazonaws:jmespath-java:1.11.754
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:11.0.2
 - commons-beanutils:commons-beanutils:1.9.3

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -20,10 +20,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:jmespath-java:1.11.754
 - com.facebook.presto:presto-hive:0.187
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:21.0
 - io.airlift:configuration:0.153

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
 - com.101tec:zkclient:0.10
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
 - io.confluent:common-utils:4.1.0
 - io.confluent:kafka-schema-registry-client:4.1.0
-- org.apache.zookeeper:zookeeper:3.4.10
+- org.apache.zookeeper:zookeeper:3.4.14

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.5
 - com.squareup.okhttp3:logging-interceptor:3.12.6
 - com.squareup.okhttp3:okhttp:3.12.1
 - com.squareup.okio:okio:1.15.0
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:kubernetes-model:4.9.2
 - io.fabric8:kubernetes-model-common:4.9.2
 - io.fabric8:zjsonpatch:0.3.0
-- org.yaml:snakeyaml:1.24
+- org.yaml:snakeyaml:1.27
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.

--- a/flink-mesos/src/main/resources/META-INF/NOTICE
+++ b/flink-mesos/src/main/resources/META-INF/NOTICE
@@ -8,9 +8,9 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.netflix.fenzo:fenzo-core:0.10.1
 - org.apache.mesos:mesos:1.0.1
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 - com.google.flatbuffers:flatbuffers-java:1.9.0
 - io.netty:netty-buffer:4.1.44.Final
 - io.netty:netty-common:4.1.44.Final

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -151,10 +151,10 @@ under the License.
 
 				[INFO] +- org.apache.calcite:calcite-core:jar:1.22.0:compile
 				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.22.0:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
 				[INFO] |  +- org.apiguardian:apiguardian-api:jar:1.1.0:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.1:runtime
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1:runtime
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.5:runtime
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:runtime
 				[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.4.0:runtime
 				[INFO] |  |  \- net.minidev:json-smart:jar:2.3:runtime
 				[INFO] |  |     \- net.minidev:accessors-smart:jar:1.2:runtime

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:19.0
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 - com.jayway.jsonpath:json-path:2.4.0
 - org.apache.calcite:calcite-core:1.22.0
 - org.apache.calcite:calcite-linq4j:1.22.0

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -129,11 +129,11 @@ under the License.
 
 				[INFO] +- org.apache.calcite:calcite-core:jar:1.22.0:compile
 				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.22.0:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.5:compile
 				[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.16.0:compile
 				[INFO] |  +- org.apiguardian:apiguardian-api:jar:1.1.0:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.1:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.5:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.5.1:compile
 				[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.4.0:runtime
 				[INFO] |  |  \- net.minidev:json-smart:jar:2.3:runtime
 				[INFO] |  |     \- net.minidev:accessors-smart:jar:1.2:runtime

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.guava:guava:19.0
-- com.fasterxml.jackson.core:jackson-annotations:2.10.1
-- com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.core:jackson-databind:2.10.1
+- com.fasterxml.jackson.core:jackson-annotations:2.10.5
+- com.fasterxml.jackson.core:jackson-core:2.10.5
+- com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 - com.jayway.jsonpath:json-path:2.4.0
 - joda-time:joda-time:2.5
 - org.apache.calcite:calcite-core:1.22.0

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,7 @@ under the License.
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>
 				<scope>import</scope>
-				<version>${jackson.version}</version>
+				<version>2.10.5.20201202</version>
 			</dependency>
 
 			<dependency>
@@ -1631,7 +1631,7 @@ under the License.
 							<rules>
 								<bannedDependencies>
 									<excludes>
-										<exclude>com.fasterxml.jackson*:*:(,2.10.0]</exclude>
+										<exclude>com.fasterxml.jackson*:*:(,2.10.4]</exclude>
 									</excludes>
 								</bannedDependencies>
 							</rules>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will bump all jackson dependencies to 2.10.5.1 in release-1.11*

## Verifying this change

This change added tests and can be verified as follows:

  - *Original Tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
