### PR TITLE
[FLINK-20654][FLINK-21104][network] Fix couple bugs in the handling of unaligned checkpoints and cancellations.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -67,8 +67,6 @@ class InputChannelRecoveredStateHandler
     @Override
     public void recover(InputChannelInfo channelInfo, Buffer buffer) {
         if (buffer.readableBytes() > 0) {
-            NetworkActionsLogger.traceRecover(
-                    "InputChannelRecoveredStateHandler#recover", buffer, channelInfo);
             getChannel(channelInfo).onRecoveredStateBuffer(buffer);
         } else {
             buffer.recycleBuffer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/logger/NetworkActionsLogger.java
@@ -40,12 +40,14 @@ public class NetworkActionsLogger {
     public static void traceInput(
             String action,
             Buffer buffer,
+            String taskName,
             InputChannelInfo channelInfo,
             ChannelStatePersister channelStatePersister,
             int sequenceNumber) {
         if (ENABLED) {
             LOG.trace(
-                    "{} {}, seq {}, {} @ {}",
+                    "[{}] {} {}, seq {}, {} @ {}",
+                    taskName,
                     action,
                     buffer.toDebugString(INCLUDE_HASH),
                     sequenceNumber,
@@ -55,15 +57,26 @@ public class NetworkActionsLogger {
     }
 
     public static void traceOutput(
-            String action, Buffer buffer, ResultSubpartitionInfo channelInfo) {
+            String action, Buffer buffer, String taskName, ResultSubpartitionInfo channelInfo) {
         if (ENABLED) {
-            LOG.trace("{} {} @ {}", action, buffer.toDebugString(INCLUDE_HASH), channelInfo);
+            LOG.trace(
+                    "[{}] {} {} @ {}",
+                    taskName,
+                    action,
+                    buffer.toDebugString(INCLUDE_HASH),
+                    channelInfo);
         }
     }
 
-    public static void traceRecover(String action, Buffer buffer, InputChannelInfo channelInfo) {
+    public static void traceRecover(
+            String action, Buffer buffer, String taskName, InputChannelInfo channelInfo) {
         if (ENABLED) {
-            LOG.trace("{} {} @ {}", action, buffer.toDebugString(INCLUDE_HASH), channelInfo);
+            LOG.trace(
+                    "[{}] {} {} @ {}",
+                    taskName,
+                    action,
+                    buffer.toDebugString(INCLUDE_HASH),
+                    channelInfo);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -325,7 +325,10 @@ public class PipelinedSubpartition extends ResultSubpartition
             // queue
             // will be 2 or more.
             NetworkActionsLogger.traceOutput(
-                    "PipelinedSubpartition#pollBuffer", buffer, subpartitionInfo);
+                    "PipelinedSubpartition#pollBuffer",
+                    buffer,
+                    parent.getOwningTaskName(),
+                    subpartitionInfo);
             return new BufferAndBacklog(
                     buffer,
                     getBuffersInBacklog(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersister.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -37,7 +39,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /** Helper class for persisting channel state via {@link ChannelStateWriter}. */
 @NotThreadSafe
@@ -67,16 +68,27 @@ public final class ChannelStatePersister {
         this.channelInfo = checkNotNull(channelInfo);
     }
 
-    protected void startPersisting(long barrierId, List<Buffer> knownBuffers) {
+    protected void startPersisting(long barrierId, List<Buffer> knownBuffers)
+            throws CheckpointException {
         logEvent("startPersisting", barrierId);
-        if (checkpointStatus != CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier < barrierId) {
+        if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED && lastSeenBarrier > barrierId) {
+            throw new CheckpointException(
+                    String.format(
+                            "Barrier for newer checkpoint %d has already been received compared to the requested checkpoint %d",
+                            lastSeenBarrier, barrierId),
+                    CheckpointFailureReason
+                            .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
+        }
+        if (lastSeenBarrier < barrierId) {
+            // Regardless of the current checkpointStatus, if we are notified about a more recent
+            // checkpoint then we have seen so far, always mark that this more recent barrier is
+            // pending.
+            // BARRIER_RECEIVED status can happen if we have seen an older barrier, that probably
+            // has not yet been processed by the task, but task is now notifying us that checkpoint
+            // has started for even newer checkpoint. We should spill the knownBuffers and mark that
+            // we are waiting for that newer barrier to arrive
             checkpointStatus = CheckpointStatus.BARRIER_PENDING;
             lastSeenBarrier = barrierId;
-        } else if (checkpointStatus == CheckpointStatus.BARRIER_RECEIVED) {
-            checkState(
-                    lastSeenBarrier >= barrierId,
-                    "Internal error, #stopPersisting for last checkpoint has not been called for "
-                            + channelInfo);
         }
         if (knownBuffers.size() > 0) {
             channelStateWriter.addInputData(
@@ -106,9 +118,9 @@ public final class ChannelStatePersister {
     }
 
     protected Optional<Long> checkForBarrier(Buffer buffer) throws IOException {
-        final AbstractEvent event = parseEvent(buffer);
+        AbstractEvent event = parseEvent(buffer);
         if (event instanceof CheckpointBarrier) {
-            final long barrierId = ((CheckpointBarrier) event).getId();
+            long barrierId = ((CheckpointBarrier) event).getId();
             long expectedBarrierId =
                     checkpointStatus == CheckpointStatus.COMPLETED
                             ? lastSeenBarrier + 1
@@ -125,8 +137,7 @@ public final class ChannelStatePersister {
         if (event instanceof EventAnnouncement) { // NOTE: only remote channels
             EventAnnouncement announcement = (EventAnnouncement) event;
             if (announcement.getAnnouncedEvent() instanceof CheckpointBarrier) {
-                final long barrierId =
-                        ((CheckpointBarrier) announcement.getAnnouncedEvent()).getId();
+                long barrierId = ((CheckpointBarrier) announcement.getAnnouncedEvent()).getId();
                 logEvent("found announcement for barrier", barrierId);
                 return Optional.of(barrierId);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -123,7 +124,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     // Consume
     // ------------------------------------------------------------------------
 
-    public void checkpointStarted(CheckpointBarrier barrier) {
+    public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         channelStatePersister.startPersisting(barrier.getId(), Collections.emptyList());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -143,10 +143,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
             if (subpartitionView == null) {
                 LOG.debug(
-                        "{}: Requesting LOCAL subpartition {} of partition {}.",
+                        "{}: Requesting LOCAL subpartition {} of partition {}. {}",
                         this,
                         subpartitionIndex,
-                        partitionId);
+                        partitionId,
+                        channelStatePersister);
 
                 try {
                     ResultSubpartitionView subpartitionView =
@@ -259,6 +260,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         NetworkActionsLogger.traceInput(
                 "LocalInputChannel#getNextBuffer",
                 buffer,
+                inputGate.getOwningTaskName(),
                 channelInfo,
                 channelStatePersister,
                 next.getSequenceNumber());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.util.Preconditions;
@@ -120,6 +121,11 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     public void onRecoveredStateBuffer(Buffer buffer) {
         boolean recycleBuffer = true;
+        NetworkActionsLogger.traceRecover(
+                "InputChannelRecoveredStateHandler#recover",
+                buffer,
+                inputGate.getOwningTaskName(),
+                channelInfo);
         try {
             final boolean wasEmpty;
             synchronized (receivedBuffers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -42,6 +42,9 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -60,6 +63,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /** An input channel, which requests a remote partition queue. */
 public class RemoteInputChannel extends InputChannel {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteInputChannel.class);
 
     private static final int NONE = -1;
 
@@ -163,6 +167,12 @@ public class RemoteInputChannel extends InputChannel {
     public void requestSubpartition(int subpartitionIndex)
             throws IOException, InterruptedException {
         if (partitionRequestClient == null) {
+            LOG.debug(
+                    "{}: Requesting REMOTE subpartition {} of partition {}. {}",
+                    this,
+                    subpartitionIndex,
+                    partitionId,
+                    channelStatePersister);
             // Create a client and request the partition
             try {
                 partitionRequestClient =
@@ -448,6 +458,7 @@ public class RemoteInputChannel extends InputChannel {
                 NetworkActionsLogger.traceInput(
                         "RemoteInputChannel#onBuffer",
                         buffer,
+                        inputGate.getOwningTaskName(),
                         channelInfo,
                         channelStatePersister,
                         sequenceNumber);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -559,6 +559,22 @@ public class RemoteInputChannel extends InputChannel {
      */
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {
         synchronized (receivedBuffers) {
+            if (barrier.getId() < lastBarrierId) {
+                throw new CheckpointException(
+                        String.format(
+                                "Sequence number for checkpoint %d is not known (it was likely been overwritten by a newer checkpoint %d)",
+                                barrier.getId(), lastBarrierId),
+                        CheckpointFailureReason
+                                .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
+                // checkpoint is possible
+            } else if (barrier.getId() > lastBarrierId) {
+                // This channel has received some obsolete barrier, older compared to the
+                // checkpointId
+                // which we are processing right now, and we should ignore that obsoleted checkpoint
+                // barrier sequence number.
+                resetLastBarrier();
+            }
+
             channelStatePersister.startPersisting(
                     barrier.getId(), getInflightBuffersUnsafe(barrier.getId()));
         }
@@ -568,14 +584,13 @@ public class RemoteInputChannel extends InputChannel {
         synchronized (receivedBuffers) {
             channelStatePersister.stopPersisting(checkpointId);
             if (lastBarrierId == checkpointId) {
-                lastBarrierId = NONE;
-                lastBarrierSequenceNumber = NONE;
+                resetLastBarrier();
             }
         }
     }
 
     @VisibleForTesting
-    List<Buffer> getInflightBuffers(long checkpointId) throws CheckpointException {
+    List<Buffer> getInflightBuffers(long checkpointId) {
         synchronized (receivedBuffers) {
             return getInflightBuffersUnsafe(checkpointId);
         }
@@ -627,18 +642,10 @@ public class RemoteInputChannel extends InputChannel {
      * Returns a list of buffers, checking the first n non-priority buffers, and skipping all
      * events.
      */
-    private List<Buffer> getInflightBuffersUnsafe(long checkpointId) throws CheckpointException {
+    private List<Buffer> getInflightBuffersUnsafe(long checkpointId) {
         assert Thread.holdsLock(receivedBuffers);
 
-        if (checkpointId < lastBarrierId) {
-            throw new CheckpointException(
-                    String.format(
-                            "Sequence number for checkpoint %d is not known (it was likely been overwritten by a newer checkpoint %d)",
-                            checkpointId, lastBarrierId),
-                    CheckpointFailureReason
-                            .CHECKPOINT_SUBSUMED); // currently, at most one active unaligned
-            // checkpoint is possible
-        }
+        checkState(checkpointId == lastBarrierId || lastBarrierId == NONE);
 
         final List<Buffer> inflightBuffers = new ArrayList<>();
         Iterator<SequenceBuffer> iterator = receivedBuffers.iterator();
@@ -657,6 +664,11 @@ public class RemoteInputChannel extends InputChannel {
         }
 
         return inflightBuffers;
+    }
+
+    private void resetLastBarrier() {
+        lastBarrierId = NONE;
+        lastBarrierSequenceNumber = NONE;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -859,6 +859,12 @@ public class SingleInputGate extends IndexedInputGate {
                     return;
                 }
 
+                if (channel.isReleased()) {
+                    // when channel is closed, EndOfPartitionEvent is send and a final notification
+                    // if EndOfPartitionEvent causes a release, we must ignore the notification
+                    return;
+                }
+
                 if (!queueChannelUnsafe(channel, priority)) {
                     return;
                 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -17,9 +17,11 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -27,8 +29,12 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -36,23 +42,35 @@ import static org.junit.Assert.assertTrue;
 public class ChannelStatePersisterTest {
 
     @Test
-    public void testNewBarrierNotOverwrittenByStopPersisting() throws IOException {
+    public void testNewBarrierNotOverwrittenByStopPersisting() throws Exception {
+        RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
         ChannelStatePersister persister =
-                new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
+                new ChannelStatePersister(channelStateWriter, channelInfo);
 
-        persister.checkForBarrier(barrier(1L));
-        persister.startPersisting(1L, Collections.emptyList());
+        long checkpointId = 1L;
+        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
+
+        persister.checkForBarrier(barrier(checkpointId));
+        persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+        assertEquals(1, channelStateWriter.getAddedInput().get(channelInfo).size());
+
+        persister.maybePersist(buildSomeBuffer());
+        assertEquals(1, channelStateWriter.getAddedInput().get(channelInfo).size());
 
         // meanwhile, checkpoint coordinator timed out the 1st checkpoint and started the 2nd
         // now task thread is picking up the barrier and aborts the 1st:
-        persister.checkForBarrier(barrier(2L));
-        persister.stopPersisting(1L);
+        persister.checkForBarrier(barrier(checkpointId + 1));
+        persister.maybePersist(buildSomeBuffer());
+        persister.stopPersisting(checkpointId);
+        persister.maybePersist(buildSomeBuffer());
+        assertEquals(1, channelStateWriter.getAddedInput().get(channelInfo).size());
 
         assertTrue(persister.hasBarrierReceived());
     }
 
     @Test
-    public void testNewBarrierNotOverwrittenByCheckForBarrier() throws IOException {
+    public void testNewBarrierNotOverwrittenByCheckForBarrier() throws Exception {
         ChannelStatePersister persister =
                 new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
 
@@ -65,38 +83,58 @@ public class ChannelStatePersisterTest {
     }
 
     @Test
-    public void testLateBarrierOnCancelledCheckpoint() throws IOException {
-        ChannelStatePersister persister =
-                new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
-
-        persister.startPersisting(1L, Collections.emptyList());
-        // checkpoint aborted
-        persister.stopPersisting(1L);
-
-        // late barrier
-        persister.checkForBarrier(barrier(1L));
-
-        persister.startPersisting(2L, Collections.emptyList());
-        persister.checkForBarrier(barrier(2L));
-
-        assertTrue(persister.hasBarrierReceived());
+    public void testLateBarrierOnStartedAndCancelledCheckpoint() throws Exception {
+        testLateBarrier(true, true);
     }
 
     @Test
-    public void testLateBarrierOnCancelledCheckpointAfterRecover() throws IOException {
+    public void testLateBarrierOnCancelledCheckpoint() throws Exception {
+        testLateBarrier(false, true);
+    }
+
+    @Test
+    public void testLateBarrierOnNotYetCancelledCheckpoint() throws Exception {
+        testLateBarrier(false, false);
+    }
+
+    private void testLateBarrier(
+            boolean startCheckpointOnLateBarrier, boolean cancelCheckpointBeforeLateBarrier)
+            throws Exception {
+        RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
+        InputChannelInfo channelInfo = new InputChannelInfo(0, 0);
+
+        ChannelStatePersister persister =
+                new ChannelStatePersister(channelStateWriter, channelInfo);
+
+        long lateCheckpointId = 1L;
+        long checkpointId = 2L;
+        if (startCheckpointOnLateBarrier) {
+            persister.startPersisting(lateCheckpointId, Collections.emptyList());
+        }
+        if (cancelCheckpointBeforeLateBarrier) {
+            persister.stopPersisting(lateCheckpointId);
+        }
+        persister.checkForBarrier(barrier(lateCheckpointId));
+        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
+        persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
+        persister.maybePersist(buildSomeBuffer());
+        persister.checkForBarrier(barrier(checkpointId));
+        persister.maybePersist(buildSomeBuffer());
+
+        assertTrue(persister.hasBarrierReceived());
+        assertEquals(2, channelStateWriter.getAddedInput().get(channelInfo).size());
+    }
+
+    @Test(expected = CheckpointException.class)
+    public void testLateBarrierTriggeringCheckpoint() throws Exception {
         ChannelStatePersister persister =
                 new ChannelStatePersister(ChannelStateWriter.NO_OP, new InputChannelInfo(0, 0));
 
-        // checkpoint aborted, stopPersisting called on recovered input channel without persister
-        persister.stopPersisting(1L);
+        long lateCheckpointId = 1L;
+        long checkpointId = 2L;
 
-        // late barrier
-        persister.checkForBarrier(barrier(1L));
-
-        persister.startPersisting(2L, Collections.emptyList());
-        persister.checkForBarrier(barrier(2L));
-
-        assertTrue(persister.hasBarrierReceived());
+        persister.checkForBarrier(barrier(checkpointId));
+        persister.startPersisting(lateCheckpointId, Collections.emptyList());
     }
 
     private static Buffer barrier(long id) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.fail;
 
 /** A mocked input channel. */
@@ -149,6 +150,8 @@ public class TestInputChannel extends InputChannel {
 
     @Override
     Optional<BufferAndAvailability> getNextBuffer() throws IOException, InterruptedException {
+        checkState(!isReleased);
+
         BufferAndAvailabilityProvider provider = buffers.poll();
 
         if (provider != null) {
@@ -178,7 +181,9 @@ public class TestInputChannel extends InputChannel {
     }
 
     @Override
-    void releaseAllResources() throws IOException {}
+    void releaseAllResources() throws IOException {
+        isReleased = true;
+    }
 
     @Override
     public void resumeConsumption() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -109,7 +109,9 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         while (hasPriorityEvent) {
             // process as many priority events as possible
             final Optional<BufferOrEvent> bufferOrEventOpt = pollNext();
-            checkState(bufferOrEventOpt.isPresent());
+            if (!bufferOrEventOpt.isPresent()) {
+                break;
+            }
             final BufferOrEvent bufferOrEvent = bufferOrEventOpt.get();
             checkState(bufferOrEvent.hasPriority(), "Should only poll priority events");
             hasPriorityEvent = bufferOrEvent.morePriorityEvents();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -32,6 +32,7 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -133,7 +134,8 @@ public class TaskMailboxImpl implements TaskMailbox {
         try {
             Mail headMail;
             while ((headMail = takeOrNull(queue, priority)) == null) {
-                notEmpty.await();
+                // to ease debugging
+                notEmpty.await(1, TimeUnit.SECONDS);
             }
             hasNewMail = !queue.isEmpty();
             return headMail;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxImpl.java
@@ -96,6 +96,17 @@ public class TaskMailboxImpl implements TaskMailbox {
         return !batch.isEmpty() || hasNewMail;
     }
 
+    @VisibleForTesting
+    public int size() {
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            return batch.size() + queue.size();
+        } finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public Optional<Mail> tryTake(int priority) {
         checkIsMailboxThread();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingControllerTest.java
@@ -719,7 +719,7 @@ public class AlternatingControllerTest {
         return barrierHandler(inputGate, target, new RecordingChannelStateWriter());
     }
 
-    private static SingleCheckpointBarrierHandler barrierHandler(
+    public static SingleCheckpointBarrierHandler barrierHandler(
             SingleInputGate inputGate, AbstractInvokable target, ChannelStateWriter stateWriter) {
         String taskName = "test";
         return new SingleCheckpointBarrierHandler(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -17,11 +17,18 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
 import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
@@ -30,21 +37,32 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Optional;
 
+import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** {@link CheckpointedInputGate} test. */
 public class CheckpointedInputGateTest {
+    private final HashMap<Integer, Integer> channelIndexToSequenceNumber = new HashMap<>();
+
+    @Before
+    public void setUp() {
+        channelIndexToSequenceNumber.clear();
+    }
+
     @Test
     public void testUpstreamResumedUponEndOfRecovery() throws Exception {
         int numberOfChannels = 11;
@@ -55,11 +73,11 @@ public class CheckpointedInputGateTest {
                     setupInputGate(numberOfChannels, bufferPool, resumeCounter);
             assertFalse(gate.pollNext().isPresent());
             for (int channelIndex = 0; channelIndex < numberOfChannels - 1; channelIndex++) {
-                emitEndOfState(gate, channelIndex);
+                enqueueEndOfState(gate, channelIndex);
                 assertFalse("should align (block all channels)", gate.pollNext().isPresent());
             }
 
-            emitEndOfState(gate, numberOfChannels - 1);
+            enqueueEndOfState(gate, numberOfChannels - 1);
             Optional<BufferOrEvent> polled = gate.pollNext();
             assertTrue(polled.isPresent());
             assertTrue(polled.get().isEvent());
@@ -73,17 +91,139 @@ public class CheckpointedInputGateTest {
         }
     }
 
-    private void emitEndOfState(CheckpointedInputGate checkpointedInputGate, int channelIndex)
+    @Test
+    public void testPersisting() throws Exception {
+        testPersisting(false);
+    }
+
+    @Test
+    public void testPersistingWithDrainingTheGate() throws Exception {
+        testPersisting(true);
+    }
+
+    /**
+     * This tests a scenario where an older triggered checkpoint, was cancelled and a newer
+     * checkpoint was triggered very quickly after the cancellation. It can happen that a task can
+     * receive first the more recent checkpoint barrier and later the obsoleted one. This can happen
+     * for many reasons (for example Source tasks not running, or just a race condition with
+     * notifyCheckpointAborted RPCs) and Task should be able to handle this properly. In FLINK-21104
+     * the problem was that this obsoleted checkpoint barrier was causing a checkState to fail.
+     */
+    public void testPersisting(boolean drainGate) throws Exception {
+
+        int numberOfChannels = 3;
+        NetworkBufferPool bufferPool = new NetworkBufferPool(numberOfChannels * 3, 1024);
+        try {
+            long checkpointId = 2L;
+            long obsoleteCheckpointId = 1L;
+            ValidatingCheckpointHandler validatingHandler =
+                    new ValidatingCheckpointHandler(checkpointId);
+            RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
+            CheckpointedInputGate gate =
+                    setupInputGateWithAlternatingController(
+                            numberOfChannels, bufferPool, validatingHandler, stateWriter);
+
+            // enqueue first checkpointId before obsoleteCheckpointId, so that we never trigger
+            // and also never cancel the obsoleteCheckpointId
+            enqueue(gate, 0, buildSomeBuffer());
+            enqueue(gate, 0, barrier(checkpointId));
+            enqueue(gate, 0, buildSomeBuffer());
+            enqueue(gate, 1, buildSomeBuffer());
+            enqueue(gate, 1, barrier(obsoleteCheckpointId));
+            enqueue(gate, 1, buildSomeBuffer());
+            enqueue(gate, 2, buildSomeBuffer());
+
+            assertEquals(0, validatingHandler.getTriggeredCheckpointCounter());
+            // trigger checkpoint
+            gate.pollNext();
+            assertEquals(1, validatingHandler.getTriggeredCheckpointCounter());
+
+            assertAddedInputSize(stateWriter, 0, 1);
+            assertAddedInputSize(stateWriter, 1, 2);
+            assertAddedInputSize(stateWriter, 2, 1);
+
+            enqueue(gate, 0, buildSomeBuffer());
+            enqueue(gate, 1, buildSomeBuffer());
+            enqueue(gate, 2, buildSomeBuffer());
+
+            while (drainGate && gate.pollNext().isPresent()) {}
+
+            assertAddedInputSize(stateWriter, 0, 1);
+            assertAddedInputSize(stateWriter, 1, 3);
+            assertAddedInputSize(stateWriter, 2, 2);
+
+            enqueue(gate, 1, barrier(checkpointId));
+            enqueue(gate, 1, buildSomeBuffer());
+            // Another obsoleted barrier that should be ignored
+            enqueue(gate, 2, barrier(obsoleteCheckpointId));
+            enqueue(gate, 2, buildSomeBuffer());
+
+            while (drainGate && gate.pollNext().isPresent()) {}
+
+            assertAddedInputSize(stateWriter, 0, 1);
+            assertAddedInputSize(stateWriter, 1, 3);
+            assertAddedInputSize(stateWriter, 2, 3);
+
+            enqueue(gate, 2, barrier(checkpointId));
+            enqueue(gate, 2, buildSomeBuffer());
+
+            while (drainGate && gate.pollNext().isPresent()) {}
+
+            assertAddedInputSize(stateWriter, 0, 1);
+            assertAddedInputSize(stateWriter, 1, 3);
+            assertAddedInputSize(stateWriter, 2, 3);
+        } finally {
+            bufferPool.destroy();
+        }
+    }
+
+    private static CheckpointBarrier barrier(long barrierId) {
+        return new CheckpointBarrier(
+                barrierId,
+                barrierId,
+                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault()));
+    }
+
+    private void assertAddedInputSize(
+            RecordingChannelStateWriter stateWriter, int channelIndex, int size) {
+        assertEquals(
+                size,
+                stateWriter.getAddedInput().get(new InputChannelInfo(0, channelIndex)).size());
+    }
+
+    private void enqueueEndOfState(CheckpointedInputGate checkpointedInputGate, int channelIndex)
             throws IOException {
+        enqueue(checkpointedInputGate, channelIndex, EndOfChannelStateEvent.INSTANCE);
+    }
+
+    private void enqueue(
+            CheckpointedInputGate checkpointedInputGate, int channelIndex, AbstractEvent event)
+            throws IOException {
+        boolean hasPriority = false;
+        if (event instanceof CheckpointBarrier) {
+            hasPriority =
+                    ((CheckpointBarrier) event).getCheckpointOptions().isUnalignedCheckpoint();
+        }
+        enqueue(checkpointedInputGate, channelIndex, EventSerializer.toBuffer(event, hasPriority));
+    }
+
+    private void enqueue(
+            CheckpointedInputGate checkpointedInputGate, int channelIndex, Buffer buffer)
+            throws IOException {
+        Integer sequenceNumber =
+                channelIndexToSequenceNumber.compute(
+                        channelIndex,
+                        (key, oldSequence) -> oldSequence == null ? 0 : oldSequence + 1);
         ((RemoteInputChannel) checkpointedInputGate.getChannel(channelIndex))
-                .onBuffer(EventSerializer.toBuffer(EndOfChannelStateEvent.INSTANCE, false), 0, 0);
+                .onBuffer(buffer, sequenceNumber, 0);
     }
 
     private CheckpointedInputGate setupInputGate(
             int numberOfChannels,
             NetworkBufferPool networkBufferPool,
-            ResumeCountingConnectionManager connectionManager)
+            ConnectionManager connectionManager)
             throws Exception {
+
         SingleInputGate singleInputGate =
                 new SingleInputGateBuilder()
                         .setBufferPoolFactory(
@@ -97,6 +237,10 @@ public class CheckpointedInputGateTest {
                         .setNumberOfChannels(numberOfChannels)
                         .build();
         singleInputGate.setup();
+        MailboxExecutorImpl mailboxExecutor =
+                new MailboxExecutorImpl(
+                        new TaskMailboxImpl(), 0, StreamTaskActionExecutor.IMMEDIATE);
+
         CheckpointBarrierTracker barrierHandler =
                 new CheckpointBarrierTracker(
                         numberOfChannels,
@@ -104,10 +248,47 @@ public class CheckpointedInputGateTest {
                             @Override
                             public void invoke() {}
                         });
+
+        CheckpointedInputGate checkpointedInputGate =
+                new CheckpointedInputGate(
+                        singleInputGate,
+                        barrierHandler,
+                        mailboxExecutor,
+                        UpstreamRecoveryTracker.forInputGate(singleInputGate));
+        for (int i = 0; i < numberOfChannels; i++) {
+            ((RemoteInputChannel) checkpointedInputGate.getChannel(i)).requestSubpartition(0);
+        }
+        return checkpointedInputGate;
+    }
+
+    private CheckpointedInputGate setupInputGateWithAlternatingController(
+            int numberOfChannels,
+            NetworkBufferPool networkBufferPool,
+            AbstractInvokable abstractInvokable,
+            RecordingChannelStateWriter stateWriter)
+            throws Exception {
+        ConnectionManager connectionManager = new TestingConnectionManager();
+        SingleInputGate singleInputGate =
+                new SingleInputGateBuilder()
+                        .setBufferPoolFactory(
+                                networkBufferPool.createBufferPool(
+                                        numberOfChannels, Integer.MAX_VALUE))
+                        .setSegmentProvider(networkBufferPool)
+                        .setChannelFactory(
+                                (builder, gate) ->
+                                        builder.setConnectionManager(connectionManager)
+                                                .buildRemoteChannel(gate))
+                        .setNumberOfChannels(numberOfChannels)
+                        .setChannelStateWriter(stateWriter)
+                        .build();
+        singleInputGate.setup();
         MailboxExecutorImpl mailboxExecutor =
                 new MailboxExecutorImpl(
                         new TaskMailboxImpl(), 0, StreamTaskActionExecutor.IMMEDIATE);
 
+        SingleCheckpointBarrierHandler barrierHandler =
+                AlternatingControllerTest.barrierHandler(
+                        singleInputGate, abstractInvokable, stateWriter);
         CheckpointedInputGate checkpointedInputGate =
                 new CheckpointedInputGate(
                         singleInputGate,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -17,21 +17,27 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.MockChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
 import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
@@ -42,12 +48,16 @@ import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 
+import org.apache.flink.shaded.guava18.com.google.common.io.Closer;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
 import static org.junit.Assert.assertEquals;
@@ -177,6 +187,78 @@ public class CheckpointedInputGateTest {
         }
     }
 
+    /**
+     * Tests a priority notification happening right before cancellation. The mail would be
+     * processed while draining mailbox but can't pull any data anymore.
+     */
+    @Test
+    public void testPriorityBeforeClose() throws IOException, InterruptedException {
+
+        NetworkBufferPool bufferPool = new NetworkBufferPool(10, 1024);
+        try (Closer closer = Closer.create()) {
+            closer.register(bufferPool::destroy);
+
+            for (int repeat = 0; repeat < 100; repeat++) {
+                setUp();
+
+                SingleInputGate singleInputGate =
+                        new SingleInputGateBuilder()
+                                .setNumberOfChannels(2)
+                                .setBufferPoolFactory(
+                                        bufferPool.createBufferPool(2, Integer.MAX_VALUE))
+                                .setSegmentProvider(bufferPool)
+                                .setChannelFactory(InputChannelBuilder::buildRemoteChannel)
+                                .build();
+                singleInputGate.setup();
+                ((RemoteInputChannel) singleInputGate.getChannel(0)).requestSubpartition(0);
+
+                final TaskMailboxImpl mailbox = new TaskMailboxImpl();
+                MailboxExecutorImpl mailboxExecutor =
+                        new MailboxExecutorImpl(mailbox, 0, StreamTaskActionExecutor.IMMEDIATE);
+
+                ValidatingCheckpointHandler validatingHandler = new ValidatingCheckpointHandler(1);
+                SingleCheckpointBarrierHandler barrierHandler =
+                        AlternatingControllerTest.barrierHandler(
+                                singleInputGate, validatingHandler, new MockChannelStateWriter());
+                CheckpointedInputGate checkpointedInputGate =
+                        new CheckpointedInputGate(
+                                singleInputGate,
+                                barrierHandler,
+                                mailboxExecutor,
+                                UpstreamRecoveryTracker.forInputGate(singleInputGate));
+
+                final int oldSize = mailbox.size();
+                enqueue(checkpointedInputGate, 0, barrier(1));
+                // wait for priority mail to be enqueued
+                Deadline deadline = Deadline.fromNow(Duration.ofMinutes(1));
+                while (deadline.hasTimeLeft() && oldSize >= mailbox.size()) {
+                    Thread.sleep(1);
+                }
+
+                // test the race condition
+                // either priority event could be handled, then we expect a checkpoint to be
+                // triggered or closing came first in which case we expect a CancelTaskException
+                CountDownLatch beforeLatch = new CountDownLatch(2);
+                final CheckedThread canceler =
+                        new CheckedThread("Canceler") {
+                            @Override
+                            public void go() throws IOException {
+                                beforeLatch.countDown();
+                                singleInputGate.close();
+                            }
+                        };
+                canceler.start();
+                beforeLatch.countDown();
+                try {
+                    while (mailboxExecutor.tryYield()) {}
+                    assertEquals(1L, validatingHandler.triggeredCheckpointCounter);
+                } catch (CancelTaskException e) {
+                }
+                canceler.join();
+            }
+        }
+    }
+
     private static CheckpointBarrier barrier(long barrierId) {
         return new CheckpointBarrier(
                 barrierId,
@@ -194,6 +276,11 @@ public class CheckpointedInputGateTest {
     private void enqueueEndOfState(CheckpointedInputGate checkpointedInputGate, int channelIndex)
             throws IOException {
         enqueue(checkpointedInputGate, channelIndex, EndOfChannelStateEvent.INSTANCE);
+    }
+
+    private void enqueueEndOfPartition(
+            CheckpointedInputGate checkpointedInputGate, int channelIndex) throws IOException {
+        enqueue(checkpointedInputGate, channelIndex, EndOfPartitionEvent.INSTANCE);
     }
 
     private void enqueue(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -206,11 +206,11 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                                 "source")
                         .slotSharingGroup(slotSharing ? "default" : "source")
                         .disableChaining()
-                        .map(i -> i)
+                        .map(i -> checkHeader(i))
                         .name("forward")
                         .uid("forward")
                         .slotSharingGroup(slotSharing ? "default" : "forward")
-                        .keyBy(i -> i % parallelism * parallelism)
+                        .keyBy(i -> withoutHeader(i) % parallelism * parallelism)
                         .process(new KeyedIdentityFunction())
                         .name("keyed")
                         .uid("keyed");
@@ -342,12 +342,21 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
         public void initializeState(FunctionInitializationContext context) throws Exception {
             super.initializeState(context);
             backpressure = false;
+            LOG.info(
+                    "Inducing backpressure=false @ {} subtask ({} attempt)",
+                    getRuntimeContext().getIndexOfThisSubtask(),
+                    getRuntimeContext().getAttemptNumber());
         }
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) throws Exception {
             super.snapshotState(context);
             backpressure = state.completedCheckpoints < minCheckpoints;
+            LOG.info(
+                    "Inducing backpressure={} @ {} subtask ({} attempt)",
+                    backpressure,
+                    getRuntimeContext().getIndexOfThisSubtask(),
+                    getRuntimeContext().getAttemptNumber());
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -201,8 +201,15 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             private final LongCounter numInputsCounter = new LongCounter();
             private LongSplit split;
             private int numAbortedCheckpoints;
-            private boolean throttle = true;
             private int numRestarts;
+            private int numCheckpointsInThisAttempt;
+            private PollingState pollingState = PollingState.THROTTLING;
+
+            enum PollingState {
+                THROTTLING,
+                PUMPING,
+                FINISHING;
+            }
 
             public LongSourceReader(final long minCheckpoints, int expectedRestarts) {
                 this.minCheckpoints = minCheckpoints;
@@ -221,15 +228,19 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                 output.collect(withHeader(split.nextNumber), split.nextNumber);
                 split.nextNumber += split.increment;
 
-                if (throttle) {
-                    // throttle source as long as sink is not backpressuring (which it does only
-                    // after full recovery)
-                    Thread.sleep(1);
+                switch (pollingState) {
+                    case FINISHING:
+                        return InputStatus.END_OF_INPUT;
+                    case THROTTLING:
+                        // throttle source as long as sink is not backpressuring (which it does only
+                        // after full recovery)
+                        Thread.sleep(1);
+                        return InputStatus.MORE_AVAILABLE;
+                    case PUMPING:
+                        return InputStatus.MORE_AVAILABLE;
+                    default:
+                        throw new IllegalStateException("Unexpected state: " + pollingState);
                 }
-                return split.numCompletedCheckpoints >= minCheckpoints
-                                && numRestarts >= expectedRestarts
-                        ? InputStatus.END_OF_INPUT
-                        : InputStatus.MORE_AVAILABLE;
             }
 
             @Override
@@ -253,9 +264,15 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                             split.numCompletedCheckpoints,
                             split.nextNumber % split.increment,
                             numRestarts);
+                    // Update polling state before final checkpoint such that if there is an issue
+                    // during finishing, after recovery the source immediately starts finishing
+                    // again. In this way, we avoid a deadlock where some tasks need another
+                    // checkpoint completed, while some tasks are finishing (and thus there are no
+                    // new checkpoint).
+                    updatePollingState();
                     split.numCompletedCheckpoints++;
+                    numCheckpointsInThisAttempt++;
                     numAbortedCheckpoints = 0;
-                    throttle = split.numCompletedCheckpoints >= minCheckpoints;
                 }
             }
 
@@ -267,6 +284,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                     // here simply also advance completed checkpoints to avoid running into a live
                     // lock
                     split.numCompletedCheckpoints++;
+                    updatePollingState();
                 }
             }
 
@@ -282,9 +300,11 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                             "Tried to add " + splits + " but already got " + split);
                 }
                 split = Iterables.getOnlyElement(splits);
+                updatePollingState();
                 LOG.info(
-                        "Added split {} @ {} subtask ({} attempt)",
+                        "Added split {}, pollingState={} @ {} subtask ({} attempt)",
                         split,
+                        pollingState,
                         split.nextNumber % split.increment,
                         numRestarts);
             }
@@ -292,10 +312,33 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             @Override
             public void notifyNoMoreSplits() {}
 
+            private void updatePollingState() {
+                if (split == null) {
+                    return;
+                }
+                if (split.numCompletedCheckpoints >= minCheckpoints
+                        && numRestarts >= expectedRestarts) {
+                    pollingState = PollingState.FINISHING;
+                } else if (numCheckpointsInThisAttempt == 0) {
+                    // speed up recovery by throttling - use a successful checkpoint as a proxy
+                    // for a finished recovery
+                    pollingState = PollingState.THROTTLING;
+                } else {
+                    // cause backpressure
+                    pollingState = PollingState.PUMPING;
+                }
+            }
+
             @Override
             public void handleSourceEvents(SourceEvent sourceEvent) {
                 if (sourceEvent instanceof RestartEvent) {
                     numRestarts = ((RestartEvent) sourceEvent).numRestarts;
+                    updatePollingState();
+                    LOG.info(
+                            "Set restarts {}, pollingState={} ({} attempt)",
+                            split,
+                            pollingState,
+                            numRestarts);
                 }
             }
 
@@ -852,9 +895,10 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         return value ^ HEADER;
     }
 
-    protected static void checkHeader(long value) {
+    protected static long checkHeader(long value) {
         if ((value & HEADER_MASK) != HEADER) {
             throw new IllegalArgumentException("Stream corrupted");
         }
+        return value;
     }
 }


### PR DESCRIPTION
This PR depends on https://github.com/apache/flink/pull/14797 (@AHeise commits at the bottom)

This PR fixes two bugs on unaligned checkpoints. First:
```
    If previous checkpoint is declined, it can happen that task receives both older and newer
    checkpoint barrier on two different channels, before processing any checkpoint cancellation
    message/RPC. If the newer checkpoint barrier happens to be processed before the obsolete one
    incorrect `checkState` in ChannelStatePersister would cause job failure. This checkState
    was assuming that the previous checkpoint would have been aborted/stopped before triggering
    the new one, while in reality, this previous checkpoint has never been triggered on this task
    so it also could not have been stopped.
```
Second:
```
    This commit fixes a bug where RemoteInputChannel was incorrectly deciding which
    buffers should be spilled, if it has received an obsoleted CheckpointBarrier,
    that hasn't been cancelled (yet?).
```
Both commits are tested by the existing UnalignedCheckpointITCase and some freshly added unit tests.

Further, it addresses some issues in cancellation:
```
During cancellation it may happen that CheckpointedInputGate may not poll a priority event if the 
corresponding channel has already been released. Until race conditions are removed, it safest to 
simply ignore an empty poll.
```
```
Do not enqueue released channels into the input gate.
```
Both commits are also tested by the existing UnalignedCheckpointITCase and covered by 1 new unit tests each.

Lastly, there is a fix for UnalignedCheckpointITCase itself, which could have run indefinitively if there is a cancellation after the final expected checkpoint.

Two related side commits increase the debuggability of network code, especially in conjunction with unaligned checkpoint.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
