### PR TITLE
[FLINK-21213][task] Degrade log level to INFO when ignore to decline checkpoint as task not running

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -287,10 +287,9 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                 } else {
                     // We never decline checkpoint after task is not running to avoid unexpected job
                     // failover, which caused by exceeding checkpoint tolerable failure threshold.
-                    LOG.warn(
-                            "As task is already not running, no longer decline checkpoint {}.",
-                            checkpointMetaData.getCheckpointId(),
-                            checkpointException);
+                    LOG.info(
+                            "Ignore decline of checkpoint {} as task is not running anymore.",
+                            checkpointMetaData.getCheckpointId());
                 }
 
                 currentState = AsyncCheckpointState.DISCARDED;


### PR DESCRIPTION
## What is the purpose of the change

Degrade log level to INFO when ignore to decline checkpoint as task not running to avoid unexpected E2E test failure.

## Brief change log

Degrade log level to INFO when ignore to decline checkpoint as task not running.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
