### PR TITLE
[hotfix] [docs] - fix typo: 'this gives' instead of 'the gives'

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -433,7 +433,7 @@ The Flink Kafka Producer needs to know how to turn Java/Scala objects into binar
 The `KafkaSerializationSchema` allows users to specify such a schema.
 The `ProducerRecord<byte[], byte[]> serialize(T element, @Nullable Long timestamp)` method gets called for each record, generating a `ProducerRecord` that is written to Kafka.
 
-The gives users fine-grained control over how data is written out to Kafka. 
+This gives users fine-grained control over how data is written out to Kafka. 
 Through the producer record you can:
 * Set header values
 * Define keys for each record


### PR DESCRIPTION

## What is the purpose of the change

Minor typo in the Kafka connector documentation: 

> "The gives users fine-grained control over" 

is now :

> "This gives users fine-grained control over"

## Brief change log

* updated doc as described above

## Verifying this change

Executed `./build_docs.sh -p` locally and checked visually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
