### PR TITLE
[FLINK-20417][k8s] Create a new watcher when the old one is closed with HTTP_GONE

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -28,6 +28,7 @@ import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesTaskManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesTooOldResourceVersionException;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
@@ -77,6 +78,8 @@ public class KubernetesResourceManagerDriver
 
     private Optional<KubernetesWatch> podsWatchOpt;
 
+    private volatile boolean running;
+
     /**
      * Incompletion of this future indicates that there was a pod creation failure recently and the
      * driver should not retry creating pods until the future become completed again. It's
@@ -93,6 +96,7 @@ public class KubernetesResourceManagerDriver
         this.kubeClientFactory = Preconditions.checkNotNull(kubeClientFactory);
         this.requestResourceFutures = new HashMap<>();
         this.podCreationCoolDown = FutureUtils.completedVoidFuture();
+        this.running = false;
     }
 
     // ------------------------------------------------------------------------
@@ -103,17 +107,18 @@ public class KubernetesResourceManagerDriver
     protected void initializeInternal() throws Exception {
         kubeClientOpt =
                 Optional.of(kubeClientFactory.fromConfiguration(flinkConfig, getIoExecutor()));
-        podsWatchOpt =
-                Optional.of(
-                        getKubeClient()
-                                .watchPodsAndDoCallback(
-                                        KubernetesUtils.getTaskManagerLabels(clusterId),
-                                        new PodCallbackHandlerImpl()));
+        podsWatchOpt = watchTaskManagerPods();
         recoverWorkerNodesFromPreviousAttempts();
+        this.running = true;
     }
 
     @Override
     public CompletableFuture<Void> terminate() {
+        if (!running) {
+            return FutureUtils.completedVoidFuture();
+        }
+        running = false;
+
         // shut down all components
         Exception exception = null;
 
@@ -312,6 +317,14 @@ public class KubernetesResourceManagerDriver
         return kubeClientOpt.get();
     }
 
+    private Optional<KubernetesWatch> watchTaskManagerPods() {
+        return Optional.of(
+                getKubeClient()
+                        .watchPodsAndDoCallback(
+                                KubernetesUtils.getTaskManagerLabels(clusterId),
+                                new PodCallbackHandlerImpl()));
+    }
+
     // ------------------------------------------------------------------------
     //  FlinkKubeClient.WatchCallbackHandler
     // ------------------------------------------------------------------------
@@ -359,8 +372,20 @@ public class KubernetesResourceManagerDriver
         }
 
         @Override
-        public void handleFatalError(Throwable throwable) {
-            getResourceEventHandler().onError(throwable);
+        public void handleError(Throwable throwable) {
+            if (throwable instanceof KubernetesTooOldResourceVersionException) {
+                getMainThreadExecutor()
+                        .execute(
+                                () -> {
+                                    if (running) {
+                                        podsWatchOpt.ifPresent(KubernetesWatch::close);
+                                        log.info("Creating a new watch on TaskManager pods.");
+                                        podsWatchOpt = watchTaskManagerPods();
+                                    }
+                                });
+            } else {
+                getResourceEventHandler().onError(throwable);
+            }
         }
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -197,6 +197,6 @@ public interface FlinkKubeClient extends AutoCloseable {
 
         void onError(List<T> resources);
 
-        void handleFatalError(Throwable throwable);
+        void handleError(Throwable throwable);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesTooOldResourceVersionException.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesTooOldResourceVersionException.java
@@ -18,38 +18,18 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.util.FlinkException;
 
-import java.util.List;
+/** Kubernetes too old resource version exception. */
+public class KubernetesTooOldResourceVersionException extends FlinkException {
 
-/**
- * Empty implementation of {@link FlinkKubeClient.WatchCallbackHandler}.
- *
- * @param <T> Type of resource to be watched
- */
-public class NoOpWatchCallbackHandler<T> implements FlinkKubeClient.WatchCallbackHandler<T> {
-    @Override
-    public void onAdded(List<T> resources) {
-        // noop
+    private static final long serialVersionUID = 1L;
+
+    public KubernetesTooOldResourceVersionException(Throwable cause) {
+        super(cause);
     }
 
-    @Override
-    public void onModified(List<T> resources) {
-        // noop
-    }
-
-    @Override
-    public void onDeleted(List<T> resources) {
-        // noop
-    }
-
-    @Override
-    public void onError(List<T> resources) {
-        // noop
-    }
-
-    @Override
-    public void handleError(Throwable throwable) {
-        // noop
+    public KubernetesTooOldResourceVersionException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -143,7 +143,7 @@ public class KubernetesResourceManagerDriverTest
                 runTest(
                         () -> {
                             final Throwable testingError = new Throwable("testing error");
-                            getPodCallbackHandler().handleFatalError(testingError);
+                            getPodCallbackHandler().handleError(testingError);
                             assertThat(
                                     onErrorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
                                     is(testingError));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -91,6 +91,8 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
         final List<CompletableFuture<FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>>>
                 configMapCallbackFutures = new ArrayList<>();
 
+        final List<TestingFlinkKubeClient.MockKubernetesWatch> configMapWatches = new ArrayList<>();
+
         final CompletableFuture<Map<String, String>> deleteConfigMapByLabelsFuture =
                 new CompletableFuture<>();
         final CompletableFuture<Void> closeKubeClientFuture = new CompletableFuture<>();
@@ -200,7 +202,10 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
                                                         KubernetesConfigMap>>
                                         future = CompletableFuture.completedFuture(handler);
                                 configMapCallbackFutures.add(future);
-                                return new TestingFlinkKubeClient.MockKubernetesWatch();
+                                final TestingFlinkKubeClient.MockKubernetesWatch watch =
+                                        new TestingFlinkKubeClient.MockKubernetesWatch();
+                                configMapWatches.add(watch);
+                                return watch;
                             })
                     .setDeleteConfigMapFunction(
                             name -> {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -20,7 +20,9 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesTooOldResourceVersionException;
 import org.apache.flink.runtime.leaderelection.LeaderInformation;
 
 import org.junit.Test;
@@ -28,11 +30,13 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_SESSION_ID_KEY;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -250,6 +254,36 @@ public class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabili
                             assertThat(
                                     leaderLabels.get(LABEL_CONFIGMAP_TYPE_KEY),
                                     is(LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testNewWatchCreationWhenKubernetesTooOldResourceVersionException()
+            throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderCallbackGrantLeadership();
+
+                            final FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>
+                                    callbackHandler = getLeaderElectionConfigMapCallback();
+                            callbackHandler.handleError(
+                                    new KubernetesTooOldResourceVersionException(
+                                            new Exception("too old resource version")));
+                            // Verify the old watch is closed and a new one is created
+                            assertThat(configMapWatches.size(), is(3));
+                            // The three watches are [old-leader-election-watch,
+                            // leader-retrieval-watch, new-leader-election-watch]
+                            assertThat(
+                                    configMapWatches.stream()
+                                            .map(
+                                                    TestingFlinkKubeClient.MockKubernetesWatch
+                                                            ::isClosed)
+                                            .collect(Collectors.toList()),
+                                    contains(true, false, false));
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderRetrievalDriverTest.java
@@ -20,13 +20,17 @@ package org.apache.flink.kubernetes.highavailability;
 
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesTooOldResourceVersionException;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -99,6 +103,36 @@ public class KubernetesLeaderRetrievalDriverTest extends KubernetesHighAvailabil
                             callbackHandler.onModified(
                                     Collections.singletonList(getLeaderConfigMap()));
                             assertThat(retrievalEventHandler.getAddress(), is(nullValue()));
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testNewWatchCreationWhenKubernetesTooOldResourceVersionException()
+            throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            leaderCallbackGrantLeadership();
+
+                            final FlinkKubeClient.WatchCallbackHandler<KubernetesConfigMap>
+                                    callbackHandler = getLeaderRetrievalConfigMapCallback();
+                            callbackHandler.handleError(
+                                    new KubernetesTooOldResourceVersionException(
+                                            new Exception("too old resource version")));
+                            // Verify the old watch is closed and a new one is created
+                            assertThat(configMapWatches.size(), is(3));
+                            // The three watches are [leader-election-watch,
+                            // old-leader-retrieval-watch, new-leader-retrieval-watch]
+                            assertThat(
+                                    configMapWatches.stream()
+                                            .map(
+                                                    TestingFlinkKubeClient.MockKubernetesWatch
+                                                            ::isClosed)
+                                            .collect(Collectors.toList()),
+                                    contains(false, true, false));
                         });
             }
         };

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -356,13 +356,20 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
 
     /** Testing implementation of {@link KubernetesWatch}. */
     public static class MockKubernetesWatch extends KubernetesWatch {
+        private boolean isClosed;
+
         public MockKubernetesWatch() {
             super(null);
+            this.isClosed = false;
         }
 
         @Override
         public void close() {
-            // noop
+            this.isClosed = true;
+        }
+
+        public boolean isClosed() {
+            return isClosed;
         }
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcherTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcherTest.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.util.TestLogger;
 
+import io.fabric8.kubernetes.api.model.StatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watcher;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static java.net.HttpURLConnection.HTTP_GONE;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -76,6 +80,24 @@ public class KubernetesPodsWatcherTest extends TestLogger {
         assertThat(podErrorList.size(), is(1));
     }
 
+    @Test
+    public void testClosingWithTooOldResourceVersion() {
+        final String errMsg = "too old resource version";
+        final KubernetesPodsWatcher podsWatcher =
+                new KubernetesPodsWatcher(
+                        new TestingCallbackHandler(
+                                e -> {
+                                    assertThat(
+                                            e,
+                                            Matchers.instanceOf(
+                                                    KubernetesTooOldResourceVersionException
+                                                            .class));
+                                    assertThat(e, FlinkMatchers.containsMessage(errMsg));
+                                }));
+        podsWatcher.onClose(
+                new KubernetesClientException(errMsg, HTTP_GONE, new StatusBuilder().build()));
+    }
+
     private class TestingCallbackHandler
             implements FlinkKubeClient.WatchCallbackHandler<KubernetesPod> {
 
@@ -106,7 +128,7 @@ public class KubernetesPodsWatcherTest extends TestLogger {
         }
 
         @Override
-        public void handleFatalError(Throwable throwable) {
+        public void handleError(Throwable throwable) {
             consumer.accept(throwable);
         }
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when the watcher(pods watcher, ConfigMap watcher) is closed with exception, we will call `WatchCallbackHandler#handleFatalError`. And this could cause JobManager/TaskManager terminating and then failover.

For most cases, this is correct. But not for "too old resource version" exception. See more information [here](https://stackoverflow.com/questions/61409596/kubernetes-too-old-resource-version). Usually this exception could happen when the APIServer is restarted or the network connection between JobManager/TaskManager pods and APIServer is not very stable. In such situation, we just need to create a new watch and continue to do the pods/ConfigMap watching. This could help the Flink cluster reducing the impact of K8s cluster restarting.

## Brief change log

* Create a new watcher when the old one is closed with `HTTP_GONE`


## Verifying this change

* Add a new UT `KubernetesPodsWatcherTest#testClosingWithTooOldResourceVersion`
* Manually test on Mac with minikube via following steps
  * Start a minikube
  * Submit a Flink application via `flink run-application ...`
  * Wait for the Flink application running
  * Use `minikube ssh` to tunnel into the virtual machine
  * Use `docker ps | grep apiserver` to find the APIServer docker container and then `docker kill {containerId}`
  * Verify the JobManager logs containing "Creating a new watch ..."

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
