### PR TITLE
[FLINK-21127][runtime][checkpoint] Stores finished status for fully finished operators in checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorState.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import javax.annotation.Nullable;
+
+/**
+ * A special operator state implementation representing the operators whose instances are all
+ * finished.
+ */
+public class FullyFinishedOperatorState extends OperatorState {
+
+    private static final long serialVersionUID = -7094972830573632176L;
+
+    public FullyFinishedOperatorState(OperatorID operatorID, int parallelism, int maxParallelism) {
+        super(operatorID, parallelism, maxParallelism);
+    }
+
+    @Override
+    public boolean isFullyFinished() {
+        return true;
+    }
+
+    @Override
+    public void putState(int subtaskIndex, OperatorSubtaskState subtaskState) {
+        throw new UnsupportedOperationException(
+                "Could not put state to a fully finished operator state.");
+    }
+
+    @Override
+    public void setCoordinatorState(@Nullable ByteStreamStateHandle coordinatorState) {
+        throw new UnsupportedOperationException(
+                "Could not set coordinator state to a fully finished operator state.");
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof FullyFinishedOperatorState) {
+            return super.equals(obj);
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "FullyFinishedOperatorState("
+                + "operatorID: "
+                + getOperatorID()
+                + ", parallelism: "
+                + getParallelism()
+                + ", maxParallelism: "
+                + getMaxParallelism()
+                + ')';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorState.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  */
 public class FullyFinishedOperatorState extends OperatorState {
 
-    private static final long serialVersionUID = -7094972830573632176L;
+    private static final long serialVersionUID = 1L;
 
     public FullyFinishedOperatorState(OperatorID operatorID, int parallelism, int maxParallelism) {
         super(operatorID, parallelism, maxParallelism);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -81,6 +81,10 @@ public class OperatorState implements CompositeStateHandle {
         return operatorID;
     }
 
+    public boolean isFullyFinished() {
+        return false;
+    }
+
     public void putState(int subtaskIndex, OperatorSubtaskState subtaskState) {
         Preconditions.checkNotNull(subtaskState);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
@@ -30,6 +30,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /**
  * (De)serializer for checkpoint metadata format version 2. This format was introduced with Apache
  * Flink 1.3.0.
@@ -71,6 +73,10 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
     @Override
     protected void serializeOperatorState(OperatorState operatorState, DataOutputStream dos)
             throws IOException {
+        checkState(
+                !operatorState.isFullyFinished(),
+                "Could not support finished Operator state in stale serializers.");
+
         // Operator ID
         dos.writeLong(operatorState.getOperatorID().getLowerPart());
         dos.writeLong(operatorState.getOperatorID().getUpperPart());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
@@ -75,7 +75,7 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
             throws IOException {
         checkState(
                 !operatorState.isFullyFinished(),
-                "Could not support finished Operator state in stale serializers.");
+                "Could not support finished Operator state in state serializers.");
 
         // Operator ID
         dos.writeLong(operatorState.getOperatorID().getLowerPart());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorStateTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Tests the properties of {@link FullyFinishedOperatorState}. */
+public class FullyFinishedOperatorStateTest {
+
+    @Test
+    public void testFullyFinishedOperatorState() {
+        OperatorState operatorState = new FullyFinishedOperatorState(new OperatorID(), 5, 256);
+        assertTrue(operatorState.isFullyFinished());
+
+        assertEquals(0, operatorState.getSubtaskStates().size());
+        assertEquals(0, operatorState.getStates().size());
+        assertEquals(0, operatorState.getNumberCollectedStates());
+
+        try {
+            operatorState.putState(0, OperatorSubtaskState.builder().build());
+            fail("Should not be able to put new subtask states for a fully finished state");
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+
+        try {
+            operatorState.setCoordinatorState(
+                    new ByteStreamStateHandle("test", new byte[] {1, 2, 3, 4}));
+            fail("Should not be able to set coordinator states for a fully finished state");
+        } catch (UnsupportedOperationException e) {
+            // Excepted
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -67,6 +67,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -576,14 +577,14 @@ public class PendingCheckpointTest {
                 .getCurrentExecutionAttempt()
                 .markFinished();
         PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
-        assertEquals(1, pendingCheckpoint.getCheckpointPlan().getFullyFinishedJobVertex().size());
-        assertEquals(
-                finishedJobVertexID,
+        assertThat(pendingCheckpoint.getCheckpointPlan().getFullyFinishedJobVertex().size(), is(1));
+        assertThat(
                 pendingCheckpoint
                         .getCheckpointPlan()
                         .getFullyFinishedJobVertex()
                         .get(0)
-                        .getJobVertexId());
+                        .getJobVertexId(),
+                is(finishedJobVertexID));
 
         // Report the state for the running operator
         ExecutionAttemptID runningTaskId =
@@ -598,15 +599,15 @@ public class PendingCheckpointTest {
         TaskAcknowledgeResult result =
                 pendingCheckpoint.acknowledgeTask(
                         runningTaskId, taskStateSnapshot, new CheckpointMetrics(), null);
-        assertEquals(TaskAcknowledgeResult.SUCCESS, result);
+        assertThat(result, is(TaskAcknowledgeResult.SUCCESS));
 
         CompletedCheckpoint completedCheckpoint =
                 pendingCheckpoint.finalizeCheckpoint(
                         new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
-        assertEquals(2, completedCheckpoint.getOperatorStates().size());
+        assertThat(completedCheckpoint.getOperatorStates().size(), is(2));
         OperatorState finishedOperatorState =
                 completedCheckpoint.getOperatorStates().get(finishedOperatorID);
-        assertTrue(finishedOperatorState.isFullyFinished());
+        assertThat(finishedOperatorState.isFullyFinished(), is(true));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -544,6 +546,69 @@ public class PendingCheckpointTest {
         assertTrue(handle2.isDisposed());
     }
 
+    @Test
+    public void testFinalizeCheckpointWithFullyFinishedOperators() throws Exception {
+        JobVertexID finishedJobVertexID = new JobVertexID();
+        JobVertexID runningJobVertexID = new JobVertexID();
+        OperatorID finishedOperatorID = new OperatorID();
+        OperatorID runningOperatorID = new OperatorID();
+
+        ExecutionGraph executionGraph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(
+                                finishedJobVertexID,
+                                1,
+                                256,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(finishedOperatorID)),
+                                true)
+                        .addJobVertex(
+                                runningJobVertexID,
+                                1,
+                                256,
+                                Collections.singletonList(
+                                        OperatorIDPair.generatedIDOnly(runningOperatorID)),
+                                true)
+                        .build();
+        executionGraph
+                .getJobVertex(finishedJobVertexID)
+                .getTaskVertices()[0]
+                .getCurrentExecutionAttempt()
+                .markFinished();
+        PendingCheckpoint pendingCheckpoint = createPendingCheckpoint(executionGraph);
+        assertEquals(1, pendingCheckpoint.getCheckpointPlan().getFullyFinishedJobVertex().size());
+        assertEquals(
+                finishedJobVertexID,
+                pendingCheckpoint
+                        .getCheckpointPlan()
+                        .getFullyFinishedJobVertex()
+                        .get(0)
+                        .getJobVertexId());
+
+        // Report the state for the running operator
+        ExecutionAttemptID runningTaskId =
+                executionGraph
+                        .getJobVertex(runningJobVertexID)
+                        .getTaskVertices()[0]
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+        TaskStateSnapshot taskStateSnapshot = new TaskStateSnapshot();
+        taskStateSnapshot.putSubtaskStateByOperatorID(
+                runningOperatorID, new OperatorSubtaskState());
+        TaskAcknowledgeResult result =
+                pendingCheckpoint.acknowledgeTask(
+                        runningTaskId, taskStateSnapshot, new CheckpointMetrics(), null);
+        assertEquals(TaskAcknowledgeResult.SUCCESS, result);
+
+        CompletedCheckpoint completedCheckpoint =
+                pendingCheckpoint.finalizeCheckpoint(
+                        new CheckpointsCleaner(), () -> {}, Executors.directExecutor(), null);
+        assertEquals(2, completedCheckpoint.getOperatorStates().size());
+        OperatorState finishedOperatorState =
+                completedCheckpoint.getOperatorStates().get(finishedOperatorID);
+        assertTrue(finishedOperatorState.isFullyFinished());
+    }
+
     // ------------------------------------------------------------------------
 
     private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props)
@@ -632,6 +697,40 @@ public class PendingCheckpointTest {
                 operatorCoordinators,
                 masterStateIdentifiers,
                 props,
+                location,
+                new CompletableFuture<>());
+    }
+
+    private PendingCheckpoint createPendingCheckpoint(ExecutionGraph executionGraph)
+            throws Exception {
+        DefaultCheckpointPlanCalculator checkpointPlanCalculator =
+                new DefaultCheckpointPlanCalculator(
+                        new JobID(),
+                        new ExecutionGraphCheckpointPlanCalculatorContext(executionGraph),
+                        executionGraph.getVerticesTopologically());
+        checkpointPlanCalculator.setAllowCheckpointsAfterTasksFinished(true);
+        CheckpointPlan checkpointPlan = checkpointPlanCalculator.calculateCheckpointPlan().get();
+
+        final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());
+        final FsCheckpointStorageLocation location =
+                new FsCheckpointStorageLocation(
+                        LocalFileSystem.getSharedInstance(),
+                        checkpointDir,
+                        checkpointDir,
+                        checkpointDir,
+                        CheckpointStorageLocationReference.getDefault(),
+                        1024,
+                        4096);
+
+        return new PendingCheckpoint(
+                executionGraph.getJobID(),
+                0,
+                1,
+                checkpointPlan,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                CheckpointProperties.forCheckpoint(
+                        CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
                 location,
                 new CompletableFuture<>());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
@@ -44,7 +44,7 @@ public class CheckpointMetadataTest {
 
         Collection<OperatorState> taskStates =
                 CheckpointTestUtils.createOperatorStates(
-                        rnd, null, numTaskStates, numSubtaskStates);
+                        rnd, null, numTaskStates, 0, numSubtaskStates);
 
         Collection<MasterState> masterStates =
                 CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint.metadata;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.FullyFinishedOperatorState;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -70,11 +71,20 @@ public class CheckpointTestUtils {
      * @param numSubtasksPerTask Number of subtask for each task.
      */
     public static Collection<OperatorState> createOperatorStates(
-            Random random, @Nullable String basePath, int numTaskStates, int numSubtasksPerTask) {
+            Random random,
+            @Nullable String basePath,
+            int numTaskStates,
+            int numFinishedTaskStates,
+            int numSubtasksPerTask) {
 
         List<OperatorState> taskStates = new ArrayList<>(numTaskStates);
 
-        for (int stateIdx = 0; stateIdx < numTaskStates; ++stateIdx) {
+        for (int stateIdx = 0; stateIdx < numFinishedTaskStates; ++stateIdx) {
+            taskStates.add(
+                    new FullyFinishedOperatorState(new OperatorID(), numSubtasksPerTask, 128));
+        }
+
+        for (int stateIdx = numFinishedTaskStates; stateIdx < numTaskStates; ++stateIdx) {
 
             OperatorState taskState = new OperatorState(new OperatorID(), numSubtasksPerTask, 128);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -108,7 +109,8 @@ public class MetadataV3SerializerTest {
             final int numTasks = rnd.nextInt(maxTaskStates) + 1;
             final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
             final Collection<OperatorState> taskStates =
-                    CheckpointTestUtils.createOperatorStates(rnd, basePath, numTasks, numSubtasks);
+                    CheckpointTestUtils.createOperatorStates(
+                            rnd, basePath, numTasks, 0, numSubtasks);
 
             final Collection<MasterState> masterStates = Collections.emptyList();
 
@@ -139,7 +141,8 @@ public class MetadataV3SerializerTest {
             final int numTasks = rnd.nextInt(maxTaskStates) + 1;
             final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
             final Collection<OperatorState> taskStates =
-                    CheckpointTestUtils.createOperatorStates(rnd, basePath, numTasks, numSubtasks);
+                    CheckpointTestUtils.createOperatorStates(
+                            rnd, basePath, numTasks, 0, numSubtasks);
 
             final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
             final Collection<MasterState> masterStates =
@@ -147,6 +150,40 @@ public class MetadataV3SerializerTest {
 
             testCheckpointSerialization(checkpointId, taskStates, masterStates, basePath);
         }
+    }
+
+    @Test
+    public void testCheckpointWithFinishedTasksForCheckpoint() throws Exception {
+        testCheckpointWithFinishedTasks(null);
+    }
+
+    @Test
+    public void testCheckpointWithFinishedTasksForSavepoint() throws Exception {
+        testCheckpointWithFinishedTasks(temporaryFolder.newFolder().toURI().toString());
+    }
+
+    private void testCheckpointWithFinishedTasks(String basePath) throws Exception {
+        final Random rnd = new Random();
+
+        final int maxNumMasterStates = 5;
+        final int maxTaskStates = 20;
+        final int maxNumSubtasks = 20;
+        final int maxFinishedSubtasks = 10;
+
+        final long checkpointId = rnd.nextLong() & 0x7fffffffffffffffL;
+
+        final int numTasks = rnd.nextInt(maxTaskStates) + 1;
+        final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
+        final int numFinished = rnd.nextInt(maxFinishedSubtasks) + 1;
+        final Collection<OperatorState> taskStates =
+                CheckpointTestUtils.createOperatorStates(
+                        rnd, basePath, numTasks, numFinished, numSubtasks);
+
+        final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
+        final Collection<MasterState> masterStates =
+                CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);
+
+        testCheckpointSerialization(checkpointId, taskStates, masterStates, basePath);
     }
 
     /**
@@ -198,6 +235,13 @@ public class MetadataV3SerializerTest {
                 serializer.deserialize(in, getClass().getClassLoader(), basePath);
         assertEquals(checkpointId, deserialized.getCheckpointId());
         assertEquals(operatorStates, deserialized.getOperatorStates());
+        assertEquals(
+                operatorStates.stream()
+                        .map(OperatorState::isFullyFinished)
+                        .collect(Collectors.toList()),
+                deserialized.getOperatorStates().stream()
+                        .map(OperatorState::isFullyFinished)
+                        .collect(Collectors.toList()));
 
         assertEquals(masterStates.size(), deserialized.getMasterStates().size());
         for (Iterator<MasterState> a = masterStates.iterator(),


### PR DESCRIPTION
## What is the purpose of the change

Stores the information of whether an operator is fully finished into the checkpoint metadata.

To not have to introduce a new version of checkpoint metadata and due to a fully finished operator state always has an empty states, we could stores a special content for the operator state to indicate that the operator is fully finished.

## Brief change log

- 37484933592e8b5a4f5cf83425ac0b7b612c7480 allows set / get fully finished flag for operator state, and marked fully finished operators according to the checkpoint brief computed.


## Verifying this change

This change added unit tests about set and get fully finished flag, and serialization / deserialization of the operator states marked as fully finished.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
