### PR TITLE
[FLINK-9844][client] PackagedProgram#close() closes ClassLoader 

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -89,7 +90,7 @@ public class PackagedProgram implements AutoCloseable {
 
     private final List<URL> classpaths;
 
-    private final ClassLoader userCodeClassLoader;
+    private final URLClassLoader userCodeClassLoader;
 
     private final SavepointRestoreSettings savepointSettings;
 
@@ -624,6 +625,11 @@ public class PackagedProgram implements AutoCloseable {
 
     @Override
     public void close() {
+        try {
+            userCodeClassLoader.close();
+        } catch (IOException e) {
+            LOG.debug("Error while closing user-code classloader.", e);
+        }
         try {
             deleteExtractedLibraries();
         } catch (Exception e) {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
@@ -22,12 +22,9 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
-import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -50,13 +47,6 @@ public class JarSubmissionITCase extends TestLogger {
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Rule public final BlobServerResource blobServerResource = new BlobServerResource();
-
-    @BeforeClass
-    public static void checkOS() {
-        Assume.assumeFalse(
-                "This test fails on Windows due to unclosed JarFiles, see FLINK-9844.",
-                OperatingSystem.isWindows());
-    }
 
     @Test
     public void testJarSubmission() throws Exception {


### PR DESCRIPTION
The `PackagedProgram` now uses a `URLClassLoader`, giving us access to the close() method with which we can close the jar files that the class loader uses.