### PR TITLE
[FLINK-21187] Provide exception history for root causes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
@@ -15,15 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
-/**
- * Common interface for the runtime {@link Execution and {@link ArchivedExecution}.
- */
+/** Common interface for the runtime {@link Execution} and {@link ArchivedExecution}. */
 public interface AccessExecution {
     /**
      * Returns the {@link ExecutionAttemptID} for this Execution.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecution.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import java.util.Optional;
+
 /** Common interface for the runtime {@link Execution} and {@link ArchivedExecution}. */
 public interface AccessExecution {
     /**
@@ -63,9 +65,11 @@ public interface AccessExecution {
      * Returns the exception that caused the job to fail. This is the first root exception that was
      * not recoverable and triggered job failure.
      *
-     * @return failure exception as a string, or {@code "(null)"}
+     * @return an {@code Optional} of {@link ErrorInfo} containing the {@code Throwable} and the
+     *     time it was registered if an error occurred. If no error occurred an empty {@code
+     *     Optional} will be returned.
      */
-    String getFailureCauseAsString();
+    Optional<ErrorInfo> getFailureInfo();
 
     /**
      * Returns the timestamp for the given {@link ExecutionState}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
+
 /** Common interface for the runtime {@link ExecutionVertex} and {@link ArchivedExecutionVertex}. */
 public interface AccessExecutionVertex {
     /**
@@ -65,9 +67,10 @@ public interface AccessExecutionVertex {
      * Returns the exception that caused the job to fail. This is the first root exception that was
      * not recoverable and triggered job failure.
      *
-     * @return failure exception as a string, or {@code "(null)"}
+     * @return failure exception wrapped in an {@code Optional} of {@link ErrorInfo}, or an empty
+     *     {@link Optional} if no exception was caught.
      */
-    String getFailureCauseAsString();
+    Optional<ErrorInfo> getFailureInfo();
 
     /**
      * Returns the {@link TaskManagerLocation} for this execution vertex.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.execution.ExecutionState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
@@ -25,6 +26,7 @@ import org.apache.flink.util.ExceptionUtils;
 
 import java.io.Serializable;
 
+/** {@code ArchivedExecution} is a readonly representation of {@link Execution}. */
 public class ArchivedExecution implements AccessExecution, Serializable {
     private static final long serialVersionUID = 4817108757483345173L;
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecution.java
@@ -22,9 +22,11 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.ExceptionUtils;
+
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /** {@code ArchivedExecution} is a readonly representation of {@link Execution}. */
 public class ArchivedExecution implements AccessExecution, Serializable {
@@ -39,7 +41,7 @@ public class ArchivedExecution implements AccessExecution, Serializable {
 
     private final ExecutionState state;
 
-    private final String failureCause; // once assigned, never changes
+    @Nullable private final ErrorInfo failureInfo; // once assigned, never changes
 
     private final TaskManagerLocation assignedResourceLocation; // for the archived execution
 
@@ -59,7 +61,7 @@ public class ArchivedExecution implements AccessExecution, Serializable {
                 execution.getAttemptId(),
                 execution.getAttemptNumber(),
                 execution.getState(),
-                ExceptionUtils.stringifyException(execution.getFailureCause()),
+                execution.getFailureInfo().orElse(null),
                 execution.getAssignedResourceLocation(),
                 execution.getAssignedAllocationID(),
                 execution.getVertex().getParallelSubtaskIndex(),
@@ -72,14 +74,14 @@ public class ArchivedExecution implements AccessExecution, Serializable {
             ExecutionAttemptID attemptId,
             int attemptNumber,
             ExecutionState state,
-            String failureCause,
+            @Nullable ErrorInfo failureCause,
             TaskManagerLocation assignedResourceLocation,
             AllocationID assignedAllocationID,
             int parallelSubtaskIndex,
             long[] stateTimestamps) {
         this.userAccumulators = userAccumulators;
         this.ioMetrics = ioMetrics;
-        this.failureCause = failureCause;
+        this.failureInfo = failureCause;
         this.assignedResourceLocation = assignedResourceLocation;
         this.attemptNumber = attemptNumber;
         this.attemptId = attemptId;
@@ -123,8 +125,8 @@ public class ArchivedExecution implements AccessExecution, Serializable {
     }
 
     @Override
-    public String getFailureCauseAsString() {
-        return failureCause;
+    public Optional<ErrorInfo> getFailureInfo() {
+        return Optional.ofNullable(failureInfo);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.util.EvictingBoundedList;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 /** {@code ArchivedExecutionVertex} is a readonly representation of {@link ExecutionVertex}. */
 public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializable {
@@ -90,8 +91,8 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
     }
 
     @Override
-    public String getFailureCauseAsString() {
-        return currentExecution.getFailureCauseAsString();
+    public Optional<ErrorInfo> getFailureInfo() {
+        return currentExecution.getFailureInfo();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -25,6 +26,7 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 
+/** {@code ArchivedExecutionVertex} is a readonly representation of {@link ExecutionVertex}. */
 public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializable {
 
     private static final long serialVersionUID = -6708241535015028576L;
@@ -33,7 +35,7 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 
     private final EvictingBoundedList<ArchivedExecution> priorExecutions;
 
-    /** The name in the format "myTask (2/7)", cached to avoid frequent string concatenations */
+    /** The name in the format "myTask (2/7)", cached to avoid frequent string concatenations. */
     private final String taskNameWithSubtask;
 
     private final ArchivedExecution currentExecution; // this field must never be null

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
@@ -18,8 +18,12 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 
@@ -35,7 +39,25 @@ public class ErrorInfo implements Serializable {
 
     private final long timestamp;
 
-    public ErrorInfo(Throwable exception, long timestamp) {
+    /**
+     * Instantiates an {@code ErrorInfo} to cover inconsistent behavior due to FLINK-21376.
+     *
+     * @param exception The error cause that might be {@code null}.
+     * @param timestamp The timestamp the error was noticed.
+     * @return a {@code ErrorInfo} containing a generic {@link FlinkException} in case of a missing
+     *     error cause.
+     */
+    public static ErrorInfo createErrorInfoWithNullableCause(
+            @Nullable Throwable exception, long timestamp) {
+        return new ErrorInfo(
+                exception != null
+                        ? exception
+                        : new FlinkException(
+                                "Unknown cause for Execution failure (this might be caused by FLINK-21376)."),
+                timestamp);
+    }
+
+    public ErrorInfo(@Nonnull Throwable exception, long timestamp) {
         Preconditions.checkNotNull(exception);
         Preconditions.checkArgument(timestamp > 0);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EvictingBoundedList;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.slf4j.Logger;
 
@@ -246,12 +245,8 @@ public class ExecutionVertex
     }
 
     @Override
-    public String getFailureCauseAsString() {
-        return ExceptionUtils.stringifyException(getFailureCause());
-    }
-
-    public Throwable getFailureCause() {
-        return currentExecution.getFailureCause();
+    public Optional<ErrorInfo> getFailureInfo() {
+        return currentExecution.getFailureInfo();
     }
 
     public CompletableFuture<TaskManagerLocation> getCurrentTaskManagerLocationFuture() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandler.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.throwable.ThrowableClassifier;
 import org.apache.flink.runtime.throwable.ThrowableType;
 import org.apache.flink.util.IterableUtils;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -77,7 +79,10 @@ public class ExecutionFailureHandler {
     public FailureHandlingResult getFailureHandlingResult(
             ExecutionVertexID failedTask, Throwable cause) {
         return handleFailure(
-                cause, failoverStrategy.getTasksNeedingRestart(failedTask, cause), false);
+                failedTask,
+                cause,
+                failoverStrategy.getTasksNeedingRestart(failedTask, cause),
+                false);
     }
 
     /**
@@ -90,6 +95,7 @@ public class ExecutionFailureHandler {
      */
     public FailureHandlingResult getGlobalFailureHandlingResult(final Throwable cause) {
         return handleFailure(
+                null,
                 cause,
                 IterableUtils.toStream(schedulingTopology.getVertices())
                         .map(SchedulingExecutionVertex::getId)
@@ -98,13 +104,16 @@ public class ExecutionFailureHandler {
     }
 
     private FailureHandlingResult handleFailure(
+            @Nullable final ExecutionVertexID failingExecutionVertexId,
             final Throwable cause,
             final Set<ExecutionVertexID> verticesToRestart,
             final boolean globalFailure) {
 
         if (isUnrecoverableError(cause)) {
             return FailureHandlingResult.unrecoverable(
-                    new JobException("The failure is not recoverable", cause), globalFailure);
+                    failingExecutionVertexId,
+                    new JobException("The failure is not recoverable", cause),
+                    globalFailure);
         }
 
         restartBackoffTimeStrategy.notifyFailure(cause);
@@ -112,9 +121,14 @@ public class ExecutionFailureHandler {
             numberOfRestarts++;
 
             return FailureHandlingResult.restartable(
-                    verticesToRestart, restartBackoffTimeStrategy.getBackoffTime(), globalFailure);
+                    failingExecutionVertexId,
+                    cause,
+                    verticesToRestart,
+                    restartBackoffTimeStrategy.getBackoffTime(),
+                    globalFailure);
         } else {
             return FailureHandlingResult.unrecoverable(
+                    failingExecutionVertexId,
                     new JobException(
                             "Recovery is suppressed by " + restartBackoffTimeStrategy, cause),
                     globalFailure);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -37,7 +37,6 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 /** Handler serving the job exceptions. */
@@ -109,8 +109,8 @@ public class JobExceptionsHandler
         List<JobExceptionsInfo.ExecutionExceptionInfo> taskExceptionList = new ArrayList<>();
         boolean truncated = false;
         for (AccessExecutionVertex task : executionGraph.getAllExecutionVertices()) {
-            String t = task.getFailureCauseAsString();
-            if (t != null && !t.equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+            Optional<ErrorInfo> failure = task.getFailureInfo();
+            if (failure.isPresent()) {
                 if (taskExceptionList.size() >= exceptionToReportMaxSize) {
                     truncated = true;
                     break;
@@ -124,7 +124,7 @@ public class JobExceptionsHandler
                 long timestamp = task.getStateTimestamp(ExecutionState.FAILED);
                 taskExceptionList.add(
                         new JobExceptionsInfo.ExecutionExceptionInfo(
-                                t,
+                                failure.get().getExceptionAsString(),
                                 task.getTaskNameWithSubtaskIndex(),
                                 locationString,
                                 timestamp == 0 ? -1 : timestamp));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -268,7 +268,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 () ->
                         FutureUtils.assertNoException(
                                 cancelFuture.thenRunAsync(
-                                        restartTasks(executionVertexVersions, globalRecovery),
+                                        () -> {
+                                            archiveFromFailureHandlingResult(failureHandlingResult);
+                                            restartTasks(executionVertexVersions, globalRecovery);
+                                        },
                                         getMainThreadExecutor())),
                 failureHandlingResult.getRestartDelayMS(),
                 TimeUnit.MILLISECONDS);
@@ -286,27 +289,24 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         }
     }
 
-    private Runnable restartTasks(
+    private void restartTasks(
             final Set<ExecutionVertexVersion> executionVertexVersions,
             final boolean isGlobalRecovery) {
-        return () -> {
-            final Set<ExecutionVertexID> verticesToRestart =
-                    executionVertexVersioner.getUnmodifiedExecutionVertices(
-                            executionVertexVersions);
+        final Set<ExecutionVertexID> verticesToRestart =
+                executionVertexVersioner.getUnmodifiedExecutionVertices(executionVertexVersions);
 
-            removeVerticesFromRestartPending(verticesToRestart);
+        removeVerticesFromRestartPending(verticesToRestart);
 
-            resetForNewExecutions(verticesToRestart);
+        resetForNewExecutions(verticesToRestart);
 
-            try {
-                restoreState(verticesToRestart, isGlobalRecovery);
-            } catch (Throwable t) {
-                handleGlobalFailure(t);
-                return;
-            }
+        try {
+            restoreState(verticesToRestart, isGlobalRecovery);
+        } catch (Throwable t) {
+            handleGlobalFailure(t);
+            return;
+        }
 
-            schedulingStrategy.restartTasks(verticesToRestart);
-        };
+        schedulingStrategy.restartTasks(verticesToRestart);
     }
 
     private CompletableFuture<?> cancelTasksAsync(final Set<ExecutionVertexID> verticesToRestart) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1039,12 +1039,12 @@ public class Task
                         newState);
             } else {
                 LOG.warn(
-                        "{} ({}) switched from {} to {}.",
+                        "{} ({}) switched from {} to {} with failure cause: {}",
                         taskNameWithSubtask,
                         executionId,
                         currentState,
                         newState,
-                        cause);
+                        ExceptionUtils.stringifyException(cause));
             }
 
             return true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -115,8 +116,17 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         runtimeGraph = scheduler.getExecutionGraph();
 
         scheduler.startScheduling();
-        scheduler.handleGlobalFailure(
-                new RuntimeException("This exception was thrown on purpose."));
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(
+                        jobGraph.getJobID(),
+                        runtimeGraph
+                                .getAllExecutionVertices()
+                                .iterator()
+                                .next()
+                                .getCurrentExecutionAttempt()
+                                .getAttemptId(),
+                        ExecutionState.FAILED,
+                        new RuntimeException("Local failure")));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -363,8 +363,12 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         assertEquals(
                 runtimeVertex.getStateTimestamp(ExecutionState.FAILED),
                 archivedVertex.getStateTimestamp(ExecutionState.FAILED));
-        assertEquals(
-                runtimeVertex.getFailureCauseAsString(), archivedVertex.getFailureCauseAsString());
+        assertThat(
+                runtimeVertex.getFailureInfo().map(ErrorInfo::getExceptionAsString),
+                is(archivedVertex.getFailureInfo().map(ErrorInfo::getExceptionAsString)));
+        assertThat(
+                runtimeVertex.getFailureInfo().map(ErrorInfo::getTimestamp),
+                is(archivedVertex.getFailureInfo().map(ErrorInfo::getTimestamp)));
         assertEquals(
                 runtimeVertex.getCurrentAssignedResourceLocation(),
                 archivedVertex.getCurrentAssignedResourceLocation());
@@ -384,9 +388,12 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         assertEquals(
                 runtimeExecution.getAssignedResourceLocation(),
                 archivedExecution.getAssignedResourceLocation());
-        assertEquals(
-                runtimeExecution.getFailureCauseAsString(),
-                archivedExecution.getFailureCauseAsString());
+        assertThat(
+                runtimeExecution.getFailureInfo().map(ErrorInfo::getExceptionAsString),
+                is(archivedExecution.getFailureInfo().map(ErrorInfo::getExceptionAsString)));
+        assertThat(
+                runtimeExecution.getFailureInfo().map(ErrorInfo::getTimestamp),
+                is(archivedExecution.getFailureInfo().map(ErrorInfo::getTimestamp)));
         assertEquals(
                 runtimeExecution.getStateTimestamp(ExecutionState.CREATED),
                 archivedExecution.getStateTimestamp(ExecutionState.CREATED));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexCancelTest.java
@@ -43,7 +43,6 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.se
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.setVertexState;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -65,7 +64,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 
             assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-            assertNull(vertex.getFailureCause());
+            assertFalse(vertex.getFailureInfo().isPresent());
 
             assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
             assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
@@ -88,7 +87,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 
             assertEquals(ExecutionState.CANCELED, vertex.getExecutionState());
 
-            assertNull(vertex.getFailureCause());
+            assertFalse(vertex.getFailureInfo().isPresent());
 
             assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
             assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
@@ -123,7 +122,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 
             assertFalse(slot.isAlive());
 
-            assertNull(vertex.getFailureCause());
+            assertFalse(vertex.getFailureInfo().isPresent());
 
             assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
             assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
@@ -165,7 +164,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 
             assertFalse(slot.isAlive());
 
-            assertNull(vertex.getFailureCause());
+            assertFalse(vertex.getFailureInfo().isPresent());
 
             assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
             assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);
@@ -197,7 +196,7 @@ public class ExecutionVertexCancelTest extends TestLogger {
 
             assertEquals(ExecutionState.CANCELING, vertex.getExecutionState());
 
-            assertNull(vertex.getFailureCause());
+            assertFalse(vertex.getFailureInfo().isPresent());
 
             assertTrue(vertex.getStateTimestamp(ExecutionState.CREATED) > 0);
             assertTrue(vertex.getStateTimestamp(ExecutionState.CANCELING) > 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecution;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -123,7 +124,9 @@ public class JobExceptionsHandlerTest extends TestLogger {
                                     new ExecutionAttemptID(),
                                     attempt,
                                     expectedState,
-                                    "error",
+                                    new ErrorInfo(
+                                            new RuntimeException("error"),
+                                            System.currentTimeMillis()),
                                     assignedResourceLocation,
                                     allocationID,
                                     subtaskIndex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -22,6 +22,8 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.hooks.TestMasterHook;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -59,6 +61,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Range;
 
 import org.junit.After;
 import org.junit.Before;
@@ -84,9 +87,12 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -259,7 +265,7 @@ public class DefaultSchedulerTest extends TestLogger {
                 archivedExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
 
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
 
         taskRestartExecutor.triggerScheduledTasks();
 
@@ -275,8 +281,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final DefaultScheduler scheduler = createSchedulerAndStartScheduling(jobGraph);
 
         final TaskExecutionState taskExecutionState =
-                new TaskExecutionState(
-                        jobGraph.getJobID(), new ExecutionAttemptID(), ExecutionState.FAILED);
+                createFailedTaskExecutionState(jobGraph.getJobID(), new ExecutionAttemptID());
 
         assertFalse(scheduler.updateTaskExecutionState(taskExecutionState));
     }
@@ -294,7 +299,7 @@ public class DefaultSchedulerTest extends TestLogger {
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
 
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
 
         taskRestartExecutor.triggerScheduledTasks();
 
@@ -423,7 +428,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 sourceExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
         testRestartBackoffTimeStrategy.setCanRestart(false);
 
         testExecutionSlotAllocator.enableAutoCompletePendingRequests();
@@ -477,7 +482,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
 
         taskRestartExecutor.triggerScheduledTasks();
 
@@ -559,19 +564,15 @@ public class DefaultSchedulerTest extends TestLogger {
         // fail v1 and let it recover to SCHEDULED
         // the initial deployment of v1 will be outdated
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(
-                        jobGraph.getJobID(),
-                        v1.getCurrentExecutionAttempt().getAttemptId(),
-                        ExecutionState.FAILED));
+                createFailedTaskExecutionState(
+                        jobGraph.getJobID(), v1.getCurrentExecutionAttempt().getAttemptId()));
         taskRestartExecutor.triggerScheduledTasks();
 
         // fail v2 to get all pending slot requests in the initial deployments to be done
         // this triggers the outdated deployment of v1
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(
-                        jobGraph.getJobID(),
-                        v2.getCurrentExecutionAttempt().getAttemptId(),
-                        ExecutionState.FAILED));
+                createFailedTaskExecutionState(
+                        jobGraph.getJobID(), v2.getCurrentExecutionAttempt().getAttemptId()));
 
         // v1 should not be affected
         assertThat(sv1.getState(), is(equalTo(ExecutionState.SCHEDULED)));
@@ -600,7 +601,7 @@ public class DefaultSchedulerTest extends TestLogger {
         assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints(), is(equalTo(1)));
 
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
         taskRestartExecutor.triggerScheduledTasks();
         assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints(), is(equalTo(0)));
     }
@@ -635,7 +636,7 @@ public class DefaultSchedulerTest extends TestLogger {
         acknowledgePendingCheckpoint(scheduler, checkpointId);
 
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
         taskRestartExecutor.triggerScheduledTasks();
         assertThat(masterHook.getRestoreCount(), is(equalTo(1)));
     }
@@ -672,7 +673,7 @@ public class DefaultSchedulerTest extends TestLogger {
         acknowledgePendingCheckpoint(scheduler, checkpointId);
 
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.FAILED));
+                createFailedTaskExecutionState(jobGraph.getJobID(), attemptId));
         taskRestartExecutor.triggerScheduledTasks();
         final List<ExecutionVertexID> deployedExecutionVertices =
                 testExecutionVertexOperations.getDeployedVertices();
@@ -868,6 +869,124 @@ public class DefaultSchedulerTest extends TestLogger {
         assertThat(v1.getExecutionState(), is(ExecutionState.FAILED));
         assertThat(v2.getExecutionState(), is(ExecutionState.CANCELED));
         assertThat(testExecutionSlotAllocator.getPendingRequests().keySet(), hasSize(0));
+    }
+
+    @Test
+    public void testExceptionHistoryWithGlobalFailOver() {
+        final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
+        final DefaultScheduler scheduler = createSchedulerAndStartScheduling(jobGraph);
+
+        final ExecutionAttemptID attemptId =
+                Iterables.getOnlyElement(scheduler.requestJob().getAllExecutionVertices())
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+
+        final Exception expectedException = new Exception("Expected exception");
+        final long start = System.currentTimeMillis();
+        scheduler.handleGlobalFailure(expectedException);
+
+        // we have to cancel the task and trigger the restart to have the exception history
+        // populated
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(
+                        jobGraph.getJobID(),
+                        attemptId,
+                        ExecutionState.CANCELED,
+                        expectedException));
+        taskRestartExecutor.triggerScheduledTasks();
+        final long end = System.currentTimeMillis();
+
+        final List<ErrorInfo> actualExceptionHistory = scheduler.getExceptionHistory();
+
+        assertThat(actualExceptionHistory, hasSize(1));
+
+        final ErrorInfo failure = actualExceptionHistory.get(0);
+        assertThat(
+                failure.getException().deserializeError(ClassLoader.getSystemClassLoader()),
+                is(expectedException));
+        assertThat(failure.getTimestamp(), greaterThanOrEqualTo(start));
+        assertThat(failure.getTimestamp(), lessThanOrEqualTo(end));
+    }
+
+    @Test
+    public void testExceptionHistoryWithRestartableFailure() {
+        final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
+        final JobID jobId = jobGraph.getJobID();
+
+        final DefaultScheduler scheduler = createSchedulerAndStartScheduling(jobGraph);
+
+        // initiate restartable failure
+        final ExecutionAttemptID restartableAttemptId =
+                Iterables.getOnlyElement(scheduler.requestJob().getAllExecutionVertices())
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+        final RuntimeException restartableException = new RuntimeException("restartable exception");
+        Range<Long> updateStateTriggeringRestartTimeframe =
+                initiateFailure(scheduler, jobId, restartableAttemptId, restartableException);
+
+        taskRestartExecutor.triggerNonPeriodicScheduledTask();
+
+        // initiate job failure
+        testRestartBackoffTimeStrategy.setCanRestart(false);
+
+        final ExecutionAttemptID failingAttemptId =
+                Iterables.getOnlyElement(scheduler.requestJob().getAllExecutionVertices())
+                        .getCurrentExecutionAttempt()
+                        .getAttemptId();
+        final RuntimeException failingException = new RuntimeException("failing exception");
+        Range<Long> updateStateTriggeringJobFailureTimeframe =
+                initiateFailure(scheduler, jobId, failingAttemptId, failingException);
+
+        List<ErrorInfo> actualExceptionHistory = scheduler.getExceptionHistory();
+        assertThat(actualExceptionHistory.size(), is(2));
+
+        // assert restarted attempt
+        ErrorInfo restartableFailure = actualExceptionHistory.get(0);
+        assertThat(
+                restartableFailure
+                        .getException()
+                        .deserializeError(ClassLoader.getSystemClassLoader()),
+                is(restartableException));
+        assertThat(
+                restartableFailure.getTimestamp(),
+                greaterThanOrEqualTo(updateStateTriggeringRestartTimeframe.lowerEndpoint()));
+        assertThat(
+                restartableFailure.getTimestamp(),
+                lessThanOrEqualTo(updateStateTriggeringRestartTimeframe.upperEndpoint()));
+
+        // assert job failure attempt
+        ErrorInfo globalFailure = actualExceptionHistory.get(1);
+        Throwable actualException =
+                globalFailure.getException().deserializeError(ClassLoader.getSystemClassLoader());
+        assertThat(actualException, instanceOf(JobException.class));
+        assertThat(actualException, FlinkMatchers.containsCause(failingException));
+        assertThat(
+                globalFailure.getTimestamp(),
+                greaterThanOrEqualTo(updateStateTriggeringJobFailureTimeframe.lowerEndpoint()));
+        assertThat(
+                globalFailure.getTimestamp(),
+                lessThanOrEqualTo(updateStateTriggeringJobFailureTimeframe.upperEndpoint()));
+    }
+
+    private static TaskExecutionState createFailedTaskExecutionState(
+            JobID jobId, ExecutionAttemptID executionAttemptID) {
+        return new TaskExecutionState(
+                jobId,
+                executionAttemptID,
+                ExecutionState.FAILED,
+                new Exception("Expected failure cause"));
+    }
+
+    private static Range<Long> initiateFailure(
+            DefaultScheduler scheduler,
+            JobID jobId,
+            ExecutionAttemptID executionAttemptID,
+            Throwable exception) {
+        long start = System.currentTimeMillis();
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(
+                        jobId, executionAttemptID, ExecutionState.FAILED, exception));
+        return Range.closed(start, System.currentTimeMillis());
     }
 
     private static JobVertex createVertex(String name, int parallelism) {


### PR DESCRIPTION
## What is the purpose of the change

This PR handles the initial exception history proposal collecting only the root causes. This is part of a major effort of providing a exception history to the Flink web UI ([FLINK-6042](https://issues.apache.org/jira/browse/FLINK-6042)).


## Brief change log

* updated `AccessExecutionGraph` interface to return `ErrorInfo` instead of a stringified version of the failure.
* FailureHandlingResult get a new member identifying the `ExecutionVertex` that failed.
* Added two maps collecting the error infos for each occurring failure root cause.

## Verifying this change

* `ExecutionFailureHandlerTest` and `FailureHandlingResultTest` were updated accordingly.
* `DefaultSchedulerTest#testExceptionHistoryWithRestartableFailure` was introduced to cover the exception history collection.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
