### PR TITLE
[FLINK-21169][kafka] flink-connector-base dependency should be scope compile

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -87,7 +87,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

Changes the scope of `flink-connector-base` dependency from `provided` to default so that the dependency becomes part of application classpath. Otherwise, it needs to be repeated downstream to be able to use the connector.  

## Verifying this change

Verified effect of the change by running application within IDE.