### PR TITLE
[FLINK-21199][python] Introduce InternalTimerService In PyFlink

### DIFF
--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -79,7 +79,8 @@ from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, 
 from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.datastream.time_domain import TimeDomain
-from pyflink.datastream.functions import ProcessFunction, TimerService
+from pyflink.datastream.functions import ProcessFunction
+from pyflink.datastream.timerservice import TimerService
 
 __all__ = [
     'StreamExecutionEnvironment',

--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -25,6 +25,7 @@ from py4j.java_gateway import JavaObject
 from pyflink.datastream.state import ValueState, ValueStateDescriptor, ListStateDescriptor, \
     ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState
 from pyflink.datastream.time_domain import TimeDomain
+from pyflink.datastream.timerservice import TimerService
 from pyflink.java_gateway import get_gateway
 
 __all__ = [
@@ -602,76 +603,6 @@ class SinkFunction(JavaFunctionWrapper):
         :param sink_func: The java SinkFunction object or the full name of the SinkFunction class.
         """
         super(SinkFunction, self).__init__(sink_func)
-
-
-class TimerService(abc.ABC):
-    """
-    Interface for working with time and timers.
-    """
-
-    @abc.abstractmethod
-    def current_processing_time(self):
-        """
-        Returns the current processing time.
-        """
-        pass
-
-    @abc.abstractmethod
-    def current_watermark(self):
-        """
-        Returns the current event-time watermark.
-        """
-        pass
-
-    @abc.abstractmethod
-    def register_processing_time_timer(self, time: int):
-        """
-        Registers a timer to be fired when processing time passes the given time.
-
-        Timers can internally be scoped to keys and/or windows. When you set a timer in a keyed
-        context, such as in an operation on KeyedStream then that context will so be active when you
-        receive the timer notification.
-
-        :param time: The processing time of the timer to be registered.
-        """
-        pass
-
-    @abc.abstractmethod
-    def register_event_time_timer(self, time: int):
-        """
-        Registers a timer tobe fired when the event time watermark passes the given time.
-
-        Timers can internally be scoped to keys and/or windows. When you set a timer in a keyed
-        context, such as in an operation on KeyedStream then that context will so be active when you
-        receive the timer notification.
-
-        :param time: The event time of the timer to be registered.
-        """
-        pass
-
-    def delete_processing_time_timer(self, time: int):
-        """
-        Deletes the processing-time timer with the given trigger time. This method has only an
-        effect if such a timer was previously registered and did not already expire.
-
-        Timers can internally be scoped to keys and/or windows. When you delete a timer, it is
-        removed from the current keyed context.
-
-        :param time: The given trigger time of timer to be deleted.
-        """
-        pass
-
-    def delete_event_time_timer(self, time: int):
-        """
-        Deletes the event-time timer with the given trigger time. This method has only an effect if
-        such a timer was previously registered and did not already expire.
-
-        Timers can internally be scoped to keys and/or windows. When you delete a timer, it is
-        removed from the current keyed context.
-
-        :param time: The given trigger time of timer to be deleted.
-        """
-        pass
 
 
 class ProcessFunction(Function):

--- a/flink-python/pyflink/datastream/timerservice.py
+++ b/flink-python/pyflink/datastream/timerservice.py
@@ -1,0 +1,247 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import time
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import TypeVar, Generic, List, Tuple
+
+K = TypeVar('K')
+N = TypeVar('N')
+
+
+class TimerService(ABC):
+    """
+    Interface for working with time and timers.
+    """
+
+    @abstractmethod
+    def current_processing_time(self):
+        """
+        Returns the current processing time.
+        """
+        pass
+
+    @abstractmethod
+    def current_watermark(self):
+        """
+        Returns the current event-time watermark.
+        """
+        pass
+
+    @abstractmethod
+    def register_processing_time_timer(self, timestamp: int):
+        """
+        Registers a timer to be fired when processing time passes the given time.
+
+        Timers can internally be scoped to keys and/or windows. When you set a timer in a keyed
+        context, such as in an operation on KeyedStream then that context will so be active when you
+        receive the timer notification.
+
+        :param timestamp: The processing time of the timer to be registered.
+        """
+        pass
+
+    @abstractmethod
+    def register_event_time_timer(self, timestamp: int):
+        """
+        Registers a timer tobe fired when the event time watermark passes the given time.
+
+        Timers can internally be scoped to keys and/or windows. When you set a timer in a keyed
+        context, such as in an operation on KeyedStream then that context will so be active when you
+        receive the timer notification.
+
+        :param timestamp: The event time of the timer to be registered.
+        """
+        pass
+
+    def delete_processing_time_timer(self, timestamp: int):
+        """
+        Deletes the processing-time timer with the given trigger time. This method has only an
+        effect if such a timer was previously registered and did not already expire.
+
+        Timers can internally be scoped to keys and/or windows. When you delete a timer, it is
+        removed from the current keyed context.
+
+        :param timestamp: The given trigger time of timer to be deleted.
+        """
+        pass
+
+    def delete_event_time_timer(self, timestamp: int):
+        """
+        Deletes the event-time timer with the given trigger time. This method has only an effect if
+        such a timer was previously registered and did not already expire.
+
+        Timers can internally be scoped to keys and/or windows. When you delete a timer, it is
+        removed from the current keyed context.
+
+        :param timestamp: The given trigger time of timer to be deleted.
+        """
+        pass
+
+
+class InternalTimerService(Generic[N], ABC):
+    """
+    Interface for working with time and timers.
+
+    This is the internal version of TimerService that allows to specify a key and a namespace to
+    which timers should be scoped.
+    """
+
+    @abstractmethod
+    def current_processing_time(self):
+        """
+        Returns the current processing time.
+        """
+        pass
+
+    @abstractmethod
+    def current_watermark(self):
+        """
+        Returns the current event-time watermark.
+        """
+        pass
+
+    @abstractmethod
+    def register_processing_time_timer(self, namespace: N, t: int):
+        """
+        Registers a timer to be fired when processing time passes the given time. The namespace you
+        pass here will be provided when the timer fires.
+
+        :param namespace: The namespace you pass here will be provided when the timer fires.
+        :param t: The processing time of the timer to be registered.
+        """
+        pass
+
+    @abstractmethod
+    def register_event_time_timer(self, namespace: N, t: int):
+        """
+        Registers a timer to be fired when event time watermark passes the given time. The namespace
+        you pass here will be provided when the timer fires.
+
+        :param namespace: The namespace you pass here will be provided when the timer fires.
+        :param t: The event time of the timer to be registered.
+        """
+        pass
+
+    def delete_processing_time_timer(self, namespace: N, t: int):
+        """
+        Deletes the timer for the given key and namespace.
+
+        :param namespace: The namespace you pass here will be provided when the timer fires.
+        :param t: The given trigger time of timer to be deleted.
+        """
+        pass
+
+    def delete_event_time_timer(self, namespace: N, t: int):
+        """
+        Deletes the timer for the given key and namespace.
+
+        :param namespace: The namespace you pass here will be provided when the timer fires.
+        :param t: The given trigger time of timer to be deleted.
+        """
+        pass
+
+
+class InternalTimer(Generic[K, N], ABC):
+
+    @abstractmethod
+    def get_timestamp(self) -> int:
+        """
+        Returns the timestamp of the timer. This value determines the point in time when the timer
+        will fire.
+        """
+        pass
+
+    @abstractmethod
+    def get_key(self) -> K:
+        """
+        Returns the key that is bound to this timer.
+        """
+        pass
+
+    @abstractmethod
+    def get_namespace(self) -> N:
+        """
+        Returns the namespace that is bound to this timer.
+        :return:
+        """
+        pass
+
+
+class InternalTimerImpl(InternalTimer[K, N]):
+
+    def __init__(self, timestamp: int, key: K, namespace: N):
+        self._timestamp = timestamp
+        self._key = key
+        self._namespace = namespace
+
+    def get_timestamp(self) -> int:
+        return self._timestamp
+
+    def get_key(self) -> K:
+        return self._key
+
+    def get_namespace(self) -> N:
+        return self._namespace
+
+
+class TimerOperandType(Enum):
+    REGISTER_EVENT_TIMER = 0
+    REGISTER_PROC_TIMER = 1
+    DELETE_EVENT_TIMER = 2
+    DELETE_PROC_TIMER = 3
+
+
+class InternalTimerServiceImpl(InternalTimerService[N]):
+    """
+    Internal implementation of InternalTimerService.
+    """
+
+    def __init__(self, keyed_state_backend):
+        self._keyed_state_backend = keyed_state_backend
+        self._current_watermark = None
+        self.timers = []  # type: List[Tuple[TimerOperandType, InternalTimer]]
+
+    def current_processing_time(self):
+        return int(time.time() * 1000)
+
+    def current_watermark(self):
+        return self._current_watermark
+
+    def advance_watermark(self, watermark: int):
+        self._current_watermark = watermark
+
+    def register_processing_time_timer(self, namespace: N, t: int):
+        current_key = self._keyed_state_backend.get_current_key()
+        self.timers.append(
+            (TimerOperandType.REGISTER_PROC_TIMER, InternalTimerImpl(t, current_key, namespace)))
+
+    def register_event_time_timer(self, namespace: N, t: int):
+        current_key = self._keyed_state_backend.get_current_key()
+        self.timers.append(
+            (TimerOperandType.REGISTER_EVENT_TIMER, InternalTimerImpl(t, current_key, namespace)))
+
+    def delete_processing_time_timer(self, namespace: N, t: int):
+        current_key = self._keyed_state_backend.get_current_key()
+        self.timers.append(
+            (TimerOperandType.DELETE_PROC_TIMER, InternalTimerImpl(t, current_key, namespace)))
+
+    def delete_event_time_timer(self, namespace: N, t: int):
+        current_key = self._keyed_state_backend.get_current_key()
+        self.timers.append(
+            (TimerOperandType.DELETE_EVENT_TIMER, InternalTimerImpl(t, current_key, namespace)))

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -25,9 +25,8 @@ from apache_beam.coders import PickleCoder
 
 from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
     ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState
-from pyflink.datastream import TimeDomain
-from pyflink.datastream.functions import RuntimeContext, TimerService, ProcessFunction, \
-    KeyedProcessFunction
+from pyflink.datastream import TimeDomain, TimerService
+from pyflink.datastream.functions import RuntimeContext, ProcessFunction, KeyedProcessFunction
 from pyflink.fn_execution import flink_fn_execution_pb2, operation_utils
 from pyflink.fn_execution.aggregate import extract_data_view_specs
 from pyflink.fn_execution.beam.beam_coders import DataViewFilterCoder


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will introduce InternalTimerService In PyFlink*


## Brief change log

  - *Introduce `InternalTimerService`*

## Verifying this change

This change added tests and can be verified as follows:

  - *`InternalTimerServiceImpl` won't be used currently, and the related tests will be added in the PR of python general group window agg operation*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
