### PR TITLE
[FLINK-21216][python] Limit numpy version in setup.py

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -326,7 +326,7 @@ run sdist.
                           'cloudpickle==1.2.2', 'avro-python3>=1.8.1,<=1.9.1', 'jsonpickle==1.2',
                           'pandas>=0.24.2,<1; python_full_version < "3.5.3"',
                           'pandas>=0.25.2,<1; python_full_version >= "3.5.3"',
-                          'pyarrow>=0.15.1,<0.18.0', 'pytz>=2018.3'],
+                          'pyarrow>=0.15.1,<0.18.0', 'pytz>=2018.3', 'numpy>=1.14.3,<1.20'],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],
         description='Apache Flink Python API',


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix numpy version in setup.py. Currently pyarrow>=0.15.1,<0.18.0 and numpy==1.20.0 have compatibility problem in Python 3.7.*


## Brief change log

  - *set numpy version >=1.14.3,<1.20*

## Verifying this change

This change added tests and can be verified as follows:

  - *original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
