### PR TITLE
[FLINK-21085][runtime][checkpoint] Allows triggering checkpoint for non-source tasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -22,11 +22,15 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
 import java.io.IOException;
+import java.util.List;
 
 /** An {@link InputGate} with a specific index. */
 public abstract class IndexedInputGate extends InputGate implements CheckpointableInput {
     /** Returns the index of this input gate. Only supported on */
     public abstract int getGateIndex();
+
+    /** Returns the list of channels that have not received EndOfPartitionEvent. */
+    public abstract List<InputChannelInfo> getUnfinishedChannels();
 
     @Override
     public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -350,6 +350,22 @@ public class SingleInputGate extends IndexedInputGate {
         return gateIndex;
     }
 
+    @Override
+    public List<InputChannelInfo> getUnfinishedChannels() {
+        List<InputChannelInfo> unfinishedChannels =
+                new ArrayList<>(
+                        numberOfInputChannels - channelsWithEndOfPartitionEvents.cardinality());
+        synchronized (inputChannelsWithData) {
+            for (int i = channelsWithEndOfPartitionEvents.nextClearBit(0);
+                    i < numberOfInputChannels;
+                    i = channelsWithEndOfPartitionEvents.nextClearBit(i + 1)) {
+                unfinishedChannels.add(getChannel(i).getChannelInfo());
+            }
+        }
+
+        return unfinishedChannels;
+    }
+
     /**
      * Returns the type of this input channel's consumed result partition.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -72,6 +73,11 @@ public class InputGateWithMetrics extends IndexedInputGate {
     @Override
     public int getGateIndex() {
         return inputGate.getGateIndex();
+    }
+
+    @Override
+    public List<InputChannelInfo> getUnfinishedChannels() {
+        return inputGate.getUnfinishedChannels();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -67,6 +67,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -883,6 +885,48 @@ public class SingleInputGateTest extends InputGateTestBase {
                 assertEquals(channelCounter++, channelInfo.getInputChannelIdx());
             }
         }
+    }
+
+    @Test
+    public void testGetUnfinishedChannels() throws IOException, InterruptedException {
+        SingleInputGate inputGate =
+                new SingleInputGateBuilder()
+                        .setSingleInputGateIndex(1)
+                        .setNumberOfChannels(3)
+                        .build();
+        final TestInputChannel[] inputChannels =
+                new TestInputChannel[] {
+                    new TestInputChannel(inputGate, 0),
+                    new TestInputChannel(inputGate, 1),
+                    new TestInputChannel(inputGate, 2)
+                };
+        inputGate.setInputChannels(inputChannels);
+
+        assertEquals(
+                Arrays.asList(
+                        inputChannels[0].getChannelInfo(),
+                        inputChannels[1].getChannelInfo(),
+                        inputChannels[2].getChannelInfo()),
+                inputGate.getUnfinishedChannels());
+
+        inputChannels[1].readEndOfPartitionEvent();
+        inputGate.notifyChannelNonEmpty(inputChannels[1]);
+        inputGate.getNext();
+        assertEquals(
+                Arrays.asList(inputChannels[0].getChannelInfo(), inputChannels[2].getChannelInfo()),
+                inputGate.getUnfinishedChannels());
+
+        inputChannels[0].readEndOfPartitionEvent();
+        inputGate.notifyChannelNonEmpty(inputChannels[0]);
+        inputGate.getNext();
+        assertEquals(
+                Collections.singletonList(inputChannels[2].getChannelInfo()),
+                inputGate.getUnfinishedChannels());
+
+        inputChannels[2].readEndOfPartitionEvent();
+        inputGate.notifyChannelNonEmpty(inputChannels[2]);
+        inputGate.getNext();
+        assertEquals(Collections.emptyList(), inputGate.getUnfinishedChannels());
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
@@ -36,12 +36,9 @@ import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
-
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -55,57 +52,6 @@ import java.util.stream.Stream;
  */
 @Internal
 public class InputProcessorUtil {
-    @SuppressWarnings("unchecked")
-    public static CheckpointedInputGate createCheckpointedInputGate(
-            AbstractInvokable toNotifyOnCheckpoint,
-            StreamConfig config,
-            SubtaskCheckpointCoordinator checkpointCoordinator,
-            IndexedInputGate[] inputGates,
-            TaskIOMetricGroup taskIOMetricGroup,
-            String taskName,
-            MailboxExecutor mailboxExecutor,
-            TimerService timerService) {
-        CheckpointedInputGate[] checkpointedInputGates =
-                createCheckpointedMultipleInputGate(
-                        toNotifyOnCheckpoint,
-                        config,
-                        checkpointCoordinator,
-                        taskIOMetricGroup,
-                        taskName,
-                        mailboxExecutor,
-                        new List[] {Arrays.asList(inputGates)},
-                        Collections.emptyList(),
-                        timerService);
-        return Iterables.getOnlyElement(Arrays.asList(checkpointedInputGates));
-    }
-
-    /**
-     * @return an array of {@link CheckpointedInputGate} created for corresponding {@link
-     *     InputGate}s supplied as parameters.
-     */
-    public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
-            AbstractInvokable toNotifyOnCheckpoint,
-            StreamConfig config,
-            SubtaskCheckpointCoordinator checkpointCoordinator,
-            TaskIOMetricGroup taskIOMetricGroup,
-            String taskName,
-            MailboxExecutor mailboxExecutor,
-            List<IndexedInputGate>[] inputGates,
-            List<StreamTaskSourceInput<?>> sourceInputs,
-            TimerService timerService) {
-        CheckpointBarrierHandler barrierHandler =
-                createCheckpointBarrierHandler(
-                        toNotifyOnCheckpoint,
-                        config,
-                        checkpointCoordinator,
-                        taskName,
-                        inputGates,
-                        sourceInputs,
-                        mailboxExecutor,
-                        timerService);
-        return createCheckpointedMultipleInputGate(
-                mailboxExecutor, inputGates, taskIOMetricGroup, barrierHandler, config);
-    }
 
     public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
             MailboxExecutor mailboxExecutor,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Function;
@@ -173,6 +174,10 @@ public class MultipleInputStreamTask<OUT>
                         getEnvironment().getTaskStateManager().getInputRescalingDescriptor(),
                         gatePartitioners,
                         getEnvironment().getTaskInfo());
