### PR TITLE
[FLINK-21151] Extract common full-snapshot writer from RocksDB full-snapshot strategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotAsyncWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotAsyncWriter.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+import static org.apache.flink.runtime.state.FullSnapshotUtil.END_OF_KEY_GROUP_MARK;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.hasMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.setMetaDataFollowsFlagInKey;
+
+/**
+ * An asynchronous writer that can write a full snapshot/savepoint from a {@link
+ * FullSnapshotResources}.
+ *
+ * @param <K> type of the backend keys.
+ */
+public class FullSnapshotAsyncWriter<K>
+        implements SnapshotStrategy.SnapshotResultSupplier<KeyedStateHandle> {
+
+    /** Supplier for the stream into which we write the snapshot. */
+    @Nonnull
+    private final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+            checkpointStreamSupplier;
+
+    @Nonnull private final FullSnapshotResources<K> snapshotResources;
+
+    public FullSnapshotAsyncWriter(
+            @Nonnull
+                    SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+                            checkpointStreamSupplier,
+            @Nonnull FullSnapshotResources<K> snapshotResources) {
+
+        this.checkpointStreamSupplier = checkpointStreamSupplier;
+        this.snapshotResources = snapshotResources;
+    }
+
+    @Override
+    public SnapshotResult<KeyedStateHandle> get(CloseableRegistry snapshotCloseableRegistry)
+            throws Exception {
+        final KeyGroupRangeOffsets keyGroupRangeOffsets =
+                new KeyGroupRangeOffsets(snapshotResources.getKeyGroupRange());
+        final CheckpointStreamWithResultProvider checkpointStreamWithResultProvider =
+                checkpointStreamSupplier.get();
+
+        snapshotCloseableRegistry.registerCloseable(checkpointStreamWithResultProvider);
+        writeSnapshotToOutputStream(checkpointStreamWithResultProvider, keyGroupRangeOffsets);
+
+        if (snapshotCloseableRegistry.unregisterCloseable(checkpointStreamWithResultProvider)) {
+            return CheckpointStreamWithResultProvider.toKeyedStateHandleSnapshotResult(
+                    checkpointStreamWithResultProvider.closeAndFinalizeCheckpointStreamResult(),
+                    keyGroupRangeOffsets);
+        } else {
+            throw new IOException("Stream is already unregistered/closed.");
+        }
+    }
+
+    private void writeSnapshotToOutputStream(
+            @Nonnull CheckpointStreamWithResultProvider checkpointStreamWithResultProvider,
+            @Nonnull KeyGroupRangeOffsets keyGroupRangeOffsets)
+            throws IOException, InterruptedException {
+
+        final DataOutputView outputView =
+                new DataOutputViewStreamWrapper(
+                        checkpointStreamWithResultProvider.getCheckpointOutputStream());
+
+        writeKVStateMetaData(outputView);
+
+        try (KeyValueStateIterator kvStateIterator = snapshotResources.createKVStateIterator()) {
+            writeKVStateData(
+                    kvStateIterator, checkpointStreamWithResultProvider, keyGroupRangeOffsets);
+        }
+    }
+
+    private void writeKVStateMetaData(final DataOutputView outputView) throws IOException {
+
+        KeyedBackendSerializationProxy<K> serializationProxy =
+                new KeyedBackendSerializationProxy<>(
+                        // TODO: this code assumes that writing a serializer is threadsafe, we
+                        // should support to
+                        // get a serialized form already at state registration time in the
+                        // future
+                        snapshotResources.getKeySerializer(),
+                        snapshotResources.getMetaInfoSnapshots(),
+                        !Objects.equals(
+                                UncompressedStreamCompressionDecorator.INSTANCE,
+                                snapshotResources.getStreamCompressionDecorator()));
+
+        serializationProxy.write(outputView);
+    }
+
+    private void writeKVStateData(
+            final KeyValueStateIterator mergeIterator,
+            final CheckpointStreamWithResultProvider checkpointStreamWithResultProvider,
+            final KeyGroupRangeOffsets keyGroupRangeOffsets)
+            throws IOException, InterruptedException {
+
+        byte[] previousKey = null;
+        byte[] previousValue = null;
+        DataOutputView kgOutView = null;
+        OutputStream kgOutStream = null;
+        CheckpointStreamFactory.CheckpointStateOutputStream checkpointOutputStream =
+                checkpointStreamWithResultProvider.getCheckpointOutputStream();
+
+        try {
+
+            // preamble: setup with first key-group as our lookahead
+            if (mergeIterator.isValid()) {
+                // begin first key-group by recording the offset
+                keyGroupRangeOffsets.setKeyGroupOffset(
+                        mergeIterator.keyGroup(), checkpointOutputStream.getPos());
+                // write the k/v-state id as metadata
+                kgOutStream =
+                        snapshotResources
+                                .getStreamCompressionDecorator()
+                                .decorateWithCompression(checkpointOutputStream);
+                kgOutView = new DataOutputViewStreamWrapper(kgOutStream);
+                // TODO this could be aware of keyGroupPrefixBytes and write only one byte
+                // if possible
+                kgOutView.writeShort(mergeIterator.kvStateId());
+                previousKey = mergeIterator.key();
+                previousValue = mergeIterator.value();
+                mergeIterator.next();
+            }
+
+            // main loop: write k/v pairs ordered by (key-group, kv-state), thereby tracking
+            // key-group offsets.
+            while (mergeIterator.isValid()) {
+
+                assert (!hasMetaDataFollowsFlag(previousKey));
+
+                // set signal in first key byte that meta data will follow in the stream
+                // after this k/v pair
+                if (mergeIterator.isNewKeyGroup() || mergeIterator.isNewKeyValueState()) {
+
+                    // be cooperative and check for interruption from time to time in the
+                    // hot loop
+                    checkInterrupted();
+
+                    setMetaDataFollowsFlagInKey(previousKey);
+                }
+
+                writeKeyValuePair(previousKey, previousValue, kgOutView);
+
+                // write meta data if we have to
+                if (mergeIterator.isNewKeyGroup()) {
+                    // TODO this could be aware of keyGroupPrefixBytes and write only one
+                    // byte if possible
+                    kgOutView.writeShort(END_OF_KEY_GROUP_MARK);
+                    // this will just close the outer stream
+                    kgOutStream.close();
+                    // begin new key-group
+                    keyGroupRangeOffsets.setKeyGroupOffset(
+                            mergeIterator.keyGroup(), checkpointOutputStream.getPos());
+                    // write the kev-state
+                    // TODO this could be aware of keyGroupPrefixBytes and write only one
+                    // byte if possible
+                    kgOutStream =
+                            snapshotResources
+                                    .getStreamCompressionDecorator()
+                                    .decorateWithCompression(checkpointOutputStream);
+                    kgOutView = new DataOutputViewStreamWrapper(kgOutStream);
+                    kgOutView.writeShort(mergeIterator.kvStateId());
+                } else if (mergeIterator.isNewKeyValueState()) {
+                    // write the k/v-state
+                    // TODO this could be aware of keyGroupPrefixBytes and write only one
+                    // byte if possible
+                    kgOutView.writeShort(mergeIterator.kvStateId());
+                }
+
+                // request next k/v pair
+                previousKey = mergeIterator.key();
+                previousValue = mergeIterator.value();
+                mergeIterator.next();
+            }
+
+            // epilogue: write last key-group
+            if (previousKey != null) {
+                assert (!hasMetaDataFollowsFlag(previousKey));
+                setMetaDataFollowsFlagInKey(previousKey);
+                writeKeyValuePair(previousKey, previousValue, kgOutView);
+                // TODO this could be aware of keyGroupPrefixBytes and write only one byte if
+                // possible
+                kgOutView.writeShort(END_OF_KEY_GROUP_MARK);
+                // this will just close the outer stream
+                kgOutStream.close();
+                kgOutStream = null;
+            }
+
+        } finally {
+            // this will just close the outer stream
+            IOUtils.closeQuietly(kgOutStream);
+        }
+    }
+
+    private void writeKeyValuePair(byte[] key, byte[] value, DataOutputView out)
+            throws IOException {
+        BytePrimitiveArraySerializer.INSTANCE.serialize(key, out);
+        BytePrimitiveArraySerializer.INSTANCE.serialize(value, out);
+    }
+
+    private void checkInterrupted() throws InterruptedException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new InterruptedException("RocksDB snapshot interrupted.");
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotResources.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+
+import java.io.IOException;
+import java.util.List;
+
+/** A {@link SnapshotResources} to be used with a backend-independent {@link SnapshotStrategy}. */
+@Internal
+public interface FullSnapshotResources extends SnapshotResources {
+
+    /**
+     * Returns the list of {@link StateMetaInfoSnapshot meta info snapshots} for this state
+     * snapshot.
+     */
+    List<StateMetaInfoSnapshot> getMetaInfoSnapshots();
+
+    /**
+     * Returns a {@link KeyValueStateIterator} for iterating over all key-value states for this
+     * snapshot resources.
+     */
+    KeyValueStateIterator createKVStateIterator() throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotResources.java
@@ -19,14 +19,20 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 
 import java.io.IOException;
 import java.util.List;
 
-/** A {@link SnapshotResources} to be used with a backend-independent {@link SnapshotStrategy}. */
+/**
+ * A {@link SnapshotResources} to be used with the backend-independent {@link
+ * FullSnapshotAsyncWriter}.
+ *
+ * @param <K> type of the backend keys.
+ */
 @Internal
-public interface FullSnapshotResources extends SnapshotResources {
+public interface FullSnapshotResources<K> extends SnapshotResources {
 
     /**
      * Returns the list of {@link StateMetaInfoSnapshot meta info snapshots} for this state
@@ -39,4 +45,13 @@ public interface FullSnapshotResources extends SnapshotResources {
      * snapshot resources.
      */
     KeyValueStateIterator createKVStateIterator() throws IOException;
+
+    /** Returns the {@link KeyGroupRange} of this snapshot. */
+    KeyGroupRange getKeyGroupRange();
+
+    /** Returns key {@link TypeSerializer}. */
+    TypeSerializer<K> getKeySerializer();
+
+    /** Returns the {@link StreamCompressionDecorator} that should be used for writing. */
+    StreamCompressionDecorator getStreamCompressionDecorator();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FullSnapshotUtil.java
@@ -16,18 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.contrib.streaming.state.snapshot;
+package org.apache.flink.runtime.state;
 
 /**
- * Utility methods and constants around RocksDB creating and restoring snapshots for {@link
- * org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend}.
+ * Utility methods and constants around creating and restoring full snapshots using {@link
+ * FullSnapshotAsyncWriter}.
  */
-public class RocksSnapshotUtil {
+public class FullSnapshotUtil {
 
-    /** File suffix of sstable files. */
-    public static final String SST_FILE_SUFFIX = ".sst";
+    public static final int FIRST_BIT_IN_BYTE_MASK = 0x80;
 
-    private RocksSnapshotUtil() {
+    public static final int END_OF_KEY_GROUP_MARK = 0xFFFF;
+
+    public static void setMetaDataFollowsFlagInKey(byte[] key) {
+        key[0] |= FIRST_BIT_IN_BYTE_MASK;
+    }
+
+    public static void clearMetaDataFollowsFlag(byte[] key) {
+        key[0] &= (~FIRST_BIT_IN_BYTE_MASK);
+    }
+
+    public static boolean hasMetaDataFollowsFlag(byte[] key) {
+        return 0 != (key[0] & FIRST_BIT_IN_BYTE_MASK);
+    }
+
+    private FullSnapshotUtil() {
         throw new AssertionError();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyValueStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyValueStateIterator.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+/**
+ * Iterator that over all key-value state entries in a {@link KeyedStateBackend}. For use during
+ * snapshotting.
+ *
+ * <p>This is required to partition all states into contiguous key-groups. The resulting iteration
+ * sequence is ordered by (key-group, kv-state).
+ */
+public interface KeyValueStateIterator extends AutoCloseable {
+
+    /**
+     * Advances the iterator. Should only be called if {@link #isValid()} returned true. Valid flag
+     * can only change after calling {@link #next()}.
+     */
+    void next();
+
+    /** Returns the key-group for the current key. */
+    int keyGroup();
+
+    byte[] key();
+
+    byte[] value();
+
+    /** Returns the Id of the K/V state to which the current key belongs. */
+    int kvStateId();
+
+    /**
+     * Indicates if current key starts a new k/v-state, i.e. belong to a different k/v-state than
+     * it's predecessor.
+     *
+     * @return true iff the current key belong to a different k/v-state than it's predecessor.
+     */
+    boolean isNewKeyValueState();
+
+    /**
+     * Indicates if current key starts a new key-group, i.e. belong to a different key-group than
+     * it's predecessor.
+     *
+     * @return true iff the current key belong to a different key-group than it's predecessor.
+     */
+    boolean isNewKeyGroup();
+
+    /**
+     * Check if the iterator is still valid. Getters like {@link #key()}, {@link #value()}, etc. as
+     * well as {@link #next()} should only be called if valid returned true. Should be checked after
+     * each call to {@link #next()} before accessing iterator state.
+     *
+     * @return True iff this iterator is valid.
+     */
+    boolean isValid();
+
+    @Override
+    void close();
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksSingleStateIterator.java
@@ -23,11 +23,13 @@ import org.apache.flink.util.IOUtils;
 
 import javax.annotation.Nonnull;
 
+import java.io.Closeable;
+
 /**
  * Wraps a RocksDB iterator to cache it's current key and assigns an id for the key/value state to
  * the iterator. Used by {@link RocksStatesPerKeyGroupMergeIterator}.
  */
-class RocksSingleStateIterator implements AutoCloseable {
+class RocksSingleStateIterator implements Closeable {
 
     /**
      * @param iterator underlying {@link RocksIteratorWrapper}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBFullRestoreOperation.java
@@ -59,9 +59,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.clearMetaDataFollowsFlag;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.hasMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.END_OF_KEY_GROUP_MARK;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.clearMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.hasMetaDataFollowsFlag;
 import static org.apache.flink.runtime.state.StateUtil.unexpectedStateHandleException;
 import static org.apache.flink.util.Preconditions.checkArgument;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBFullSnapshotResources.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBFullSnapshotResources.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.snapshot;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
+import org.apache.flink.contrib.streaming.state.iterator.RocksStatesPerKeyGroupMergeIterator;
+import org.apache.flink.contrib.streaming.state.iterator.RocksTransformingIteratorWrapper;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.state.FullSnapshotResources;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyValueStateIterator;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.ResourceGuard;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.Snapshot;
+
+import javax.annotation.Nonnegative;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A {@link FullSnapshotResources} for the RocksDB backend. */
+class RocksDBFullSnapshotResources<K> implements FullSnapshotResources<K> {
+    private final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots;
+    private final ResourceGuard.Lease lease;
+    private final Snapshot snapshot;
+    private final RocksDB db;
+    private final List<MetaData> metaData;
+
+    /** Number of bytes in the key-group prefix. */
+    @Nonnegative private final int keyGroupPrefixBytes;
+
+    private final KeyGroupRange keyGroupRange;
+    private final TypeSerializer<K> keySerializer;
+    private final StreamCompressionDecorator streamCompressionDecorator;
+
+    public RocksDBFullSnapshotResources(
+            ResourceGuard.Lease lease,
+            Snapshot snapshot,
+            List<RocksDBKeyedStateBackend.RocksDbKvStateInfo> metaDataCopy,
+            List<StateMetaInfoSnapshot> stateMetaInfoSnapshots,
+            RocksDB db,
+            int keyGroupPrefixBytes,
+            KeyGroupRange keyGroupRange,
+            TypeSerializer<K> keySerializer,
+            StreamCompressionDecorator streamCompressionDecorator) {
+        this.lease = lease;
+        this.snapshot = snapshot;
+        this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
+        this.db = db;
+        this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+        this.keyGroupRange = keyGroupRange;
+        this.keySerializer = keySerializer;
+        this.streamCompressionDecorator = streamCompressionDecorator;
+
+        // we need to to this in the constructor, i.e. in the synchronous part of the snapshot
+        // TODO: better yet, we can do it outside the constructor
+        this.metaData = fillMetaData(metaDataCopy);
+    }
+
+    private List<MetaData> fillMetaData(
+            List<RocksDBKeyedStateBackend.RocksDbKvStateInfo> metaDataCopy) {
+        List<MetaData> metaData = new ArrayList<>(metaDataCopy.size());
+        for (RocksDBKeyedStateBackend.RocksDbKvStateInfo rocksDbKvStateInfo : metaDataCopy) {
+            StateSnapshotTransformer<byte[]> stateSnapshotTransformer = null;
+            if (rocksDbKvStateInfo.metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
+                stateSnapshotTransformer =
+                        ((RegisteredKeyValueStateBackendMetaInfo<?, ?>) rocksDbKvStateInfo.metaInfo)
+                                .getStateSnapshotTransformFactory()
+                                .createForSerializedState()
+                                .orElse(null);
+            }
+            metaData.add(new MetaData(rocksDbKvStateInfo, stateSnapshotTransformer));
+        }
+        return metaData;
+    }
+
+    @Override
+    public KeyValueStateIterator createKVStateIterator() throws IOException {
+        CloseableRegistry closeableRegistry = new CloseableRegistry();
+
+        try {
+            ReadOptions readOptions = new ReadOptions();
+            closeableRegistry.registerCloseable(readOptions::close);
+            readOptions.setSnapshot(snapshot);
+
+            List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators =
+                    createKVStateIterators(closeableRegistry, readOptions);
+
+            // Here we transfer ownership of the required resources to the
+            // RocksStatesPerKeyGroupMergeIterator
+            return new RocksStatesPerKeyGroupMergeIterator(
+                    closeableRegistry, new ArrayList<>(kvStateIterators), keyGroupPrefixBytes);
+        } catch (Throwable t) {
+            // If anything goes wrong, clean up our stuff. If things went smoothly the
+            // merging iterator is now responsible for closing the resources
+            IOUtils.closeQuietly(closeableRegistry);
+            throw new IOException("Error creating merge iterator", t);
+        }
+    }
+
+    private List<Tuple2<RocksIteratorWrapper, Integer>> createKVStateIterators(
+            CloseableRegistry closeableRegistry, ReadOptions readOptions) throws IOException {
+
+        final List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators =
+                new ArrayList<>(metaData.size());
+
+        int kvStateId = 0;
+
+        for (MetaData metaDataEntry : metaData) {
+            RocksIteratorWrapper rocksIteratorWrapper =
+                    createRocksIteratorWrapper(
+                            db,
+                            metaDataEntry.rocksDbKvStateInfo.columnFamilyHandle,
+                            metaDataEntry.stateSnapshotTransformer,
+                            readOptions);
+            kvStateIterators.add(Tuple2.of(rocksIteratorWrapper, kvStateId));
+            closeableRegistry.registerCloseable(rocksIteratorWrapper);
+            ++kvStateId;
+        }
+
+        return kvStateIterators;
+    }
+
+    private static RocksIteratorWrapper createRocksIteratorWrapper(
+            RocksDB db,
+            ColumnFamilyHandle columnFamilyHandle,
+            StateSnapshotTransformer<byte[]> stateSnapshotTransformer,
+            ReadOptions readOptions) {
+        RocksIterator rocksIterator = db.newIterator(columnFamilyHandle, readOptions);
+        return stateSnapshotTransformer == null
+                ? new RocksIteratorWrapper(rocksIterator)
+                : new RocksTransformingIteratorWrapper(rocksIterator, stateSnapshotTransformer);
+    }
+
+    @Override
+    public List<StateMetaInfoSnapshot> getMetaInfoSnapshots() {
+        return stateMetaInfoSnapshots;
+    }
+
+    @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return keyGroupRange;
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return keySerializer;
+    }
+
+    @Override
+    public StreamCompressionDecorator getStreamCompressionDecorator() {
+        return streamCompressionDecorator;
+    }
+
+    @Override
+    public void release() {
+        db.releaseSnapshot(snapshot);
+        IOUtils.closeQuietly(snapshot);
+        IOUtils.closeQuietly(lease);
+    }
+
+    private static class MetaData {
+        final RocksDBKeyedStateBackend.RocksDbKvStateInfo rocksDbKvStateInfo;
+        final StateSnapshotTransformer<byte[]> stateSnapshotTransformer;
+
+        private MetaData(
+                RocksDBKeyedStateBackend.RocksDbKvStateInfo rocksDbKvStateInfo,
+                StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
+
+            this.rocksDbKvStateInfo = rocksDbKvStateInfo;
+            this.stateSnapshotTransformer = stateSnapshotTransformer;
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -19,12 +19,7 @@
 package org.apache.flink.contrib.streaming.state.snapshot;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
-import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
-import org.apache.flink.contrib.streaming.state.iterator.RocksStatesPerKeyGroupMergeIterator;
-import org.apache.flink.contrib.streaming.state.iterator.RocksTransformingIteratorWrapper;
-import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
@@ -32,22 +27,15 @@ import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.FullSnapshotAsyncWriter;
 import org.apache.flink.runtime.state.FullSnapshotResources;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.KeyValueStateIterator;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.SnapshotResult;
-import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
-import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.ResourceGuard;
 import org.apache.flink.util.function.SupplierWithException;
 
-import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
-import org.rocksdb.RocksIterator;
 import org.rocksdb.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -115,7 +102,7 @@ public class RocksFullSnapshotStrategy<K>
         final ResourceGuard.Lease lease = rocksDBResourceGuard.acquireResource();
         final Snapshot snapshot = db.getSnapshot();
 
-        return new FullRocksDBSnapshotResources<>(
+        return new RocksDBFullSnapshotResources<>(
                 lease,
                 snapshot,
                 metaDataCopy,
@@ -180,159 +167,5 @@ public class RocksFullSnapshotStrategy<K>
                 : () ->
                         CheckpointStreamWithResultProvider.createSimpleStream(
                                 CheckpointedStateScope.EXCLUSIVE, primaryStreamFactory);
-    }
-
-    static class FullRocksDBSnapshotResources<K> implements FullSnapshotResources<K> {
-        private final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots;
-        private final ResourceGuard.Lease lease;
-        private final Snapshot snapshot;
-        private final RocksDB db;
-        private final List<MetaData> metaData;
-
-        /** Number of bytes in the key-group prefix. */
-        @Nonnegative private final int keyGroupPrefixBytes;
-
-        private final KeyGroupRange keyGroupRange;
-        private final TypeSerializer<K> keySerializer;
-        private final StreamCompressionDecorator streamCompressionDecorator;
-
-        public FullRocksDBSnapshotResources(
-                ResourceGuard.Lease lease,
-                Snapshot snapshot,
-                List<RocksDbKvStateInfo> metaDataCopy,
-                List<StateMetaInfoSnapshot> stateMetaInfoSnapshots,
-                RocksDB db,
-                int keyGroupPrefixBytes,
-                KeyGroupRange keyGroupRange,
-                TypeSerializer<K> keySerializer,
-                StreamCompressionDecorator streamCompressionDecorator) {
-            this.lease = lease;
-            this.snapshot = snapshot;
-            this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
-            this.db = db;
-            this.keyGroupPrefixBytes = keyGroupPrefixBytes;
-            this.keyGroupRange = keyGroupRange;
-            this.keySerializer = keySerializer;
-            this.streamCompressionDecorator = streamCompressionDecorator;
-
-            // we need to to this in the constructor, i.e. in the synchronous part of the snapshot
-            // TODO: better yet, we can do it outside the constructor
-            this.metaData = fillMetaData(metaDataCopy);
-        }
-
-        private List<MetaData> fillMetaData(List<RocksDbKvStateInfo> metaDataCopy) {
-            List<MetaData> metaData = new ArrayList<>(metaDataCopy.size());
-            for (RocksDbKvStateInfo rocksDbKvStateInfo : metaDataCopy) {
-                StateSnapshotTransformer<byte[]> stateSnapshotTransformer = null;
-                if (rocksDbKvStateInfo.metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
-                    stateSnapshotTransformer =
-                            ((RegisteredKeyValueStateBackendMetaInfo<?, ?>)
-                                            rocksDbKvStateInfo.metaInfo)
-                                    .getStateSnapshotTransformFactory()
-                                    .createForSerializedState()
-                                    .orElse(null);
-                }
-                metaData.add(new MetaData(rocksDbKvStateInfo, stateSnapshotTransformer));
-            }
-            return metaData;
-        }
-
-        @Override
-        public KeyValueStateIterator createKVStateIterator() throws IOException {
-            CloseableRegistry closeableRegistry = new CloseableRegistry();
-
-            try {
-                ReadOptions readOptions = new ReadOptions();
-                closeableRegistry.registerCloseable(readOptions::close);
-                readOptions.setSnapshot(snapshot);
-
-                List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators =
-                        createKVStateIterators(closeableRegistry, readOptions);
-
-                // Here we transfer ownership of the required resources to the
-                // RocksStatesPerKeyGroupMergeIterator
-                return new RocksStatesPerKeyGroupMergeIterator(
-                        closeableRegistry, new ArrayList<>(kvStateIterators), keyGroupPrefixBytes);
-            } catch (Throwable t) {
-                // If anything goes wrong, clean up our stuff. If things went smoothly the
-                // merging iterator is now responsible for closing the resources
-                IOUtils.closeQuietly(closeableRegistry);
-                throw new IOException("Error creating merge iterator", t);
-            }
-        }
-
-        private List<Tuple2<RocksIteratorWrapper, Integer>> createKVStateIterators(
-                CloseableRegistry closeableRegistry, ReadOptions readOptions) throws IOException {
-
-            final List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators =
-                    new ArrayList<>(metaData.size());
-
-            int kvStateId = 0;
-
-            for (MetaData metaDataEntry : metaData) {
-                RocksIteratorWrapper rocksIteratorWrapper =
-                        createRocksIteratorWrapper(
-                                db,
-                                metaDataEntry.rocksDbKvStateInfo.columnFamilyHandle,
-                                metaDataEntry.stateSnapshotTransformer,
-                                readOptions);
-                kvStateIterators.add(Tuple2.of(rocksIteratorWrapper, kvStateId));
-                closeableRegistry.registerCloseable(rocksIteratorWrapper);
-                ++kvStateId;
-            }
-
-            return kvStateIterators;
-        }
-
-        private static RocksIteratorWrapper createRocksIteratorWrapper(
-                RocksDB db,
-                ColumnFamilyHandle columnFamilyHandle,
-                StateSnapshotTransformer<byte[]> stateSnapshotTransformer,
-                ReadOptions readOptions) {
-            RocksIterator rocksIterator = db.newIterator(columnFamilyHandle, readOptions);
-            return stateSnapshotTransformer == null
-                    ? new RocksIteratorWrapper(rocksIterator)
-                    : new RocksTransformingIteratorWrapper(rocksIterator, stateSnapshotTransformer);
-        }
-
-        @Override
-        public List<StateMetaInfoSnapshot> getMetaInfoSnapshots() {
-            return stateMetaInfoSnapshots;
-        }
-
-        @Override
-        public KeyGroupRange getKeyGroupRange() {
-            return keyGroupRange;
-        }
-
-        @Override
-        public TypeSerializer<K> getKeySerializer() {
-            return keySerializer;
-        }
-
-        @Override
-        public StreamCompressionDecorator getStreamCompressionDecorator() {
-            return streamCompressionDecorator;
-        }
-
-        @Override
-        public void release() {
-            db.releaseSnapshot(snapshot);
-            IOUtils.closeQuietly(snapshot);
-            IOUtils.closeQuietly(lease);
-        }
-
-        private static class MetaData {
-            final RocksDbKvStateInfo rocksDbKvStateInfo;
-            final StateSnapshotTransformer<byte[]> stateSnapshotTransformer;
-
-            private MetaData(
-                    RocksDbKvStateInfo rocksDbKvStateInfo,
-                    StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
-
-                this.rocksDbKvStateInfo = rocksDbKvStateInfo;
-                this.stateSnapshotTransformer = stateSnapshotTransformer;
-            }
-        }
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -93,11 +93,11 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.END_OF_KEY_GROUP_MARK;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.FIRST_BIT_IN_BYTE_MASK;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.clearMetaDataFollowsFlag;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.hasMetaDataFollowsFlag;
-import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUtil.setMetaDataFollowsFlagInKey;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.END_OF_KEY_GROUP_MARK;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.FIRST_BIT_IN_BYTE_MASK;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.clearMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.hasMetaDataFollowsFlag;
+import static org.apache.flink.runtime.state.FullSnapshotUtil.setMetaDataFollowsFlagInKey;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.contrib.streaming.state.iterator.RocksStatesPerKeyGroupMergeIterator;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.util.IOUtils;
 
@@ -59,7 +60,7 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
     public void testEmptyMergeIterator() throws Exception {
         RocksStatesPerKeyGroupMergeIterator emptyIterator =
                 new RocksStatesPerKeyGroupMergeIterator(
-                        new ReadOptions(), Collections.emptyList(), 2);
+                        new CloseableRegistry(), Collections.emptyList(), 2);
         Assert.assertFalse(emptyIterator.isValid());
     }
 
@@ -130,7 +131,7 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
 
             try (RocksStatesPerKeyGroupMergeIterator mergeIterator =
                     new RocksStatesPerKeyGroupMergeIterator(
-                            new ReadOptions(),
+                            new CloseableRegistry(),
                             rocksIteratorsWithKVStateId,
                             maxParallelism <= Byte.MAX_VALUE ? 1 : 2)) {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
@@ -58,7 +58,8 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
     @Test
     public void testEmptyMergeIterator() throws Exception {
         RocksStatesPerKeyGroupMergeIterator emptyIterator =
-                new RocksStatesPerKeyGroupMergeIterator(Collections.emptyList(), 2);
+                new RocksStatesPerKeyGroupMergeIterator(
+                        new ReadOptions(), Collections.emptyList(), 2);
         Assert.assertFalse(emptyIterator.isValid());
     }
 
@@ -129,6 +130,7 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
 
             try (RocksStatesPerKeyGroupMergeIterator mergeIterator =
                     new RocksStatesPerKeyGroupMergeIterator(
+                            new ReadOptions(),
                             rocksIteratorsWithKVStateId,
                             maxParallelism <= Byte.MAX_VALUE ? 1 : 2)) {
 


### PR DESCRIPTION
As described in FLIP-41, the RocksDB full-snapshot format will serve as the common, unified savepoint format. We need to extract the common parts and make them reusable by other state backends.

The commits themselves have good description of what's going on, it's easiest to follow the commits one by one instead of reviewing the final results.

## Verifying this change

This is a pure refactoring and should be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
