### PR TITLE
[FLINK-19592] [Table SQL / Runtime] MiniBatchGroupAggFunction and MiniBatchGlobalGroupAggFunction emit messages to prevent too early state eviction

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGroupAggFunction.java
@@ -221,8 +221,15 @@ public class MiniBatchGroupAggFunction
 
                 // if this was not the first row and we have to emit retractions
                 if (!firstRow) {
-                    if (!equaliser.equals(prevAggValue, newAggValue)) {
-                        // new row is not same with prev row
+                    if (stateRetentionTime <= 0 && equaliser.equals(prevAggValue, newAggValue)) {
+                        // new row is the same with prev row and state cleaning is not enabled,
+                        // we do not emit retraction and acc message.
+                        // if state cleaning is enabled, we have to emit messages to prevent
+                        // too early state eviction of downstream operators.
+                        return;
+                    } else {
+                        // new row is not the same with prev row or state cleaning is enabled,
+                        // retract previous result.
                         if (generateUpdateBefore) {
                             // prepare UPDATE_BEFORE message for previous row
                             resultRow
@@ -234,7 +241,6 @@ public class MiniBatchGroupAggFunction
                         resultRow.replace(currentKey, newAggValue).setRowKind(RowKind.UPDATE_AFTER);
                         out.collect(resultRow);
                     }
-                    // new row is same with prev row, no need to output
                 } else {
                     // this is the first, output new result
                     // prepare INSERT message for new row


### PR DESCRIPTION
… of downstream operators when state cleaning is enabled


## What is the purpose of the change

This pull request makes MiniBatchGroupAggFunction and MiniBatchGlobalGroupAggFunction emit messages when state cleaning is enabled. That way we avoid too early state eviction of the downstream operators. 


## Brief change log

  - GroupAggFunction is currently doing so and we implement the same way for MiniBatchGroupAggFunction and MiniBatchGlobalGroupAggFunction.
  - If state cleaning is enabled, emit messages even if it's the same with a previous row to prevent too early state eviction of downstream operators.


## Verifying this change

This change is already covered by existing tests, such as org.apache.flink.table.planner.runtime.harness.GroupAggregateHarnessTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduces a new feature? no
