### PR TITLE
[FLINK-21123][fs] Bump beanutils to 1.9.4

### DIFF
--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -32,6 +32,17 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Bumped for security purposes -->
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<!-- The Hadoop file system abstraction  -->
 		<dependency>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.7
 - commons-logging:commons-logging:1.1.3
-- commons-beanutils:commons-beanutils:1.9.3
+- commons-beanutils:commons-beanutils:1.9.4
 - com.google.guava:guava:11.0.2
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -48,6 +48,13 @@ under the License.
 				<artifactId>httpclient</artifactId>
 				<version>4.5.9</version>
 			</dependency>
+
+			<dependency>
+				<!-- Bumped for security purposes -->
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -15,7 +15,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:11.0.2
-- commons-beanutils:commons-beanutils:1.9.3
+- commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.7

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -259,6 +259,13 @@ under the License.
 					</exclusion>
 				</exclusions>
 			</dependency>
+
+			<dependency>
+				<!-- Bumped for security purposes -->
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- commons-beanutils:commons-beanutils:1.9.3
+- commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.7


### PR DESCRIPTION
Bumps our 1.9.x beanutils dependencies to 1.9.4 .
flink-fs-swift-hadoop (and it's bundled 1.8 dependency) are excluded from this change since we have no way to verify whether this has any functional impact on the filesystem. (aka, we have not a single test; see FLINK-20804)