### PR TITLE
[FLINK-21207] Fix source table with 'csv.disable-quote-character' = 'true' can not take effect

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
@@ -193,10 +193,14 @@ public final class CsvFormatFactory
                 .map(delimiter -> StringEscapeUtils.unescapeJava(delimiter).charAt(0))
                 .ifPresent(schemaBuilder::setFieldDelimiter);
 
-        formatOptions
-                .getOptional(QUOTE_CHARACTER)
-                .map(quote -> quote.charAt(0))
-                .ifPresent(schemaBuilder::setQuoteCharacter);
+        if (formatOptions.get(DISABLE_QUOTE_CHARACTER)) {
+            schemaBuilder.disableQuoteCharacter();
+        } else {
+            formatOptions
+                    .getOptional(QUOTE_CHARACTER)
+                    .map(quote -> quote.charAt(0))
+                    .ifPresent(schemaBuilder::setQuoteCharacter);
+        }
 
         formatOptions.getOptional(ALLOW_COMMENTS).ifPresent(schemaBuilder::setAllowComments);
 
@@ -244,3 +248,4 @@ public final class CsvFormatFactory
         formatOptions.getOptional(NULL_LITERAL).ifPresent(schemaBuilder::setNullLiteral);
     }
 }
+

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
@@ -248,4 +248,3 @@ public final class CsvFormatFactory
         formatOptions.getOptional(NULL_LITERAL).ifPresent(schemaBuilder::setNullLiteral);
     }
 }
-

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -114,6 +114,11 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
             return this;
         }
 
+        public Builder disableQuoteCharacter() {
+            this.csvSchema = this.csvSchema.rebuild().disableQuoteChar().build();
+            return this;
+        }
+
         public Builder setQuoteCharacter(char c) {
             this.csvSchema = this.csvSchema.rebuild().setQuoteChar(c).build();
             return this;
@@ -204,3 +209,4 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
                 csvSchema.getNullValue());
     }
 }
+

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -209,4 +209,3 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
                 csvSchema.getNullValue());
     }
 }
-

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -100,6 +100,20 @@ public class CsvFormatFactoryTest extends TestLogger {
                             opts.remove("csv.quote-character");
                         });
 
+        final CsvRowDataDeserializationSchema expectedDeser =
+                new CsvRowDataDeserializationSchema.Builder(ROW_TYPE, InternalTypeInfo.of(ROW_TYPE))
+                        .setFieldDelimiter(';')
+                        .setAllowComments(true)
+                        .setIgnoreParseErrors(true)
+                        .setArrayElementDelimiter("|")
+                        .setEscapeCharacter('\\')
+                        .setNullLiteral("n/a")
+                        .disableQuoteCharacter()
+                        .build();
+        DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
+
+        assertEquals(expectedDeser, actualDeser);
+
         final CsvRowDataSerializationSchema expectedSer =
                 new CsvRowDataSerializationSchema.Builder(ROW_TYPE)
                         .setFieldDelimiter(';')

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFormatFactoryTest.java
@@ -207,6 +207,29 @@ public class CsvFormatFactoryTest extends TestLogger {
     }
 
     @Test
