### PR TITLE
[FLINK-21048][docs] Refactor documentation related to switch memory allocator

### DIFF
--- a/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/deployment/resource-providers/standalone/docker.md
@@ -336,10 +336,12 @@ $ docker build --tag pyflink:latest .
 Flink introduced `jemalloc` as default memory allocator to resolve memory fragmentation problem (please refer to [FLINK-19125](https://issues.apache.org/jira/browse/FLINK-19125)).
 
 You could switch back to use `glibc` as memory allocator to restore the old behavior or if any unexpected memory consumption or problem observed
-(and please report the issue via JIRA or mailing list if you found any), by passing `disable-jemalloc` parameter:
+(and please report the issue via JIRA or mailing list if you found any), by setting environment variable `DISABLE_JEMALLOC` as true:
 
 ```sh
-    $ docker run <jobmanager|standalone-job|taskmanager> disable-jemalloc
+    $ docker run \
+        --env DISABLE_JEMALLOC=true \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
 ```
 
 ### Advanced customization

--- a/docs/deployment/resource-providers/standalone/docker.zh.md
+++ b/docs/deployment/resource-providers/standalone/docker.zh.md
@@ -326,10 +326,12 @@ $ docker build --tag pyflink:latest .
 Flink introduced `jemalloc` as default memory allocator to resolve memory fragmentation problem (please refer to [FLINK-19125](https://issues.apache.org/jira/browse/FLINK-19125)).
 
 You could switch back to use `glibc` as memory allocator to restore the old behavior or if any unexpected memory consumption or problem observed
-(and please report the issue via JIRA or mailing list if you found any), by passing `disable-jemalloc` parameter:
+(and please report the issue via JIRA or mailing list if you found any), by setting environment variable `DISABLE_JEMALLOC` as true:
 
 ```sh
-    $ docker run <jobmanager|standalone-job|taskmanager> disable-jemalloc
+    $ docker run \
+        --env DISABLE_JEMALLOC=true \
+        flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %} <jobmanager|standalone-job|taskmanager>
 ```
 
 ### Advanced customization


### PR DESCRIPTION
## What is the purpose of the change

Since we decide to change the switch of memory allocator from command to environment variable in FLINK-21034, we should also change related documentation.

## Brief change log

Change related documentation to disable jemalloc memory allocator.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
