### PR TITLE
[FLINK-21086][runtime][checkpoint] CheckpointBarrierHandler Insert barriers for channels received EndOfPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/FinalizeBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/FinalizeBarrier.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * A prioritized event inserted when received EndOfPartition to notify the checkpoint barrier. It
+ * could be viewed as a notification that all the barriers whose id is greater than or equal to
+ * {@code nextBarrierId} will need inserting.
+ */
+public class FinalizeBarrier extends RuntimeEvent {
+    private final long nextBarrierId;
+
+    public FinalizeBarrier(long nextBarrierId) {
+        this.nextBarrierId = nextBarrierId;
+    }
+
+    public long getNextBarrierId() {
+        return nextBarrierId;
+    }
+
+    @Override
+    public void write(DataOutputView out) throws IOException {
+        throw new UnsupportedOperationException("This method should never be called");
+    }
+
+    @Override
+    public void read(DataInputView in) throws IOException {
+        throw new UnsupportedOperationException("This method should never be called");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FinalizeBarrier that = (FinalizeBarrier) o;
+        return nextBarrierId == that.nextBarrierId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nextBarrierId);
+    }
+
+    @Override
+    public String toString() {
+        return "FinalizeBarrier{" + "nextBarrierId=" + nextBarrierId + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractReader.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
 import org.apache.flink.runtime.io.network.api.TaskEventHandler;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.util.event.EventListener;
@@ -88,6 +89,9 @@ public abstract class AbstractReader implements ReaderBase {
             // channel, at which it was received.
             if (eventType == EndOfPartitionEvent.class) {
                 return true;
+            } else if (eventType == FinalizeBarrier.class) {
+                // Batch tasks do not have checkpoints and should ignore FinalizeBarrier event.
+                return false;
             } else if (eventType == EndOfSuperstepEvent.class) {
                 return incrementEndOfSuperstepEventAndCheck();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.api.reader;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.DeserializationResult;
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
@@ -129,6 +130,11 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
                 currentRecordDeserializer = recordDeserializers.get(bufferOrEvent.getChannelInfo());
                 currentRecordDeserializer.setNextBuffer(bufferOrEvent.getBuffer());
             } else {
+                // Batch tasks do not have checkpoints and should ignore FinalizeBarrier event.
+                if (bufferOrEvent.getEvent() instanceof FinalizeBarrier) {
+                    continue;
+                }
+
                 // sanity check for leftover data in deserializers. events should only come between
                 // records, not in the middle of a fragment
                 if (recordDeserializers.get(bufferOrEvent.getChannelInfo()).hasUnfinishedData()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
@@ -64,6 +65,8 @@ public class EventSerializer {
     private static final int END_OF_CHANNEL_STATE_EVENT = 5;
 
     private static final int ANNOUNCEMENT_EVENT = 6;
+
+    private static final int FINALIZE_BARRIER_EVENT = 7;
 
     private static final int CHECKPOINT_TYPE_CHECKPOINT = 0;
 
@@ -105,6 +108,13 @@ public class EventSerializer {
             serializedAnnouncement.put(serializedAnnouncedEvent);
             serializedAnnouncement.flip();
             return serializedAnnouncement;
+        } else if (eventClass == FinalizeBarrier.class) {
+            FinalizeBarrier finalizeBarrier = (FinalizeBarrier) event;
+
+            ByteBuffer buf = ByteBuffer.allocate(12);
+            buf.putInt(0, FINALIZE_BARRIER_EVENT);
+            buf.putLong(4, finalizeBarrier.getNextBarrierId());
+            return buf;
         } else {
             try {
                 final DataOutputSerializer serializer = new DataOutputSerializer(128);
@@ -145,6 +155,9 @@ public class EventSerializer {
                 int sequenceNumber = buffer.getInt();
                 AbstractEvent announcedEvent = fromSerializedEvent(buffer, classLoader);
                 return new EventAnnouncement(announcedEvent, sequenceNumber);
+            } else if (type == FINALIZE_BARRIER_EVENT) {
+                long nextBarrierId = buffer.getLong();
+                return new FinalizeBarrier(nextBarrierId);
             } else if (type == OTHER_EVENT) {
                 try {
                     final DataInputDeserializer deserializer = new DataInputDeserializer(buffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -189,6 +189,10 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
         return deque.peek();
     }
 
+    public T removeLast() {
+        return deque.removeLast();
+    }
+
     /** Returns the current number of priority elements ([0; {@link #size()}]). */
     public int getNumPriorityElements() {
         return numPriorityElements;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/CheckpointableInput.java
@@ -46,4 +46,7 @@ public interface CheckpointableInput {
     int getInputGateIndex();
 
     void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException;
+
+    void insertBarrierBeforeEndOfPartition(int channelIndex, CheckpointBarrier barrier)
+            throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/IndexedInputGate.java
@@ -60,4 +60,10 @@ public abstract class IndexedInputGate extends InputGate implements Checkpointab
     public void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException {
         getChannel(channelIndex).convertToPriorityEvent(sequenceNumber);
     }
+
+    @Override
+    public void insertBarrierBeforeEndOfPartition(int channelIndex, CheckpointBarrier barrier)
+            throws IOException {
+        getChannel(channelIndex).insertBarrierBeforeEndOfPartition(barrier);
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -789,12 +789,13 @@ public class SingleInputGate extends IndexedInputGate {
 
     @Override
     public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
-        checkState(!isFinished(), "InputGate already finished.");
-        // BEWARE: consumption resumption only happens for streaming jobs in which all slots
-        // are allocated together so there should be no UnknownInputChannel. As a result, it
-        // is safe to not synchronize the requestLock here. We will refactor the code to not
-        // rely on this assumption in the future.
-        channels[channelInfo.getInputChannelIdx()].resumeConsumption();
+        if (!isFinished()) {
+            // BEWARE: consumption resumption only happens for streaming jobs in which all slots
+            // are allocated together so there should be no UnknownInputChannel. As a result, it
+            // is safe to not synchronize the requestLock here. We will refactor the code to not
+            // rely on this assumption in the future.
+            channels[channelInfo.getInputChannelIdx()].resumeConsumption();
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -108,8 +108,8 @@ public class InputGateFairnessTest {
 
         setupInputGate(gate, inputChannels);
 
-        // read all the buffers and the EOF event
-        for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
+        // read all the buffers, finalize barriers and the EOF event
+        for (int i = numberOfChannels * (buffersPerChannel + 2); i > 0; --i) {
             assertNotNull(gate.getNext());
 
             int min = Integer.MAX_VALUE;
@@ -229,8 +229,8 @@ public class InputGateFairnessTest {
         gate.setup();
         gate.requestPartitions();
 
-        // read all the buffers and the EOF event
-        for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
+        // read all the buffers, finalize barriers and the EOF event
+        for (int i = numberOfChannels * (buffersPerChannel + 2); i > 0; --i) {
             assertNotNull(gate.getNext());
 
             int min = Integer.MAX_VALUE;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -66,6 +66,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.CheckpointableOneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
@@ -123,7 +124,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         BasicTypeInfo.STRING_TYPE_INFO,
                         BasicTypeInfo.STRING_TYPE_INFO);
         testHarness.setupOutputForSingletonOperatorChain();
@@ -260,7 +261,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
     public void testCancelFullyAsyncCheckpoints() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         BasicTypeInfo.STRING_TYPE_INFO,
                         BasicTypeInfo.STRING_TYPE_INFO);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -135,6 +135,10 @@ public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Checkpointa
     public void convertToPriorityEvent(int channelIndex, int sequenceNumber) throws IOException {}
 
     @Override
+    public void insertBarrierBeforeEndOfPartition(int channelIndex, CheckpointBarrier barrier)
+            throws IOException {}
+
+    @Override
     public int getInputIndex() {
         return inputIndex;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -71,6 +72,10 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
     @Override
     public void close() throws IOException {}
+
+    public abstract boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
+            throws IOException;
 
     public abstract void processBarrier(
             CheckpointBarrier receivedBarrier, InputChannelInfo channelInfo) throws IOException;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -37,7 +39,7 @@ import java.util.ArrayDeque;
  * from which input channels. Once it has observed all checkpoint barriers for a checkpoint ID, it
  * notifies its listener of a completed checkpoint.
  *
- * <p>Unlike the {@link CheckpointBarrierAligner}, the BarrierTracker does not block the input
+ * <p>Unlike the {@link SingleCheckpointBarrierHandler}, the BarrierTracker does not block the input
  * channels that have sent barriers, so it cannot be used to gain "exactly-once" processing
  * guarantees. It can, however, be used to gain "at least once" processing guarantees.
  *
@@ -76,6 +78,13 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         super(toNotifyOnCheckpoint);
         this.totalNumberOfInputChannels = totalNumberOfInputChannels;
         this.pendingCheckpoints = new ArrayDeque<>();
+    }
+
+    @Override
+    public boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
+            throws IOException {
+        throw new UnsupportedOperationException("not supported yet");
     }
 
     public void processBarrier(CheckpointBarrier receivedBarrier, InputChannelInfo channelInfo)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
@@ -182,8 +183,11 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         } else if (eventClass == CancelCheckpointMarker.class) {
             barrierHandler.processCancellationBarrier(
                     (CancelCheckpointMarker) bufferOrEvent.getEvent());
+        } else if (eventClass == FinalizeBarrier.class) {
+            FinalizeBarrier finalizeBarrier = (FinalizeBarrier) bufferOrEvent.getEvent();
+            barrierHandler.processFinalizeBarrier(finalizeBarrier, bufferOrEvent.getChannelInfo());
         } else if (eventClass == EndOfPartitionEvent.class) {
-            barrierHandler.processEndOfPartition();
+            barrierHandler.processEndOfPartition(bufferOrEvent.getChannelInfo());
         } else if (eventClass == EventAnnouncement.class) {
             EventAnnouncement eventAnnouncement = (EventAnnouncement) bufferOrEvent.getEvent();
             AbstractEvent announcedEvent = eventAnnouncement.getAnnouncedEvent();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/FinalizeBarrierComplementProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/FinalizeBarrierComplementProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Responses for inserting barriers for channels that have received EndOfPartition but has not
+ * processed yet. The inserting happens when a new checkpoint starts or FinalizeBarrier received
+ * from one channel (which means this channel has received EndOfPartition).
+ */
+public class FinalizeBarrierComplementProcessor {
+
+    private final CheckpointableInput[] inputs;
+
+    /** The channels that have received EndOfPartition and their next barrier id. */
+    private final Map<InputChannelInfo, Long> nextBarrierIds = new HashMap<>();
+
+    /** The ongoing checkpoints. */
+    private final TreeMap<Long, CheckpointBarrier> pendingCheckpoints = new TreeMap<>();
+
+    /**
+     * TODO: temporary flag to disable inserting barriers.
+     *
+     * <p>This flag is required since before the recovery process if modified, if some checkpoints
+     * after tasks finished are done, after recovery the finished operators could not be skipped and
+     * would cause data duplication. This flag would be remove together with flags at JM side after
+     * all the PRs are merged.
+     */
+    private boolean allowComplementBarrier;
+
+    public FinalizeBarrierComplementProcessor(CheckpointableInput... inputs) {
+        this.inputs = inputs;
+    }
+
+    public void setAllowComplementBarrier(boolean allowComplementBarrier) {
+        this.allowComplementBarrier = allowComplementBarrier;
+    }
+
+    public boolean isAllowComplementBarrier() {
+        return allowComplementBarrier;
+    }
+
+    public void processFinalBarrier(
+            FinalizeBarrier finalizeBarrier, InputChannelInfo inputChannelInfo) throws IOException {
+        checkState(!nextBarrierIds.containsKey(inputChannelInfo));
+
+        nextBarrierIds.put(inputChannelInfo, finalizeBarrier.getNextBarrierId());
+        insertBarriers(inputChannelInfo);
+    }
+
+    public void onEndOfPartition(InputChannelInfo inputChannelInfo) {
+        nextBarrierIds.remove(inputChannelInfo);
+    }
+
+    public void onCheckpointAlignmentStart(CheckpointBarrier receivedBarrier) throws IOException {
+        onNewCheckpoint(receivedBarrier);
+    }
+
+    public void onCheckpointAlignmentEnd(long checkpointId) {
+        pendingCheckpoints.headMap(checkpointId, true).clear();
+    }
+
+    public void onTriggeringCheckpoint(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
+            throws IOException {
+        onNewCheckpoint(
+                new CheckpointBarrier(
+                        checkpointMetaData.getCheckpointId(),
+                        checkpointMetaData.getTimestamp(),
+                        checkpointOptions));
+    }
+
+    private void onNewCheckpoint(CheckpointBarrier receivedBarrier) throws IOException {
+        // Checkpoints trigger via RPC would get notification again when received the first
+        // inserted barrier, we should ignore the repeat notification.
+        if (!pendingCheckpoints.containsKey(receivedBarrier.getId())) {
+            pendingCheckpoints.put(receivedBarrier.getId(), receivedBarrier);
+            for (InputChannelInfo inputChannelInfo : nextBarrierIds.keySet()) {
+                insertBarriers(inputChannelInfo);
+            }
+        }
+    }
+
+    private void insertBarriers(InputChannelInfo inputChannelInfo) throws IOException {
+        long nextBarrierId = nextBarrierIds.get(inputChannelInfo);
+
+        NavigableMap<Long, CheckpointBarrier> barriersToInsert =
+                pendingCheckpoints.tailMap(nextBarrierId, true);
+        if (barriersToInsert.size() > 0) {
+            for (Map.Entry<Long, CheckpointBarrier> entry : barriersToInsert.entrySet()) {
+                if (allowComplementBarrier) {
+                    inputs[inputChannelInfo.getGateIdx()].insertBarrierBeforeEndOfPartition(
+                            inputChannelInfo.getInputChannelIdx(), entry.getValue());
+                }
+            }
+
+            nextBarrierIds.put(inputChannelInfo, barriersToInsert.lastEntry().getKey() + 1);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
@@ -32,11 +32,8 @@ import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
 import org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinator;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
-
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -47,53 +44,11 @@ import java.util.stream.Stream;
  */
 @Internal
 public class InputProcessorUtil {
-    @SuppressWarnings("unchecked")
-    public static CheckpointedInputGate createCheckpointedInputGate(
-            AbstractInvokable toNotifyOnCheckpoint,
-            StreamConfig config,
-            SubtaskCheckpointCoordinator checkpointCoordinator,
-            IndexedInputGate[] inputGates,
-            TaskIOMetricGroup taskIOMetricGroup,
-            String taskName,
-            MailboxExecutor mailboxExecutor) {
-        CheckpointedInputGate[] checkpointedInputGates =
-                createCheckpointedMultipleInputGate(
-                        toNotifyOnCheckpoint,
-                        config,
-                        checkpointCoordinator,
-                        taskIOMetricGroup,
-                        taskName,
-                        mailboxExecutor,
-                        new List[] {Arrays.asList(inputGates)},
-                        Collections.emptyList());
-        return Iterables.getOnlyElement(Arrays.asList(checkpointedInputGates));
-    }
 
     /**
      * @return an array of {@link CheckpointedInputGate} created for corresponding {@link
      *     InputGate}s supplied as parameters.
      */
-    public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
-            AbstractInvokable toNotifyOnCheckpoint,
-            StreamConfig config,
-            SubtaskCheckpointCoordinator checkpointCoordinator,
-            TaskIOMetricGroup taskIOMetricGroup,
-            String taskName,
-            MailboxExecutor mailboxExecutor,
-            List<IndexedInputGate>[] inputGates,
-            List<StreamTaskSourceInput<?>> sourceInputs) {
-        CheckpointBarrierHandler barrierHandler =
-                createCheckpointBarrierHandler(
-                        toNotifyOnCheckpoint,
-                        config,
-                        checkpointCoordinator,
-                        taskName,
-                        inputGates,
-                        sourceInputs);
-        return createCheckpointedMultipleInputGate(
-                mailboxExecutor, inputGates, taskIOMetricGroup, barrierHandler, config);
-    }
-
     public static CheckpointedInputGate[] createCheckpointedMultipleInputGate(
             MailboxExecutor mailboxExecutor,
             List<IndexedInputGate>[] inputGates,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -101,6 +103,13 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         this.taskName = taskName;
         this.numOpenChannels = numOpenChannels;
         this.controller = controller;
+    }
+
+    @Override
+    public boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
+            throws IOException {
+        throw new UnsupportedOperationException("not supported yet");
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractNonSourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractNonSourceStreamTask.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.security.FlinkSecurityManager;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+
+import javax.annotation.Nullable;
+
+/** Base class for non-source tasks which need to trigger {@link CheckpointBarrierHandler}. */
+public abstract class AbstractNonSourceStreamTask<OUT, OP extends StreamOperator<OUT>>
+        extends StreamTask<OUT, OP> {
+
+    protected AbstractNonSourceStreamTask(Environment env) throws Exception {
+        super(env);
+    }
+
+    protected AbstractNonSourceStreamTask(Environment env, @Nullable TimerService timerService)
+            throws Exception {
+        super(env, timerService);
+    }
+
+    protected AbstractNonSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler);
+    }
+
+    protected AbstractNonSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+            StreamTaskActionExecutor actionExecutor)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler, actionExecutor);
+    }
+
+    protected AbstractNonSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+            StreamTaskActionExecutor actionExecutor,
+            TaskMailbox mailbox)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler, actionExecutor, mailbox);
+    }
+
+    @Nullable
+    protected abstract CheckpointBarrierHandler getCheckpointBarrierHandler();
+
+    @Override
+    protected boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            boolean advanceToEndOfEventTime)
+            throws Exception {
+
+        FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
+
+        try {
+            CheckpointBarrierHandler checkpointBarrierHandler = getCheckpointBarrierHandler();
+            if (checkpointBarrierHandler == null) {
+                return false;
+            }
+
+            boolean success =
+                    checkpointBarrierHandler.triggerCheckpoint(
+                            checkpointMetaData, checkpointOptions);
+            if (!success) {
+                declineCheckpoint(checkpointMetaData.getCheckpointId());
+            }
+            return success;
+        } catch (Exception e) {
+            if (isRunning) {
+                throw new Exception(
+                        "Could not perform checkpoint "
+                                + checkpointMetaData.getCheckpointId()
+                                + " for task "
+                                + getName()
+                                + '.',
+                        e);
+            } else {
+                LOG.debug(
+                        "Could not perform checkpoint {} for task {} while the "
+                                + "invokable was not in state running.",
+                        checkpointMetaData.getCheckpointId(),
+                        getName(),
+                        e);
+                return false;
+            }
+        } finally {
+            FlinkSecurityManager.unmonitorUserSystemExitForCurrentThread();
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractSourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractSourceStreamTask.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.security.FlinkSecurityManager;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+
+import javax.annotation.Nullable;
+
+/** Base class for source stream tasks which need to trigger a new checkpoint. */
+public abstract class AbstractSourceStreamTask<OUT, OP extends StreamOperator<OUT>>
+        extends StreamTask<OUT, OP> {
+
+    protected long latestAsyncCheckpointStartDelayNanos;
+
+    protected AbstractSourceStreamTask(Environment env) throws Exception {
+        super(env);
+    }
+
+    protected AbstractSourceStreamTask(Environment env, @Nullable TimerService timerService)
+            throws Exception {
+        super(env, timerService);
+    }
+
+    protected AbstractSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler);
+    }
+
+    protected AbstractSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+            StreamTaskActionExecutor actionExecutor)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler, actionExecutor);
+    }
+
+    protected AbstractSourceStreamTask(
+            Environment environment,
+            @Nullable TimerService timerService,
+            Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
+            StreamTaskActionExecutor actionExecutor,
+            TaskMailbox mailbox)
+            throws Exception {
+        super(environment, timerService, uncaughtExceptionHandler, actionExecutor, mailbox);
+    }
+
+    @Override
+    protected boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            boolean advanceToEndOfEventTime)
+            throws Exception {
+
+        FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
+        try {
+            latestAsyncCheckpointStartDelayNanos =
+                    1_000_000
+                            * Math.max(
+                                    0,
+                                    System.currentTimeMillis() - checkpointMetaData.getTimestamp());
+
+            // No alignment if we inject a checkpoint
+            CheckpointMetricsBuilder checkpointMetrics =
+                    new CheckpointMetricsBuilder()
+                            .setAlignmentDurationNanos(0L)
+                            .setBytesProcessedDuringAlignment(0L);
+
+            subtaskCheckpointCoordinator.initCheckpoint(
+                    checkpointMetaData.getCheckpointId(), checkpointOptions);
+
+            boolean success =
+                    performCheckpoint(
+                            checkpointMetaData,
+                            checkpointOptions,
+                            checkpointMetrics,
+                            advanceToEndOfEventTime);
+            if (!success) {
+                declineCheckpoint(checkpointMetaData.getCheckpointId());
+            }
+            return success;
+        } catch (Exception e) {
+            // propagate exceptions only if the task is still in "running" state
+            if (isRunning) {
+                throw new Exception(
+                        "Could not perform checkpoint "
+                                + checkpointMetaData.getCheckpointId()
+                                + " for operator "
+                                + getName()
+                                + '.',
+                        e);
+            } else {
+                LOG.debug(
+                        "Could not perform checkpoint {} for operator {} while the "
+                                + "invokable was not in state running.",
+                        checkpointMetaData.getCheckpointId(),
+                        getName(),
+                        e);
+                return false;
+            }
+        } finally {
+            FlinkSecurityManager.unmonitorUserSystemExitForCurrentThread();
+        }
+    }
+
+    protected long getAsyncCheckpointStartDelayNanos() {
+        return latestAsyncCheckpointStartDelayNanos;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -33,7 +33,7 @@ import java.util.List;
 /** Abstract class for executing a {@link TwoInputStreamOperator}. */
 @Internal
 public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT>
-        extends StreamTask<OUT, TwoInputStreamOperator<IN1, IN2, OUT>> {
+        extends AbstractNonSourceStreamTask<OUT, TwoInputStreamOperator<IN1, IN2, OUT>> {
 
     protected final WatermarkGauge input1WatermarkGauge;
     protected final WatermarkGauge input2WatermarkGauge;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskInput;
 import org.apache.flink.streaming.runtime.io.StreamTaskNetworkInput;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.checkpointing.InputProcessorUtil;
 import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
@@ -43,7 +44,13 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 
+import org.apache.flink.shaded.curator4.com.google.common.collect.Iterables;
+
 import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.flink.streaming.api.graph.StreamConfig.requiresSorting;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -52,6 +59,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 /** A {@link StreamTask} for executing a {@link OneInputStreamOperator}. */
 @Internal
 public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamOperator<IN, OUT>> {
+
+    @Nullable private CheckpointBarrierHandler checkpointBarrierHandler;
 
     private final WatermarkGauge inputWatermarkGauge = new WatermarkGauge();
 
@@ -133,17 +142,28 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                 this);
     }
 
+    @SuppressWarnings("unchecked")
     private CheckpointedInputGate createCheckpointedInputGate() {
         IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
 
-        return InputProcessorUtil.createCheckpointedInputGate(
-                this,
-                configuration,
-                getCheckpointCoordinator(),
-                inputGates,
-                getEnvironment().getMetricGroup().getIOMetricGroup(),
-                getTaskNameWithSubtaskAndId(),
-                mainMailboxExecutor);
+        checkpointBarrierHandler =
+                InputProcessorUtil.createCheckpointBarrierHandler(
+                        this,
+                        configuration,
+                        getCheckpointCoordinator(),
+                        getTaskNameWithSubtaskAndId(),
+                        new List[] {Arrays.asList(inputGates)},
+                        Collections.emptyList());
+
+        CheckpointedInputGate[] checkpointedInputGates =
+                InputProcessorUtil.createCheckpointedMultipleInputGate(
+                        mainMailboxExecutor,
+                        new List[] {Arrays.asList(inputGates)},
+                        getEnvironment().getMetricGroup().getIOMetricGroup(),
+                        checkpointBarrierHandler,
+                        configuration);
+
+        return Iterables.getOnlyElement(Arrays.asList(checkpointedInputGates));
     }
 
     private DataOutput<IN> createDataOutput(Counter numRecordsIn) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -58,7 +58,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /** A {@link StreamTask} for executing a {@link OneInputStreamOperator}. */
 @Internal
-public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamOperator<IN, OUT>> {
+public class OneInputStreamTask<IN, OUT>
+        extends AbstractNonSourceStreamTask<OUT, OneInputStreamOperator<IN, OUT>> {
 
     @Nullable private CheckpointBarrierHandler checkpointBarrierHandler;
 
@@ -87,6 +88,12 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
     public OneInputStreamTask(Environment env, @Nullable TimerService timeProvider)
             throws Exception {
         super(env, timeProvider);
+    }
+
+    @Nullable
+    @Override
+    protected CheckpointBarrierHandler getCheckpointBarrierHandler() {
+        return checkpointBarrierHandler;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -49,7 +49,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A subclass of {@link StreamTask} for executing the {@link SourceOperator}. */
 @Internal
-public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T, ?>> {
+public class SourceOperatorStreamTask<T> extends AbstractSourceStreamTask<T, SourceOperator<T, ?>> {
 
     private AsyncDataOutputToOutput<T> output;
     private boolean isExternallyInducedSource;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -55,7 +55,7 @@ import java.util.concurrent.Future;
 @Internal
 public class SourceStreamTask<
                 OUT, SRC extends SourceFunction<OUT>, OP extends StreamSource<OUT, SRC>>
-        extends StreamTask<OUT, OP> {
+        extends AbstractSourceStreamTask<OUT, OP> {
 
     private final LegacySourceFunctionThread sourceThread;
     private final Object lock;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -46,6 +46,12 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
         super(env);
     }
 
+    @Nullable
+    @Override
+    protected CheckpointBarrierHandler getCheckpointBarrierHandler() {
+        return checkpointBarrierHandler;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     protected void createInputProcessor(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.CheckpointableOneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -485,7 +486,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
     public void testStateSnapshotAndRestore() throws Exception {
         final OneInputStreamTaskTestHarness<Integer, Integer> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         1,
                         1,
                         BasicTypeInfo.INT_TYPE_INFO,
@@ -542,7 +543,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
 
         final OneInputStreamTaskTestHarness<Integer, Integer> restoredTaskHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         BasicTypeInfo.INT_TYPE_INFO,
                         BasicTypeInfo.INT_TYPE_INFO);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
@@ -76,7 +76,8 @@ public class AlignedControllerMassiveRandomTest {
                                     new AlignedController(myIG) {
                                         @Override
                                         protected void resetPendingCheckpoint(long cancelledId) {}
-                                    }),
+                                    },
+                                    new FinalizeBarrierComplementProcessor(myIG)),
                             new SyncMailboxExecutor());
 
             for (int i = 0; i < 2000000; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingControllerTest.java
@@ -729,7 +729,8 @@ public class AlternatingControllerTest {
                 new AlternatingController(
                         new AlignedController(inputGate),
                         new UnalignedController(
-                                new TestSubtaskCheckpointCoordinator(stateWriter), inputGate)));
+                                new TestSubtaskCheckpointCoordinator(stateWriter), inputGate)),
+                new FinalizeBarrierComplementProcessor(inputGate));
     }
 
     private static CheckpointedInputGate buildGate(AbstractInvokable target, int numChannels) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -334,7 +334,8 @@ public class CheckpointedInputGateTest {
                         new AbstractInvokable(new DummyEnvironment()) {
                             @Override
                             public void invoke() {}
-                        });
+                        },
+                        new FinalizeBarrierComplementProcessor(singleInputGate));
 
         CheckpointedInputGate checkpointedInputGate =
                 new CheckpointedInputGate(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/FinalizeBarrierComplementProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/FinalizeBarrierComplementProcessorTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.FinalizeBarrier;
+import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.runtime.checkpoint.CheckpointOptions.alignedNoTimeout;
+import static org.apache.flink.runtime.checkpoint.CheckpointOptions.alignedWithTimeout;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
+import static org.junit.Assert.assertEquals;
+
+/*
+ * Tests the behavior of {@link FinalizeBarrierComplementProcessor}.
+ */
+public class FinalizeBarrierComplementProcessorTest {
+    private static final CheckpointOptions UNALIGNED = CheckpointOptions.unaligned(getDefault());
+    private static final CheckpointOptions ALIGNED_WITH_TIMEOUT =
+            alignedWithTimeout(getDefault(), 10);
+    private static final CheckpointOptions ALIGNED_NO_TIMEOUT =
+            alignedNoTimeout(CheckpointType.CHECKPOINT, getDefault());
+
+    @Test
+    public void testNotInsertOnFinalizeBarrierWithoutPendingCheckpoints() throws IOException {
+        RecordingCheckpointableInput[] inputs = createInputs(2);
+        FinalizeBarrierComplementProcessor processor =
+                createFinalizeBarrierComplementProcessor(inputs);
+
+        processor.processFinalBarrier(new FinalizeBarrier(5), new InputChannelInfo(0, 0));
+        assertEquals(0, inputs[0].getInsertedBarriers(0).size());
+    }
+
+    @Test
+    public void testInsertOnFinalizeBarrierForPendingCheckpoint() throws IOException {
+        RecordingCheckpointableInput[] inputs = createInputs(2);
+        FinalizeBarrierComplementProcessor processor =
+                createFinalizeBarrierComplementProcessor(inputs);
+
+        CheckpointBarrier[] barriers = {
+            createBarrier(4, ALIGNED_NO_TIMEOUT),
+            createBarrier(5, ALIGNED_WITH_TIMEOUT),
+            createBarrier(6, UNALIGNED),
+            createBarrier(9, ALIGNED_NO_TIMEOUT)
+        };
+
+        for (CheckpointBarrier barrier : barriers) {
+            processor.onCheckpointAlignmentStart(barrier);
+        }
+
+        processor.processFinalBarrier(new FinalizeBarrier(5), new InputChannelInfo(0, 0));
+        assertEquals(
+                Arrays.asList(barriers[1], barriers[2], barriers[3]),
+                inputs[0].getInsertedBarriers(0));
+    }
+
+    @Test
+    public void testInsertBarriersOnCheckpointStart() throws IOException {
+        RecordingCheckpointableInput[] inputs = createInputs(2);
+        FinalizeBarrierComplementProcessor processor =
+                createFinalizeBarrierComplementProcessor(inputs);
+
+        processor.processFinalBarrier(new FinalizeBarrier(5), new InputChannelInfo(0, 0));
+        processor.processFinalBarrier(new FinalizeBarrier(0), new InputChannelInfo(0, 1));
+        processor.processFinalBarrier(new FinalizeBarrier(3), new InputChannelInfo(1, 0));
+
+        CheckpointBarrier barrier = createBarrier(3, UNALIGNED);
+        processor.onCheckpointAlignmentStart(barrier);
+
+        for (InputChannelInfo channelInfo :
+                Arrays.asList(new InputChannelInfo(0, 1), new InputChannelInfo(1, 0))) {
+            assertEquals(
+                    Collections.singletonList(barrier),
+                    inputs[channelInfo.getGateIdx()].getInsertedBarriers(
+                            channelInfo.getInputChannelIdx()));
+        }
+    }
+
+    @Test
+    public void testPendingCheckpointsRemovedOnCheckpointStop() throws IOException {
+        RecordingCheckpointableInput[] inputs = createInputs(2);
+        FinalizeBarrierComplementProcessor processor =
+                createFinalizeBarrierComplementProcessor(inputs);
+
+        CheckpointBarrier[] barriers = {
+            createBarrier(4, ALIGNED_NO_TIMEOUT),
+            createBarrier(5, ALIGNED_WITH_TIMEOUT),
+            createBarrier(6, UNALIGNED),
+            createBarrier(9, ALIGNED_NO_TIMEOUT)
+        };
+
+        for (CheckpointBarrier barrier : barriers) {
+            processor.onCheckpointAlignmentStart(barrier);
+        }
+
+        // Which would clean all the checkpoints whose id <= 5.
+        processor.onCheckpointAlignmentEnd(5);
+
+        processor.processFinalBarrier(new FinalizeBarrier(0), new InputChannelInfo(0, 0));
+        assertEquals(Arrays.asList(barriers[2], barriers[3]), inputs[0].getInsertedBarriers(0));
+    }
+
+    @Test
+    public void testInsertBarriersOnRpcTrigger() throws IOException {
+        RecordingCheckpointableInput[] inputs = createInputs(2);
+        FinalizeBarrierComplementProcessor processor =
+                createFinalizeBarrierComplementProcessor(inputs);
+
+        processor.processFinalBarrier(new FinalizeBarrier(5), new InputChannelInfo(0, 0));
+        processor.processFinalBarrier(new FinalizeBarrier(0), new InputChannelInfo(0, 1));
+        processor.processFinalBarrier(new FinalizeBarrier(3), new InputChannelInfo(1, 0));
+
+        CheckpointBarrier barrier = createBarrier(3, UNALIGNED);
+        processor.onTriggeringCheckpoint(
+                new CheckpointMetaData(barrier.getId(), barrier.getTimestamp()),
+                barrier.getCheckpointOptions());
+
+        for (InputChannelInfo channelInfo :
+                Arrays.asList(new InputChannelInfo(0, 1), new InputChannelInfo(1, 0))) {
+            assertEquals(
+                    Collections.singletonList(barrier),
+                    inputs[channelInfo.getGateIdx()].getInsertedBarriers(
+                            channelInfo.getInputChannelIdx()));
+        }
+    }
+
+    // ---------------------  Utilities -----------------------------------
+
+    private CheckpointBarrier createBarrier(long checkpointId, CheckpointOptions options) {
+        return new CheckpointBarrier(checkpointId, 101, options);
+    }
+
+    private FinalizeBarrierComplementProcessor createFinalizeBarrierComplementProcessor(
+            RecordingCheckpointableInput... inputs) {
+        FinalizeBarrierComplementProcessor processor =
+                new FinalizeBarrierComplementProcessor(inputs);
+        processor.setAllowComplementBarrier(true);
+        return processor;
+    }
+
+    private RecordingCheckpointableInput[] createInputs(int numberOfInputs) {
+        RecordingCheckpointableInput[] inputs = new RecordingCheckpointableInput[numberOfInputs];
+        for (int i = 0; i < numberOfInputs; ++i) {
+            inputs[i] = new RecordingCheckpointableInput();
+        }
+
+        return inputs;
+    }
+
+    private static class RecordingCheckpointableInput implements CheckpointableInput {
+        private Map<Integer, List<CheckpointBarrier>> insertedBarriers = new HashMap<>();
+
+        @Override
+        public void insertBarrierBeforeEndOfPartition(int channelIndex, CheckpointBarrier barrier)
+                throws IOException {
+            insertedBarriers.computeIfAbsent(channelIndex, k -> new ArrayList<>()).add(barrier);
+        }
+
+        public List<CheckpointBarrier> getInsertedBarriers(int channelIndex) {
+            return insertedBarriers.getOrDefault(channelIndex, new ArrayList<>());
+        }
+
+        public void reset() {
+            insertedBarriers.clear();
+        }
+
+        @Override
+        public void blockConsumption(InputChannelInfo channelInfo) {}
+
+        @Override
+        public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {}
+
+        @Override
+        public List<InputChannelInfo> getChannelInfos() {
+            return null;
+        }
+
+        @Override
+        public int getNumberOfInputChannels() {
+            return 0;
+        }
+
+        @Override
+        public void checkpointStarted(CheckpointBarrier barrier) throws CheckpointException {}
+
+        @Override
+        public void checkpointStopped(long cancelledCheckpointId) {}
+
+        @Override
+        public int getInputGateIndex() {
+            return 0;
+        }
+
+        @Override
+        public void convertToPriorityEvent(int channelIndex, int sequenceNumber)
+                throws IOException {}
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
@@ -68,22 +68,26 @@ public class InputProcessorUtilTest {
                         Collections.singletonList(getGate(0, 2)),
                     };
 
-            CheckpointedInputGate[] checkpointedMultipleInputGate =
-                    InputProcessorUtil.createCheckpointedMultipleInputGate(
+            CheckpointBarrierHandler barrierHandler =
+                    InputProcessorUtil.createCheckpointBarrierHandler(
                             streamTask,
                             streamConfig,
                             new TestSubtaskCheckpointCoordinator(new MockChannelStateWriter()),
-                            environment.getMetricGroup().getIOMetricGroup(),
                             streamTask.getName(),
-                            new SyncMailboxExecutor(),
                             inputGates,
                             Collections.emptyList());
+
+            CheckpointedInputGate[] checkpointedMultipleInputGate =
+                    InputProcessorUtil.createCheckpointedMultipleInputGate(
+                            new SyncMailboxExecutor(),
+                            inputGates,
+                            environment.getMetricGroup().getIOMetricGroup(),
+                            barrierHandler,
+                            streamConfig);
+
             for (CheckpointedInputGate checkpointedInputGate : checkpointedMultipleInputGate) {
                 registry.registerCloseable(checkpointedInputGate);
             }
-
-            CheckpointBarrierHandler barrierHandler =
-                    checkpointedMultipleInputGate[0].getCheckpointBarrierHandler();
 
             List<IndexedInputGate> allInputGates =
                     Arrays.stream(inputGates)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointableOneInputStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointableOneInputStreamTask.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+
+/** A test stream task that also response to the checkpoint trigger requirement. */
+public class CheckpointableOneInputStreamTask<IN, OUT> extends OneInputStreamTask<IN, OUT> {
+
+    public CheckpointableOneInputStreamTask(Environment env) throws Exception {
+        super(env);
+    }
+
+    @Override
+    protected boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData,
+            CheckpointOptions checkpointOptions,
+            boolean advanceToEndOfEventTime)
+            throws Exception {
+
+        CheckpointMetricsBuilder checkpointMetrics =
+                new CheckpointMetricsBuilder()
+                        .setAlignmentDurationNanos(0L)
+                        .setBytesProcessedDuringAlignment(0L);
+        subtaskCheckpointCoordinator.initCheckpoint(
+                checkpointMetaData.getCheckpointId(), checkpointOptions);
+        return performCheckpoint(
+                checkpointMetaData, checkpointOptions, checkpointMetrics, advanceToEndOfEventTime);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -573,7 +573,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         BasicTypeInfo.STRING_TYPE_INFO,
                         BasicTypeInfo.STRING_TYPE_INFO);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -218,7 +218,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         1,
                         1,
                         BasicTypeInfo.STRING_TYPE_INFO,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -220,7 +220,7 @@ public class StreamTaskTerminationTest extends TestLogger {
      * certain interleaving with a concurrently running checkpoint operation.
      */
     public static class BlockingStreamTask<T, OP extends StreamOperator<T>>
-            extends StreamTask<T, OP> {
+            extends AbstractSourceStreamTask<T, OP> {
 
         private boolean isRunning;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1124,7 +1124,7 @@ public class StreamTaskTest extends TestLogger {
             RunningTask<StreamTask<?, ?>> task =
                     runTask(
                             () ->
-                                    new StreamTask<Object, StreamOperator<Object>>(
+                                    new AbstractSourceStreamTask<Object, StreamOperator<Object>>(
                                             mockEnvironment) {
                                         @Override
                                         protected void init() throws Exception {}
@@ -1513,7 +1513,8 @@ public class StreamTaskTest extends TestLogger {
      * @param <T>
      * @param <OP>
      */
-    public static class NoOpStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
+    public static class NoOpStreamTask<T, OP extends StreamOperator<T>>
+            extends AbstractSourceStreamTask<T, OP> {
 
         public NoOpStreamTask(Environment environment) throws Exception {
             super(environment);
@@ -1710,7 +1711,8 @@ public class StreamTaskTest extends TestLogger {
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------
 
-    private static class MockStreamTask extends StreamTask<String, AbstractStreamOperator<String>> {
+    private static class MockStreamTask
+            extends AbstractSourceStreamTask<String, AbstractStreamOperator<String>> {
 
         private final OperatorChain<String, AbstractStreamOperator<String>> overrideOperatorChain;
 
@@ -1789,7 +1791,7 @@ public class StreamTaskTest extends TestLogger {
      * closed them correctly.
      */
     public static class StateBackendTestSource
-            extends StreamTask<Long, StreamSource<Long, SourceFunction<Long>>> {
+            extends AbstractSourceStreamTask<Long, StreamSource<Long, SourceFunction<Long>>> {
 
         private static volatile boolean fail;
 
@@ -1888,7 +1890,7 @@ public class StreamTaskTest extends TestLogger {
     }
 
     private static class ThreadInspectingTask
-            extends StreamTask<String, AbstractStreamOperator<String>> {
+            extends AbstractSourceStreamTask<String, AbstractStreamOperator<String>> {
 
         private final long taskThreadId;
         private final ClassLoader taskClassLoader;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -131,7 +131,7 @@ public class SynchronousCheckpointITCase {
      * A {@link StreamTask} which makes sure that the different phases of a synchronous checkpoint
      * are reflected in the {@link SynchronousCheckpointITCase#eventQueue}.
      */
-    public static class SynchronousCheckpointTestingTask extends StreamTask {
+    public static class SynchronousCheckpointTestingTask extends AbstractSourceStreamTask {
         // Flag to emit the first event only once.
         private boolean isRunning;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestCheckpointBarrierHandler.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
+import org.apache.flink.streaming.runtime.io.checkpointing.FinalizeBarrierComplementProcessor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ public class TestCheckpointBarrierHandler extends CheckpointBarrierHandler {
     private final List<CheckpointBarrier> triggeredCheckpoints = new ArrayList<>();
 
     public TestCheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint) {
-        super(toNotifyOnCheckpoint);
+        super(toNotifyOnCheckpoint, new FinalizeBarrierComplementProcessor(), 0);
     }
 
     @Override
@@ -70,7 +71,7 @@ public class TestCheckpointBarrierHandler extends CheckpointBarrierHandler {
             throws IOException {}
 
     @Override
-    public void processEndOfPartition() throws IOException {}
+    public void processEndOfPartition(InputChannelInfo inputChannelInfo) throws IOException {}
 
     @Override
     public long getLatestCheckpointId() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestCheckpointBarrierHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A test {@link TestCheckpointBarrierHandler} that records the history of checkpoint triggering.
+ */
+public class TestCheckpointBarrierHandler extends CheckpointBarrierHandler {
+    private final List<CheckpointBarrier> triggeredCheckpoints = new ArrayList<>();
+
+    public TestCheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint) {
+        super(toNotifyOnCheckpoint);
+    }
+
+    @Override
+    public boolean triggerCheckpoint(
+            CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
+            throws IOException {
+        triggeredCheckpoints.add(
+                new CheckpointBarrier(
+                        checkpointMetaData.getCheckpointId(),
+                        checkpointMetaData.getTimestamp(),
+                        checkpointOptions));
+        return true;
+    }
+
+    public List<CheckpointBarrier> getTriggeredCheckpoints() {
+        return triggeredCheckpoints;
+    }
+
+    @Override
+    public void processBarrier(CheckpointBarrier receivedBarrier, InputChannelInfo channelInfo)
+            throws IOException {}
+
+    @Override
+    public void processBarrierAnnouncement(
+            CheckpointBarrier announcedBarrier, int sequenceNumber, InputChannelInfo channelInfo)
+            throws IOException {}
+
+    @Override
+    public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier)
+            throws IOException {}
+
+    @Override
+    public void processEndOfPartition() throws IOException {}
+
+    @Override
+    public long getLatestCheckpointId() {
+        return 0;
+    }
+
+    @Override
+    protected boolean isCheckpointPending() {
+        return false;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.CheckpointableOneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
@@ -114,7 +115,7 @@ public class StatefulOperatorChainedTaskTest {
         File localRootDir = temporaryFolder.newFolder();
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
-                        OneInputStreamTask::new,
+                        CheckpointableOneInputStreamTask::new,
                         1,
                         1,
                         BasicTypeInfo.STRING_TYPE_INFO,


### PR DESCRIPTION
## What is the purpose of the change

This PR makes `CheckpointBarrierHandler` inserts barrier for channels that have received EndPartition but not processed it yet. 

When an input channel received EndOfPartition, it would insert a prioritized `FinalizeBarrier` at the head of queue, which indicating to `CheckpointBarrierHandler` that this channel has received `EndOfPartition` and what its next expected barrier id is. 

For `CheckpointBarrierHandler`, it introduce a new component `FinalizeBarrierComplementProcessor` to deal with `FinalizedBarrier` and insert barriers.
1.  When start checkpoint due to received barrier from another channel or RPC trigger, it would insert barriers for all the input channels received EndOfPartition
2. When received `FinalizeBarrier` from one input channel, it would insert barriers for all the pending checkpoints for this channel.
It would also record the next expected barrier id for each channel and would not insert stale barriers.

**LocalInputChannel** 

Previously LocalInputChannel would directly pull buffer from `ResultPartition` and would not cache buffers. However, with inserted barriers, LocalInputChannel would have to support caching some buffers. We would like to use a FIFO queue to cache buffers instead of a prioritized queue to simplify the notification to InputGates (e.g., do not need to notifyPrioritizedEvent for the `LocalInputChannel` as before).

## Brief change log

- 7b5bcb2aea349560a6fac8d07e879f6e135f2e67 introduces the `FinalizedBarrier` event.
- 6f78a9a3c18c8ed8c43cfe6213e80c793e84f5b3 InputChannels insert `FinalizedBarrier` before EndOfPartition and support inserting barriers before EndOfPartition
- 1240dbb9879bedee17ac69d69ab8fd514589febd Modify the `CheckpointBarrierHandler` to support insert barriers when needed and support alignment with EndOfPartition.

## Verifying this change

This change added tests and can be verified via added UT for input channels and checkpoint barrier handlers.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
