### PR TITLE
[FLINK-21168][python][table-planner-blink] Add support for general python group window aggregate function in Physical Rule and Node

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -28,6 +28,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
+import org.apache.flink.table.planner.expressions.PlannerWindowEnd;
+import org.apache.flink.table.planner.expressions.PlannerWindowStart;
 import org.apache.flink.table.runtime.operators.python.aggregate.arrow.AbstractArrowPythonAggregateFunctionOperator;
 import org.apache.flink.table.runtime.operators.window.Window;
 import org.apache.flink.table.runtime.operators.window.assigners.SlidingWindowAssigner;
@@ -450,7 +453,12 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                 windowAssigner,
                 trigger,
                 0,
-                new int[] {0, 1},
+                new FlinkRelBuilder.PlannerNamedWindowProperty[] {
+                    new FlinkRelBuilder.PlannerNamedWindowProperty(
+                            "start", new PlannerWindowStart(null)),
+                    new FlinkRelBuilder.PlannerNamedWindowProperty(
+                            "end", new PlannerWindowEnd(null))
+                },
                 groupingSet,
                 udafInputOffsets);
     }
@@ -467,7 +475,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
                 WindowAssigner windowAssigner,
                 Trigger trigger,
                 long allowedLateness,
-                int[] namedProperties,
+                FlinkRelBuilder.PlannerNamedWindowProperty[] namedProperties,
                 int[] groupingSet,
                 int[] udafInputOffsets) {
             super(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -221,7 +221,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                             outputRowType,
                             inputTimeFieldIndex,
                             windowAssigner,
-                            emitStrategy.getAllowLateness(),
                             namePropertyTypeArray,
                             aggInfoList,
                             config);
@@ -347,7 +346,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                     RowType outputRowType,
                     int inputTimeFieldIndex,
                     WindowAssigner<?> windowAssigner,
-                    long allowance,
                     int[] namePropertyTypeArray,
                     AggregateInfoList aggInfoList,
                     Configuration config) {
@@ -366,7 +364,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                         windowAssigner,
                         pythonFunctionInfos,
                         dataViewSpecs,
-                        allowance,
                         inputTimeFieldIndex,
                         namePropertyTypeArray,
                         inputCountIndex,
@@ -442,7 +439,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                     WindowAssigner<?> windowAssigner,
                     PythonAggregateFunctionInfo[] aggregateFunctions,
                     DataViewUtils.DataViewSpec[][] dataViewSpecs,
-                    long allowance,
                     int inputTimeFieldIndex,
                     int[] namedProperties,
                     int indexOfCountStar,
@@ -466,7 +462,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                             int.class,
                             WindowAssigner.class,
                             LogicalWindow.class,
-                            long.class,
                             int[].class);
             return ctor.newInstance(
                     config,
@@ -481,7 +476,6 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                     inputTimeFieldIndex,
                     windowAssigner,
                     window,
-                    allowance,
                     namedProperties);
         } catch (NoSuchMethodException
                 | IllegalAccessException

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.xml
@@ -82,4 +82,87 @@ PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverCount">
+	<Resource name="ast">
+  	  <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, proctime, 5, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, proctime, 5, 2)], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverTime">
+    <Resource name="ast">
+	  <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, rowtime, 5)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeSlidingGroupWindowOverTime">
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+	</Resource>
+    <Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SlidingGroupWindow('w, rowtime, 5, 2)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeTumblingGroupWindowOverCount">
+    <Resource name="ast">
+	  <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$0=[TestPythonAggregateFunction($0, $2)], window=[TumblingGroupWindow('w, proctime, 2)], properties=[])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+PythonGroupWindowAggregate(groupBy=[b], window=[TumblingGroupWindow('w, proctime, 2)], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$0])
++- Exchange(distribution=[hash[b]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, proctime)]]], fields=[a, b, c, proctime])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testGeneralEventTimeSessionGroupWindowOverTime">
+	<Resource name="ast">
+	  <![CDATA[
+LogicalProject(b=[$0], EXPR$0=[$2], EXPR$1=[$3], EXPR$2=[$1])
++- LogicalWindowAggregate(group=[{1}], EXPR$2=[TestPythonAggregateFunction($0, $2)], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]])
+]]>
+	</Resource>
+	<Resource name="optimized exec plan">
+	  <![CDATA[
+Calc(select=[b, EXPR$0, EXPR$1, EXPR$2])
++- PythonGroupWindowAggregate(groupBy=[b], window=[SessionGroupWindow('w, rowtime, 7)], properties=[EXPR$0, EXPR$1], select=[b, TestPythonAggregateFunction(a, c) AS EXPR$2, start('w) AS EXPR$0, end('w) AS EXPR$1])
+   +- Exchange(distribution=[hash[b]])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, rowtime)]]], fields=[a, b, c, rowtime])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/PythonGroupWindowAggregateTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.stream.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
-import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.PandasAggregateFunction
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.{PandasAggregateFunction, TestPythonAggregateFunction}
 import org.apache.flink.table.planner.utils.TableTestBase
 
 import org.junit.Test
@@ -93,6 +93,80 @@ class PythonGroupWindowAggregateTest extends TableTestBase {
     val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
       "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
     val func = new PandasAggregateFunction
+
+    val windowedTable = sourceTable
+      .window(Session withGap 7.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start, 'w.end, func('a, 'c))
+    util.verifyExecPlan(windowedTable)
+  }
+
+  @Test
+  def testGeneralEventTimeTumblingGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new TestPythonAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Tumble over 5.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start,'w.end, func('a, 'c))
+
+    util.verifyExecPlan(resultTable)
+  }
+
+  @Test
+  def testGeneralEventTimeTumblingGroupWindowOverCount(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)](
+      "MyTable", 'a, 'b, 'c, 'proctime.proctime)
+    val func = new TestPythonAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Tumble over 2.rows on 'proctime as 'w)
+      .groupBy('w, 'b)
+      .select('b, func('a, 'c))
+
+    util.verifyExecPlan(resultTable)
+  }
+
+  @Test
+  def testGeneralEventTimeSlidingGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new TestPythonAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Slide over 5.millis every 2.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start,'w.end, func('a, 'c))
+
+    util.verifyExecPlan(resultTable)
+  }
+
+  @Test
+  def testGeneralEventTimeSlidingGroupWindowOverCount(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int)](
+      "MyTable", 'a, 'b, 'c, 'proctime.proctime)
+    val func = new TestPythonAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Slide over 5.rows every 2.rows on 'proctime as 'w)
+      .groupBy('w, 'b)
+      .select('b, func('a, 'c))
+
+    util.verifyExecPlan(resultTable)
+  }
+
+  @Test
+  def testGeneralEventTimeSessionGroupWindowOverTime(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new TestPythonAggregateFunction
 
     val windowedTable = sourceTable
       .window(Session withGap 7.millis on 'rowtime as 'w)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add support for general python group window aggregate function in Physical Rule and Node*


## Brief change log

  - *Add the logic of support for general python window agg in rule and node*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT `PythonGroupWindowAggregateTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
