### PR TITLE
[FLINK-21150][table-planner-blink] Introduce ExecEdge to connect two ExecNodes

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecEdge.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecEdge.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.delegation.Planner;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The representation of an edge connecting two {@link ExecNode}. */
+public class ExecEdge {
+    /** The source node of this edge. */
+    private final ExecNode<?> source;
+    /** The target node of this edge. */
+    private final ExecNode<?> target;
+    /** The {@link Shuffle} on this edge from source to target. */
+    private final Shuffle shuffle;
+    /** The {@link ShuffleMode} defines the data exchange mode on this edge. */
+    private final ShuffleMode shuffleMode;
+
+    public ExecEdge(
+            ExecNode<?> source, ExecNode<?> target, Shuffle shuffle, ShuffleMode shuffleMode) {
+        this.source = checkNotNull(source);
+        this.target = checkNotNull(target);
+        this.shuffle = checkNotNull(shuffle);
+        this.shuffleMode = checkNotNull(shuffleMode);
+
+        // TODO once FLINK-21224 [Remove BatchExecExchange and StreamExecExchange, and replace their
+        //  functionality with ExecEdge] is finished, we should remove the following validation.
+        if (shuffle.getType() != Shuffle.Type.FORWARD) {
+            throw new TableException("Only FORWARD shuffle is supported now.");
+        }
+        if (shuffleMode != ShuffleMode.PIPELINED) {
+            throw new TableException("Only PIPELINED shuffle mode is supported now.");
+        }
+    }
+
+    public ExecNode<?> getSource() {
+        return source;
+    }
+
+    public ExecNode<?> getTarget() {
+        return target;
+    }
+
+    public Shuffle getShuffle() {
+        return shuffle;
+    }
+
+    public ShuffleMode getShuffleMode() {
+        return shuffleMode;
+    }
+
+    /** Returns the output {@link LogicalType} of the data passing this edge. */
+    public LogicalType getOutputType() {
+        return source.getOutputType();
+    }
+
+    @Override
+    public String toString() {
+        return "ExecEdge{"
+                + "source="
+                + source.getDescription()
+                + ", target="
+                + target.getDescription()
+                + ", shuffle="
+                + shuffle
+                + ", shuffleMode="
+                + shuffleMode
+                + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder of the {@link ExecEdge}. */
+    public static class Builder {
+        private ExecNode<?> source;
+        private ExecNode<?> target;
+        private Shuffle shuffle = FORWARD_SHUFFLE;
+        private ShuffleMode shuffleMode = ShuffleMode.PIPELINED;
+
+        public Builder source(ExecNode<?> source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder target(ExecNode<?> target) {
+            this.target = target;
+            return this;
+        }
+
+        public Builder shuffle(Shuffle shuffle) {
+            this.shuffle = shuffle;
+            return this;
+        }
+
+        public Builder requiredDistribution(
+                InputProperty.RequiredDistribution requiredDistribution) {
+            return shuffle(fromRequiredDistribution(requiredDistribution));
+        }
+
+        public Builder shuffleMode(ShuffleMode shuffleMode) {
+            this.shuffleMode = shuffleMode;
+            return this;
+        }
+
+        public ExecEdge build() {
+            return new ExecEdge(source, target, shuffle, shuffleMode);
+        }
+
+        private Shuffle fromRequiredDistribution(
+                InputProperty.RequiredDistribution requiredDistribution) {
+            switch (requiredDistribution.getType()) {
+                case ANY:
+                    return ANY_SHUFFLE;
+                case SINGLETON:
+                    return SINGLETON_SHUFFLE;
+                case BROADCAST:
+                    return BROADCAST_SHUFFLE;
+                case HASH:
+                    InputProperty.HashDistribution hashDistribution =
+                            (InputProperty.HashDistribution) requiredDistribution;
+                    return hashShuffle(hashDistribution.getKeys());
+                default:
+                    throw new TableException(
+                            "Unsupported RequiredDistribution type: "
+                                    + requiredDistribution.getType());
+            }
+        }
+    }
+
+    /** The shuffle for records when passing this edge. */
+    public abstract static class Shuffle {
+        private final Type type;
+
+        protected Shuffle(Type type) {
+            this.type = type;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return type.name();
+        }
+
+        /** Enumeration which describes the shuffle type for records when passing this edge. */
+        public enum Type {
+            /** Any type of shuffle is OK when passing through this edge. */
+            ANY,
+
+            /** Records are shuffle by hash when passing through this edge. */
+            HASH,
+
+            /** Full records are provided for each parallelism of the target node. */
+            BROADCAST,
+
+            /** The parallelism of the target node must be 1. */
+            SINGLETON,
+
+            /** Records are shuffled in same parallelism (function call). */
+            FORWARD
+        }
+    }
+
+    /** Records are shuffle by hash when passing through this edge. */
+    public static class HashShuffle extends Shuffle {
+        private final int[] keys;
+
+        public HashShuffle(int[] keys) {
+            super(Type.HASH);
+            this.keys = checkNotNull(keys);
+            checkArgument(keys.length > 0, "Hash keys must no be empty.");
+        }
+
+        public int[] getKeys() {
+            return keys;
+        }
+
+        @Override
+        public String toString() {
+            return "HASH" + Arrays.toString(keys);
+        }
+    }
+
+    /** Any type of shuffle is OK when passing through this edge. */
+    public static final Shuffle ANY_SHUFFLE = new Shuffle(Shuffle.Type.ANY) {};
+
+    /** Full records are provided for each parallelism of the target node. */
+    public static final Shuffle BROADCAST_SHUFFLE = new Shuffle(Shuffle.Type.BROADCAST) {};
+
+    /** The parallelism of the target node must be 1. */
+    public static final Shuffle SINGLETON_SHUFFLE = new Shuffle(Shuffle.Type.SINGLETON) {};
+
+    /** Records are shuffled in same parallelism (function call). */
+    public static final Shuffle FORWARD_SHUFFLE = new Shuffle(Shuffle.Type.FORWARD) {};
+
+    /**
+     * Return hash {@link Shuffle}.
+     *
+     * @param keys hash keys
+     */
+    public static Shuffle hashShuffle(int[] keys) {
+        return new HashShuffle(keys);
+    }
+
+    /**
+     * Translates this edge into a Flink operator.
+     *
+     * @param planner The {@link Planner} of the translated Table.
+     */
+    public Transformation<?> translateToPlan(Planner planner) {
+        return source.translateToPlan(planner);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNode.java
@@ -49,29 +49,37 @@ public interface ExecNode<T> {
     LogicalType getOutputType();
 
     /**
-     * Returns a list of this node's input nodes. If there are no inputs, returns an empty list, not
-     * null.
+     * Returns a list of this node's input properties.
      *
-     * @return List of this node's input nodes
-     */
-    List<ExecNode<?>> getInputNodes();
-
-    /**
-     * Returns a list of this node's input properties. If there are no inputs, returns an empty
-     * list, not null.
+     * <p>NOTE: If there are no inputs, returns an empty list, not null.
      *
-     * @return List of this node's input properties
+     * @return List of this node's input properties.
      */
     List<InputProperty> getInputProperties();
 
     /**
-     * Replaces the <code>ordinalInParent</code><sup>th</sup> input. Once we introduce source node
-     * and target node for {@link InputProperty}, we will remove this method.
+     * Returns a list of this node's input {@link ExecEdge}s.
      *
-     * @param ordinalInParent Position of the child input, 0 is the first
-     * @param newInputNode New node that should be put at position ordinalInParent
+     * <p>NOTE: If there are no inputs, returns an empty list, not null.
      */
-    void replaceInputNode(int ordinalInParent, ExecNode<?> newInputNode);
+    List<ExecEdge> getInputEdges();
+
+    /**
+     * Sets the input {@link ExecEdge}s which connect this nodes and its input nodes.
+     *
+     * <p>NOTE: If there are no inputs, the given inputEdges should be empty, not null.
+     *
+     * @param inputEdges the input {@link ExecEdge}s.
+     */
+    void setInputEdges(List<ExecEdge> inputEdges);
+
+    /**
+     * Replaces the <code>ordinalInParent</code><sup>th</sup> input edge.
+     *
+     * @param index Position of the child input edge, 0 is the first.
+     * @param newInputEdge New edge that should be put at position `index`.
+     */
+    void replaceInputEdge(int index, ExecEdge newInputEdge);
 
     /**
      * Translates this node into a Flink operator.
@@ -85,7 +93,7 @@ public interface ExecNode<T> {
     /**
      * Accepts a visit from a {@link ExecNodeVisitor}.
      *
-     * @param visitor ExecNodeVisitor
+     * @param visitor ExecNodeVisitor.
      */
     void accept(ExecNodeVisitor visitor);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeGraphGenerator.java
@@ -72,8 +72,12 @@ public class ExecNodeGraphGenerator {
         }
 
         execNode = rel.translateToExecNode();
-        // connects the input/output nodes
-        ((ExecNodeBase<?>) execNode).setInputNodes(inputNodes);
+        // connects the input nodes
+        List<ExecEdge> inputEdges = new ArrayList<>(inputNodes.size());
+        for (ExecNode<?> inputNode : inputNodes) {
+            inputEdges.add(ExecEdge.builder().source(inputNode).target(execNode).build());
+        }
+        execNode.setInputEdges(inputEdges);
 
         visitedRels.put(rel, execNode);
         return execNode;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/InputProperty.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/InputProperty.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.Input;
 
+import java.util.Arrays;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -70,6 +72,18 @@ public class InputProperty {
         return priority;
     }
 
+    @Override
+    public String toString() {
+        return "InputProperty{"
+                + "requiredDistribution="
+                + requiredDistribution
+                + ", damBehavior="
+                + damBehavior
+                + ", priority="
+                + priority
+                + '}';
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -117,6 +131,11 @@ public class InputProperty {
         public DistributionType getType() {
             return type;
         }
+
+        @Override
+        public String toString() {
+            return type.name();
+        }
     }
 
     /**
@@ -134,6 +153,11 @@ public class InputProperty {
 
         public int[] getKeys() {
             return keys;
+        }
+
+        @Override
+        public String toString() {
+            return "HASH" + Arrays.toString(keys);
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.LongHashJoinGenerator;
 import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
@@ -83,14 +83,16 @@ public class BatchExecHashJoin extends ExecNodeBase<RowData> implements BatchExe
     @Override
     @SuppressWarnings("unchecked")
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> leftInputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        ExecNode<RowData> rightInputNode = (ExecNode<RowData>) getInputNodes().get(1);
+        ExecEdge leftInputEdge = getInputEdges().get(0);
+        ExecEdge rightInputEdge = getInputEdges().get(1);
 
-        Transformation<RowData> leftInputTransform = leftInputNode.translateToPlan(planner);
-        Transformation<RowData> rightInputTransform = rightInputNode.translateToPlan(planner);
-        // get type
-        RowType leftType = (RowType) leftInputNode.getOutputType();
-        RowType rightType = (RowType) rightInputNode.getOutputType();
+        Transformation<RowData> leftInputTransform =
+                (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
+        Transformation<RowData> rightInputTransform =
+                (Transformation<RowData>) rightInputEdge.translateToPlan(planner);
+        // get input types
+        RowType leftType = (RowType) leftInputEdge.getOutputType();
+        RowType rightType = (RowType) rightInputEdge.getOutputType();
 
         JoinUtil.validateJoinSpec(joinSpec, leftType, rightType, false);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.codegen.agg.batch.HashWindowCodeGenerator;
 import org.apache.flink.table.planner.codegen.agg.batch.WindowCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.logical.LogicalWindow;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -95,17 +96,18 @@ public class BatchExecHashWindowAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
         final AggregateInfoList aggInfos =
                 AggregateUtil.transformToBatchAggregateInfoList(
                         aggInputRowType,
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
-                        null,
-                        null);
+                        null, // aggCallNeedRetractions
+                        null); // orderKeyIndexes
         final TableConfig tableConfig = planner.getTableConfig();
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final HashWindowCodeGenerator hashWindowCodeGenerator =
                 new HashWindowCodeGenerator(
                         new CodeGeneratorContext(tableConfig),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
@@ -20,12 +20,12 @@ package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
-import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.sort.LimitOperator;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -54,17 +54,16 @@ public class BatchExecLimit extends ExecNodeBase<RowData> implements BatchExecNo
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        Transformation<RowData> input =
-                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
         LimitOperator operator = new LimitOperator(isGlobal, limitStart, limitEnd);
         Transformation<RowData> transformation =
-                ExecNodeUtil.createOneInputTransformation(
-                        input,
+                new OneInputTransformation<>(
+                        inputTransform,
                         getDescription(),
                         SimpleOperatorFactory.of(operator),
-                        input.getOutputType(),
-                        input.getParallelism(),
-                        0);
+                        inputTransform.getOutputType(),
+                        inputTransform.getParallelism());
         if (inputsContainSingleton()) {
             transformation.setParallelism(1);
             transformation.setMaxParallelism(1);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -79,8 +80,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final List<Transformation<?>> inputTransforms = new ArrayList<>();
-        for (ExecNode<?> input : getInputNodes()) {
-            inputTransforms.add(input.translateToPlan(planner));
+        for (ExecEdge inputEdge : getInputEdges()) {
+            inputTransforms.add(inputEdge.translateToPlan(planner));
         }
         final Transformation<?> outputTransform = rootNode.translateToPlan(planner);
         final int[] readOrders =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.NestedLoopJoinCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
@@ -69,15 +69,17 @@ public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
     @Override
     @SuppressWarnings("unchecked")
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> leftInputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        ExecNode<RowData> rightInputNode = (ExecNode<RowData>) getInputNodes().get(1);
+        ExecEdge leftInputEdge = getInputEdges().get(0);
+        ExecEdge rightInputEdge = getInputEdges().get(1);
 
-        Transformation<RowData> leftInputTransform = leftInputNode.translateToPlan(planner);
-        Transformation<RowData> rightInputTransform = rightInputNode.translateToPlan(planner);
+        Transformation<RowData> leftInputTransform =
+                (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
+        Transformation<RowData> rightInputTransform =
+                (Transformation<RowData>) rightInputEdge.translateToPlan(planner);
 
-        // get type
-        RowType leftType = (RowType) leftInputNode.getOutputType();
-        RowType rightType = (RowType) rightInputNode.getOutputType();
+        // get input types
+        RowType leftType = (RowType) leftInputEdge.getOutputType();
+        RowType rightType = (RowType) rightInputEdge.getOutputType();
 
         TableConfig config = planner.getTableConfig();
         CodeGenOperatorFactory<RowData> operator =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregateBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregateBase.java
@@ -52,7 +52,7 @@ public abstract class BatchExecOverAggregateBase extends ExecNodeBase<RowData>
     }
 
     protected RowType getInputTypeWithConstants() {
-        final RowType inputRowType = (RowType) getInputNodes().get(0).getOutputType();
+        final RowType inputRowType = (RowType) getInputEdges().get(0).getOutputType();
         final List<LogicalType> inputTypesWithConstants =
                 new ArrayList<>(inputRowType.getChildren());
         final List<String> inputTypeNamesWithConstants =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -69,9 +70,10 @@ public class BatchExecPythonGroupAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final RowType outputRowType = InternalTypeInfo.of(getOutputType()).toRowType();
         Configuration config =
                 CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.planner.expressions.PlannerWindowEnd;
 import org.apache.flink.table.planner.expressions.PlannerWindowProperty;
 import org.apache.flink.table.planner.expressions.PlannerWindowStart;
 import org.apache.flink.table.planner.plan.logical.LogicalWindow;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -88,9 +89,10 @@ public class BatchExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final RowType outputRowType = InternalTypeInfo.of(getOutputType()).toRowType();
 
         final Tuple2<Long, Long> windowSizeAndSlideSize = WindowCodeGenerator.getWindowDef(window);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.CommonPythonUtil;
@@ -75,9 +76,10 @@ public class BatchExecPythonOverAggregate extends BatchExecOverAggregateBase {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputType = (RowType) inputEdge.getOutputType();
 
         List<OverSpec.GroupSpec> groups = overSpec.getGroups();
         boolean[] isRangeWindows = new boolean[groups.size()];

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.utils.SortUtil;
@@ -68,10 +68,11 @@ public class BatchExecRank extends ExecNodeBase<RowData> implements BatchExecNod
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        RowType inputType = (RowType) inputNode.getOutputType();
+        RowType inputType = (RowType) inputEdge.getOutputType();
 
         // operator needn't cache data
         // The collation for the partition-by and order-by fields is inessential here,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -58,7 +58,7 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
     @Override
     protected Transformation<Object> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
-                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+                (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
         return createSinkTransformation(
                 planner.getExecEnv(), planner.getTableConfig(), inputTransform, -1);
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.sort.SortCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
@@ -58,11 +58,12 @@ public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNod
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
         TableConfig config = planner.getTableConfig();
-        RowType inputType = (RowType) inputNode.getOutputType();
+        RowType inputType = (RowType) inputEdge.getOutputType();
         SortCodeGenerator codeGen = new SortCodeGenerator(config, inputType, sortSpec);
 
         SortOperator operator =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.agg.batch.AggWithoutKeysCodeGenerator;
 import org.apache.flink.table.planner.codegen.agg.batch.SortAggCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -75,10 +76,11 @@ public class BatchExecSortAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final RowType outputRowType = (RowType) getOutputType();
 
         final CodeGeneratorContext ctx = new CodeGeneratorContext(planner.getTableConfig());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.SortSpec;
@@ -70,10 +70,11 @@ public class BatchExecSortLimit extends ExecNodeBase<RowData> implements BatchEx
             throw new TableException("Not support limitEnd is max value now!");
         }
 
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        RowType inputType = (RowType) inputNode.getOutputType();
+        RowType inputType = (RowType) inputEdge.getOutputType();
         // generate comparator
         GeneratedRecordComparator genComparator =
                 ComparatorCodeGenerator.gen(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.planner.codegen.agg.batch.SortWindowCodeGenerator;
 import org.apache.flink.table.planner.codegen.agg.batch.WindowCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.logical.LogicalWindow;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -95,15 +96,16 @@ public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
         final AggregateInfoList aggInfos =
                 AggregateUtil.transformToBatchAggregateInfoList(
                         aggInputRowType,
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
-                        null,
-                        null);
+                        null, // aggCallNeedRetractions
+                        null); // orderKeyIndexes
 
         final TableConfig tableConfig = planner.getTableConfig();
         final int groupBufferLimitSize =
@@ -121,10 +123,10 @@ public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
                         inputTimeIsDate,
                         JavaScalaConversionUtil.toScala(Arrays.asList(namedWindowProperties)),
                         aggInfos,
-                        (RowType) inputNode.getOutputType(),
+                        (RowType) inputEdge.getOutputType(),
                         (RowType) getOutputType(),
                         groupBufferLimitSize,
-                        0L,
+                        0L, // windowStart
                         windowSizeAndSlideSize.f0,
                         windowSizeAndSlideSize.f1,
                         grouping,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -24,7 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CalcCodeGenerator;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -60,8 +60,9 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData> {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         final CodeGeneratorContext ctx =
                 new CodeGeneratorContext(planner.getTableConfig())
                         .setOperatorBaseClass(operatorBaseClass);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.CorrelateCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -66,8 +67,9 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData> {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         final CodeGeneratorContext ctx =
                 new CodeGeneratorContext(planner.getTableConfig())
                         .setOperatorBaseClass(operatorBaseClass);
@@ -76,7 +78,7 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData> {
                         planner.getTableConfig(),
                         ctx,
                         inputTransform,
-                        (RowType) inputNode.getOutputType(),
+                        (RowType) inputEdge.getOutputType(),
                         invocation,
                         JavaScalaConversionUtil.toScala(Optional.ofNullable(condition)),
                         (RowType) getOutputType(),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.ExpandCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -56,13 +57,14 @@ public abstract class CommonExecExpand extends ExecNodeBase<RowData> {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
         final CodeGenOperatorFactory<RowData> operatorFactory =
                 ExpandCodeGenerator.generateExpandOperator(
                         new CodeGeneratorContext(planner.getTableConfig()),
-                        (RowType) inputNode.getOutputType(),
+                        (RowType) inputEdge.getOutputType(),
                         (RowType) getOutputType(),
                         projects,
                         retainHeader,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.codegen.CodeGenUtils;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.SinkCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -161,9 +162,10 @@ public abstract class CommonExecLegacySink<T> extends ExecNodeBase<Object> {
                             + "Use the toRetractStream() in order to handle add and retract messages.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final RowType convertedInputRowType = checkAndConvertInputTypeIfNeeded(inputRowType);
         final DataType resultDataType = tableSink.getConsumedDataType();
         if (CodeGenUtils.isInternalClass(resultDataType)) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.LookupJoinCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -161,8 +162,8 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData> {
     @Override
     @SuppressWarnings("unchecked")
     public Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        RowType inputRowType = (RowType) inputEdge.getOutputType();
         RowType tableSourceRowType = FlinkTypeFactory.toLogicalRowType(temporalTable.getRowType());
         RowType resultRowType = (RowType) getOutputType();
         validateLookupKeyType(lookupKeys, inputRowType, tableSourceRowType);
@@ -204,7 +205,8 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData> {
                             planner.getExecEnv().getConfig().isObjectReuseEnabled());
         }
 
-        Transformation<RowData> inputTransformation = inputNode.translateToPlan(planner);
+        Transformation<RowData> inputTransformation =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         OneInputTransformation<RowData, RowData> transform =
                 new OneInputTransformation<>(
                         inputTransformation,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.functions.python.PythonFunctionKind;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.CommonPythonUtil;
@@ -77,8 +77,9 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData> {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         final Configuration config =
                 CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> ret =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -71,8 +72,9 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData> {
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         final Configuration config =
                 CommonPythonUtil.getMergedConfig(planner.getExecEnv(), planner.getTableConfig());
         OneInputTransformation<RowData, RowData> transform =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -109,7 +109,7 @@ public abstract class CommonExecSink extends ExecNodeBase<Object> {
         final SinkNotNullEnforcer enforcer =
                 new SinkNotNullEnforcer(notNullEnforcer, notNullFieldIndices, fieldNames);
         final InternalTypeInfo<RowData> inputTypeInfo =
-                InternalTypeInfo.of(getInputNodes().get(0).getOutputType());
+                InternalTypeInfo.of(getInputEdges().get(0).getOutputType());
 
         if (runtimeProvider instanceof DataStreamSinkProvider) {
             if (runtimeProvider instanceof ParallelismProvider) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecUnion.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -45,8 +46,8 @@ public abstract class CommonExecUnion extends ExecNodeBase<RowData> {
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final List<Transformation<RowData>> inputTransforms = new ArrayList<>();
-        for (ExecNode<?> input : getInputNodes()) {
-            inputTransforms.add((Transformation<RowData>) input.translateToPlan(planner));
+        for (ExecEdge inputEdge : getInputEdges()) {
+            inputTransforms.add((Transformation<RowData>) inputEdge.translateToPlan(planner));
         }
         return new UnionTransformation(inputTransforms);
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputOrderCalculator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputOrderCalculator.java
@@ -162,7 +162,7 @@ public class InputOrderCalculator extends InputPriorityGraphGenerator {
                         .stricterOrEqual(InputProperty.DamBehavior.END_INPUT)) {
                     continue;
                 }
-                visit(node.getInputNodes().get(i));
+                visit(node.getInputEdges().get(i).getSource());
                 if (res) {
                     return;
                 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityGraphGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityGraphGenerator.java
@@ -138,7 +138,7 @@ public abstract class InputPriorityGraphGenerator {
         // group inputs by input priorities
         TreeMap<Integer, List<Integer>> inputPriorityGroupMap = new TreeMap<>();
         Preconditions.checkState(
-                node.getInputNodes().size() == node.getInputProperties().size(),
+                node.getInputEdges().size() == node.getInputProperties().size(),
                 "Number of inputs nodes does not equal to number of input edges for node "
                         + node.getClass().getName()
                         + ". This is a bug.");
@@ -162,8 +162,8 @@ public abstract class InputPriorityGraphGenerator {
     }
 
     private void addTopologyEdges(ExecNode<?> node, int higherInput, int lowerInput) {
-        ExecNode<?> higherNode = node.getInputNodes().get(higherInput);
-        ExecNode<?> lowerNode = node.getInputNodes().get(lowerInput);
+        ExecNode<?> higherNode = node.getInputEdges().get(higherInput).getSource();
+        ExecNode<?> lowerNode = node.getInputEdges().get(lowerInput).getSource();
         List<ExecNode<?>> lowerAncestors = calculatePipelinedAncestors(lowerNode);
 
         List<Tuple2<ExecNode<?>, ExecNode<?>>> linkedEdges = new ArrayList<>();
@@ -202,7 +202,7 @@ public abstract class InputPriorityGraphGenerator {
                                     continue;
                                 }
                                 hasAncestor = true;
-                                node.getInputNodes().get(i).accept(this);
+                                node.getInputEdges().get(i).getSource().accept(this);
                             }
                         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/TopologyGraph.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/TopologyGraph.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor.utils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecBoundedStreamScan;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
@@ -59,8 +60,8 @@ class TopologyGraph {
                         if (boundaries.contains(node)) {
                             return;
                         }
-                        for (ExecNode<?> input : node.getInputNodes()) {
-                            link(input, node);
+                        for (ExecEdge inputEdge : node.getInputEdges()) {
+                            link(inputEdge.getSource(), node);
                         }
                         visitInputs(node);
                     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -35,6 +35,12 @@ public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<Row
             InputProperty inputProperty,
             RowType outputType,
             String description) {
-        super(calcProgram, TableStreamOperator.class, true, inputProperty, outputType, description);
+        super(
+                calcProgram,
+                TableStreamOperator.class,
+                true, // retainHeader
+                inputProperty,
+                outputType,
+                description);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -67,9 +68,9 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<?> inputNode = getInputNodes().get(0);
+        final ExecEdge inputEdge = getInputEdges().get(0);
         final Transformation<RowData> inputTransform =
-                (Transformation<RowData>) inputNode.translateToPlan(planner);
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
         final InternalTypeInfo<RowData> rowTypeInfo =
                 (InternalTypeInfo<RowData>) inputTransform.getOutputType();
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCorrelate.java
@@ -48,7 +48,7 @@ public class StreamExecCorrelate extends CommonExecCorrelate implements StreamEx
                 invocation,
                 condition,
                 TableStreamOperator.class,
-                true,
+                true, // retainHeader
                 inputProperty,
                 outputType,
                 description);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -95,10 +96,11 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final InternalTypeInfo<RowData> rowTypeInfo =
                 (InternalTypeInfo<RowData>) inputTransform.getOutputType();
         final TypeSerializer<RowData> rowSerializer =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -48,7 +48,7 @@ public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
-                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+                (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
         final StreamFilter<RowData> operator = new StreamFilter<>(new DropUpdateBeforeFunction());
 
         return new OneInputTransformation<>(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExchange.java
@@ -41,7 +41,7 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.DEFAULT_LOW
 /**
  * This {@link ExecNode} represents a change of partitioning of the input elements for stream.
  *
- * <p>TODO Remove this class once its functionality is replaced by ExecEdge.
+ * <p>TODO Remove this class once FLINK-21224 is finished.
  */
 public class StreamExecExchange extends CommonExecExchange implements StreamExecNode<RowData> {
 
@@ -53,7 +53,7 @@ public class StreamExecExchange extends CommonExecExchange implements StreamExec
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
-                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+                (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
 
         final StreamPartitioner<RowData> partitioner;
         final int parallelism;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecExpand.java
@@ -36,6 +36,11 @@ public class StreamExecExpand extends CommonExecExpand implements StreamExecNode
             InputProperty inputProperty,
             RowType outputType,
             String description) {
-        super(projects, true, inputProperty, outputType, description);
+        super(
+                projects,
+                true, // retainHeader
+                inputProperty,
+                outputType,
+                description);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -102,9 +103,10 @@ public class StreamExecGroupAggregate extends ExecNodeBase<RowData>
                             + "state size. You may specify a retention time of 0 to not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final AggsHandlerCodeGenerator generator =
                 new AggsHandlerCodeGenerator(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -94,9 +95,10 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
                             + "state size. You may specify a retention time of 0 to not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final AggsHandlerCodeGenerator generator =
                 new AggsHandlerCodeGenerator(
@@ -121,8 +123,8 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         aggCallNeedRetractions,
                         needRetraction,
-                        true,
-                        true);
+                        true, // isStateBackendDataViews
+                        true); // needDistinctInfo
         final GeneratedTableAggsHandleFunction aggsHandler =
                 generator.generateTableAggsHandler("GroupTableAggHandler", aggInfoList);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.planner.plan.logical.LogicalWindow;
 import org.apache.flink.table.planner.plan.logical.SessionGroupWindow;
 import org.apache.flink.table.planner.plan.logical.SlidingGroupWindow;
 import org.apache.flink.table.planner.plan.logical.TumblingGroupWindow;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -131,9 +132,10 @@ public class StreamExecGroupWindowAggregate extends ExecNodeBase<RowData>
                             + "excessive state size. You may specify a retention time of 0 to not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final int inputTimeFieldIndex;
         if (isRowtimeAttribute(window.timeAttribute())) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.IntervalJoinSpec;
@@ -76,13 +76,15 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
     @Override
     @SuppressWarnings("unchecked")
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        ExecNode<RowData> leftInput = (ExecNode<RowData>) getInputNodes().get(0);
-        ExecNode<RowData> rightInput = (ExecNode<RowData>) getInputNodes().get(1);
+        ExecEdge leftInputEdge = getInputEdges().get(0);
+        ExecEdge rightInputEdge = getInputEdges().get(1);
 
-        RowType leftRowType = (RowType) leftInput.getOutputType();
-        RowType rightRowType = (RowType) rightInput.getOutputType();
-        Transformation<RowData> leftInputTransform = leftInput.translateToPlan(planner);
-        Transformation<RowData> rightInputTransform = rightInput.translateToPlan(planner);
+        RowType leftRowType = (RowType) leftInputEdge.getOutputType();
+        RowType rightRowType = (RowType) rightInputEdge.getOutputType();
+        Transformation<RowData> leftInputTransform =
+                (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
+        Transformation<RowData> rightInputTransform =
+                (Transformation<RowData>) rightInputEdge.translateToPlan(planner);
 
         RowType returnType = (RowType) getOutputType();
         InternalTypeInfo<RowData> returnTypeInfo = InternalTypeInfo.of(returnType);
@@ -164,6 +166,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
 
     private static class FilterAllFlatMapFunction
             implements FlatMapFunction<RowData, RowData>, ResultTypeQueryable<RowData> {
+        private static final long serialVersionUID = 1L;
 
         private final InternalTypeInfo<RowData> outputTypeInfo;
 
@@ -182,6 +185,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
 
     private static class PaddingLeftMapFunction
             implements MapFunction<RowData, RowData>, ResultTypeQueryable<RowData> {
+        private static final long serialVersionUID = 1L;
 
         private final OuterJoinPaddingUtil paddingUtil;
         private final InternalTypeInfo<RowData> outputTypeInfo;
@@ -205,6 +209,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
 
     private static class PaddingRightMapFunction
             implements MapFunction<RowData, RowData>, ResultTypeQueryable<RowData> {
+        private static final long serialVersionUID = 1L;
 
         private final OuterJoinPaddingUtil paddingUtil;
         private final InternalTypeInfo<RowData> outputTypeInfo;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.JoinSpec;
@@ -73,16 +73,16 @@ public class StreamExecJoin extends ExecNodeBase<RowData> implements StreamExecN
     @Override
     @SuppressWarnings("unchecked")
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final TableConfig tableConfig = planner.getTableConfig();
+        final ExecEdge leftInputEdge = getInputEdges().get(0);
+        final ExecEdge rightInputEdge = getInputEdges().get(1);
 
-        final ExecNode<RowData> leftInput = (ExecNode<RowData>) getInputNodes().get(0);
-        final ExecNode<RowData> rightInput = (ExecNode<RowData>) getInputNodes().get(1);
+        final Transformation<RowData> leftTransform =
+                (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
+        final Transformation<RowData> rightTransform =
+                (Transformation<RowData>) rightInputEdge.translateToPlan(planner);
 
-        final Transformation<RowData> leftTransform = leftInput.translateToPlan(planner);
-        final Transformation<RowData> rightTransform = rightInput.translateToPlan(planner);
-
-        final RowType leftType = (RowType) leftInput.getOutputType();
-        final RowType rightType = (RowType) rightInput.getOutputType();
+        final RowType leftType = (RowType) leftInputEdge.getOutputType();
+        final RowType rightType = (RowType) rightInputEdge.getOutputType();
         JoinUtil.validateJoinSpec(joinSpec, leftType, rightType, true);
 
         final int[] leftJoinKey = joinSpec.getLeftKeys();
@@ -96,6 +96,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData> implements StreamExecN
         final JoinInputSideSpec rightInputSpec =
                 JoinUtil.analyzeJoinInput(rightTypeInfo, rightJoinKey, rightUniqueKeys);
 
+        final TableConfig tableConfig = planner.getTableConfig();
         GeneratedJoinCondition generatedCondition =
                 JoinUtil.generateConditionFunction(tableConfig, joinSpec, leftType, rightType);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -72,9 +73,10 @@ public class StreamExecLocalGroupAggregate extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final AggsHandlerCodeGenerator generator =
                 new AggsHandlerCodeGenerator(
@@ -94,8 +96,8 @@ public class StreamExecLocalGroupAggregate extends ExecNodeBase<RowData>
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         aggCallNeedRetractions,
                         needRetraction,
-                        false,
-                        true);
+                        false, // isStateBackendDataViews
+                        true); // needDistinctInfo
         final GeneratedAggsHandleFunction aggsHandler =
                 generator.generateAggsHandler("GroupAggsHandler", aggInfoList);
         final MiniBatchLocalGroupAggFunction aggFunction =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.MatchCodeGenerator;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -93,12 +94,13 @@ public class StreamExecMatch extends ExecNodeBase<RowData> implements StreamExec
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final TableConfig config = planner.getTableConfig();
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         checkOrderKeys(inputRowType);
+        final TableConfig config = planner.getTableConfig();
         final EventComparator<RowData> eventComparator =
                 createEventComparator(config, inputRowType);
         final Transformation<RowData> timestampedInputTransform =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -64,7 +64,7 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
         final Transformation<RowData> inputTransform =
-                (Transformation<RowData>) getInputNodes().get(0).translateToPlan(planner);
+                (Transformation<RowData>) getInputEdges().get(0).translateToPlan(planner);
 
         final OneInputStreamOperator<RowData, RowData> operator;
         if (miniBatchInterval.mode() == MiniBatchMode.ProcTime()) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
 import org.apache.flink.table.planner.codegen.agg.AggsHandlerCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -110,9 +111,10 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
                             + "excessive state size. You may specify a retention time of 0 to not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final int orderKey = orderKeys[0];
         final LogicalType orderKeyType = inputRowType.getFields().get(orderKey).getType();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -93,9 +94,10 @@ public class StreamExecPythonGroupAggregate extends ExecNodeBase<RowData>
                             + "to prevent excessive state size. You may specify a retention time "
                             + "of 0 to not clean up the state.");
         }
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final AggregateInfoList aggInfoList =
                 AggregateUtil.transformToStreamAggregateInfoList(
@@ -103,8 +105,8 @@ public class StreamExecPythonGroupAggregate extends ExecNodeBase<RowData>
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         aggCallNeedRetractions,
                         needRetraction,
-                        true,
-                        true);
+                        true, // isStateBackendDataViews
+                        true); // needDistinctInfo
         final int inputCountIndex = aggInfoList.getIndexOfCountStar();
         final boolean countStarInserted = aggInfoList.countStarInserted();
         Tuple2<PythonAggregateFunctionInfo[], DataViewUtils.DataViewSpec[][]>

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -41,6 +41,7 @@ import org.apache.flink.table.planner.expressions.PlannerWindowStart;
 import org.apache.flink.table.planner.plan.logical.LogicalWindow;
 import org.apache.flink.table.planner.plan.logical.SlidingGroupWindow;
 import org.apache.flink.table.planner.plan.logical.TumblingGroupWindow;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -133,9 +134,10 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                             + " not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
         final RowType outputRowType = InternalTypeInfo.of(getOutputType()).toRowType();
 
         final int inputTimeFieldIndex;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -112,9 +113,10 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
                             + "excessive state size. You may specify a retention time of 0 to not clean up the state.");
         }
 
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final int orderKey = orderKeys[0];
         final LogicalType orderKeyType = inputRowType.getFields().get(orderKey).getType();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -113,10 +114,11 @@ public class StreamExecRank extends ExecNodeBase<RowData> implements StreamExecN
                                 "Streaming tables do not support %s rank function.", rankType));
         }
 
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        RowType inputType = (RowType) inputNode.getOutputType();
+        RowType inputType = (RowType) inputEdge.getOutputType();
         InternalTypeInfo<RowData> inputRowTypeInfo = InternalTypeInfo.of(inputType);
         int[] sortFields = sortSpec.getFieldIndices();
         RowDataKeySelector sortKeySelector =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecSink;
@@ -64,9 +65,10 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<Object> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
-        final RowType inputRowType = (RowType) inputNode.getOutputType();
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+        final RowType inputRowType = (RowType) inputEdge.getOutputType();
 
         final List<Integer> rowtimeFieldIndices = new ArrayList<>();
         for (int i = 0; i < inputRowType.getFieldCount(); ++i) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.SortSpec;
@@ -66,10 +66,11 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
                             + "please re-check sort statement according to the description above");
         }
 
-        ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
-        RowType inputType = (RowType) inputNode.getOutputType();
+        RowType inputType = (RowType) inputEdge.getOutputType();
         LogicalType timeType = inputType.getTypeAt(sortSpec.getFieldSpec(0).getFieldIndex());
         TableConfig config = planner.getTableConfig();
         if (timeType instanceof TimestampType) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.WatermarkGeneratorCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -59,15 +60,15 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
     @SuppressWarnings("unchecked")
     @Override
     protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
-        final ExecNode<RowData> inputNode = (ExecNode<RowData>) getInputNodes().get(0);
-        final Transformation<RowData> inputTransform = inputNode.translateToPlan(planner);
+        final ExecEdge inputEdge = getInputEdges().get(0);
+        final Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
 
         final TableConfig tableConfig = planner.getTableConfig();
-
         final GeneratedWatermarkGenerator watermarkGenerator =
                 WatermarkGeneratorCodeGenerator.generateWatermarkGenerator(
                         tableConfig,
-                        (RowType) inputNode.getOutputType(),
+                        (RowType) inputEdge.getOutputType(),
                         watermarkExpr,
                         JavaScalaConversionUtil.toScala(Optional.empty()));
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.utils;
 
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLegacySink;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -373,7 +375,10 @@ public class ExecNodePlanDumper {
             // whether visit input nodes of current node
             final boolean visitInputs =
                     (firstVisited || !isReuseNode) && !stopVisitNodes.contains(node);
-            final List<ExecNode<?>> inputNodes = node.getInputNodes();
+            final List<ExecNode<?>> inputNodes =
+                    node.getInputEdges().stream()
+                            .map(ExecEdge::getSource)
+                            .collect(Collectors.toList());
             if (visitInputs && inputNodes.size() > 1) {
                 inputNodes
                         .subList(0, inputNodes.size() - 1)

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/visitor/AbstractExecNodeExactlyOnceVisitor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/visitor/AbstractExecNodeExactlyOnceVisitor.java
@@ -43,6 +43,6 @@ public abstract class AbstractExecNodeExactlyOnceVisitor implements ExecNodeVisi
     protected abstract void visitNode(ExecNode<?> node);
 
     protected void visitInputs(ExecNode<?> node) {
-        node.getInputNodes().forEach(n -> n.accept(this));
+        node.getInputEdges().forEach(n -> n.getSource().accept(this));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/visitor/ExecNodeVisitorImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/visitor/ExecNodeVisitorImpl.java
@@ -31,6 +31,6 @@ public class ExecNodeVisitorImpl implements ExecNodeVisitor {
     }
 
     protected void visitInputs(ExecNode<?> node) {
-        node.getInputNodes().forEach(n -> n.accept(this));
+        node.getInputEdges().forEach(n -> n.getSource().accept(this));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -106,8 +106,8 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
         ExecNodeGraphGenerator generator = new ExecNodeGraphGenerator();
         ExecNodeGraph execGraph = generator.generate(Collections.singletonList(optimizedRel));
         ExecNode<?> execNode = execGraph.getRootNodes().get(0);
-        while (!execNode.getInputNodes().isEmpty()) {
-            execNode = execNode.getInputNodes().get(0);
+        while (!execNode.getInputEdges().isEmpty()) {
+            execNode = execNode.getInputEdges().get(0).getSource();
         }
         DAGProcessContext context = new DAGProcessContext(util.getPlanner());
         Assert.assertEquals(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputOrderCalculatorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputOrderCalculatorTest.java
@@ -44,7 +44,7 @@ public class InputOrderCalculatorTest {
         // 5 -P-> 6 -B-/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[7];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[3].addInput(nodes[1]);
@@ -82,7 +82,7 @@ public class InputOrderCalculatorTest {
         // 2 -(P1)-> 5 -(P1)-/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[9];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[3].addInput(nodes[0], InputProperty.builder().priority(1).build());
         nodes[4].addInput(nodes[1], InputProperty.builder().priority(1).build());
@@ -131,7 +131,7 @@ public class InputOrderCalculatorTest {
         //           3 -(P1)-/           6 -(B0)-/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[7];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[2].addInput(
@@ -169,7 +169,7 @@ public class InputOrderCalculatorTest {
         //                     7 --(B0)--/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[8];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[2].addInput(
@@ -204,8 +204,8 @@ public class InputOrderCalculatorTest {
 
     @Test(expected = IllegalStateException.class)
     public void testCalculateInputOrderWithLoop() {
-        TestingBatchExecNode a = new TestingBatchExecNode();
-        TestingBatchExecNode b = new TestingBatchExecNode();
+        TestingBatchExecNode a = new TestingBatchExecNode("TestingBatchExecNode0");
+        TestingBatchExecNode b = new TestingBatchExecNode("TestingBatchExecNode1");
         for (int i = 0; i < 2; i++) {
             b.addInput(a, InputProperty.builder().priority(i).build());
         }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor.utils;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.TestingBatchExecNode;
@@ -52,7 +53,7 @@ public class InputPriorityConflictResolverTest {
         // 6 ---------(P100)----------------/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[9];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0], InputProperty.builder().priority(0).build());
         nodes[2].addInput(nodes[1], InputProperty.builder().priority(0).build());
@@ -86,12 +87,14 @@ public class InputPriorityConflictResolverTest {
         Assert.assertEquals(
                 Optional.of(ShuffleMode.BATCH),
                 ((BatchExecExchange) nodes[7].getInputNodes().get(2)).getRequiredShuffleMode());
-        Assert.assertEquals(nodes[3], nodes[7].getInputNodes().get(2).getInputNodes().get(0));
+        Assert.assertEquals(
+                nodes[3], nodes[7].getInputNodes().get(2).getInputEdges().get(0).getSource());
         Assert.assertTrue(nodes[7].getInputNodes().get(3) instanceof BatchExecExchange);
         Assert.assertEquals(
                 Optional.of(ShuffleMode.BATCH),
                 ((BatchExecExchange) nodes[7].getInputNodes().get(3)).getRequiredShuffleMode());
-        Assert.assertEquals(nodes[4], nodes[7].getInputNodes().get(3).getInputNodes().get(0));
+        Assert.assertEquals(
+                nodes[4], nodes[7].getInputNodes().get(3).getInputEdges().get(0).getSource());
         Assert.assertEquals(nodes[5], nodes[7].getInputNodes().get(4));
         Assert.assertEquals(nodes[6], nodes[7].getInputNodes().get(5));
     }
@@ -104,7 +107,7 @@ public class InputPriorityConflictResolverTest {
         //                    \-(P1)-/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[2];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
 
         BatchExecExchange exchange =
@@ -115,7 +118,8 @@ public class InputPriorityConflictResolverTest {
                         (RowType) nodes[0].getOutputType(),
                         "Exchange");
         exchange.setRequiredShuffleMode(ShuffleMode.BATCH);
-        exchange.setInputNodes(Collections.singletonList(nodes[0]));
+        ExecEdge execEdge = ExecEdge.builder().source(nodes[0]).target(exchange).build();
+        exchange.setInputEdges(Collections.singletonList(execEdge));
 
         nodes[1].addInput(exchange, InputProperty.builder().priority(0).build());
         nodes[1].addInput(exchange, InputProperty.builder().priority(1).build());
@@ -137,7 +141,7 @@ public class InputPriorityConflictResolverTest {
                     Assert.assertTrue(execNode instanceof BatchExecExchange);
                     BatchExecExchange e = (BatchExecExchange) execNode;
                     Assert.assertEquals(Optional.of(ShuffleMode.BATCH), e.getRequiredShuffleMode());
-                    Assert.assertEquals(nodes[0], e.getInputNodes().get(0));
+                    Assert.assertEquals(nodes[0], e.getInputEdges().get(0).getSource());
                 };
         checkExchange.accept(input0);
         checkExchange.accept(input1);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityGraphGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityGraphGeneratorTest.java
@@ -43,7 +43,7 @@ public class InputPriorityGraphGeneratorTest {
         // 6 -----E-----/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[7];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[2].addInput(
@@ -78,7 +78,7 @@ public class InputPriorityGraphGeneratorTest {
         // 3 -P-> 4 -E/
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[5];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[2].addInput(nodes[1]);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/TopologyGraphTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/TopologyGraphTest.java
@@ -39,7 +39,7 @@ public class TopologyGraphTest {
         //             \-> 6 -> 7
         TestingBatchExecNode[] nodes = new TestingBatchExecNode[8];
         for (int i = 0; i < nodes.length; i++) {
-            nodes[i] = new TestingBatchExecNode();
+            nodes[i] = new TestingBatchExecNode("TestingBatchExecNode" + i);
         }
         nodes[1].addInput(nodes[0]);
         nodes[2].addInput(nodes[1]);


### PR DESCRIPTION

## What is the purpose of the change

*Introduce ExecEdge to connect two ExecNodes*


## Brief change log

  - *Introduce ExecEdge to connect two ExecNodes*
  - *introduce getInputEdges, setInputEdges, replaceInputEdge in ExecNode*
  - *remove getInputNodes, replaceInputNode, and all places where the getInputNodes method is used should be replaced with getInputEdges*
  - *Introduce toString method in InputProperty for easily debugging*


## Verifying this change


This change is already covered by existing tests, such as *InputPriorityConflictResolverTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
