### PR TITLE
[FLINK-21210][coordination] ApplicationClusterEntryPoint should explicitly close PackagedProgram

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base class for cluster entry points targeting executing applications in "Application Mode". The
- * lifecycle of the enrtypoint is bound to that of the specific application being executed, and the
+ * lifecycle of the entry point is bound to that of the specific application being executed, and the
  * {@code main()} method of the application is run on the cluster.
  */
 public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
@@ -113,5 +113,16 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
         classpath.addAll(program.getClasspaths());
         return Collections.unmodifiableList(
                 classpath.stream().distinct().collect(Collectors.toList()));
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            // Close the packaged program explicitly to clean up temporary jars.
+            program.close();
+        } catch (Exception e) {
+            LOG.debug("Error while closing the packaged program.", e);
+            throw e;
+        }
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerCo
 import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
 import org.apache.flink.runtime.rest.JobRestEndpointFactory;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -116,7 +117,7 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
     }
 
     @Override
-    public void close() throws Exception {
+    public void cleanupDirectories() throws IOException {
         try {
             // Close the packaged program explicitly to clean up temporary jars.
             program.close();
@@ -124,5 +125,6 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
             LOG.debug("Error while closing the packaged program.", e);
             throw e;
         }
+        super.cleanupDirectories();
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationClusterEntryPoint.java
@@ -117,14 +117,9 @@ public class ApplicationClusterEntryPoint extends ClusterEntrypoint {
     }
 
     @Override
-    public void cleanupDirectories() throws IOException {
-        try {
-            // Close the packaged program explicitly to clean up temporary jars.
-            program.close();
-        } catch (Exception e) {
-            LOG.debug("Error while closing the packaged program.", e);
-            throw e;
-        }
+    protected void cleanupDirectories() throws IOException {
+        // Close the packaged program explicitly to clean up temporary jars.
+        program.close();
         super.cleanupDirectories();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -506,7 +506,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
      *
      * @throws IOException if the temporary directories could not be cleaned up
      */
-    public void cleanupDirectories() throws IOException {
+    protected void cleanupDirectories() throws IOException {
         ShutdownHookUtil.removeShutdownHook(shutDownHook, getClass().getSimpleName(), LOG);
 
         final String webTmpDir = configuration.getString(WebOptions.TMP_DIR);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -506,7 +506,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
      *
      * @throws IOException if the temporary directories could not be cleaned up
      */
-    private void cleanupDirectories() throws IOException {
+    public void cleanupDirectories() throws IOException {
         ShutdownHookUtil.removeShutdownHook(shutDownHook, getClass().getSimpleName(), LOG);
 
         final String webTmpDir = configuration.getString(WebOptions.TMP_DIR);


### PR DESCRIPTION
## What is the purpose of the change

*[FLINK-21164](https://issues.apache.org/jira/browse/FLINK-21164) introduced #PackagedProgram#close# to clean up temporary jars, and with [FLINK-9844](https://issues.apache.org/jira/browse/FLINK-9844) the contained classloader will also be closed beforehand. To make it obvious that this also happens in the application cluster entrypoints. `ApplicationClusterEntryPoint` should adjust the entrypoints to explicitly close the `PackagedProgram`.*

## Brief change log

  - *`ApplicationClusterEntryPoint` overrides the `close` to invoke the `close` method of `PackagedProgram`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)