### PR TITLE
[FLINK-10520][rest] Properly handle optional savepoint parameters

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -42,10 +42,9 @@ public class SavepointTriggerRequestBody implements RequestBody {
     @JsonCreator
     public SavepointTriggerRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-            @JsonProperty(value = FIELD_NAME_CANCEL_JOB, defaultValue = "false")
-                    final boolean cancelJob) {
+            @Nullable @JsonProperty(FIELD_NAME_CANCEL_JOB) final Boolean cancelJob) {
         this.targetDirectory = targetDirectory;
-        this.cancelJob = cancelJob;
+        this.cancelJob = cancelJob != null ? cancelJob : false;
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/stop/StopWithSavepointRequestBody.java
@@ -42,9 +42,9 @@ public class StopWithSavepointRequestBody implements RequestBody {
     @JsonCreator
     public StopWithSavepointRequestBody(
             @Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-            @JsonProperty(value = FIELD_NAME_DRAIN, defaultValue = "false") final boolean drain) {
+            @Nullable @JsonProperty(FIELD_NAME_DRAIN) final Boolean drain) {
         this.targetDirectory = targetDirectory;
-        this.drain = drain;
+        this.drain = drain != null ? drain : false;
     }
 
     @Nullable

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SavepointHandlerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SavepointHandlerRequestBodyTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.stop.StopWithSavepointRequestBody;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the savepoint request bodies. */
+public class SavepointHandlerRequestBodyTest {
+
+    @Test
+    public void testSavepointRequestCanBeParsedFromEmptyObject() throws JsonProcessingException {
+        final SavepointTriggerRequestBody defaultParseResult =
+                getDefaultParseResult(SavepointTriggerRequestBody.class);
+
+        assertThat(defaultParseResult.isCancelJob(), is(false));
+
+        assertThat(defaultParseResult.getTargetDirectory(), nullValue());
+    }
+
+    @Test
+    public void testStopWithSavepointRequestCanBeParsedFromEmptyObject()
+            throws JsonProcessingException {
+        final StopWithSavepointRequestBody defaultParseResult =
+                getDefaultParseResult(StopWithSavepointRequestBody.class);
+
+        assertThat(defaultParseResult.shouldDrain(), is(false));
+
+        assertThat(defaultParseResult.getTargetDirectory(), nullValue());
+    }
+
+    private static <T> T getDefaultParseResult(Class<T> clazz) throws JsonProcessingException {
+        final ObjectMapper mapper = RestMapperUtils.getStrictObjectMapper();
+        return mapper.readValue("{}", clazz);
+    }
+}


### PR DESCRIPTION
The parameter for triggering savepoints (the `targetDirectory` and whether the job should be canceled/drained) are supposed to be optional, but this is not working as expected because we fail on missing primitives.
I assume the expectation was that the `defaultValue` attribute of the `JsonProperty` annotation would handle it, but as it turns out this is just for documentation purposes.

To fix it we no longer use primitives.
We could also disable `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES`, but ain't no one got time to ensure this doesn't break anything for other bodies.