### PR TITLE
[FLINK-21182] Make HeapPriorityQueueStateSnapshot iterable 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupPartitioner.java
@@ -43,46 +43,43 @@ public class KeyGroupPartitioner<T> {
      * The input data for the partitioning. All elements to consider must be densely in the index
      * interval [0, {@link #numberOfElements}[, without null values.
      */
-    @Nonnull protected final T[] partitioningSource;
+    @Nonnull private final T[] partitioningSource;
 
     /**
      * The output array for the partitioning. The size must be {@link #numberOfElements} (or
      * bigger).
      */
-    @Nonnull protected final T[] partitioningDestination;
+    @Nonnull private final T[] partitioningDestination;
 
     /** Total number of input elements. */
-    @Nonnegative protected final int numberOfElements;
+    @Nonnegative private final int numberOfElements;
 
     /** The total number of key-groups in the job. */
-    @Nonnegative protected final int totalKeyGroups;
-
-    /** The key-group range for the input data, covered in this partitioning. */
-    @Nonnull protected final KeyGroupRange keyGroupRange;
+    @Nonnegative private final int totalKeyGroups;
 
     /**
      * This bookkeeping array is used to count the elements in each key-group. In a second step, it
      * is transformed into a histogram by accumulation.
      */
-    @Nonnull protected final int[] counterHistogram;
+    @Nonnull private final int[] counterHistogram;
 
     /**
      * This is a helper array that caches the key-group for each element, so we do not have to
      * compute them twice.
      */
-    @Nonnull protected final int[] elementKeyGroups;
+    @Nonnull private final int[] elementKeyGroups;
 
     /** Cached value of keyGroupRange#firstKeyGroup. */
-    @Nonnegative protected final int firstKeyGroup;
+    @Nonnegative private final int firstKeyGroup;
 
     /** Function to extract the key from a given element. */
-    @Nonnull protected final KeyExtractorFunction<T> keyExtractorFunction;
+    @Nonnull private final KeyExtractorFunction<T> keyExtractorFunction;
 
     /** Function to write an element to a {@link DataOutputView}. */
-    @Nonnull protected final ElementWriterFunction<T> elementWriterFunction;
+    @Nonnull private final ElementWriterFunction<T> elementWriterFunction;
 
     /** Cached result. */
-    @Nullable protected StateSnapshot.StateKeyGroupWriter computedResult;
+    @Nullable private StateSnapshot.StateKeyGroupWriter computedResult;
 
     /**
      * Creates a new {@link KeyGroupPartitioner}.
@@ -114,7 +111,6 @@ public class KeyGroupPartitioner<T> {
         this.partitioningSource = partitioningSource;
         this.partitioningDestination = partitioningDestination;
         this.numberOfElements = numberOfElements;
-        this.keyGroupRange = keyGroupRange;
         this.totalKeyGroups = totalKeyGroups;
         this.keyExtractorFunction = keyExtractorFunction;
         this.elementWriterFunction = elementWriterFunction;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupPartitionerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupPartitionerTestBase.java
@@ -21,8 +21,10 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,11 +33,21 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
 
 /** Abstract test base for implementations of {@link KeyGroupPartitioner}. */
 public abstract class KeyGroupPartitionerTestBase<T> extends TestLogger {
@@ -65,7 +77,6 @@ public abstract class KeyGroupPartitionerTestBase<T> extends TestLogger {
         testPartitionByKeyGroupForSize(10, random);
     }
 
-    @SuppressWarnings("unchecked")
     private void testPartitionByKeyGroupForSize(int testSize, Random random) throws IOException {
 
         final Set<T> allElementsIdentitySet = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -92,6 +103,57 @@ public abstract class KeyGroupPartitionerTestBase<T> extends TestLogger {
         }
 
         validatingElementWriter.validateAllElementsSeen();
+    }
+
+    @Test
+    public void testPartitionByKeyGroupWithIterator() throws IOException {
+
+        final Random random = new Random(0x42);
+        testPartitionByKeyGroupForSizeWithIterator(0, random);
+        testPartitionByKeyGroupForSizeWithIterator(1, random);
+        testPartitionByKeyGroupForSizeWithIterator(2, random);
+        testPartitionByKeyGroupForSizeWithIterator(10, random);
+    }
+
+    private void testPartitionByKeyGroupForSizeWithIterator(int testSize, Random random) {
+        // Test with 5 key-groups.
+        final KeyGroupRange range = new KeyGroupRange(0, 4);
+        final int numberOfKeyGroups = range.getNumberOfKeyGroups();
+
+        final Set<T> allElementsIdentitySet = Collections.newSetFromMap(new IdentityHashMap<>());
+        final T[] data = generateTestInput(random, testSize, allElementsIdentitySet);
+        Map<Integer, List<T>> partitionedData =
+                Arrays.stream(data)
+                        .filter(Objects::nonNull)
+                        .collect(
+                                Collectors.toMap(
+                                        el -> computeKeyGroup(numberOfKeyGroups, el),
+                                        Arrays::asList,
+                                        (l1, l2) -> {
+                                            List<T> mergedList = new ArrayList<>(l1);
+                                            mergedList.addAll(l2);
+                                            return mergedList;
+                                        }));
+
+        final KeyGroupPartitioner<T> testInstance =
+                createPartitioner(
+                        data, testSize, range, numberOfKeyGroups, new NoOpElementWriter<>());
+        final KeyGroupPartitioner.PartitioningResult<T> result = testInstance.partitionByKeyGroup();
+
+        for (int keyGroup = 0; keyGroup < numberOfKeyGroups; ++keyGroup) {
+            Iterator<T> iterator = result.iterator(keyGroup);
+            assertThat(
+                    CollectionUtil.iteratorToList(iterator),
+                    containsInAnyOrder(
+                            partitionedData.getOrDefault(keyGroup, Collections.emptyList()).stream()
+                                    .map(Matchers::equalTo)
+                                    .collect(Collectors.toList())));
+        }
+    }
+
+    private int computeKeyGroup(int numberOfKeyGroups, T el) {
+        return KeyGroupRangeAssignment.assignToKeyGroup(
+                keyExtractorFunction.extractKeyFromElement(el), numberOfKeyGroups);
     }
 
     @SuppressWarnings("unchecked")
@@ -131,6 +193,13 @@ public abstract class KeyGroupPartitionerTestBase<T> extends TestLogger {
                 totalKeyGroups,
                 keyExtractorFunction,
                 elementWriterFunction);
+    }
+
+    static final class NoOpElementWriter<T>
+            implements KeyGroupPartitioner.ElementWriterFunction<T> {
+        @Override
+        public void writeElement(@Nonnull T element, @Nonnull DataOutputView dov)
+                throws IOException {}
     }
 
     /** Simple test implementation with validation . */


### PR DESCRIPTION
## What is the purpose of the change

In order to implement an iterator for a unified savepoint we need a way
to iterate over all entries in a priority queue snapshot.

## Verifying this change

Added tests in `KeyGroupPartitionerTestBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
