### PR TITLE
[FLINK-21072][hotfix] Clear resources in HeapSnapshotStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -247,16 +247,20 @@ class HeapSnapshotStrategy<K>
         private final Map<StateUID, Integer> stateNamesToId;
 
         HeapSnapshotResources(
-                List<StateMetaInfoSnapshot> metaInfoSnapshots,
-                Map<StateUID, StateSnapshot> cowStateStableSnapshots,
-                Map<StateUID, Integer> stateNamesToId) {
+                @Nonnull List<StateMetaInfoSnapshot> metaInfoSnapshots,
+                @Nonnull Map<StateUID, StateSnapshot> cowStateStableSnapshots,
+                @Nonnull Map<StateUID, Integer> stateNamesToId) {
             this.metaInfoSnapshots = metaInfoSnapshots;
             this.cowStateStableSnapshots = cowStateStableSnapshots;
             this.stateNamesToId = stateNamesToId;
         }
 
         @Override
-        public void release() {}
+        public void release() {
+            for (StateSnapshot stateSnapshot : cowStateStableSnapshots.values()) {
+                stateSnapshot.release();
+            }
+        }
 
         public List<StateMetaInfoSnapshot> getMetaInfoSnapshots() {
             return metaInfoSnapshots;


### PR DESCRIPTION
## What is the purpose of the change

A fix for a bug introduced in #14719. The resources in HeapSnapshotStrategy are not being closed properly.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
