### PR TITLE
[FLINK-21172][canal][json] canal-json format include es field

### DIFF
--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -193,7 +193,7 @@ metadata fields for its value format.
     <tr>
       <td><code>event-timestamp</code></td>
       <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
-      <td>The timestamp at which the connector produced the event. Corresponds to the <code>es</code>
+      <td>The timestamp when the corresponding change was executed in MySQL server. Corresponds to the <code>es</code>
       field in the Canal record.</td>
     </tr>
     </tbody>

--- a/docs/dev/table/connectors/formats/canal.md
+++ b/docs/dev/table/connectors/formats/canal.md
@@ -190,6 +190,12 @@ metadata fields for its value format.
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts</code>
       field in the Canal record.</td>
     </tr>
+    <tr>
+      <td><code>event-timestamp</code></td>
+      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td>The timestamp at which the connector produced the event. Corresponds to the <code>es</code>
+      field in the Canal record.</td>
+    </tr>
     </tbody>
 </table>
 
@@ -204,9 +210,11 @@ CREATE TABLE KafkaTable (
   origin_sql_type MAP<STRING, INT> METADATA FROM 'value.sql-type' VIRTUAL,
   origin_pk_names ARRAY<STRING> METADATA FROM 'value.pk-names' VIRTUAL,
   origin_ts TIMESTAMP(3) METADATA FROM 'value.ingestion-timestamp' VIRTUAL,
+  origin_es TIMESTAMP(3) METADATA FROM 'value.event-timestamp' VIRTUAL,
   user_id BIGINT,
   item_id BIGINT,
-  behavior STRING
+  behavior STRING,
+  WATERMARK FOR origin_es AS origin_es - INTERVAL '5' SECOND
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -186,7 +186,7 @@ metadata fields for its value format.
     <tr>
       <td><code>ingestion-timestamp</code></td>
       <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
-      <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts</code>
+      <td>The timestamp when the corresponding change was executed in MySQL server. Corresponds to the <code>ts</code>
       field in the Canal record.</td>
     </tr>
     <tr>

--- a/docs/dev/table/connectors/formats/canal.zh.md
+++ b/docs/dev/table/connectors/formats/canal.zh.md
@@ -189,6 +189,12 @@ metadata fields for its value format.
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts</code>
       field in the Canal record.</td>
     </tr>
+    <tr>
+      <td><code>event-timestamp</code></td>
+      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td>The timestamp at which the connector produced the event. Corresponds to the <code>es</code>
+      field in the Canal record.</td>
+    </tr>
     </tbody>
 </table>
 
@@ -203,9 +209,11 @@ CREATE TABLE KafkaTable (
   origin_sql_type MAP<STRING, INT> METADATA FROM 'value.sql-type' VIRTUAL,
   origin_pk_names ARRAY<STRING> METADATA FROM 'value.pk-names' VIRTUAL,
   origin_ts TIMESTAMP(3) METADATA FROM 'value.ingestion-timestamp' VIRTUAL,
+  origin_es TIMESTAMP(3) METADATA FROM 'value.event-timestamp' VIRTUAL,
   user_id BIGINT,
   item_id BIGINT,
-  behavior STRING
+  behavior STRING,
+  WATERMARK FOR origin_es AS origin_es - INTERVAL '5' SECOND
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDecodingFormat.java
@@ -201,6 +201,22 @@ public class CanalJsonDecodingFormat implements DecodingFormat<DeserializationSc
                         }
                         return TimestampData.fromEpochMillis(row.getLong(pos));
                     }
+                }),
+
+        EVENT_TIMESTAMP(
+                "event-timestamp",
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).nullable(),
+                DataTypes.FIELD("es", DataTypes.BIGINT()),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(GenericRowData row, int pos) {
+                        if (row.isNullAt(pos)) {
+                            return null;
+                        }
+                        return TimestampData.fromEpochMillis(row.getLong(pos));
+                    }
                 });
 
         final String key;

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -109,6 +109,7 @@ public class CanalJsonSerDeSchemaTest {
                     assertThat(row.getMap(6).size(), equalTo(4));
                     assertThat(row.getArray(7).getString(0).toString(), equalTo("id"));
                     assertThat(row.getTimestamp(8, 3).getMillisecond(), equalTo(1589373515477L));
+                    assertThat(row.getTimestamp(9, 3).getMillisecond(), equalTo(1589373515000L));
                 });
         testDeserializationWithMetadata(
                 "canal-data-filter-table.txt",
@@ -124,6 +125,7 @@ public class CanalJsonSerDeSchemaTest {
                     assertThat(row.getMap(6).size(), equalTo(4));
                     assertThat(row.getArray(7).getString(0).toString(), equalTo("id"));
                     assertThat(row.getTimestamp(8, 3).getMillisecond(), equalTo(1598944146308L));
+                    assertThat(row.getTimestamp(9, 3).getMillisecond(), equalTo(1598944132000L));
                 });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Metadata column of `CanalJsonDecodingFormat` doesn't support to extract the `es` field of Canal JSON record, which field extracts from MySQL binlog represent for the row data real change time in MySQL. The `event-timestamp` metadata column expresses the event time.*

## Brief change log

  - *`CanalJsonDecodingFormat` adds `event-timestamp` metadata column for the `es` field of Canal JSON record.*

## Verifying this change

  - *`CanalJsonSerDeSchemaTest` adds the validation to verify whether the `event-timestamp` metadata column value is equal to the value of `es` field.*
  - *`KafkaChangelogTableITCase` adds the `event-timestamp` metadata column in the DDL of Kafka source table to verify the `event-timestamp` metadata column could be used as event time.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)