+    }
+
+    protected Optional<CheckpointBarrierHandler> getCheckpointBarrierHandler() {
+        return Optional.ofNullable(checkpointBarrierHandler);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -184,6 +184,15 @@ public class MultipleInputStreamTask<OUT>
     public Future<Boolean> triggerCheckpointAsync(
             CheckpointMetaData metadata, CheckpointOptions options) {
 
+        if (operatorChain.getSourceTaskInputs().size() == 0) {
+            return super.triggerCheckpointAsync(metadata, options);
+        }
+
+        // If there are chained sources, we would always only trigger
+        // the chained sources for checkpoint. This means that for
+        // the checkpoints during the upstream task finished and
+        // this task receives the EndOfPartitionEvent, the checkpoint
+        // would not subsume the pending ones.
         CompletableFuture<Boolean> resultFuture = new CompletableFuture<>();
         mainMailboxExecutor.execute(
                 () -> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -188,11 +188,12 @@ public class MultipleInputStreamTask<OUT>
             return super.triggerCheckpointAsync(metadata, options);
         }
 
-        // If there are chained sources, we would always only trigger
-        // the chained sources for checkpoint. This means that for
-        // the checkpoints during the upstream task finished and
-        // this task receives the EndOfPartitionEvent, the checkpoint
-        // would not subsume the pending ones.
+        // If there are chained sources, we would always only trigger the
+        // chained sources for checkpoint. This means that for the checkpoints
+        // during the upstream task finished and this task receives the
+        // EndOfPartitionEvent, we would not complement barriers for the
+        // unfinished network inputs, and the checkpoint would be triggered
+        // after received all the EndOfPartitionEvent.
         CompletableFuture<Boolean> resultFuture = new CompletableFuture<>();
         mainMailboxExecutor.execute(
                 () -> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1012,6 +1012,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         }
     }
 
+    protected Optional<CheckpointBarrierHandler> getCheckpointBarrierHandler() {
+        return Optional.empty();
+    }
+
     @Override
     public void triggerCheckpointOnBarrier(
             CheckpointMetaData checkpointMetaData,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1052,6 +1052,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         return true;
     }
 
+    /**
+     * Acquires the optional {@link CheckpointBarrierHandler} associated with this stream task. The
+     * {@code CheckpointBarrierHandler} should exist if the task has data inputs and requires to
+     * align the barriers.
+     */
     protected Optional<CheckpointBarrierHandler> getCheckpointBarrierHandler() {
         return Optional.empty();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -43,6 +43,12 @@ import java.util.function.Supplier;
 @Internal
 public interface SubtaskCheckpointCoordinator extends Closeable {
 
+    /**
+     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
+     * removed in the last PR.
+     */
+    void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished);
+
     /** Initialize new checkpoint. */
     void initInputsCheckpoint(long id, CheckpointOptions checkpointOptions)
             throws CheckpointException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -81,7 +81,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
      * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
      * removed in the last PR.
      */
-    protected boolean enableCheckpointAfterTasksFinished;
+    private boolean enableCheckpointAfterTasksFinished;
 
     private final CachingCheckpointStorageWorkerView checkpointStorage;
     private final String taskName;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -77,6 +77,12 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
     private static final int CHECKPOINT_EXECUTION_DELAY_LOG_THRESHOLD_MS = 30_000;
 
+    /**
+     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
+     * removed in the last PR.
+     */
+    protected boolean enableCheckpointAfterTasksFinished;
+
     private final CachingCheckpointStorageWorkerView checkpointStorage;
     private final String taskName;
     private final ExecutorService asyncOperationsThreadPool;
@@ -197,6 +203,11 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         taskName, env.getTaskInfo().getIndexOfThisSubtask(), checkpointStorage);
         writer.open();
         return writer;
+    }
+
+    @Override
+    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {
+        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
     }
 
     @Override
