### PR TITLE
[FLINK-21164][rest] Delete temporary jars

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -242,12 +242,8 @@ public class CliFrontend {
 
         LOG.debug("Effective executor configuration: {}", effectiveConfiguration);
 
-        final PackagedProgram program = getPackagedProgram(programOptions, effectiveConfiguration);
-
-        try {
+        try (PackagedProgram program = getPackagedProgram(programOptions, effectiveConfiguration)) {
             executeProgram(effectiveConfiguration, program);
-        } finally {
-            program.deleteExtractedLibraries();
         }
     }
 
@@ -387,7 +383,7 @@ public class CliFrontend {
             }
         } finally {
             if (program != null) {
-                program.deleteExtractedLibraries();
+                program.close();
             }
         }
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -295,7 +295,7 @@ public class PackagedProgram implements AutoCloseable {
     }
 
     /** Deletes all temporary files created for contained packaged libraries. */
-    public void deleteExtractedLibraries() {
+    private void deleteExtractedLibraries() {
         deleteExtractedLibraries(this.extractedTempLibraries);
         this.extractedTempLibraries.clear();
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -26,6 +26,9 @@ import org.apache.flink.runtime.security.FlinkSecurityManager;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.JarUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.BufferedInputStream;
@@ -58,7 +61,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * This class encapsulates represents a program, packaged in a jar file. It supplies functionality
  * to extract nested libraries, search for the program entry point, and extract a program plan.
  */
-public class PackagedProgram {
+public class PackagedProgram implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PackagedProgram.class);
 
     /**
      * Property name of the entry in JAR manifest file that describes the Flink specific entry
@@ -614,6 +619,15 @@ public class PackagedProgram {
                     "Cannot access jar file"
                             + (t.getMessage() == null ? "." : ": " + t.getMessage()),
                     t);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            deleteExtractedLibraries();
+        } catch (Exception e) {
+            LOG.debug("Error while deleting jars extracted from user-jar.", e);
         }
     }
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -145,23 +145,19 @@ public class JarListHandler
                             for (String clazz : classes) {
                                 clazz = clazz.trim();
 
-                                PackagedProgram program = null;
-                                try {
-                                    program =
-                                            PackagedProgram.newBuilder()
-                                                    .setJarFile(f)
-                                                    .setEntryPointClassName(clazz)
-                                                    .setConfiguration(configuration)
-                                                    .build();
-                                } catch (Exception ignored) {
-                                    // ignore jar files which throw an error upon creating a
-                                    // PackagedProgram
-                                }
-                                if (program != null) {
+                                try (PackagedProgram program =
+                                        PackagedProgram.newBuilder()
+                                                .setJarFile(f)
+                                                .setEntryPointClassName(clazz)
+                                                .setConfiguration(configuration)
+                                                .build()) {
                                     JarListInfo.JarEntryInfo jarEntryInfo =
                                             new JarListInfo.JarEntryInfo(
                                                     clazz, program.getDescription());
                                     jarEntryList.add(jarEntryInfo);
+                                } catch (Exception ignored) {
+                                    // ignore jar files which throw an error upon creating a
+                                    // PackagedProgram
                                 }
                             }
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
@@ -111,7 +111,7 @@ public class JarPlanHandler
                         try {
                             packagedProgram.deleteExtractedLibraries();
                         } catch (Exception e) {
-                            log.debug("Error while deleting jars extracted from user-jar.");
+                            log.debug("Error while deleting jars extracted from user-jar.", e);
                         }
                     }
                 },

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHandler.java
@@ -101,18 +101,11 @@ public class JarPlanHandler
 
         return CompletableFuture.supplyAsync(
                 () -> {
-                    final PackagedProgram packagedProgram =
-                            context.toPackagedProgram(configuration);
-                    try {
+                    try (PackagedProgram packagedProgram =
+                            context.toPackagedProgram(configuration)) {
                         final JobGraph jobGraph =
                                 context.toJobGraph(packagedProgram, configuration, true);
                         return planGenerator.apply(jobGraph);
-                    } finally {
-                        try {
-                            packagedProgram.deleteExtractedLibraries();
-                        } catch (Exception e) {
-                            log.debug("Error while deleting jars extracted from user-jar.", e);
-                        }
                     }
                 },
                 executor);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -103,6 +103,11 @@ public class JarRunHandler
                         executor)
                 .handle(
                         (jobIds, throwable) -> {
+                            try {
+                                program.deleteExtractedLibraries();
+                            } catch (Exception e) {
+                                log.debug("Error while deleting jars extracted from user-jar.");
+                            }
                             if (throwable != null) {
                                 throw new CompletionException(
                                         new RestHandlerException(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -103,11 +103,7 @@ public class JarRunHandler
                         executor)
                 .handle(
                         (jobIds, throwable) -> {
-                            try {
-                                program.deleteExtractedLibraries();
-                            } catch (Exception e) {
-                                log.debug("Error while deleting jars extracted from user-jar.", e);
-                            }
+                            program.close();
                             if (throwable != null) {
                                 throw new CompletionException(
                                         new RestHandlerException(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -106,7 +106,7 @@ public class JarRunHandler
                             try {
                                 program.deleteExtractedLibraries();
                             } catch (Exception e) {
-                                log.debug("Error while deleting jars extracted from user-jar.");
+                                log.debug("Error while deleting jars extracted from user-jar.", e);
                             }
                             if (throwable != null) {
                                 throw new CompletionException(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -151,9 +151,11 @@ public class JarHandlerUtils {
                     URL::toString);
         }
 
-        public JobGraph toJobGraph(Configuration configuration, boolean suppressOutput) {
+        public JobGraph toJobGraph(
+                PackagedProgram packagedProgram,
+                Configuration configuration,
+                boolean suppressOutput) {
             try {
-                final PackagedProgram packagedProgram = toPackagedProgram(configuration);
                 return PackagedProgramUtils.createJobGraph(
                         packagedProgram, configuration, parallelism, jobId, suppressOutput);
             } catch (final ProgramInvocationException e) {


### PR DESCRIPTION
Modifies the Jar(Run|Plan)Handler to call `PackagedProgram#deleteExtractedLibraries` once we are done with the job submission / plan generation.

This is not **covered** by tests; I don't see a good way to do that since from the outside it is neither obvious which files are supposed to (not) exist nor where the temporary files would be located (by virtue of PackagedProgram not respecting the `io.tmp.dirs` option).