### PR TITLE
[FLINK-21215][task] Do not overwrite the original CheckpointFailureReason in AsyncCheckpointRunnable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -257,8 +257,8 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 Math.max(lastCancelledOrCompletedCheckpointId, cancelledId);
         numBarriersReceived = 0;
         controller.abortPendingCheckpoint(cancelledId, exception);
-        allBarriersReceivedFuture.completeExceptionally(exception);
         notifyAbort(cancelledId, exception);
+        allBarriersReceivedFuture.completeExceptionally(exception);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -263,11 +264,20 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                     // Otherwise this followup exception could race the original exception in
                     // failing the task.
                     try {
+                        Optional<CheckpointException> underlyingCheckpointException =
+                                ExceptionUtils.findThrowable(
+                                        checkpointException, CheckpointException.class);
+
+                        // If this failure is already a CheckpointException, do not overwrite the
+                        // original CheckpointFailureReason
+                        CheckpointFailureReason reportedFailureReason =
+                                underlyingCheckpointException
+                                        .map(exception -> exception.getCheckpointFailureReason())
+                                        .orElse(CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
                         taskEnvironment.declineCheckpoint(
                                 checkpointMetaData.getCheckpointId(),
                                 new CheckpointException(
-                                        CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION,
-                                        checkpointException));
+                                        reportedFailureReason, checkpointException));
                     } catch (Exception unhandled) {
                         AsynchronousException asyncException = new AsynchronousException(unhandled);
                         asyncExceptionHandler.handleAsyncException(


### PR DESCRIPTION
Previously there were two issues:
1. Original failure reason would be hidden and replaced with CHECKPOINT_ASYNC_EXCEPTION
2. The order of cancelling AsyncCheckpointRunnable and notifing the JM was sub-optimal.
   Instead of notifing the JM first, we were first cancelling the future, which could
   create a race condition, were the secondary failure was reported first, causing
   slightly less readable logs/error messages.

## Verifying this change

Added unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