@@ -559,7 +570,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 
         for (final StreamOperatorWrapper<?, ?> operatorWrapper :
                 operatorChain.getAllOperators(true)) {
-            if (operatorWrapper.isClosed()) {
+            if (!enableCheckpointAfterTasksFinished && operatorWrapper.isClosed()) {
                 env.declineCheckpoint(
                         checkpointMetaData.getCheckpointId(),
                         new CheckpointException(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -22,12 +22,16 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessorFactory;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.checkpointing.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -39,10 +43,18 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTask<IN1, IN2, OUT> {
 
+    @Nullable private CheckpointBarrierHandler checkpointBarrierHandler;
+
     public TwoInputStreamTask(Environment env) throws Exception {
         super(env);
     }
 
+    @Override
+    protected Optional<CheckpointBarrierHandler> getCheckpointBarrierHandler() {
+        return Optional.ofNullable(checkpointBarrierHandler);
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
     protected void createInputProcessor(
             List<IndexedInputGate> inputGates1,
@@ -50,17 +62,25 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
             Function<Integer, StreamPartitioner<?>> gatePartitioners) {
 
         // create an input instance for each input
-        CheckpointedInputGate[] checkpointedInputGates =
-                InputProcessorUtil.createCheckpointedMultipleInputGate(
+        checkpointBarrierHandler =
+                InputProcessorUtil.createCheckpointBarrierHandler(
                         this,
-                        getConfiguration(),
+                        configuration,
                         getCheckpointCoordinator(),
-                        getEnvironment().getMetricGroup().getIOMetricGroup(),
                         getTaskNameWithSubtaskAndId(),
-                        mainMailboxExecutor,
                         new List[] {inputGates1, inputGates2},
                         Collections.emptyList(),
+                        mainMailboxExecutor,
                         systemTimerService);
+
+        CheckpointedInputGate[] checkpointedInputGates =
+                InputProcessorUtil.createCheckpointedMultipleInputGate(
+                        mainMailboxExecutor,
+                        new List[] {inputGates1, inputGates2},
+                        getEnvironment().getMetricGroup().getIOMetricGroup(),
+                        checkpointBarrierHandler,
+                        configuration);
+
         checkState(checkpointedInputGates.length == 2);
 
         inputProcessor =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -106,5 +107,10 @@ public class MockIndexedInputGate extends IndexedInputGate {
     @Override
     public int getGateIndex() {
         return gateIndex;
+    }
+
+    @Override
+    public List<InputChannelInfo> getUnfinishedChannels() {
+        return Collections.emptyList();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -165,5 +166,10 @@ public class MockInputGate extends IndexedInputGate {
     @Override
     public int getGateIndex() {
         return 0;
+    }
+
+    @Override
+    public List<InputChannelInfo> getUnfinishedChannels() {
+        return Collections.emptyList();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -253,6 +254,11 @@ public class AlignedCheckpointsMassiveRandomTest {
         @Override
         public int getGateIndex() {
             return 0;
+        }
+
+        @Override
+        public List<InputChannelInfo> getUnfinishedChannels() {
+            return Collections.emptyList();
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
@@ -69,23 +69,28 @@ public class InputProcessorUtilTest {
                         Collections.singletonList(getGate(0, 2)),
                     };
 
-            CheckpointedInputGate[] checkpointedMultipleInputGate =
-                    InputProcessorUtil.createCheckpointedMultipleInputGate(
+            CheckpointBarrierHandler barrierHandler =
+                    InputProcessorUtil.createCheckpointBarrierHandler(
                             streamTask,
                             streamConfig,
                             new TestSubtaskCheckpointCoordinator(new MockChannelStateWriter()),
-                            environment.getMetricGroup().getIOMetricGroup(),
                             streamTask.getName(),
-                            new SyncMailboxExecutor(),
                             inputGates,
                             Collections.emptyList(),
+                            new SyncMailboxExecutor(),
                             new TestProcessingTimeService());
+
+            CheckpointedInputGate[] checkpointedMultipleInputGate =
+                    InputProcessorUtil.createCheckpointedMultipleInputGate(
+                            new SyncMailboxExecutor(),
+                            inputGates,
+                            environment.getMetricGroup().getIOMetricGroup(),
+                            barrierHandler,
+                            streamConfig);
+
             for (CheckpointedInputGate checkpointedInputGate : checkpointedMultipleInputGate) {
                 registry.registerCloseable(checkpointedInputGate);
             }
-
-            CheckpointBarrierHandler barrierHandler =
-                    checkpointedMultipleInputGate[0].getCheckpointBarrierHandler();
 
             List<IndexedInputGate> allInputGates =
                     Arrays.stream(inputGates)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -18,15 +18,18 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.TimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
@@ -38,10 +41,12 @@ import org.junit.Test;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.addSourceRecords;
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.buildTestHarness;
+import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.triggerCheckpoint;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -227,6 +232,56 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                     actualOutput.subList(0, expectedOutput.size()),
                     containsInAnyOrder(expectedOutput.toArray()));
             assertThat(actualOutput.get(expectedOutput.size()), equalTo(barrier));
+        }
+    }
+
+    @Test
+    public void testRpcTriggerCheckpointWithSourceChain() throws Exception {
+        AtomicReference<Future<?>> lastCheckpointTriggerFuture = new AtomicReference<>();
+
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                env ->
+                                        new MultipleInputStreamTaskTest
+                                                .HoldingOnAfterInvokeMultipleInputStreamTask(
+                                                env, lastCheckpointTriggerFuture),
+                                BasicTypeInfo.STRING_TYPE_INFO)
+                        .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                        .modifyExecutionConfig(ExecutionConfig::enableObjectReuse)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                        .addSourceInput(
+                                new SourceOperatorFactory<>(
+                                        new MultipleInputStreamTaskTest.LifeCycleTrackingMockSource(
+                                                Boundedness.BOUNDED, 1),
+                                        WatermarkStrategy.noWatermarks()))
+                        .addSourceInput(
+                                new SourceOperatorFactory<>(
+                                        new MultipleInputStreamTaskTest.LifeCycleTrackingMockSource(
+                                                Boundedness.BOUNDED, 1),
+                                        WatermarkStrategy.noWatermarks()))
+                        .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(4))
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+
+            testHarness
+                    .getStreamTask()
+                    .getCheckpointCoordinator()
+                    .setEnableCheckpointAfterTasksFinished(true);
+
+            // TODO: Would add the test of part of channel finished after we are able to
+            // complement pending checkpoints when received EndOfPartitionEvent.
+
+            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
+            Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 4);
+            lastCheckpointTriggerFuture.set(checkpointFuture);
+
+            // The checkpoint 4 would be triggered successfully.
+            // TODO: Would also check the checkpoint succeed after we also waiting
+            // for the asynchronous step to finish on finish.
+            testHarness.finishProcessing();
+            assertTrue(checkpointFuture.isDone());
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -53,6 +53,9 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
     }
 
     @Override
+    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {}
+
+    @Override
     public void initInputsCheckpoint(long id, CheckpointOptions checkpointOptions) {
         channelStateWriter.start(id, checkpointOptions);
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR enables triggering checkpoint barrier handle for non-source tasks. 

To support checkpoints after some tasks finished, non-source tasks might also receive RPC trigger of checkpoint after all their precedent tasks get finished. In this case, it need to trigger checkpoint barrier handler to insert barriers. This PR provides the functionality to notify checkpoint barrier on RPC trigger

## Brief change log

  - a3daa2b88a7c1609daf2bb55742971eabe5dacf0 refactors the current implementation to expose CheckpointBarrierHandler.
  - b4baae6e24556aec841fb1c4fcedfec234e3c0cd notifies the non-source stream tasks' checkpoint barrier handler on RPC trigger.
  - 326d8751ac2aac4255b5e94da8e8f46a424c55c5 fixes the tests that using non-source task that directly perform checkpoint on trigger.


## Verifying this change

This PR does not come with test right now since it does not have affect to the current process, and it is not easy to write tests since the CheckpointBarrierHandler is not updated yet. We would add the unit tests as a whole in the next PR, which also modifies the `CheckpointBarrierHandler`'s logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
