### PR TITLE
[FLINK-21149][table-common] Remove deprecated CatalogBaseTable.getProperties()

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -51,8 +51,7 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
         CatalogTable table = checkNotNull(context.getTable());
         Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-        boolean isGeneric =
-                Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
+        boolean isGeneric = Boolean.parseBoolean(table.getOptions().get(CatalogConfig.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {
@@ -68,8 +67,7 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
         CatalogTable table = checkNotNull(context.getTable());
         Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-        boolean isGeneric =
-                Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
+        boolean isGeneric = Boolean.parseBoolean(table.getOptions().get(CatalogConfig.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -574,7 +574,7 @@ public class HiveCatalog extends AbstractCatalog {
                         hiveTable,
                         (CatalogTable) newCatalogTable,
                         hiveTable.getParameters(),
-                        newCatalogTable.getProperties(),
+                        newCatalogTable.getOptions(),
                         hiveTable.getSd());
             }
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -354,7 +354,7 @@ public class HiveTableUtil {
                         tablePath.getDatabaseName(), tablePath.getObjectName());
         hiveTable.setCreateTime((int) (System.currentTimeMillis() / 1000));
 
-        Map<String, String> properties = new HashMap<>(table.getProperties());
+        Map<String, String> properties = new HashMap<>(table.getOptions());
         // Table comment
         if (table.getComment() != null) {
             properties.put(HiveCatalogConfig.COMMENT, table.getComment());

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import warnings
 from typing import Dict, List, Optional
 
 from py4j.java_gateway import java_import

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -729,19 +729,6 @@ class CatalogBaseTable(object):
         """
         return dict(self._j_catalog_base_table.getOptions())
 
-    def get_properties(self) -> Dict[str, str]:
-        """
-        Get the properties of the table.
-
-        :return: Property map of the table/view.
-
-        .. note:: This method is deprecated. Use :func:`~pyflink.table.CatalogBaseTable.get_options`
-                  instead.
-        """
-        warnings.warn("Deprecated in 1.11. Use CatalogBaseTable#get_options instead.",
-                      DeprecationWarning)
-        return dict(self._j_catalog_base_table.getProperties())
-
     def get_schema(self) -> TableSchema:
         """
         Get the schema of the table.

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -57,12 +57,12 @@ class CatalogTestBase(PyFlinkTestCase):
 
     def check_catalog_table_equals(self, t1, t2):
         self.assertEqual(t1.get_schema(), t2.get_schema())
-        self.assertEqual(t1.get_properties(), t2.get_properties())
+        self.assertEqual(t1.get_options(), t2.get_options())
         self.assertEqual(t1.get_comment(), t2.get_comment())
 
     def check_catalog_view_equals(self, v1, v2):
         self.assertEqual(v1.get_schema(), v1.get_schema())
-        self.assertEqual(v1.get_properties(), v2.get_properties())
+        self.assertEqual(v1.get_options(), v2.get_options())
         self.assertEqual(v1.get_comment(), v2.get_comment())
 
     def check_catalog_function_equals(self, f1, f2):

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -97,8 +97,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
     @Override
     public StreamTableSink<Row> createTableSink(TableSinkFactory.Context context) {
         return new TestTableSink(
-                context.getTable().getSchema(),
-                context.getTable().getProperties().get(testProperty));
+                context.getTable().getSchema(), context.getTable().getOptions().get(testProperty));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -108,7 +108,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
                 SchemaValidator.deriveRowtimeAttributes(params);
         return new TestTableSource(
                 schema,
-                context.getTable().getProperties().get(testProperty),
+                context.getTable().getOptions().get(testProperty),
                 proctime.orElse(null),
                 rowtime);
     }

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
@@ -54,7 +54,7 @@
     "org.apache.flink.sql.parser.ddl.constraint.SqlUniqueSpec"
     "org.apache.flink.sql.parser.ddl.SqlAlterDatabase"
     "org.apache.flink.sql.parser.ddl.SqlAlterTable"
-    "org.apache.flink.sql.parser.ddl.SqlAlterTableProperties"
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableOptions"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableRename"
     "org.apache.flink.sql.parser.ddl.SqlAlterView"
     "org.apache.flink.sql.parser.ddl.SqlAlterViewAs"

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlAlterHiveTable.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.sql.parser.hive.ddl;
 
-import org.apache.flink.sql.parser.ddl.SqlAlterTableProperties;
+import org.apache.flink.sql.parser.ddl.SqlAlterTableOptions;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNodeList;
@@ -29,7 +29,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
  * Abstract class for ALTER DDL of a Hive table. Any ALTER TABLE operations that need to be encoded
  * as table properties should extend this class.
  */
-public abstract class SqlAlterHiveTable extends SqlAlterTableProperties {
+public abstract class SqlAlterHiveTable extends SqlAlterTableOptions {
 
     public static final String ALTER_TABLE_OP = "alter.table.op";
     public static final String ALTER_COL_CASCADE = "alter.column.cascade";

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -31,7 +31,7 @@
     "org.apache.flink.sql.parser.ddl.SqlAlterTable"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableAddConstraint"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableDropConstraint"
-    "org.apache.flink.sql.parser.ddl.SqlAlterTableProperties"
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableOptions"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableRename"
     "org.apache.flink.sql.parser.ddl.SqlCreateCatalog"
     "org.apache.flink.sql.parser.ddl.SqlCreateDatabase"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -452,7 +452,7 @@ SqlAlterTable SqlAlterTable() :
         <SET>
         propertyList = TableProperties()
         {
-            return new SqlAlterTableProperties(
+            return new SqlAlterTableOptions(
                         startPos.plus(getPos()),
                         tableIdentifier,
                         propertyList);

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableOptions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableOptions.java
@@ -30,16 +30,16 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 /** ALTER TABLE [[catalogName.] dataBasesName].tableName SET ( name=value [, name=value]*). */
-public class SqlAlterTableProperties extends SqlAlterTable {
+public class SqlAlterTableOptions extends SqlAlterTable {
 
     private final SqlNodeList propertyList;
 
-    public SqlAlterTableProperties(
+    public SqlAlterTableOptions(
             SqlParserPos pos, SqlIdentifier tableName, SqlNodeList propertyList) {
         this(pos, tableName, null, propertyList);
     }
 
-    public SqlAlterTableProperties(
+    public SqlAlterTableOptions(
             SqlParserPos pos,
             SqlIdentifier tableName,
             SqlNodeList partitionSpec,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -106,7 +106,7 @@ import org.apache.flink.table.operations.ddl.AlterPartitionPropertiesOperation;
 import org.apache.flink.table.operations.ddl.AlterTableAddConstraintOperation;
 import org.apache.flink.table.operations.ddl.AlterTableDropConstraintOperation;
 import org.apache.flink.table.operations.ddl.AlterTableOperation;
-import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOptionsOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.AlterTableSchemaOperation;
 import org.apache.flink.table.operations.ddl.AlterViewAsOperation;
@@ -817,9 +817,9 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                             alterTableRenameOp.getTableIdentifier().toObjectPath(),
                             alterTableRenameOp.getNewTableIdentifier().getObjectName(),
                             false);
-                } else if (alterTableOperation instanceof AlterTablePropertiesOperation) {
-                    AlterTablePropertiesOperation alterTablePropertiesOp =
-                            (AlterTablePropertiesOperation) operation;
+                } else if (alterTableOperation instanceof AlterTableOptionsOperation) {
+                    AlterTableOptionsOperation alterTablePropertiesOp =
+                            (AlterTableOptionsOperation) operation;
                     catalog.alterTable(
                             alterTablePropertiesOp.getTableIdentifier().toObjectPath(),
                             alterTablePropertiesOp.getCatalogTable(),

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogTable.java
@@ -35,26 +35,26 @@ public abstract class AbstractCatalogTable implements CatalogTable {
     // partitioned
     private final List<String> partitionKeys;
     // Properties of the table
-    private final Map<String, String> properties;
+    private final Map<String, String> options;
     // Comment of the table
     private final String comment;
 
     public AbstractCatalogTable(
-            TableSchema tableSchema, Map<String, String> properties, String comment) {
-        this(tableSchema, new ArrayList<>(), properties, comment);
+            TableSchema tableSchema, Map<String, String> options, String comment) {
+        this(tableSchema, new ArrayList<>(), options, comment);
     }
 
     public AbstractCatalogTable(
             TableSchema tableSchema,
             List<String> partitionKeys,
-            Map<String, String> properties,
+            Map<String, String> options,
             String comment) {
         this.tableSchema = checkNotNull(tableSchema, "tableSchema cannot be null");
         this.partitionKeys = checkNotNull(partitionKeys, "partitionKeys cannot be null");
-        this.properties = checkNotNull(properties, "properties cannot be null");
+        this.options = checkNotNull(options, "options cannot be null");
 
         checkArgument(
-                properties.entrySet().stream()
+                options.entrySet().stream()
                         .allMatch(e -> e.getKey() != null && e.getValue() != null),
                 "properties cannot have null keys or values");
 
@@ -72,8 +72,8 @@ public abstract class AbstractCatalogTable implements CatalogTable {
     }
 
     @Override
-    public Map<String, String> getProperties() {
-        return properties;
+    public Map<String, String> getOptions() {
+        return options;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogView.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/AbstractCatalogView.java
@@ -38,14 +38,14 @@ public abstract class AbstractCatalogView implements CatalogView {
     private final String expandedQuery;
 
     private final TableSchema schema;
-    private final Map<String, String> properties;
+    private final Map<String, String> options;
     private final String comment;
 
     public AbstractCatalogView(
             String originalQuery,
             String expandedQuery,
             TableSchema schema,
-            Map<String, String> properties,
+            Map<String, String> options,
             String comment) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(originalQuery),
@@ -57,7 +57,7 @@ public abstract class AbstractCatalogView implements CatalogView {
         this.originalQuery = originalQuery;
         this.expandedQuery = expandedQuery;
         this.schema = checkNotNull(schema, "schema cannot be null");
-        this.properties = checkNotNull(properties, "properties cannot be null");
+        this.options = checkNotNull(options, "options cannot be null");
         this.comment = comment;
     }
 
@@ -72,8 +72,8 @@ public abstract class AbstractCatalogView implements CatalogView {
     }
 
     @Override
-    public Map<String, String> getProperties() {
-        return this.properties;
+    public Map<String, String> getOptions() {
+        return this.options;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -50,7 +50,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
         return new CatalogTableImpl(
                 getSchema().copy(),
                 new ArrayList<>(getPartitionKeys()),
-                new HashMap<>(getProperties()),
+                new HashMap<>(getOptions()),
                 getComment());
     }
 
@@ -71,7 +71,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
         descriptor.putTableSchema(Schema.SCHEMA, getSchema());
         descriptor.putPartitionKeys(getPartitionKeys());
 
-        Map<String, String> properties = new HashMap<>(getProperties());
+        Map<String, String> properties = new HashMap<>(getOptions());
         properties.remove(CatalogConfig.IS_GENERIC);
 
         descriptor.putProperties(properties);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogViewImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogViewImpl.java
@@ -41,7 +41,7 @@ public class CatalogViewImpl extends AbstractCatalogView {
                 getOriginalQuery(),
                 getExpandedQuery(),
                 getSchema().copy(),
-                new HashMap<>(getProperties()),
+                new HashMap<>(getOptions()),
                 getComment());
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOptionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableOptionsOperation.java
@@ -25,11 +25,10 @@ import org.apache.flink.table.operations.OperationUtils;
 import java.util.stream.Collectors;
 
 /** Operation to describe a ALTER TABLE .. SET .. statement. */
-public class AlterTablePropertiesOperation extends AlterTableOperation {
+public class AlterTableOptionsOperation extends AlterTableOperation {
     private final CatalogTable catalogTable;
 
-    public AlterTablePropertiesOperation(
-            ObjectIdentifier tableIdentifier, CatalogTable catalogTable) {
+    public AlterTableOptionsOperation(ObjectIdentifier tableIdentifier, CatalogTable catalogTable) {
         super(tableIdentifier);
         this.catalogTable = catalogTable;
     }
@@ -41,7 +40,7 @@ public class AlterTablePropertiesOperation extends AlterTableOperation {
     @Override
     public String asSummaryString() {
         String description =
-                catalogTable.getProperties().entrySet().stream()
+                catalogTable.getOptions().entrySet().stream()
                         .map(
                                 entry ->
                                         OperationUtils.formatParameter(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -90,12 +90,12 @@ public class TableEnvironmentTest {
                                 .build()));
         assertThat(table.getPartitionKeys(), equalTo(Arrays.asList("my_part_1", "my_part_2")));
 
-        Map<String, String> properties = new HashMap<>();
-        properties.put("update-mode", "append");
-        properties.put("connector.property-version", "1");
-        properties.put("format.type", "my_format");
-        properties.put("format.property-version", "1");
-        properties.put("connector.type", "table-source-factory-mock");
-        assertThat(table.getProperties(), equalTo(properties));
+        Map<String, String> options = new HashMap<>();
+        options.put("update-mode", "append");
+        options.put("connector.property-version", "1");
+        options.put("format.type", "my_format");
+        options.put("format.property-version", "1");
+        options.put("connector.type", "table-source-factory-mock");
+        assertThat(table.getOptions(), equalTo(options));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -30,10 +30,6 @@ import java.util.Optional;
  */
 public interface CatalogBaseTable {
 
-    /** @deprecated Use {@link #getOptions()}. */
-    @Deprecated
-    Map<String, String> getProperties();
-
     /**
      * Returns a map of string-based options.
      *
@@ -41,9 +37,7 @@ public interface CatalogBaseTable {
      * configuration for accessing the data in the external system. See {@link DynamicTableFactory}
      * for more information.
      */
-    default Map<String, String> getOptions() {
-        return getProperties();
-    }
+    Map<String, String> getOptions();
 
     /**
      * Get the schema of the table.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -1383,7 +1383,7 @@ public abstract class CatalogTest {
     public static class TestTable implements CatalogBaseTable {
 
         @Override
-        public Map<String, String> getProperties() {
+        public Map<String, String> getOptions() {
             return null;
         }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -49,18 +49,18 @@ public class CatalogTestUtil {
         assertEquals(t1.isPartitioned(), t2.isPartitioned());
 
         assertEquals(
-                t1.getProperties().get(CatalogConfig.IS_GENERIC),
-                t2.getProperties().get(CatalogConfig.IS_GENERIC));
+                t1.getOptions().get(CatalogConfig.IS_GENERIC),
+                t2.getOptions().get(CatalogConfig.IS_GENERIC));
 
         // Hive tables may have properties created by itself
         // thus properties of Hive table is a super set of those in its corresponding Flink table
-        if (Boolean.valueOf(t1.getProperties().get(CatalogConfig.IS_GENERIC))) {
-            assertEquals(t1.getProperties(), t2.getProperties());
+        if (Boolean.parseBoolean(t1.getOptions().get(CatalogConfig.IS_GENERIC))) {
+            assertEquals(t1.getOptions(), t2.getOptions());
         } else {
             assertTrue(
-                    t2.getProperties().keySet().stream()
+                    t2.getOptions().keySet().stream()
                             .noneMatch(k -> k.startsWith(FLINK_PROPERTY_PREFIX)));
-            assertTrue(t2.getProperties().entrySet().containsAll(t1.getProperties().entrySet()));
+            assertTrue(t2.getOptions().entrySet().containsAll(t1.getOptions().entrySet()));
         }
     }
 
@@ -73,13 +73,13 @@ public class CatalogTestUtil {
 
         // Hive tables may have properties created by itself
         // thus properties of Hive table is a super set of those in its corresponding Flink table
-        if (Boolean.valueOf(v1.getProperties().get(CatalogConfig.IS_GENERIC))) {
-            assertEquals(v1.getProperties(), v2.getProperties());
+        if (Boolean.parseBoolean(v1.getOptions().get(CatalogConfig.IS_GENERIC))) {
+            assertEquals(v1.getOptions(), v2.getOptions());
         } else {
             assertTrue(
-                    v2.getProperties().keySet().stream()
+                    v2.getOptions().keySet().stream()
                             .noneMatch(k -> k.startsWith(FLINK_PROPERTY_PREFIX)));
-            assertTrue(v2.getProperties().entrySet().containsAll(v1.getProperties().entrySet()));
+            assertTrue(v2.getOptions().entrySet().containsAll(v1.getOptions().entrySet()));
         }
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -349,11 +349,6 @@ public class FactoryUtilTest {
         }
 
         @Override
-        public Map<String, String> getProperties() {
-            return options;
-        }
-
-        @Override
         public Map<String, String> getOptions() {
             return options;
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -353,7 +353,7 @@ abstract class PlannerBase(
       case Some(table: CatalogTable) =>
         val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
         val tableToFind = if (dynamicOptions.nonEmpty) {
-          table.copy(FlinkHints.mergeTableOptions(dynamicOptions, table.getProperties))
+          table.copy(FlinkHints.mergeTableOptions(dynamicOptions, table.getOptions))
         } else {
           table
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalLegacySinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalLegacySinkRule.scala
@@ -56,7 +56,7 @@ class BatchPhysicalLegacySinkRule extends ConverterRule(
 
             val shuffleEnable = sinkNode
                 .catalogTable
-                .getProperties
+                .getOptions
                 .get(FileSystemOptions.SINK_SHUFFLE_BY_PARTITION.key())
 
             if (shuffleEnable != null && shuffleEnable.toBoolean) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLegacySinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLegacySinkRule.scala
@@ -55,7 +55,7 @@ class StreamPhysicalLegacySinkRule extends ConverterRule(
 
             val shuffleEnable = sinkNode
                 .catalogTable
-                .getProperties
+                .getOptions
                 .get(FileSystemOptions.SINK_SHUFFLE_BY_PARTITION.key())
 
             if (shuffleEnable != null && shuffleEnable.toBoolean) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
@@ -176,7 +176,7 @@ class LegacyCatalogSourceTable[T](
       catalogTable.copy(
         FlinkHints.mergeTableOptions(
           hintedOptions,
-          catalogTable.getProperties))
+          catalogTable.getOptions))
     } else {
       catalogTable
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/JavaCatalogTableTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/catalog/JavaCatalogTableTest.java
@@ -176,7 +176,7 @@ public class JavaCatalogTableTest extends TableTestBase {
         }
 
         @Override
-        public Map<String, String> getProperties() {
+        public Map<String, String> getOptions() {
             Map<String, String> map = new HashMap<>();
             map.put("connector", "values");
             map.put("bounded", Boolean.toString(!isStreamingMode));

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -53,7 +53,7 @@ import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterTableAddConstraintOperation;
 import org.apache.flink.table.operations.ddl.AlterTableDropConstraintOperation;
-import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOptionsOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
@@ -157,9 +157,9 @@ public class SqlToOperationConverterTest {
                         .field("c", DataTypes.INT())
                         .field("d", DataTypes.VARCHAR(Integer.MAX_VALUE))
                         .build();
-        Map<String, String> properties = new HashMap<>();
-        properties.put("connector", "COLLECTION");
-        final CatalogTable catalogTable = new CatalogTableImpl(tableSchema, properties, "");
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "COLLECTION");
+        final CatalogTable catalogTable = new CatalogTableImpl(tableSchema, options, "");
         catalog.createTable(path1, catalogTable, true);
         catalog.createTable(path2, catalogTable, true);
     }
@@ -463,10 +463,10 @@ public class SqlToOperationConverterTest {
         assert operation instanceof CreateTableOperation;
         CreateTableOperation op = (CreateTableOperation) operation;
         CatalogTable catalogTable = op.getCatalogTable();
-        Map<String, String> properties =
-                catalogTable.getProperties().entrySet().stream()
+        Map<String, String> options =
+                catalogTable.getOptions().entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        Map<String, String> sortedProperties = new TreeMap<>(properties);
+        Map<String, String> sortedProperties = new TreeMap<>(options);
         final String expected =
                 "{a-B-c-d124=Ab, "
                         + "a.b-c-d.*=adad, "
@@ -1062,20 +1062,20 @@ public class SqlToOperationConverterTest {
             assertEquals(expectedIdentifier, alterTableRenameOperation.getTableIdentifier());
             assertEquals(expectedNewIdentifier, alterTableRenameOperation.getNewTableIdentifier());
         }
-        // test alter table properties
+        // test alter table options
         Operation operation =
                 parse(
                         "alter table cat1.db1.tb1 set ('k1' = 'v1', 'K2' = 'V2')",
                         SqlDialect.DEFAULT);
-        assert operation instanceof AlterTablePropertiesOperation;
-        final AlterTablePropertiesOperation alterTablePropertiesOperation =
-                (AlterTablePropertiesOperation) operation;
-        assertEquals(expectedIdentifier, alterTablePropertiesOperation.getTableIdentifier());
-        assertEquals(2, alterTablePropertiesOperation.getCatalogTable().getProperties().size());
-        Map<String, String> properties = new HashMap<>();
-        properties.put("k1", "v1");
-        properties.put("K2", "V2");
-        assertEquals(properties, alterTablePropertiesOperation.getCatalogTable().getProperties());
+        assert operation instanceof AlterTableOptionsOperation;
+        final AlterTableOptionsOperation alterTableOptionsOperation =
+                (AlterTableOptionsOperation) operation;
+        assertEquals(expectedIdentifier, alterTableOptionsOperation.getTableIdentifier());
+        assertEquals(2, alterTableOptionsOperation.getCatalogTable().getOptions().size());
+        Map<String, String> options = new HashMap<>();
+        options.put("k1", "v1");
+        options.put("K2", "V2");
+        assertEquals(options, alterTableOptionsOperation.getCatalogTable().getOptions());
     }
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -88,7 +88,7 @@ public class OperationMatchers {
                 equalTo(mapOf(entries)), "options of the derived table", "options") {
             @Override
             protected Map<String, String> featureValueOf(CreateTableOperation actual) {
-                return actual.getCatalogTable().getProperties();
+                return actual.getCatalogTable().getOptions();
             }
         };
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -186,7 +186,7 @@ class TableEnvironmentTest {
     assertEquals(
       Map("connector" -> "COLLECTION", "is-bounded" -> "false", "k1" -> "a", "k2" -> "b").asJava,
       tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
-        .getTable(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")).getProperties)
+        .getTable(ObjectPath.fromString(s"${tableEnv.getCurrentDatabase}.tbl1")).getOptions)
 
     val tableResult3 = tableEnv.executeSql("DROP TABLE tbl1")
     assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -984,14 +984,14 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     tableEnv.executeSql("alter table t1 rename to t2")
     assert(tableEnv.listTables().sameElements(Array[String]("t2")))
     tableEnv.executeSql("alter table t2 set ('k1' = 'a', 'k2' = 'b')")
-    val expectedProperties = new util.HashMap[String, String]()
-    expectedProperties.put("connector", "COLLECTION")
-    expectedProperties.put("k1", "a")
-    expectedProperties.put("k2", "b")
-    val properties = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+    val expectedOptions = new util.HashMap[String, String]()
+    expectedOptions.put("connector", "COLLECTION")
+    expectedOptions.put("k1", "a")
+    expectedOptions.put("k2", "b")
+    val options = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
       .getTable(new ObjectPath(tableEnv.getCurrentDatabase, "t2"))
-      .getProperties
-    assertEquals(expectedProperties, properties)
+      .getOptions
+    assertEquals(expectedOptions, options)
     val currentCatalog = tableEnv.getCurrentCatalog
     val currentDB = tableEnv.getCurrentDatabase
     tableEnv.executeSql("alter table t2 add constraint ct1 primary key(a) not enforced")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
@@ -102,7 +102,7 @@ object TestCollectionTableFactory {
 
   def getCollectionSource(context: TableSourceFactory.Context): CollectionTableSource = {
     val schema = context.getTable.getSchema
-    val isBounded = context.getTable.getProperties.getOrDefault(IS_BOUNDED, "true").toBoolean
+    val isBounded = context.getTable.getOptions.getOrDefault(IS_BOUNDED, "true").toBoolean
     new CollectionTableSource(emitIntervalMS, getPhysicalSchema(schema), isBounded)
   }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.sqlexec;
 import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
 import org.apache.flink.sql.parser.ddl.SqlAlterFunction;
 import org.apache.flink.sql.parser.ddl.SqlAlterTable;
-import org.apache.flink.sql.parser.ddl.SqlAlterTableProperties;
+import org.apache.flink.sql.parser.ddl.SqlAlterTableOptions;
 import org.apache.flink.sql.parser.ddl.SqlAlterTableRename;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
@@ -79,7 +79,7 @@ import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOptionsOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
@@ -306,29 +306,29 @@ public class SqlToOperationConverter {
             ObjectIdentifier newTableIdentifier =
                     catalogManager.qualifyIdentifier(newUnresolvedIdentifier);
             return new AlterTableRenameOperation(tableIdentifier, newTableIdentifier);
-        } else if (sqlAlterTable instanceof SqlAlterTableProperties) {
+        } else if (sqlAlterTable instanceof SqlAlterTableOptions) {
             Optional<CatalogManager.TableLookupResult> optionalCatalogTable =
                     catalogManager.getTable(tableIdentifier);
             if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
                 CatalogTable originalCatalogTable =
                         (CatalogTable) optionalCatalogTable.get().getTable();
-                Map<String, String> properties = new HashMap<>();
-                properties.putAll(originalCatalogTable.getProperties());
-                ((SqlAlterTableProperties) sqlAlterTable)
+                Map<String, String> options = new HashMap<>();
+                options.putAll(originalCatalogTable.getOptions());
+                ((SqlAlterTableOptions) sqlAlterTable)
                         .getPropertyList()
                         .getList()
                         .forEach(
                                 p ->
-                                        properties.put(
+                                        options.put(
                                                 ((SqlTableOption) p).getKeyString(),
                                                 ((SqlTableOption) p).getValueString()));
                 CatalogTable catalogTable =
                         new CatalogTableImpl(
                                 originalCatalogTable.getSchema(),
                                 originalCatalogTable.getPartitionKeys(),
-                                properties,
+                                options,
                                 originalCatalogTable.getComment());
-                return new AlterTablePropertiesOperation(tableIdentifier, catalogTable);
+                return new AlterTableOptionsOperation(tableIdentifier, catalogTable);
             } else {
                 throw new ValidationException(
                         String.format(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -681,7 +681,7 @@ abstract class TableEnvImpl(
                 alterTableRenameOp.getTableIdentifier.toObjectPath,
                 alterTableRenameOp.getNewTableIdentifier.getObjectName,
                 false)
-            case alterTablePropertiesOp: AlterTablePropertiesOperation =>
+            case alterTablePropertiesOp: AlterTableOptionsOperation =>
               catalog.alterTable(
                 alterTablePropertiesOp.getTableIdentifier.toObjectPath,
                 alterTablePropertiesOp.getCatalogTable,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -52,7 +52,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
-import org.apache.flink.table.operations.ddl.AlterTablePropertiesOperation;
+import org.apache.flink.table.operations.ddl.AlterTableOptionsOperation;
 import org.apache.flink.table.operations.ddl.AlterTableRenameOperation;
 import org.apache.flink.table.operations.ddl.CreateDatabaseOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
@@ -339,7 +339,7 @@ public class SqlToOperationConverterTest {
         CreateTableOperation op = (CreateTableOperation) operation;
         CatalogTable catalogTable = op.getCatalogTable();
         Map<String, String> properties =
-                catalogTable.getProperties().entrySet().stream()
+                catalogTable.getOptions().entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         Map<String, String> sortedProperties = new TreeMap<>(properties);
         final String expected =
@@ -653,15 +653,15 @@ public class SqlToOperationConverterTest {
                 parse(
                         "alter table cat1.db1.tb1 set ('k1' = 'v1', 'K2' = 'V2')",
                         SqlDialect.DEFAULT);
-        assert operation instanceof AlterTablePropertiesOperation;
-        final AlterTablePropertiesOperation alterTablePropertiesOperation =
-                (AlterTablePropertiesOperation) operation;
-        assertEquals(expectedIdentifier, alterTablePropertiesOperation.getTableIdentifier());
-        assertEquals(2, alterTablePropertiesOperation.getCatalogTable().getProperties().size());
+        assert operation instanceof AlterTableOptionsOperation;
+        final AlterTableOptionsOperation alterTableOptionsOperation =
+                (AlterTableOptionsOperation) operation;
+        assertEquals(expectedIdentifier, alterTableOptionsOperation.getTableIdentifier());
+        assertEquals(2, alterTableOptionsOperation.getCatalogTable().getOptions().size());
         Map<String, String> properties = new HashMap<>();
         properties.put("k1", "v1");
         properties.put("K2", "V2");
-        assertEquals(properties, alterTablePropertiesOperation.getCatalogTable().getProperties());
+        assertEquals(properties, alterTableOptionsOperation.getCatalogTable().getOptions());
     }
 
     // ~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -99,7 +99,7 @@ class BatchTableEnvironmentTest extends TableTestBase {
     assertEquals(
       Map("connector" -> "COLLECTION", "is-bounded" -> "true", "k1" -> "a", "k2" -> "b").asJava,
       util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
-        .getTable(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.tbl1")).getProperties)
+        .getTable(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.tbl1")).getOptions)
 
     val tableResult3 = util.tableEnv.executeSql("DROP TABLE tbl1")
     assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -633,7 +633,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
     expectedProperties.put("k2", "b")
     val properties = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
       .getTable(new ObjectPath(tableEnv.getCurrentDatabase, "t2"))
-      .getProperties
+      .getOptions
     assertEquals(expectedProperties, properties)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This removes the deprecated `CatalogBaseTable.getProperties()` with `CatalogBaseTable.getOptions()` and makes sure that we have a clear distinction between options (the WITH part of a CREATE TABLE) and properties (a general Map<String, String> and the full CREATE TABLE when persisting).

## Brief change log

- Removal of `CatalogBaseTable.getProperties()`
- Renaming of `AlterTableProperties` to `AlterTableOptions`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
