### PR TITLE
[FLINK-20254][hive] Make PartitionMonitor fetching partitions with same create time properly

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHiveSplitEnumerator.java
@@ -174,7 +174,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
         }
     }
 
-    private static class PartitionMonitor<T extends Comparable<T>>
+    static class PartitionMonitor<T extends Comparable<T>>
             implements Callable<NewSplitsAndState<T>> {
 
         // keep these locally so that we don't need to share state with main thread
@@ -186,7 +186,7 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
         private final ContinuousPartitionFetcher<Partition, T> fetcher;
         private final HiveTableSource.HiveContinuousPartitionFetcherContext<T> fetcherContext;
 
-        private PartitionMonitor(
+        PartitionMonitor(
                 T currentReadOffset,
                 Collection<List<String>> seenPartitionsSinceOffset,
                 ObjectPath tablePath,
@@ -220,10 +220,10 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
                 List<String> partSpec = partition.getValues();
                 if (seenPartitionsSinceOffset.add(partSpec)) {
                     T offset = tuple2.f1;
-                    if (offset.compareTo(currentReadOffset) > 0) {
+                    if (offset.compareTo(currentReadOffset) >= 0) {
                         nextSeen.add(partSpec);
                     }
-                    if (offset.compareTo(maxOffset) > 0) {
+                    if (offset.compareTo(maxOffset) >= 0) {
                         maxOffset = offset;
                     }
                     LOG.info(
@@ -248,10 +248,10 @@ public class ContinuousHiveSplitEnumerator<T extends Comparable<T>>
     }
 
     /** The result passed from monitor thread to main thread. */
-    private static class NewSplitsAndState<T extends Comparable<T>> {
-        private final T offset;
-        private final Collection<List<String>> seenPartitions;
-        private final Collection<HiveSourceSplit> newSplits;
+    static class NewSplitsAndState<T extends Comparable<T>> {
+        final T offset;
+        final Collection<List<String>> seenPartitions;
+        final Collection<HiveSourceSplit> newSplits;
 
         private NewSplitsAndState(
                 Collection<HiveSourceSplit> newSplits,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connectors.hive.read.HiveContinuousPartitionContext;
 import org.apache.flink.connectors.hive.read.HiveContinuousPartitionFetcher;
 import org.apache.flink.connectors.hive.read.HivePartitionFetcherContextBase;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
@@ -320,7 +321,7 @@ public class HiveTableSource
     @SuppressWarnings("unchecked")
     public static class HiveContinuousPartitionFetcherContext<T extends Comparable<T>>
             extends HivePartitionFetcherContextBase<Partition>
-            implements ContinuousPartitionFetcher.Context<Partition, T> {
+            implements HiveContinuousPartitionContext<Partition, T> {
 
         private static final long serialVersionUID = 1L;
         private static final Long DEFAULT_MIN_TIME_OFFSET = 0L;
@@ -399,7 +400,7 @@ public class HiveTableSource
          *
          * <p>the time is the the folder/file modification time in filesystem when fetched in
          * create-time order, the time is extracted from partition name when fetched in
-         * partition-time order, the time is partion create time in metaStore when fetched in
+         * partition-time order, the time is partition create time in metaStore when fetched in
          * partition-name order.
          */
         public long getModificationTime(Partition partition, T partitionOffset) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousPartitionContext.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousPartitionContext.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.filesystem.ContinuousPartitionFetcher;
+
+/**
+ * Context for Hive continuous partition fetcher.
+ *
+ * @param <P> The type of partition.
+ */
+@Internal
+public interface HiveContinuousPartitionContext<P, T extends Comparable<T>>
+        extends HivePartitionContext<P>, ContinuousPartitionFetcher.Context<P, T> {}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionContext.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionContext.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.table.filesystem.PartitionFetcher;
+
+/**
+ * Context for Hive partition fetcher.
+ *
+ * @param <P> The type of partition.
+ */
+@Internal
+public interface HivePartitionContext<P> extends PartitionFetcher.Context<P> {
+
+    /** Convert partition to {@link HiveTablePartition}. */
+    HiveTablePartition toHiveTablePartition(P partition);
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HivePartitionFetcherContextBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive.read;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connectors.hive.ConsumeOrder;
+import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HiveConfUtils;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
@@ -27,7 +28,6 @@ import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
 import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.filesystem.PartitionFetcher;
 import org.apache.flink.table.filesystem.PartitionTimeExtractor;
 import org.apache.flink.table.types.DataType;
 
@@ -50,12 +50,8 @@ import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_PARTITION_ORDER;
 import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionValues;
 
-/**
- * Base class for table partition fetcher context.
- *
- * @param <P> The type of partition.
- */
-public abstract class HivePartitionFetcherContextBase<P> implements PartitionFetcher.Context<P> {
+/** Base class for table partition fetcher context. */
+public abstract class HivePartitionFetcherContextBase<P> implements HivePartitionContext<P> {
 
     private static final long serialVersionUID = 1L;
     protected final ObjectPath tablePath;
@@ -209,5 +205,10 @@ public abstract class HivePartitionFetcherContextBase<P> implements PartitionFet
         if (this.metaStoreClient != null) {
             this.metaStoreClient.close();
         }
+    }
+
+    @Override
+    public HiveTablePartition toHiveTablePartition(P partition) {
+        return null;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.filesystem.ContinuousPartitionFetcher;
+import org.apache.flink.table.filesystem.PartitionFetcher;
+
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.http.util.Asserts;
+import org.apache.thrift.TException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Test for {@link ContinuousHiveSplitEnumerator.PartitionMonitor}. */
+public class PartitionMonitorTest {
+
+    private ContinuousHiveSplitEnumerator.PartitionMonitor partitionMonitor;
+    private List<Partition> testPartitionWithOffset = new ArrayList<>();
+
+    @Test
+    public void testPartitionWithSameCreateTime() throws Exception {
+        preparePartitionMonitor(0L);
+        commitPartitionWithGivenCreateTime(Arrays.asList("p1=A1", "p2=B1"), 1);
+        commitPartitionWithGivenCreateTime(Arrays.asList("p1=A1", "p2=B2"), 2);
+        ContinuousHiveSplitEnumerator.NewSplitsAndState<Long> newSplitsAndState =
+                partitionMonitor.call();
+        assertPartitionEquals(
+                Arrays.asList(Arrays.asList("p1=A1", "p2=B1"), Arrays.asList("p1=A1", "p2=B2")),
+                newSplitsAndState.seenPartitions);
+
+        commitPartitionWithGivenCreateTime(Arrays.asList("p1=A1", "p2=B3"), 3);
+        newSplitsAndState = partitionMonitor.call();
+        assertPartitionEquals(
+                Arrays.asList(Arrays.asList("p1=A1", "p2=B3")), newSplitsAndState.seenPartitions);
+
+        // check the partition with same create time can be monitored
+        commitPartitionWithGivenCreateTime(Arrays.asList("p1=A1", "p2=B4"), 3);
+        commitPartitionWithGivenCreateTime(Arrays.asList("p1=A1", "p2=B5"), 4);
+        newSplitsAndState = partitionMonitor.call();
+        assertPartitionEquals(
+                Arrays.asList(Arrays.asList("p1=A1", "p2=B4"), Arrays.asList("p1=A1", "p2=B5")),
+                newSplitsAndState.seenPartitions);
+    }
+
+    private void assertPartitionEquals(
+            Collection<List<String>> expected, Collection<List<String>> actual) {
+        assertTrue(expected != null && actual != null && expected.size() == actual.size());
+        assertArrayEquals(
+                expected.stream()
+                        .map(p -> p.toString())
+                        .sorted()
+                        .collect(Collectors.toList())
+                        .toArray(),
+                actual.stream()
+                        .map(p -> p.toString())
+                        .sorted()
+                        .collect(Collectors.toList())
+                        .toArray());
+    }
+
+    private void commitPartitionWithGivenCreateTime(
+            List<String> partitionValues, Integer createTime) {
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setLocation("/test");
+        Partition partition =
+                new Partition(
+                        partitionValues, "testDb", "testTable", createTime, createTime, sd, null);
+
+        partition.setValues(partitionValues);
+        testPartitionWithOffset.add(partition);
+    }
+
+    private void preparePartitionMonitor(Long currentReadOffset) {
+        List<List<String>> seenPartitionsSinceOffset = new ArrayList<>();
+        JobConf jobConf = new JobConf();
+        Configuration configuration = new Configuration();
+
+        ObjectPath tablePath = new ObjectPath("testDb", "testTable");
+        configuration.setString("streaming-source.consume-order", "create-time");
+        HiveTableSource.HiveContinuousPartitionFetcherContext<Long> fetcherContext =
+                new HiveTableSource.HiveContinuousPartitionFetcherContext<Long>(
+                        null, null, null, null, null, null, configuration, null) {
+
+                    @Override
+                    public Optional<Partition> getPartition(List<String> partValues)
+                            throws TException {
+                        return super.getPartition(partValues);
+                    }
+
+                    @Override
+                    public ObjectPath getTablePath() {
+                        return super.getTablePath();
+                    }
+
+                    @Override
+                    public long getModificationTime(Partition partition, Long partitionOffset) {
+                        return super.getModificationTime(partition, partitionOffset);
+                    }
+
+                    @Override
+                    public HiveTablePartition toHiveTablePartition(Partition partition) {
+                        StorageDescriptor sd = partition.getSd();
+                        Map<String, Object> partitionColValues = new HashMap<>();
+                        for (String partCol : partition.getValues()) {
+                            String[] arr = partCol.split("=");
+                            Asserts.check(
+                                    arr.length == 2, "partition string should be key=value format");
+                            partitionColValues.put(arr[0], arr[1]);
+                        }
+                        return new HiveTablePartition(sd, partitionColValues, new Properties());
+                    }
+
+                    @Override
+                    public TypeSerializer<Long> getTypeSerializer() {
+                        return super.getTypeSerializer();
+                    }
+
+                    @Override
+                    public Long getConsumeStartOffset() {
+                        return super.getConsumeStartOffset();
+                    }
+
+                    @Override
+                    public void close() throws Exception {
+                        super.close();
+                    }
+
+                    @Override
+                    public void open() throws Exception {
+                        super.open();
+                    }
+
+                    @Override
+                    public List<ComparablePartitionValue> getComparablePartitionValueList()
+                            throws Exception {
+                        return super.getComparablePartitionValueList();
+                    }
+                };
+
+        ContinuousPartitionFetcher<Partition, Long> continuousPartitionFetcher =
+                new ContinuousPartitionFetcher<Partition, Long>() {
+
+                    @Override
+                    public List<Tuple2<Partition, Long>> fetchPartitions(
+                            Context<Partition, Long> context, Long previousOffset)
+                            throws Exception {
+                        return testPartitionWithOffset.stream()
+                                .filter(p -> Long.valueOf(p.getCreateTime()) >= previousOffset)
+                                .map(p -> Tuple2.of(p, Long.valueOf(p.getCreateTime())))
+                                .collect(Collectors.toList());
+                    }
+
+                    @Override
+                    public List<Partition> fetch(PartitionFetcher.Context<Partition> context)
+                            throws Exception {
+                        return null;
+                    }
+                };
+
+        partitionMonitor =
+                new ContinuousHiveSplitEnumerator.PartitionMonitor(
+                        currentReadOffset,
+                        seenPartitionsSinceOffset,
+                        tablePath,
+                        jobConf,
+                        continuousPartitionFetcher,
+                        fetcherContext);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix the `PartitionMonitor` can not deals  partitions with same create time but fetched in different call.


## Brief change log

  - update `PartitionMonitor` filter logic

## Verifying this change

Add unit test to cover the case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
