### PR TITLE
[FLINK-21354][WIP] Wrapped StateBackend to forward state changes to StateChangleLog

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -44,6 +44,16 @@ public class CheckpointingOptions {
                     .noDefaultValue()
                     .withDescription("The state backend to be used to checkpoint state.");
 
+    /** Whether to enable state change log. */
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
+    @Documentation.ExcludeFromDocumentation("Hidden for now")
+    public static final ConfigOption<Boolean> ENABLE_STATE_CHANGE_LOG =
+            ConfigOptions.key("state.backend.enable-statechangelog")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable state backend to write state changes to StateChangeLog.");
+
     /** The maximum number of completed checkpoints to retain. */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -235,7 +235,7 @@ public class ExecutionGraphBuilder {
             final StateBackend rootBackend;
             try {
                 rootBackend =
-                        StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        StateBackendLoader.loadStateBackend(
                                 applicationConfiguredBackend, jobManagerConfig, classLoader, log);
             } catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
                 throw new JobExecutionException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -274,7 +274,7 @@ public abstract class AbstractKeyedStateBackend<K>
         return (S) kvState;
     }
 
-    private void publishQueryableStateIfEnabled(
+    public void publishQueryableStateIfEnabled(
             StateDescriptor<?, ?> stateDescriptor, InternalKvState<?, ?, ?> kvState) {
         if (stateDescriptor.isQueryable()) {
             if (kvStateRegistry == null) {
@@ -335,10 +335,6 @@ public abstract class AbstractKeyedStateBackend<K>
         return keyGroupCompressionDecorator;
     }
 
-    /** Returns the total number of state entries across all keys/namespaces. */
-    @VisibleForTesting
-    public abstract int numKeyValueStateEntries();
-
     @VisibleForTesting
     public int numKeyValueStatesByName() {
         return keyValueStatesByName.size();
@@ -347,5 +343,9 @@ public abstract class AbstractKeyedStateBackend<K>
     // TODO remove this once heap-based timers are working with RocksDB incremental snapshots!
     public boolean requiresLegacySynchronousTimerSnapshots() {
         return false;
+    }
+
+    public boolean supportConcurrentModification() {
+        return true;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.state.proxy.ProxyStateBackend;
 import org.apache.flink.util.DynamicCodeLoadingException;
 import org.apache.flink.util.Preconditions;
 
@@ -162,14 +163,19 @@ public class CheckpointStorageLoader {
         Preconditions.checkNotNull(classLoader, "classLoader");
         Preconditions.checkNotNull(configuredStateBackend, "statebackend");
 
-        if (configuredStateBackend instanceof CheckpointStorage) {
+        StateBackend rootStateBackend =
+                (configuredStateBackend instanceof ProxyStateBackend)
+                        ? ((ProxyStateBackend) configuredStateBackend).getProxiedStateBackend()
+                        : configuredStateBackend;
+
+        if (rootStateBackend instanceof CheckpointStorage) {
             if (logger != null) {
                 logger.info(
                         "Using legacy state backend {} as Job checkpoint storage",
-                        configuredStateBackend);
+                        rootStateBackend);
             }
 
-            return (CheckpointStorage) configuredStateBackend;
+            return (CheckpointStorage) rootStateBackend;
         } else if (fromApplication instanceof ConfigurableCheckpointStorage) {
             if (logger != null) {
                 logger.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -135,6 +136,10 @@ public interface KeyedStateBackend<K>
      * @return returns true iff listener was registered before.
      */
     boolean deregisterKeySelectionListener(KeySelectionListener<K> listener);
+
+    /** Returns the total number of state entries across all keys/namespaces. */
+    @VisibleForTesting
+    int numKeyValueStateEntries();
 
     /** Listener is given a callback when {@link #setCurrentKey} is called (key context changes). */
     @FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -394,6 +394,11 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
     }
 
     @Override
+    public boolean supportConcurrentModification() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "HeapKeyedStateBackend";
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.state.internal.InternalValueState;
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
  */
-class HeapValueState<K, N, V> extends AbstractHeapState<K, N, V>
+public class HeapValueState<K, N, V> extends AbstractHeapState<K, N, V>
         implements InternalValueState<K, N, V> {
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyAggregatingState.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+import java.util.Collection;
+
+/** */
+public class ProxyAggregatingState<K, N, IN, ACC, OUT>
+        implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+    private final InternalAggregatingState<K, N, IN, ACC, OUT> aggregatingState;
+
+    ProxyAggregatingState(InternalAggregatingState<K, N, IN, ACC, OUT> aggregatingState) {
+        this.aggregatingState = aggregatingState;
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        aggregatingState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public ACC getInternal() throws Exception {
+        return aggregatingState.getInternal();
+    }
+
+    @Override
+    public void updateInternal(ACC valueToStore) throws Exception {
+        aggregatingState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public OUT get() throws Exception {
+        return aggregatingState.get();
+    }
+
+    @Override
+    public void add(IN value) throws Exception {
+        aggregatingState.add(value);
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return aggregatingState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return aggregatingState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<ACC> getValueSerializer() {
+        return aggregatingState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        aggregatingState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<ACC> safeValueSerializer)
+            throws Exception {
+        return aggregatingState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, ACC> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return aggregatingState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        aggregatingState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> aggregatingState) {
+        return (IS)
+                new ProxyAggregatingState<>(
+                        (InternalAggregatingState<K, N, T, SV, ?>) aggregatingState);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyKeyedStateBackend.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateFunction;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.ttl.TtlStateFactory;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+public class ProxyKeyedStateBackend<K>
+        implements CheckpointableKeyedStateBackend<K>, CheckpointListener {
+    AbstractKeyedStateBackend<K> keyedStateBackend;
+
+    private static final Map<Class<? extends StateDescriptor>, StateFactory> STATE_FACTORIES =
+            Stream.of(
+                            Tuple2.of(
+                                    ValueStateDescriptor.class,
+                                    (StateFactory) ProxyValueState::create),
+                            Tuple2.of(
+                                    ListStateDescriptor.class,
+                                    (StateFactory) ProxyListState::create),
+                            Tuple2.of(
+                                    ReducingStateDescriptor.class,
+                                    (StateFactory) ProxyReducingState::create),
+                            Tuple2.of(
+                                    AggregatingStateDescriptor.class,
+                                    (StateFactory) ProxyAggregatingState::create),
+                            Tuple2.of(
+                                    MapStateDescriptor.class, (StateFactory) ProxyMapState::create))
+                    .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    // ==============================================================
+    //  cache maintained by the proxyKeyedStateBackend itself
+    //  not the same as the underlying wrapped keyedStateBackend
+    //  InternalKvState is a ProxyXXState, XX stands for Value, List ...
+    /** So that we can give out state when the user uses the same key. */
+    protected final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
+
+    @SuppressWarnings("rawtypes")
+    protected InternalKvState lastState;
+
+    /** For caching the last accessed partitioned state. */
+    protected String lastName;
+
+    // ==============================================================
+    // ==== the same as the wrapped keyedStateBackend
+
+    public final ExecutionConfig executionConfig;
+
+    public final TtlTimeProvider ttlTimeProvider;
+
+    public ProxyKeyedStateBackend(
+            AbstractKeyedStateBackend<K> keyedStateBackend,
+            ExecutionConfig executionConfig,
+            TtlTimeProvider ttlTimeProvider) {
+        this.keyedStateBackend = keyedStateBackend;
+        this.executionConfig = executionConfig;
+        this.ttlTimeProvider = ttlTimeProvider;
+
+        this.keyValueStatesByName = new HashMap<>();
+    }
+
+    @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return keyedStateBackend.getKeyGroupRange();
+    }
+
+    @Override
+    public void close() throws IOException {
+        keyedStateBackend.close();
+    }
+
+    @Override
+    public void setCurrentKey(K newKey) {
+        keyedStateBackend.setCurrentKey(newKey);
+    }
+
+    @Override
+    public K getCurrentKey() {
+        return keyedStateBackend.getCurrentKey();
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return keyedStateBackend.getKeySerializer();
+    }
+
+    @Override
+    public <N, S extends State, T> void applyToAllKeys(
+            N namespace,
+            TypeSerializer<N> namespaceSerializer,
+            StateDescriptor<S, T> stateDescriptor,
+            KeyedStateFunction<K, S> function)
+            throws Exception {
+        try (Stream<K> keyStream = getKeys(stateDescriptor.getName(), namespace)) {
+
+            final S state = getPartitionedState(namespace, namespaceSerializer, stateDescriptor);
+
+            if (keyedStateBackend.supportConcurrentModification()) {
+                keyStream.forEach(
+                        (K key) -> {
+                            setCurrentKey(key);
+                            try {
+                                function.process(key, state);
+                            } catch (Throwable e) {
+                                // we wrap the checked exception in an unchecked
+                                // one and catch it (and re-throw it) later.
+                                throw new RuntimeException(e);
+                            }
+                        });
+            } else {
+                final List<K> keys = keyStream.collect(Collectors.toList());
+                for (K key : keys) {
+                    setCurrentKey(key);
+                    function.process(key, state);
+                }
+            }
+        }
+    }
+
+    @Override
+    public <N> Stream<K> getKeys(String state, N namespace) {
+        return keyedStateBackend.getKeys(state, namespace);
+    }
+
+    @Override
+    public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+        return keyedStateBackend.getKeysAndNamespaces(state);
+    }
+
+    @Override
+    public <N, S extends State, T> S getOrCreateKeyedState(
+            TypeSerializer<N> namespaceSerializer, StateDescriptor<S, T> stateDescriptor)
+            throws Exception {
+        checkNotNull(namespaceSerializer, "Namespace serializer");
+        checkNotNull(
+                getKeySerializer(),
+                "State key serializer has not been configured in the config. "
+                        + "This operation cannot use partitioned state.");
+
+        InternalKvState<K, ?, ?> kvState = keyValueStatesByName.get(stateDescriptor.getName());
+        if (kvState == null) {
+            if (!stateDescriptor.isSerializerInitialized()) {
+                stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+            }
+            kvState =
+                    TtlStateFactory.createStateAndWrapWithTtlIfEnabled(
+                            namespaceSerializer, stateDescriptor, this, ttlTimeProvider);
+            keyValueStatesByName.put(stateDescriptor.getName(), kvState);
+            keyedStateBackend.publishQueryableStateIfEnabled(stateDescriptor, kvState);
+        }
+        return (S) kvState;
+    }
+
+    @Override
+    public <N, S extends State> S getPartitionedState(
+            N namespace,
+            TypeSerializer<N> namespaceSerializer,
+            StateDescriptor<S, ?> stateDescriptor)
+            throws Exception {
+
+        checkNotNull(namespace, "Namespace");
+
+        if (lastName != null && lastName.equals(stateDescriptor.getName())) {
+            lastState.setCurrentNamespace(namespace);
+            return (S) lastState;
+        }
+
+        InternalKvState<K, ?, ?> previous = keyValueStatesByName.get(stateDescriptor.getName());
+        if (previous != null) {
+            lastState = previous;
+            lastState.setCurrentNamespace(namespace);
+            lastName = stateDescriptor.getName();
+            return (S) previous;
+        }
+
+        final S state = getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
+        final InternalKvState<K, N, ?> kvState = (InternalKvState<K, N, ?>) state;
+
+        lastName = stateDescriptor.getName();
+        lastState = kvState;
+        kvState.setCurrentNamespace(namespace);
+
+        return state;
+    }
+
+    @Override
+    public void dispose() {
+        keyedStateBackend.dispose();
+        lastName = null;
+        lastState = null;
+        keyValueStatesByName.clear();
+    }
+
+    @Override
+    public void registerKeySelectionListener(KeySelectionListener<K> listener) {
+        keyedStateBackend.registerKeySelectionListener(listener);
+    }
+
+    @Override
+    public boolean deregisterKeySelectionListener(KeySelectionListener<K> listener) {
+        return keyedStateBackend.deregisterKeySelectionListener(listener);
+    }
+
+    @Override
+    public int numKeyValueStateEntries() {
+        return keyedStateBackend.numKeyValueStateEntries();
+    }
+
+    @Nonnull
+    @Override
+    public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<S, SV> stateDesc,
+            @Nonnull
+                    StateSnapshotTransformer.StateSnapshotTransformFactory<SEV>
+                            snapshotTransformFactory)
+            throws Exception {
+        StateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+        if (stateFactory == null) {
+            String message =
+                    String.format(
+                            "State %s is not supported by %s",
+                            stateDesc.getClass(), this.getClass());
+            throw new FlinkRuntimeException(message);
+        }
+
+        return stateFactory.create(
+                keyedStateBackend.createInternalState(
+                        namespaceSerializer, stateDesc, snapshotTransformFactory));
+    }
+
+    @Nonnull
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable & Keyed>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+        return keyedStateBackend.create(stateName, byteOrderedElementSerializer);
+    }
+
+    @Nonnull
+    @Override
+    public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+            long checkpointId,
+            long timestamp,
+            @Nonnull CheckpointStreamFactory streamFactory,
+            @Nonnull CheckpointOptions checkpointOptions)
+            throws Exception {
+        return keyedStateBackend.snapshot(
+                checkpointId, timestamp, streamFactory, checkpointOptions);
+    }
+
+    // -------------------- CheckpointListener --------------------------------
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        keyedStateBackend.notifyCheckpointComplete(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        keyedStateBackend.notifyCheckpointAborted(checkpointId);
+    }
+
+    public AbstractKeyedStateBackend<K> getProxiedKeyedStateBackend() {
+        return keyedStateBackend;
+    }
+
+    // Factory function interface
+    private interface StateFactory {
+        <K, N, SV, S extends State, IS extends S> IS create(InternalKvState<K, N, SV> kvState)
+                throws Exception;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyListState.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.Collection;
+import java.util.List;
+
+/** */
+public class ProxyListState<K, N, V> implements InternalListState<K, N, V> {
+    private final InternalListState<K, N, V> listState;
+
+    ProxyListState(InternalListState<K, N, V> listState) {
+        this.listState = listState;
+    }
+
+    // State Merging
+    @Override
+    public void update(List<V> values) throws Exception {
+        // Here is where change is forwarded to StateChangeLog,
+        listState.update(values);
+    }
+
+    @Override
+    public void addAll(List<V> values) throws Exception {
+        // Here is where change is forwarded to StateChangeLog
+        listState.addAll(values);
+    }
+
+    @Override
+    public void updateInternal(List<V> valueToStore) throws Exception {
+        // Here is where change is forwarded to StateChangeLog
+        listState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public void add(V value) throws Exception {
+        // Here is where change is forwarded to StateChangeLog
+        listState.add(value);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        listState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public List<V> getInternal() throws Exception {
+        return listState.getInternal();
+    }
+
+    @Override
+    public Iterable<V> get() throws Exception {
+        return listState.get();
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return listState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return listState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<List<V>> getValueSerializer() {
+        return listState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        listState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<List<V>> safeValueSerializer)
+            throws Exception {
+        return listState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, List<V>> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return listState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        listState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> listState) {
+        return (IS) new ProxyListState<>((InternalListState<K, N, SV>) listState);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyMapState.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/** */
+public class ProxyMapState<K, N, UK, UV> implements InternalMapState<K, N, UK, UV> {
+    private final InternalMapState<K, N, UK, UV> mapState;
+
+    ProxyMapState(InternalMapState<K, N, UK, UV> mapState) {
+        this.mapState = mapState;
+    }
+
+    @Override
+    public UV get(UK key) throws Exception {
+        return mapState.get(key);
+    }
+
+    @Override
+    public void put(UK key, UV value) throws Exception {
+        mapState.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<UK, UV> map) throws Exception {
+        mapState.putAll(map);
+    }
+
+    @Override
+    public void remove(UK key) throws Exception {
+        mapState.remove(key);
+    }
+
+    @Override
+    public boolean contains(UK key) throws Exception {
+        return mapState.contains(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<UK, UV>> entries() throws Exception {
+        return mapState.entries();
+    }
+
+    @Override
+    public Iterable<UK> keys() throws Exception {
+        return mapState.keys();
+    }
+
+    @Override
+    public Iterable<UV> values() throws Exception {
+        return mapState.values();
+    }
+
+    @Override
+    public Iterator<Map.Entry<UK, UV>> iterator() throws Exception {
+        return mapState.iterator();
+    }
+
+    @Override
+    public boolean isEmpty() throws Exception {
+        return mapState.isEmpty();
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return mapState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return mapState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<Map<UK, UV>> getValueSerializer() {
+        return mapState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        mapState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<Map<UK, UV>> safeValueSerializer)
+            throws Exception {
+        return mapState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, Map<UK, UV>> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return mapState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        mapState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <UK, UV, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> mapState) {
+        return (IS) new ProxyMapState<>((InternalMapState<K, N, UK, UV>) mapState);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyReducingState.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+import java.util.Collection;
+
+/** */
+public class ProxyReducingState<K, N, V> implements InternalReducingState<K, N, V> {
+    InternalReducingState<K, N, V> reducingState;
+
+    ProxyReducingState(InternalReducingState<K, N, V> internalReducingState) {
+        this.reducingState = internalReducingState;
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        reducingState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public V getInternal() throws Exception {
+        return reducingState.getInternal();
+    }
+
+    @Override
+    public void updateInternal(V valueToStore) throws Exception {
+        reducingState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public V get() throws Exception {
+        return reducingState.get();
+    }
+
+    @Override
+    public void add(V value) throws Exception {
+        reducingState.add(value);
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return reducingState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return reducingState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<V> getValueSerializer() {
+        return reducingState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        reducingState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<V> safeValueSerializer)
+            throws Exception {
+        return reducingState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, V> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return reducingState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        reducingState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> reducingState) {
+        return (IS) new ProxyReducingState<>((InternalReducingState<K, N, SV>) reducingState);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyStateBackend.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+
+/** */
+public class ProxyStateBackend implements StateBackend {
+    private static final Logger LOG = LoggerFactory.getLogger(ProxyStateBackend.class);
+
+    final StateBackend proxiedStateBackend;
+
+    public ProxyStateBackend(StateBackend stateBackend) {
+        this.proxiedStateBackend = stateBackend;
+    }
+
+    @Override
+    // this is called when StreamTask create KeyedStateBackend
+    public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws Exception {
+        LOG.debug("createKeyedStateBackend is called");
+        AbstractKeyedStateBackend<K> keyedStateBackend =
+                (AbstractKeyedStateBackend<K>)
+                        proxiedStateBackend.createKeyedStateBackend(
+                                env,
+                                jobID,
+                                operatorIdentifier,
+                                keySerializer,
+                                numberOfKeyGroups,
+                                keyGroupRange,
+                                kvStateRegistry,
+                                ttlTimeProvider,
+                                metricGroup,
+                                stateHandles,
+                                cancelStreamRegistry);
+        return new ProxyKeyedStateBackend<>(
+                keyedStateBackend, env.getExecutionConfig(), ttlTimeProvider);
+    }
+
+    @Override
+    public OperatorStateBackend createOperatorStateBackend(
+            Environment env,
+            String operatorIdentifier,
+            @Nonnull Collection<OperatorStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws Exception {
+        LOG.debug("createOperatorStateBackend is called");
+        return proxiedStateBackend.createOperatorStateBackend(
+                env, operatorIdentifier, stateHandles, cancelStreamRegistry);
+    }
+
+    public StateBackend getProxiedStateBackend() {
+        return proxiedStateBackend;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/proxy/ProxyValueState.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.proxy;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+import java.io.IOException;
+
+/** */
+public class ProxyValueState<K, N, V> implements InternalValueState<K, N, V> {
+    InternalValueState<K, N, V> valueState;
+
+    ProxyValueState(InternalValueState<K, N, V> valueState) {
+        this.valueState = valueState;
+    }
+
+    @Override
+    public V value() throws IOException {
+        return valueState.value();
+    }
+
+    @Override
+    public void update(V value) throws IOException {
+        // Here is where change is forwarded to StateChangeLog
+        valueState.update(value);
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return valueState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return valueState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<V> getValueSerializer() {
+        return valueState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        valueState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<V> safeValueSerializer)
+            throws Exception {
+        return valueState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, V> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return valueState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        valueState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> valueState) {
+        return (IS) new ProxyValueState<>((InternalValueState<K, N, SV>) valueState);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
@@ -29,7 +29,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Tests for the keyed state backend and operator state backend, as created by the {@link
@@ -38,12 +38,16 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class FileStateBackendTest extends StateBackendTestBase<FsStateBackend> {
 
-    @Parameterized.Parameters
-    public static List<Boolean> modes() {
-        return Arrays.asList(true, false);
+    @Parameterized.Parameters(name = "useAsyncmode = {0}, useProxyStateBackend = {1}")
+    public static Collection<Object[]> modes() {
+        return Arrays.asList(
+                new Object[][] {{true, true}, {true, false}, {false, true}, {false, false}});
     }
 
     @Parameterized.Parameter public boolean useAsyncMode;
+
+    @Parameterized.Parameter(1)
+    public boolean useProxyStateBackend;
 
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -61,6 +65,11 @@ public class FileStateBackendTest extends StateBackendTestBase<FsStateBackend> {
     @Override
     protected boolean supportsAsynchronousSnapshots() {
         return useAsyncMode;
+    }
+
+    @Override
+    protected boolean useProxyStateBackend() {
+        return useProxyStateBackend;
     }
 
     // disable these because the verification does not work for this state backend

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -26,18 +26,22 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collection;
 
 /** Tests for the {@link org.apache.flink.runtime.state.memory.MemoryStateBackend}. */
 @RunWith(Parameterized.class)
 public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBackend> {
 
-    @Parameterized.Parameters(name = "useAsyncmode")
-    public static List<Boolean> modes() {
-        return Arrays.asList(true, false);
+    @Parameterized.Parameters(name = "useAsyncmode = {0}, useProxyStateBackend = {1}")
+    public static Collection<Object[]> modes() {
+        return Arrays.asList(
+                new Object[][] {{true, true}, {true, false}, {false, true}, {false, false}});
     }
 
     @Parameterized.Parameter public boolean useAsyncmode;
+
+    @Parameterized.Parameter(1)
+    public boolean useProxyStateBackend;
 
     @Override
     protected MemoryStateBackend getStateBackend() {
@@ -52,6 +56,11 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
     @Override
     protected boolean supportsAsynchronousSnapshots() {
         return useAsyncmode;
+    }
+
+    @Override
+    protected boolean useProxyStateBackend() {
+        return useProxyStateBackend;
     }
 
     // disable these because the verification does not work for this state backend

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -71,6 +71,7 @@ import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.runtime.state.proxy.ProxyStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.types.IntValue;
@@ -181,6 +182,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     protected abstract boolean supportsAsynchronousSnapshots();
 
+    protected abstract boolean useProxyStateBackend();
+
     protected CheckpointStreamFactory createStreamFactory() throws Exception {
         if (checkpointStreamFactory == null) {
             checkpointStreamFactory =
@@ -193,37 +196,51 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         return checkpointStreamFactory;
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer)
-            throws Exception {
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer) throws Exception {
         return createKeyedBackend(keySerializer, env);
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer, Environment env) throws Exception {
         return createKeyedBackend(keySerializer, 10, new KeyGroupRange(0, 9), env);
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,
             KeyGroupRange keyGroupRange,
             Environment env)
             throws Exception {
 
-        AbstractKeyedStateBackend<K> backend =
-                getStateBackend()
-                        .createKeyedStateBackend(
-                                env,
-                                new JobID(),
-                                "test_op",
-                                keySerializer,
-                                numberOfKeyGroups,
-                                keyGroupRange,
-                                env.getTaskKvStateRegistry(),
-                                TtlTimeProvider.DEFAULT,
-                                new UnregisteredMetricsGroup(),
-                                Collections.emptyList(),
-                                new CloseableRegistry());
+        CheckpointableKeyedStateBackend<K> backend =
+                useProxyStateBackend()
+                        ? new ProxyStateBackend(getStateBackend())
+                                .createKeyedStateBackend(
+                                        env,
+                                        new JobID(),
+                                        "test_op",
+                                        keySerializer,
+                                        numberOfKeyGroups,
+                                        keyGroupRange,
+                                        env.getTaskKvStateRegistry(),
+                                        TtlTimeProvider.DEFAULT,
+                                        new UnregisteredMetricsGroup(),
+                                        Collections.emptyList(),
+                                        new CloseableRegistry())
+                        : getStateBackend()
+                                .createKeyedStateBackend(
+                                        env,
+                                        new JobID(),
+                                        "test_op",
+                                        keySerializer,
+                                        numberOfKeyGroups,
+                                        keyGroupRange,
+                                        env.getTaskKvStateRegistry(),
+                                        TtlTimeProvider.DEFAULT,
+                                        new UnregisteredMetricsGroup(),
+                                        Collections.emptyList(),
+                                        new CloseableRegistry());
 
         return backend;
     }
@@ -271,7 +288,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final int namespace1ElementsNum = 1000;
         final int namespace2ElementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             ValueState<Integer> keyedState1 =
@@ -336,7 +354,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testGetKeysAndNamespaces() throws Exception {
         final int elementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             ValueState<Integer> keyedState1 =
@@ -384,7 +403,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoDefaultSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         // cast because our test serializer is not typed to TestPojo
@@ -450,7 +469,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoDefaultSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         // cast because our test serializer is not typed to TestPojo
@@ -518,7 +537,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         env.getExecutionConfig()
                 .registerTypeWithKryoSerializer(
@@ -582,7 +601,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         env.getExecutionConfig()
@@ -655,7 +674,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithRegisteredType() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         TypeInformation<TestPojo> pojoType = new GenericTypeInfo<>(TestPojo.class);
@@ -727,7 +746,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithDefaultSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
 
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE, env);
@@ -853,7 +872,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
 
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE, env);
@@ -968,7 +987,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         env.getExecutionConfig().registerKryoType(TestNestedPojoClassA.class);
         env.getExecutionConfig().registerKryoType(TestNestedPojoClassB.class);
 
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         try {
@@ -1097,7 +1116,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         env.getExecutionConfig().registerPojoType(TestNestedPojoClassA.class);
         env.getExecutionConfig().registerPojoType(TestNestedPojoClassB.class);
 
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         try {
@@ -1192,7 +1211,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testValueState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -1393,7 +1413,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testValueStateWorkWithTtl() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             ValueStateDescriptor<MutableLong> kvId =
                     new ValueStateDescriptor<>("id", MutableLong.class);
@@ -1419,7 +1440,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testValueStateRace() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
         final Integer namespace = 1;
 
@@ -1549,7 +1570,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMultipleValueStates() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, 1, new KeyGroupRange(0, 0), env);
 
         ValueStateDescriptor<String> desc1 =
@@ -1637,7 +1658,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<Long> kvId =
                 new ValueStateDescriptor<>("id", LongSerializer.INSTANCE, 42L);
@@ -1692,7 +1714,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testListState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -1917,7 +1940,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -1945,7 +1968,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddAllNullEntries() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -1978,7 +2001,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddAllNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2006,7 +2029,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateUpdateNullEntries() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2039,7 +2062,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateUpdateNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2064,7 +2087,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testListStateAPIs() throws Exception {
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2140,7 +2163,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testListStateMerging() throws Exception {
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2260,7 +2283,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testReducingState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ReducingStateDescriptor<String> kvId =
                 new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
@@ -2466,7 +2490,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final ReducingStateDescriptor<Long> stateDescr =
                 new ReducingStateDescriptor<>("my-state", (a, b) -> a + b, Long.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2529,7 +2553,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2644,7 +2668,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new AggregatingStateDescriptor<>(
                         "my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2708,7 +2732,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2823,7 +2847,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new AggregatingStateDescriptor<>(
                         "my-state", new ImmutableAggregatingAddingFunction(), Long.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2887,7 +2911,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -3000,7 +3024,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMapState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<String> backend = createKeyedBackend(StringSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<String> backend =
+                createKeyedBackend(StringSerializer.INSTANCE);
 
         MapStateDescriptor<Integer, String> kvId =
                 new MapStateDescriptor<>("id", Integer.class, String.class);
@@ -3332,7 +3357,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         MapStateDescriptor<Integer, Long> kvId =
                 new MapStateDescriptor<>("id", Integer.class, Long.class);
 
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapState<Integer, Long> state =
@@ -3367,7 +3393,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         MapStateDescriptor<Integer, Long> kvId =
                 new MapStateDescriptor<>("id", Integer.class, Long.class);
 
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapState<Integer, Long> state =
@@ -3411,7 +3438,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that {@link ValueStateDescriptor} allows {@code null} as default. */
     @Test
     public void testValueStateNullAsDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
 
@@ -3434,7 +3462,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ValueState} will yield the default value. */
     @Test
     public void testValueStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, "Hello");
 
@@ -3457,7 +3486,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ReduceState} yields {@code null}. */
     @Test
     public void testReducingStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ReducingStateDescriptor<String> kvId =
                 new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
@@ -3481,7 +3511,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ListState} yields {@code null}. */
     @Test
     public void testListStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -3504,7 +3535,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code MapState} yields {@code null}. */
     @Test
     public void testMapStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         MapStateDescriptor<String, String> kvId =
                 new MapStateDescriptor<>("id", String.class, String.class);
@@ -3535,7 +3567,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testSnapshotNonAccessedState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<String> backend = createKeyedBackend(StringSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<String> backend =
+                createKeyedBackend(StringSerializer.INSTANCE);
 
         final String stateName = "test-name";
         try {
@@ -3680,7 +3713,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         List<KeyGroupRange> keyGroupRanges = new ArrayList<>();
-        List<AbstractKeyedStateBackend<Integer>> stateBackends = new ArrayList<>();
+        List<CheckpointableKeyedStateBackend<Integer>> stateBackends = new ArrayList<>();
         for (int i = 0; i < sourceParallelism; ++i) {
             keyGroupRanges.add(
                     KeyGroupRange.of(
@@ -3702,7 +3735,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         List<Integer> keyInKeyGroups = new ArrayList<>(maxParallelism);
         List<String> expectedValue = new ArrayList<>(maxParallelism);
         for (int i = 0; i < sourceParallelism; ++i) {
-            AbstractKeyedStateBackend<Integer> backend = stateBackends.get(i);
+            CheckpointableKeyedStateBackend<Integer> backend = stateBackends.get(i);
             KeyGroupRange range = keyGroupRanges.get(i);
             for (int j = range.getStartKeyGroup(); j <= range.getEndKeyGroup(); ++j) {
                 ValueState<String> state =
@@ -3756,11 +3789,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
 
         // restore and verify
-        List<AbstractKeyedStateBackend<Integer>> targetBackends =
+        List<CheckpointableKeyedStateBackend<Integer>> targetBackends =
                 new ArrayList<>(targetParallelism);
 
         for (int i = 0; i < targetParallelism; ++i) {
-            AbstractKeyedStateBackend<Integer> backend =
+            CheckpointableKeyedStateBackend<Integer> backend =
                     restoreKeyedBackend(
                             IntSerializer.INSTANCE,
                             maxParallelism,
@@ -3794,7 +3827,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
         // use an IntSerializer at first
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -3837,7 +3871,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testValueStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
@@ -3893,7 +3928,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testListStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
@@ -3948,7 +3984,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testReducingStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ReducingStateDescriptor<String> kvId =
@@ -4007,7 +4044,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMapStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapStateDescriptor<String, String> kvId =
@@ -4064,7 +4102,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testCopyDefaultValue() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<IntValue> kvId =
@@ -4094,7 +4132,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testRequireNonNullNamespace() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<IntValue> kvId =
@@ -4128,7 +4166,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     protected void testConcurrentMapIfQueryable() throws Exception {
         final int numberOfKeyGroups = 1;
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(
                         IntSerializer.INSTANCE,
                         numberOfKeyGroups,
@@ -4260,7 +4298,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         KeyGroupRange expectedKeyGroupRange = backend.getKeyGroupRange();
 
@@ -4324,7 +4362,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         try {
             CheckpointStreamFactory streamFactory = createStreamFactory();
             SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-            AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+            CheckpointableKeyedStateBackend<Integer> backend =
+                    createKeyedBackend(IntSerializer.INSTANCE);
 
             ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -4351,7 +4390,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testNumStateEntries() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -4406,7 +4446,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         streamFactory.setBlockerLatch(blocker);
         streamFactory.setAfterNumberInvocations(10);
 
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
@@ -4476,7 +4516,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testNonConcurrentSnapshotTransformerAccess() throws Exception {
         BlockerCheckpointStreamFactory streamFactory =
                 new BlockerCheckpointStreamFactory(1024 * 1024);
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE);
             new StateSnapshotTransformerTest(backend, streamFactory)
@@ -4496,7 +4536,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new BlockerCheckpointStreamFactory(1024 * 1024);
         streamFactory.setWaiterLatch(waiter);
 
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
         KeyedStateHandle stateHandle = null;
 
         try {
@@ -4585,7 +4625,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testConcurrentModificationWithApplyToAllKeys() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> listStateDescriptor =
@@ -4673,7 +4714,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testApplyToAllKeysLambdaFunction() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> listStateDescriptor =
@@ -4713,7 +4755,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         streamFactory.setBlockerLatch(blocker);
         streamFactory.setAfterNumberInvocations(10);
 
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
@@ -4772,7 +4814,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final int namespace1ElementsNum = 1000;
         final int namespace2ElementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             MapState<String, Integer> keyedState1 =
@@ -4841,7 +4884,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testCheckConcurrencyProblemWhenPerformingCheckpointAsync() throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         ExecutorService executorService = Executors.newScheduledThreadPool(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -42,12 +42,12 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 class StateSnapshotTransformerTest {
-    private final AbstractKeyedStateBackend<Integer> backend;
+    private final CheckpointableKeyedStateBackend<Integer> backend;
     private final BlockerCheckpointStreamFactory streamFactory;
     private final StateSnapshotTransformFactory<?> snapshotTransformFactory;
 
     StateSnapshotTransformerTest(
-            AbstractKeyedStateBackend<Integer> backend,
+            CheckpointableKeyedStateBackend<Integer> backend,
             BlockerCheckpointStreamFactory streamFactory) {
 
         this.backend = backend;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -215,6 +215,12 @@ class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedStateBack
         return keySelectionListeners.remove(listener);
     }
 
+    @Override
+    public int numKeyValueStateEntries() {
+        throw new UnsupportedOperationException(
+                "numKeyValueStateEntries not supported in BATCH runtime mode");
+    }
+
     @Nonnull
     @Override
     public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1141,7 +1141,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         final StateBackend fromApplication =
                 configuration.getStateBackend(getUserCodeClassLoader());
 
-        return StateBackendLoader.fromApplicationOrConfigOrDefault(
+        return StateBackendLoader.loadStateBackend(
                 fromApplication,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),
                 getUserCodeClassLoader(),


### PR DESCRIPTION
## What is the purpose of the change

This change is to wrap the existing state backend so that we can (in the future) forward state changes to StateChangeLog as well as state updating.

## Couple of things to highlight
1. We only provide a way to enable ProxyStateBackend through "state.backend.enable-statechangelog". We do not want to expose ProxyStateBackend directly to users, so we do not support things like:
           `evn.setStateBackend(new ProxyStateBackend(...))`
Besides the effort to disentangle CheckpointStorage from StateBackend is ongoing. So we want to make the loading wrapper as simple as possible for now, which is in
           `StateBackendLoader.loadStateBackend`

2. we should wrap the access to states when updating them, and such states access entries are maintained in `AbstractKeyedStateBackend<K>` through
`private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName; `
Such `InternalKvState` should be a `ProxyXXXState` in `ProxyKeyedStateBackend`.

3. Other functionalities are delegated to the underlying wrapped state backend. So, we should have 
`ProxyKeyedStateBackend` wrapped on a `Heap/RocksDBKeyedStateBackend`

4. Notice that ProxyKeyedStateBackend access `ProxyXXXState`, while its wrapped Heap/RocksDBKeyedStateBackend operates on the wrapped `Heap/RocksDBXXXState`, so the underlying real state is the same one. So the proxy state creation has to go through Heap/RocksDBKeyedStateBackend.createState

5. Physical holding of states are backend specific, through
`private final Map<String, StateTable<K, ?, ?>> registeredKVStates;`

## Things need to improve
Heap/RocksDBKeyedStateBackend have an individual `private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName; `, while the map is empty when Heap/RocksDBKeyedStateBackend is wrapped. In the wrapped case, the map is maintained in ProxyKeyedStateBackend.

This is ugly, and easy to lead to error. We should improve it. On the other hand, not sure how to combine the map? They are indeed different.

## Things to do
1. There are a lot of rocksdb test case failure after enable "state.backend.enable-statechangelog" by default. Need to investigate.
2. How the ttl wraper works with the wrapper. Need better understaning.