### PR TITLE
[FLINK-21159][connector/kafka] Send NoMoreSplitsEvent to all readers even if the reader is not assigned with any splits

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -248,14 +248,15 @@ public class KafkaSourceEnumerator
         }
         // TODO: Handle removed partitions.
         addPartitionSplitChangeToPendingAssignments(partitionSplitChange.newPartitionSplits);
+        assignPendingPartitionSplits();
         if (partitionDiscoveryIntervalMs < 0) {
             noMoreNewPartitionSplits = true;
+            signalNoMoreSplitToFinishingReaders();
         }
-        assignPendingPartitionSplits();
-        signalNoMoreSplitToFinishingReaders();
     }
 
     private void signalNoMoreSplitToFinishingReaders() {
+        // Send NoMoreSplitsEvent to readers that are added before the first partition discovery
         finishingReaders.forEach(context::signalNoMoreSplits);
         finishingReaders.clear();
     }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -110,7 +110,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
     /**
      * Invoke the given callable periodically and handover the return value to the handler which
      * will be executed by the source coordinator. When this method is invoked multiple times, The
-     * <code>Coallble</code>s may be executed in a thread pool concurrently.
+     * <code>Callable</code>s may be executed in a thread pool concurrently.
      *
      * <p>It is important to make sure that the callable does not modify any shared state,
      * especially the states that will be a part of the {@link SplitEnumerator#snapshotState()}.

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -92,7 +92,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 
     /**
      * Invoke the callable and handover the return value to the handler which will be executed by
-     * the source coordinator. When this method is invoked multiple times, The <code>Coallble</code>
+     * the source coordinator. When this method is invoked multiple times, The <code>Callable</code>
      * s may be executed in a thread pool concurrently.
      *
      * <p>It is important to make sure that the callable does not modify any shared state,


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes bug in ```KafkaSourceEnumerator``` that only sending ```NoMoreSplitsEvent``` to readers assigned with splits, which will lead to job hanging forever even if the source is bounded.

## Brief change log

*(for example:)*
  - Signal ```NoMoreSplitsEvent``` to reader in ```addReader``` and ```addSplitsBack``` instead of during split assigning
  - Add IT case for testing cases that a reader is not assigned with any splits
  - Fix a typo in JavaDoc of SplitEnumeratorContext#callAsync

## Verifying this change
This change added tests and can be verified as follows:
  - *Add IT case for testing cases that a reader is not assigned with any splits*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
