### PR TITLE
[FLINK-21163][python] Fix the issue that Python dependencies specified via CLI override the dependencies specified in configuration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -127,11 +127,11 @@ public enum ProgramOptionsUtils {
                 programOptions.getClass().getDeclaredField("pythonConfiguration");
         pythonConfiguration.setAccessible(true);
         ClassLoader classLoader = getPythonClassLoader();
-        Class<?> PythonDependencyUtilsClazz =
+        Class<?> pythonDependencyUtilsClazz =
                 Class.forName(
                         "org.apache.flink.python.util.PythonDependencyUtils", false, classLoader);
         Method mergeMethod =
-                PythonDependencyUtilsClazz.getDeclaredMethod(
+                pythonDependencyUtilsClazz.getDeclaredMethod(
                         "merge", Configuration.class, Configuration.class);
         mergeMethod.invoke(null, configuration, pythonConfiguration.get(programOptions));
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -72,19 +73,7 @@ public enum ProgramOptionsUtils {
     public static ProgramOptions createPythonProgramOptions(CommandLine line)
             throws CliArgsException {
         try {
-            ClassLoader classLoader;
-            try {
-                classLoader =
-                        new URLClassLoader(
-                                new URL[] {PackagedProgramUtils.getPythonJar()},
-                                Thread.currentThread().getContextClassLoader());
-            } catch (RuntimeException e) {
-                LOG.warn(
-                        "An attempt to load the flink-python jar from the \"opt\" directory failed, "
-                                + "fall back to use the context class loader.",
-                        e);
-                classLoader = Thread.currentThread().getContextClassLoader();
-            }
+            ClassLoader classLoader = getPythonClassLoader();
             Class<?> pythonProgramOptionsClazz =
                     Class.forName(
                             "org.apache.flink.client.cli.PythonProgramOptions", false, classLoader);
@@ -103,9 +92,22 @@ public enum ProgramOptionsUtils {
         }
     }
 
+    private static ClassLoader getPythonClassLoader() {
+        try {
+            return new URLClassLoader(
+                    new URL[] {PackagedProgramUtils.getPythonJar()},
+                    Thread.currentThread().getContextClassLoader());
+        } catch (RuntimeException e) {
+            LOG.warn(
+                    "An attempt to load the flink-python jar from the \"opt\" directory failed, "
+                            + "fall back to use the context class loader.",
+                    e);
+            return Thread.currentThread().getContextClassLoader();
+        }
+    }
+
     public static void configurePythonExecution(
-            Configuration configuration, PackagedProgram packagedProgram)
-            throws CliArgsException, NoSuchFieldException, IllegalAccessException {
+            Configuration configuration, PackagedProgram packagedProgram) throws Exception {
         final Options commandOptions = CliFrontendParser.getRunCommandOptions();
         final CommandLine commandLine =
                 CliFrontendParser.parse(commandOptions, packagedProgram.getArguments(), true);
@@ -124,6 +126,13 @@ public enum ProgramOptionsUtils {
         Field pythonConfiguration =
                 programOptions.getClass().getDeclaredField("pythonConfiguration");
         pythonConfiguration.setAccessible(true);
-        configuration.addAll((Configuration) pythonConfiguration.get(programOptions));
+        ClassLoader classLoader = getPythonClassLoader();
+        Class<?> PythonDependencyUtilsClazz =
+                Class.forName(
+                        "org.apache.flink.python.util.PythonDependencyUtils", false, classLoader);
+        Method mergeMethod =
+                PythonDependencyUtilsClazz.getDeclaredMethod(
+                        "merge", Configuration.class, Configuration.class);
+        mergeMethod.invoke(null, configuration, pythonConfiguration.get(programOptions));
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.client.deployment.application;
 
-import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.ProgramOptionsUtils;
 import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
 import org.apache.flink.client.program.PackagedProgram;
@@ -84,9 +83,7 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
     }
 
     protected static void configureExecution(
-            final Configuration configuration, final PackagedProgram program)
-            throws MalformedURLException, IllegalAccessException, NoSuchFieldException,
-                    CliArgsException {
+            final Configuration configuration, final PackagedProgram program) throws Exception {
         configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
         ConfigUtils.encodeCollectionToConfig(
                 configuration,

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -405,7 +405,7 @@ class StreamExecutionEnvironment(object):
             .getEnvironmentConfig(self._j_stream_execution_environment)
         python_files = env_config.getString(jvm.PythonOptions.PYTHON_FILES.key(), None)
         if python_files is not None:
-            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([python_files, file_path])
+            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([file_path, python_files])
         else:
             python_files = file_path
         env_config.setString(jvm.PythonOptions.PYTHON_FILES.key(), python_files)

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1132,7 +1132,7 @@ class TableEnvironment(object, metaclass=ABCMeta):
         python_files = self.get_config().get_configuration().get_string(
             jvm.PythonOptions.PYTHON_FILES.key(), None)
         if python_files is not None:
-            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([python_files, file_path])
+            python_files = jvm.PythonDependencyUtils.FILE_DELIMITER.join([file_path, python_files])
         else:
             python_files = file_path
         self.get_config().get_configuration().set_string(

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -39,8 +39,17 @@ class DependencyTests(object):
         os.mkdir(python_file_dir)
         python_file_path = os.path.join(python_file_dir, "test_dependency_manage_lib.py")
         with open(python_file_path, 'w') as f:
-            f.write("def add_two(a):\n    return a + 2")
+            f.write("def add_two(a):\n    raise Exception('This function should not be called!')")
         self.t_env.add_python_file(python_file_path)
+
+        python_file_dir_with_higher_priority = os.path.join(
+            self.tempdir, "python_file_dir_" + str(uuid.uuid4()))
+        os.mkdir(python_file_dir_with_higher_priority)
+        python_file_path_higher_priority = os.path.join(python_file_dir_with_higher_priority,
+                                                        "test_dependency_manage_lib.py")
+        with open(python_file_path_higher_priority, 'w') as f:
+            f.write("def add_two(a):\n    return a + 2")
+        self.t_env.add_python_file(python_file_path_higher_priority)
 
         def plus_two(i):
             from test_dependency_manage_lib import add_two

--- a/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
@@ -33,6 +33,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.ARGS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 import static org.apache.flink.client.cli.ProgramOptionsUtils.isPythonEntryPoint;
+import static org.apache.flink.python.util.PythonDependencyUtils.merge;
 
 /**
  * The class for command line options that refer to a Python program or JAR program with Python
@@ -95,6 +96,6 @@ public class PythonProgramOptions extends ProgramOptions {
     @Override
     public void applyToConfiguration(Configuration configuration) {
         super.applyToConfiguration(configuration);
-        configuration.addAll(pythonConfiguration);
+        merge(configuration, pythonConfiguration);
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.python;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.python.util.PythonDependencyUtils;
 import org.apache.flink.table.functions.python.PythonFunction;
 
 import py4j.GatewayServer;
@@ -79,7 +80,7 @@ public interface PythonFunctionFactory {
         Configuration mergedConfig =
                 new Configuration(
                         ExecutionEnvironment.getExecutionEnvironment().getConfiguration());
-        mergedConfig.addAll((Configuration) config);
+        PythonDependencyUtils.merge(mergedConfig, (Configuration) config);
         PythonFunctionFactory pythonFunctionFactory = getPythonFunctionFactory(mergedConfig);
         return pythonFunctionFactory.getPythonFunction(moduleName, objectName);
     }

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -111,7 +112,7 @@ public final class PythonDependencyInfo {
     public static PythonDependencyInfo create(
             PythonConfig pythonConfig, DistributedCache distributedCache) {
 
-        Map<String, String> pythonFiles = new HashMap<>();
+        Map<String, String> pythonFiles = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : pythonConfig.getPythonFilesInfo().entrySet()) {
             File pythonFile = distributedCache.getFile(entry.getKey());
             String filePath = pythonFile.getAbsolutePath();

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -303,7 +303,7 @@ public class PythonConfigUtil {
             StreamExecutionEnvironment env, TableConfig tableConfig) {
         try {
             Configuration config = new Configuration(getEnvironmentConfig(env));
-            config.addAll(tableConfig.getConfiguration());
+            PythonDependencyUtils.merge(config, tableConfig.getConfiguration());
             Configuration mergedConfig =
                     PythonDependencyUtils.configurePythonDependencies(env.getCachedFiles(), config);
             mergedConfig.setString("table.exec.timezone", tableConfig.getLocalTimeZone().getId());
@@ -319,7 +319,7 @@ public class PythonConfigUtil {
             Field field = ExecutionEnvironment.class.getDeclaredField("cacheFile");
             field.setAccessible(true);
             Configuration config = new Configuration(env.getConfiguration());
-            config.addAll(tableConfig.getConfiguration());
+            PythonDependencyUtils.merge(config, tableConfig.getConfiguration());
             Configuration mergedConfig =
                     PythonDependencyUtils.configurePythonDependencies(
                             (List<Tuple2<String, DistributedCache.DistributedCacheEntry>>)

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
@@ -113,6 +113,38 @@ public class PythonDependencyUtils {
         return config;
     }
 
+    public static void merge(Configuration config, Configuration pythonConfiguration) {
+        Configuration toMerge = new Configuration(pythonConfiguration);
+        if (toMerge.contains(PythonOptions.PYTHON_FILES)) {
+            if (config.contains(PythonOptions.PYTHON_FILES)) {
+                config.set(
+                        PythonOptions.PYTHON_FILES,
+                        String.join(
+                                FILE_DELIMITER,
+                                toMerge.get(PythonOptions.PYTHON_FILES),
+                                config.get(PythonOptions.PYTHON_FILES)));
+            } else {
+                config.set(PythonOptions.PYTHON_FILES, toMerge.get(PythonOptions.PYTHON_FILES));
+            }
+            toMerge.removeConfig(PythonOptions.PYTHON_FILES);
+        }
+        if (toMerge.contains(PythonOptions.PYTHON_ARCHIVES)) {
+            if (config.contains(PythonOptions.PYTHON_ARCHIVES)) {
+                config.set(
+                        PythonOptions.PYTHON_ARCHIVES,
+                        String.join(
+                                FILE_DELIMITER,
+                                toMerge.get(PythonOptions.PYTHON_ARCHIVES),
+                                config.get(PythonOptions.PYTHON_ARCHIVES)));
+            } else {
+                config.set(
+                        PythonOptions.PYTHON_ARCHIVES, toMerge.get(PythonOptions.PYTHON_ARCHIVES));
+            }
+            toMerge.removeConfig(PythonOptions.PYTHON_ARCHIVES);
+        }
+        config.addAll(toMerge);
+    }
+
     /** Helper class for Python dependency management. */
     private static class PythonDependencyManager {
 

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -176,7 +177,7 @@ public class PythonDependencyUtils {
             String fileKey = generateUniqueFileKey(PYTHON_FILE_PREFIX, filePath);
             registerCachedFileIfNotExist(filePath, fileKey);
             if (!internalConfig.contains(PYTHON_FILES)) {
-                internalConfig.set(PYTHON_FILES, new HashMap<>());
+                internalConfig.set(PYTHON_FILES, new LinkedHashMap<>());
             }
             internalConfig.get(PYTHON_FILES).put(fileKey, new File(filePath).getName());
         }

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.client.program.PackagedProgram;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 
@@ -48,9 +47,7 @@ public class PythonProgramOptionsITCase {
      * ITCase.
      */
     @Test
-    public void testConfigurePythonExecution()
-            throws IllegalAccessException, NoSuchFieldException, CliArgsException,
-                    ProgramInvocationException, IOException {
+    public void testConfigurePythonExecution() throws Exception {
         final String[] args = {
             "--python", "xxx.py",
             "--pyModule", "xxx",

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
@@ -35,7 +35,13 @@ import java.util.stream.Collectors;
 import static org.apache.flink.python.PythonOptions.PYTHON_CLIENT_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
-import static org.apache.flink.python.util.PythonDependencyUtils.*;
+import static org.apache.flink.python.util.PythonDependencyUtils.CACHE;
+import static org.apache.flink.python.util.PythonDependencyUtils.FILE;
+import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_ARCHIVES;
+import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_FILES;
+import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_REQUIREMENTS_FILE;
+import static org.apache.flink.python.util.PythonDependencyUtils.configurePythonDependencies;
+import static org.apache.flink.python.util.PythonDependencyUtils.merge;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for PythonDependencyUtils. */

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
@@ -35,12 +35,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.python.PythonOptions.PYTHON_CLIENT_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
-import static org.apache.flink.python.util.PythonDependencyUtils.CACHE;
-import static org.apache.flink.python.util.PythonDependencyUtils.FILE;
-import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_ARCHIVES;
-import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_FILES;
-import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_REQUIREMENTS_FILE;
-import static org.apache.flink.python.util.PythonDependencyUtils.configurePythonDependencies;
+import static org.apache.flink.python.util.PythonDependencyUtils.*;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for PythonDependencyUtils. */
@@ -204,6 +199,33 @@ public class PythonDependencyUtilsTest {
         expectedConfiguration.set(PYTHON_EXECUTABLE, "venv/bin/python3");
         expectedConfiguration.set(PYTHON_CLIENT_EXECUTABLE, "python37");
         verifyConfiguration(expectedConfiguration, actual);
+    }
+
+    @Test
+    public void testPythonDependencyConfigMerge() {
+        Configuration config = new Configuration();
+        config.set(
+                PythonOptions.PYTHON_ARCHIVES,
+                "hdfs:///tmp_dir/file1.zip,hdfs:///tmp_dir/file2.zip");
+        config.set(
+                PythonOptions.PYTHON_FILES, "hdfs:///tmp_dir/file3.zip,hdfs:///tmp_dir/file4.zip");
+
+        Configuration config2 = new Configuration();
+        config2.set(
+                PythonOptions.PYTHON_ARCHIVES,
+                "hdfs:///tmp_dir/file5.zip,hdfs:///tmp_dir/file6.zip");
+        config2.set(
+                PythonOptions.PYTHON_FILES, "hdfs:///tmp_dir/file7.zip,hdfs:///tmp_dir/file8.zip");
+
+        Configuration expectedConfiguration = new Configuration();
+        expectedConfiguration.set(
+                PythonOptions.PYTHON_ARCHIVES,
+                "hdfs:///tmp_dir/file5.zip,hdfs:///tmp_dir/file6.zip,hdfs:///tmp_dir/file1.zip,hdfs:///tmp_dir/file2.zip");
+        expectedConfiguration.set(
+                PythonOptions.PYTHON_FILES,
+                "hdfs:///tmp_dir/file7.zip,hdfs:///tmp_dir/file8.zip,hdfs:///tmp_dir/file3.zip,hdfs:///tmp_dir/file4.zip");
+        merge(config, config2);
+        verifyConfiguration(expectedConfiguration, config);
     }
 
     private void verifyCachedFiles(Map<String, String> expected) {


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix the issue that Python dependencies specified via CLI override the dependencies specified in configuration. It will merge the cli option `-pyfs` with the configuration `python.files` and merge the cli option `pyarch` with the configuration `python.archives` *

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test PythonDependencyUtilsTest#testPythonDependencyConfigMerge*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
