### PR TITLE
[FLINK-21134] Introduce 'scheduler-mode' config option

### DIFF
--- a/docs/_includes/generated/expert_scheduling_section.html
+++ b/docs/_includes/generated/expert_scheduling_section.html
@@ -15,6 +15,12 @@
             <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
         </tr>
         <tr>
+            <td><h5>scheduler-mode</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td><p>Enum</p>Possible values: [REACTIVE]</td>
+            <td>Determines the mode of the scheduler. Note that <span markdown="span">`scheduler-mode`</span>=<span markdown="span">`REACTIVE`</span> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.</td>
+        </tr>
+        <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -129,6 +129,12 @@
             <td>The max number of completed jobs that can be kept in the job store.</td>
         </tr>
         <tr>
+            <td><h5>scheduler-mode</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td><p>Enum</p>Possible values: [REACTIVE]</td>
+            <td>Determines the mode of the scheduler. Note that <span markdown="span">`scheduler-mode`</span>=<span markdown="span">`REACTIVE`</span> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.</td>
+        </tr>
+        <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterEntryPoint.java
@@ -85,6 +85,11 @@ public final class StandaloneApplicationClusterEntryPoint extends ApplicationClu
         ClusterEntrypoint.runClusterEntrypoint(entrypoint);
     }
 
+    @Override
+    protected boolean supportsReactiveMode() {
+        return true;
+    }
+
     @VisibleForTesting
     static Configuration loadConfigurationFromClusterConfig(
             StandaloneApplicationClusterConfiguration clusterConfiguration) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
+import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
 
 /** Configuration options for the JobManager. */
@@ -358,6 +359,18 @@ public class JobManagerOptions {
                                     .list(text("'ng': new generation scheduler"))
                                     .build());
 
+    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    public static final ConfigOption<SchedulerExecutionMode> SCHEDULER_MODE =
+            key("scheduler-mode")
+                    .enumType(SchedulerExecutionMode.class)
+                    .defaultValue(null)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Determines the mode of the scheduler. Note that %s=%s is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.",
+                                            code("scheduler-mode"),
+                                            code(SchedulerExecutionMode.REACTIVE.name()))
+                                    .build());
     /**
      * Config parameter controlling whether partitions should already be released during the job
      * execution.

--- a/flink-core/src/main/java/org/apache/flink/configuration/SchedulerExecutionMode.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SchedulerExecutionMode.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.Experimental;
+
+/** Enum for controlling whether REACTIVE mode is enabled or not. */
+@Experimental
+public enum SchedulerExecutionMode {
+    REACTIVE
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -233,7 +233,8 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
                 detached
                         ? ClusterEntrypoint.ExecutionMode.DETACHED
                         : ClusterEntrypoint.ExecutionMode.NORMAL;
-        flinkConfig.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
+        flinkConfig.setString(
+                ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, executionMode.toString());
 
         flinkConfig.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, entryPoint);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import java.util.Collection;
 
-import static org.apache.flink.runtime.entrypoint.ClusterEntrypoint.EXECUTION_MODE;
+import static org.apache.flink.runtime.entrypoint.ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE;
 
 /** {@link DispatcherFactory} which creates a {@link MiniDispatcher}. */
 public enum JobDispatcherFactory implements DispatcherFactory {
@@ -45,7 +45,7 @@ public enum JobDispatcherFactory implements DispatcherFactory {
 
         final Configuration configuration =
                 partialDispatcherServicesWithJobGraphStore.getConfiguration();
-        final String executionModeValue = configuration.getString(EXECUTION_MODE);
+        final String executionModeValue = configuration.getString(INTERNAL_CLUSTER_EXECUTION_MODE);
         final ClusterEntrypoint.ExecutionMode executionMode =
                 ClusterEntrypoint.ExecutionMode.valueOf(executionModeValue);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -99,7 +99,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErrorHandler {
 
-    public static final ConfigOption<String> EXECUTION_MODE =
+    public static final ConfigOption<String> INTERNAL_CLUSTER_EXECUTION_MODE =
             ConfigOptions.key("internal.cluster.execution-mode")
                     .defaultValue(ExecutionMode.NORMAL.toString());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.dispatcher.ArchivedExecutionGraphStore;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+/** Tests for the {@link ClusterEntrypoint}. */
+public class ClusterEntrypointTest {
+
+    @Test(expected = IllegalConfigurationException.class)
+    public void testStandaloneSessionClusterEntrypointDeniedInReactiveMode() {
+        Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
+        new MockEntryPoint(configuration);
+        fail("Entrypoint initialization is supposed to fail");
+    }
+
+    private static class MockEntryPoint extends ClusterEntrypoint {
+
+        protected MockEntryPoint(Configuration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        protected DispatcherResourceManagerComponentFactory
+                createDispatcherResourceManagerComponentFactory(Configuration configuration)
+                        throws IOException {
+            throw new UnsupportedOperationException("Not needed for this test");
+        }
+
+        @Override
+        protected ArchivedExecutionGraphStore createSerializableExecutionGraphStore(
+                Configuration configuration, ScheduledExecutor scheduledExecutor)
+                throws IOException {
+            throw new UnsupportedOperationException("Not needed for this test");
+        }
+    }
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -586,7 +586,8 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                         ? ClusterEntrypoint.ExecutionMode.DETACHED
                         : ClusterEntrypoint.ExecutionMode.NORMAL;
 
-        flinkConfiguration.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
+        flinkConfiguration.setString(
+                ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, executionMode.toString());
 
         ApplicationReport report =
                 startAppMaster(


### PR DESCRIPTION

## What is the purpose of the change

This is part of FLIP-159 / Reactive Mode. The execution-mode config option is introduced for checking if it is supported with the used cluster entrypoint implementation.


## Verifying this change


This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / no**no**/ don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

I updated the config options
