### PR TITLE
[release-1.12][FLINK-21169][kafka] flink-connector-base dependency should be scope compile

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -87,7 +87,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
Backport of https://github.com/apache/flink/pull/14783

