### PR TITLE
[FLINK-21160][connector/kafka] Fix bug of referencing uninitialized deserializer when using KafkaRecordDeserializer#valueOnly

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializerWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaValueOnlyDeserializerWrapper.java
@@ -39,14 +39,14 @@ class KafkaValueOnlyDeserializerWrapper<T> implements KafkaRecordDeserialization
     private static final long serialVersionUID = 5409547407386004054L;
     private static final Logger LOG =
             LoggerFactory.getLogger(KafkaValueOnlyDeserializerWrapper.class);
-    private final String deserializerClass;
+    private final Class<? extends Deserializer<T>> deserializerClass;
     private final Map<String, String> config;
 
     private transient Deserializer<T> deserializer;
 
     KafkaValueOnlyDeserializerWrapper(
             Class<? extends Deserializer<T>> deserializerClass, Map<String, String> config) {
-        this.deserializerClass = deserializerClass.getName();
+        this.deserializerClass = deserializerClass;
         this.config = config;
     }
 
@@ -59,7 +59,7 @@ class KafkaValueOnlyDeserializerWrapper<T> implements KafkaRecordDeserialization
             deserializer =
                     (Deserializer<T>)
                             InstantiationUtil.instantiate(
-                                    deserializerClass,
+                                    deserializerClass.getName(),
                                     Deserializer.class,
                                     getClass().getClassLoader());
             if (deserializer instanceof Configurable) {
@@ -93,7 +93,6 @@ class KafkaValueOnlyDeserializerWrapper<T> implements KafkaRecordDeserialization
 
     @Override
     public TypeInformation<T> getProducedType() {
-        return TypeExtractor.createTypeInfo(
-                Deserializer.class, deserializer.getClass(), 0, null, null);
+        return TypeExtractor.createTypeInfo(Deserializer.class, deserializerClass, 0, null, null);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes bug of referencing uninitialized deserializer in ```ValueDeserializerWrapper``` when using ```KafkaRecordDeserializer#valueOnly```, which would lead to NPE at job compiling stage. 

## Brief change log

- Keep the ```deserializeClass``` directly in the instance of ```ValueDeserializerWrapper``` as a member instead of storing the name of the class
- Add an IT case for testing value only deserializer.

## Verifying this change
  - *Added integration tests for using ```KafkaRecordDeserializer#valueOnly``` to build a KafkaSource*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