+    public void testDeserializeWithDisableQuoteCharacter() throws IOException {
+        // test deserialization schema
+        final Map<String, String> options =
+                getModifiedOptions(
+                        opts -> {
+                            opts.put("csv.disable-quote-character", "true");
+                            opts.remove("csv.quote-character");
+                        });
+
+        final DynamicTableSource actualSource = createTableSource(options);
+        assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
+        TestDynamicTableFactory.DynamicTableSourceMock sourceMock =
+                (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
+
+        DeserializationSchema<RowData> deserializationSchema =
+                sourceMock.valueFormat.createRuntimeDecoder(
+                        ScanRuntimeProviderContext.INSTANCE, SCHEMA.toRowDataType());
+        RowData expected = GenericRowData.of(fromString("\"abc"), 123, false);
+        RowData actual = deserializationSchema.deserialize("\"abc;123;false".getBytes());
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void testInvalidIgnoreParseError() {
         thrown.expect(ValidationException.class);
         thrown.expect(

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -300,24 +300,12 @@ public class CsvRowDataSerDeSchemaTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testDeserializationWithDisableQuoteCharacter() throws Exception {
-        DataType dataType =
-                ROW(FIELD("f0", STRING()), FIELD("f1", STRING()), FIELD("f2", STRING()));
-        RowType rowType = (RowType) dataType.getLogicalType();
-        String csv = "BEGIN,\"abc,END";
-        Row expectedRow = Row.of("BEGIN", "\"abc", "END");
+        Consumer<CsvRowDataDeserializationSchema.Builder> deserConfig =
+                (deserSchemaBuilder) ->
+                        deserSchemaBuilder.disableQuoteCharacter().setFieldDelimiter(',');
 
-        // deserialization
-        CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
-                new CsvRowDataDeserializationSchema.Builder(rowType, InternalTypeInfo.of(rowType));
-        deserSchemaBuilder.disableQuoteCharacter();
-        RowData deserializedRow = deserialize(deserSchemaBuilder, csv);
-        Row actualRow =
-                (Row)
-                        DataFormatConverters.getConverterForDataType(dataType)
-                                .toExternal(deserializedRow);
-        assertEquals(expectedRow, actualRow);
+        testFieldDeserialization(STRING(), "\"abc", "\"abc", deserConfig, ",");
     }
 
     private void testNullableField(DataType fieldType, String string, Object value)

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -299,6 +299,27 @@ public class CsvRowDataSerDeSchemaTest {
         testSerDeConsistency(nullRow, serSchemaBuilder, deserSchemaBuilder);
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDeserializationWithDisableQuoteCharacter() throws Exception {
+        DataType dataType =
+                ROW(FIELD("f0", STRING()), FIELD("f1", STRING()), FIELD("f2", STRING()));
+        RowType rowType = (RowType) dataType.getLogicalType();
+        String csv = "BEGIN,\"abc,END";
+        Row expectedRow = Row.of("BEGIN", "\"abc", "END");
+
+        // deserialization
+        CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
+                new CsvRowDataDeserializationSchema.Builder(rowType, InternalTypeInfo.of(rowType));
+        deserSchemaBuilder.disableQuoteCharacter();
+        RowData deserializedRow = deserialize(deserSchemaBuilder, csv);
+        Row actualRow =
+                (Row)
+                        DataFormatConverters.getConverterForDataType(dataType)
+                                .toExternal(deserializedRow);
+        assertEquals(expectedRow, actualRow);
+    }
+
     private void testNullableField(DataType fieldType, String string, Object value)
             throws Exception {
         testField(


### PR DESCRIPTION
## What is the purpose of the change
Fix source table with 'csv.disable-quote-character' = 'true' can not take effect.
```
Caused by: org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException: Missing closing quote for value
 at [Source: UNKNOWN; line: 1, column: 29]
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1840)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:712)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvParser._reportParsingError(CsvParser.java:1250)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.impl.CsvDecoder._nextQuotedString(CsvDecoder.java:785)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.impl.CsvDecoder.nextString(CsvDecoder.java:630)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvParser._handleNextEntry(CsvParser.java:846)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvParser.nextFieldName(CsvParser.java:665)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:249)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:68)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:15)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1719)
	at org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1282)
	at org.apache.flink.formats.csv.CsvRowDataDeserializationSchema.deserialize(CsvRowDataDeserializationSchema.java:155)
	... 30 more
```

## Brief change log
* Invoke `disableQuoteChar` of `CsvSchema` when 'disable-quote-character' is enabled

## Verifying this change
This change added tests and can be verified as follows:

* It can be verified in `CsvFormatFactoryTest#testDeserializeWithDisableQuoteCharacter`.

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
* The S3 file system connector: (no)

## Documentation
* Does this pull request introduce a new feature? (no)
* If yes, how is the feature documented? (not applicable)
