### PR TITLE
[FLINK-21006] Fix hbase 1.4 tests on Hadoop 3.x

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ stages:
             vmImage: 'ubuntu-16.04'
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
-          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+          environment: PROFILE="-Dinclude_hadoop_aws -Dhadoop.version=3.1.3 -Phadoop3-tests"
           run_end_to_end: false
           container: flink-build-container
           jdk: jdk8

--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -275,6 +275,10 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-auth</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
## Verifying this change

The issue occurred on the hadoop 3.1.3 nightly profile. Therefore, I'm testing it on my personal CI against that version: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=8820&view=results

On the PR CI, we'll verify the change against the normal versions.
