### PR TITLE
[FLINK-21104][network] Ensure that converted input channels start in the correct persisting state. [1.12]

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -74,7 +74,8 @@ public final class ChannelStatePersister {
         } else if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED) {
             checkState(
                     lastSeenBarrier >= barrierId,
-                    "Internal error, #stopPersisting for last checkpoint has not been called.");
+                    "Internal error, #stopPersisting for last checkpoint has not been called for "
+                            + channelInfo);
         }
         if (knownBuffers.size() > 0) {
             channelStateWriter.addInputData(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -69,6 +69,8 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     protected final int networkBuffersPerChannel;
     private boolean exclusiveBuffersAssigned;
 
+    private long lastStoppedCheckpointId = -1;
+
     RecoveredInputChannel(
             SingleInputGate inputGate,
             int channelIndex,
@@ -100,7 +102,14 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     public final InputChannel toInputChannel() throws IOException {
         Preconditions.checkState(
                 stateConsumedFuture.isDone(), "recovered state is not fully consumed");
-        return toInputChannelInternal();
+        final InputChannel inputChannel = toInputChannelInternal();
+        inputChannel.checkpointStopped(lastStoppedCheckpointId);
+        return inputChannel;
+    }
+
+    @Override
+    public void checkpointStopped(long checkpointId) {
+        this.lastStoppedCheckpointId = checkpointId;
     }
 
     protected abstract InputChannel toInputChannelInternal() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -296,6 +296,7 @@ public class SingleInputGate extends IndexedInputGate {
 
     @VisibleForTesting
     void convertRecoveredInputChannels() {
+        LOG.info("Converting recovered input channels ({} channels)", getNumberOfInputChannels());
         for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry :
                 inputChannels.entrySet()) {
             InputChannel inputChannel = entry.getValue();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/SingleCheckpointBarrierHandler.java
@@ -173,6 +173,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         final long cancelledId = cancelBarrier.getCheckpointId();
         if (cancelledId > currentCheckpointId
                 || (cancelledId == currentCheckpointId && numBarriersReceived > 0)) {
+            LOG.debug("{}: Received cancellation {}.", taskName, cancelledId);
             abortInternal(
                     cancelledId,
                     new CheckpointException(


### PR DESCRIPTION
Unchanged backport of #14736.