### PR TITLE
[FLINK-21238][python] Support to close PythonFunctionFactory

### DIFF
--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -65,7 +65,9 @@ def get_gateway():
             callback_server_listening_address = callback_server.get_listening_address()
             callback_server_listening_port = callback_server.get_listening_port()
             _gateway.jvm.org.apache.flink.client.python.PythonEnvUtils.resetCallbackClient(
-                callback_server_listening_address, callback_server_listening_port)
+                _gateway.java_gateway_server,
+                callback_server_listening_address,
+                callback_server_listening_port)
             # import the flink view
             import_flink_view(_gateway)
             install_exception_handler()

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
@@ -24,13 +24,12 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.python.util.PythonDependencyUtils;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.table.functions.python.PythonFunction;
+import org.apache.flink.util.FileUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
 import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
 import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
 import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
-
-import org.apache.flink.util.FileUtils;
 
 import py4j.GatewayServer;
 

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
@@ -22,33 +22,74 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.python.util.PythonDependencyUtils;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.table.functions.python.PythonFunction;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
+import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
 
 import py4j.GatewayServer;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.client.python.PythonEnvUtils.CHECK_INTERVAL;
+import static org.apache.flink.client.python.PythonEnvUtils.PythonProcessShutdownHook;
+import static org.apache.flink.client.python.PythonEnvUtils.TIMEOUT_MILLIS;
 import static org.apache.flink.client.python.PythonEnvUtils.getGatewayServer;
 import static org.apache.flink.client.python.PythonEnvUtils.launchPy4jPythonClient;
-import static org.apache.flink.client.python.PythonEnvUtils.setGatewayServer;
+import static org.apache.flink.client.python.PythonEnvUtils.maxConcurrentPythonFunctionFactories;
+import static org.apache.flink.client.python.PythonEnvUtils.shutdownPythonProcess;
 import static org.apache.flink.client.python.PythonEnvUtils.startGatewayServer;
 
 /** The factory which creates the PythonFunction objects from given module name and object name. */
 public interface PythonFunctionFactory {
 
-    long CHECK_INTERVAL = 100;
+    ScheduledExecutorService CACHE_CLEANUP_EXECUTOR_SERVICE =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ExecutorThreadFactory("PythonFunctionFactory"));
 
-    long TIMEOUT_MILLIS = 10000;
+    AtomicReference<Boolean> CACHE_CLEANUP_EXECUTOR_SERVICE_STARTED = new AtomicReference<>(false);
 
-    AtomicReference<PythonFunctionFactory> PYTHON_FUNCTION_FACTORY_REF = new AtomicReference<>();
+    LoadingCache<CacheKey, PythonFunctionFactory> PYTHON_FUNCTION_FACTORY_CACHE =
+            CacheBuilder.newBuilder()
+                    .expireAfterAccess(1, TimeUnit.MINUTES)
+                    .maximumSize(maxConcurrentPythonFunctionFactories)
+                    .removalListener(
+                            (RemovalListener<CacheKey, PythonFunctionFactory>)
+                                    removalNotification -> {
+                                        if (removalNotification.getValue() instanceof Closeable) {
+                                            try {
+                                                ((Closeable) removalNotification.getValue())
+                                                        .close();
+                                            } catch (IOException ignore) {
+                                            }
+                                        }
+                                    })
+                    .build(
+                            new CacheLoader<CacheKey, PythonFunctionFactory>() {
+                                @Override
+                                public PythonFunctionFactory load(CacheKey cacheKey) {
+                                    try {
+                                        return createPythonFunctionFactory(cacheKey.config);
+                                    } catch (Throwable t) {
+                                        throw new RuntimeException(t);
+                                    }
+                                }
+                            });
 
     /**
      * Returns PythonFunction according to moduleName and objectName.
@@ -65,10 +106,12 @@ public interface PythonFunctionFactory {
      *
      * @param fullyQualifiedName The fully qualified name of the Python UDF.
      * @param config The configuration of python dependencies.
+     * @param classLoader The classloader which is used to identify different jobs.
      * @return The PythonFunction object which represents the Python UDF.
      */
-    static PythonFunction getPythonFunction(String fullyQualifiedName, ReadableConfig config)
-            throws IOException, ExecutionException, InterruptedException {
+    static PythonFunction getPythonFunction(
+            String fullyQualifiedName, ReadableConfig config, ClassLoader classLoader)
+            throws ExecutionException {
         int splitIndex = fullyQualifiedName.lastIndexOf(".");
         if (splitIndex <= 0) {
             throw new IllegalArgumentException(
@@ -81,111 +124,107 @@ public interface PythonFunctionFactory {
                 new Configuration(
                         ExecutionEnvironment.getExecutionEnvironment().getConfiguration());
         PythonDependencyUtils.merge(mergedConfig, (Configuration) config);
-        PythonFunctionFactory pythonFunctionFactory = getPythonFunctionFactory(mergedConfig);
+        PythonFunctionFactory pythonFunctionFactory =
+                PYTHON_FUNCTION_FACTORY_CACHE.get(CacheKey.of(mergedConfig, classLoader));
+        ensureCacheCleanupExecutorServiceStarted();
         return pythonFunctionFactory.getPythonFunction(moduleName, objectName);
     }
 
-    static PythonFunctionFactory getPythonFunctionFactory(ReadableConfig config)
+    static void ensureCacheCleanupExecutorServiceStarted() {
+        if (CACHE_CLEANUP_EXECUTOR_SERVICE_STARTED.compareAndSet(false, true)) {
+            CACHE_CLEANUP_EXECUTOR_SERVICE.scheduleAtFixedRate(
+                    PYTHON_FUNCTION_FACTORY_CACHE::cleanUp, 1, 1, TimeUnit.MINUTES);
+        }
+    }
+
+    static PythonFunctionFactory createPythonFunctionFactory(ReadableConfig config)
             throws ExecutionException, InterruptedException, IOException {
-        synchronized (PythonFunctionFactory.class) {
-            if (PYTHON_FUNCTION_FACTORY_REF.get() != null) {
-                return PYTHON_FUNCTION_FACTORY_REF.get();
-            } else {
-                Map<String, Object> entryPoint;
-                if (getGatewayServer() == null) {
-                    GatewayServer gatewayServer = null;
-                    Process pythonProcess = null;
-                    try {
-                        gatewayServer = startGatewayServer();
-                        setGatewayServer(gatewayServer);
-                        List<String> commands = new ArrayList<>();
-                        commands.add("-m");
-                        commands.add("pyflink.pyflink_callback_server");
-                        String tmpDir =
-                                System.getProperty("java.io.tmpdir")
-                                        + File.separator
-                                        + "pyflink"
-                                        + File.separator
-                                        + UUID.randomUUID();
-                        pythonProcess =
-                                launchPy4jPythonClient(
-                                        gatewayServer, config, commands, null, tmpDir, false);
-                        entryPoint =
-                                (Map<String, Object>) gatewayServer.getGateway().getEntryPoint();
-                        int i = 0;
-                        while (!entryPoint.containsKey("PythonFunctionFactory")) {
-                            if (!pythonProcess.isAlive()) {
-                                throw new RuntimeException("Python callback server start failed!");
-                            }
-                            try {
-                                Thread.sleep(CHECK_INTERVAL);
-                            } catch (InterruptedException e) {
-                                throw new RuntimeException(
-                                        "Interrupted while waiting for the python process to start.",
-                                        e);
-                            }
-                            i++;
-                            if (i > TIMEOUT_MILLIS / CHECK_INTERVAL) {
-                                throw new RuntimeException("Python callback server start failed!");
-                            }
-                        }
-                    } catch (Throwable e) {
-                        try {
-                            setGatewayServer(null);
-                            if (gatewayServer != null) {
-                                gatewayServer.shutdown();
-                            }
-                        } catch (Throwable e2) {
-                            // ignore, do not swallow the origin exception.
-                        }
-                        try {
-                            if (pythonProcess != null) {
-                                shutdownPythonProcess(pythonProcess, TIMEOUT_MILLIS);
-                            }
-                        } catch (Throwable e3) {
-                            // ignore, do not swallow the origin exception.
-                        }
-                        throw e;
+        Map<String, Object> entryPoint;
+        PythonProcessShutdownHook shutdownHook = null;
+        if (getGatewayServer() == null) {
+            GatewayServer gatewayServer = null;
+            Process pythonProcess = null;
+            String tmpDir;
+            try {
+                gatewayServer = startGatewayServer();
+                List<String> commands = new ArrayList<>();
+                commands.add("-m");
+                commands.add("pyflink.pyflink_callback_server");
+                tmpDir =
+                        System.getProperty("java.io.tmpdir")
+                                + File.separator
+                                + "pyflink"
+                                + File.separator
+                                + UUID.randomUUID();
+                pythonProcess =
+                        launchPy4jPythonClient(
+                                gatewayServer, config, commands, null, tmpDir, false);
+                entryPoint = (Map<String, Object>) gatewayServer.getGateway().getEntryPoint();
+                int i = 0;
+                while (!entryPoint.containsKey("PythonFunctionFactory")) {
+                    if (!pythonProcess.isAlive()) {
+                        throw new RuntimeException("Python callback server start failed!");
                     }
-                    Runtime.getRuntime()
-                            .addShutdownHook(new PythonProcessShutdownHook(pythonProcess));
-                } else {
-                    entryPoint =
-                            (Map<String, Object>) getGatewayServer().getGateway().getEntryPoint();
+                    try {
+                        Thread.sleep(CHECK_INTERVAL);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(
+                                "Interrupted while waiting for the python process to start.", e);
+                    }
+                    i++;
+                    if (i > TIMEOUT_MILLIS / CHECK_INTERVAL) {
+                        throw new RuntimeException("Python callback server start failed!");
+                    }
                 }
-                PythonFunctionFactory pythonFunctionFactory =
-                        (PythonFunctionFactory) entryPoint.get("PythonFunctionFactory");
-                PYTHON_FUNCTION_FACTORY_REF.set(pythonFunctionFactory);
-                return pythonFunctionFactory;
+            } catch (Throwable e) {
+                try {
+                    if (gatewayServer != null) {
+                        gatewayServer.shutdown();
+                    }
+                } catch (Throwable e2) {
+                    // ignore, do not swallow the origin exception.
+                }
+                try {
+                    if (pythonProcess != null) {
+                        shutdownPythonProcess(pythonProcess, TIMEOUT_MILLIS);
+                    }
+                } catch (Throwable e3) {
+                    // ignore, do not swallow the origin exception.
+                }
+                throw e;
             }
+            shutdownHook = new PythonProcessShutdownHook(pythonProcess, gatewayServer, tmpDir);
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        } else {
+            entryPoint = (Map<String, Object>) getGatewayServer().getGateway().getEntryPoint();
         }
+
+        return new PythonFunctionFactoryImpl(
+                (PythonFunctionFactory) entryPoint.get("PythonFunctionFactory"), shutdownHook);
     }
 
-    static void shutdownPythonProcess(Process pythonProcess, long timeoutMillis) {
-        pythonProcess.destroy();
-        try {
-            pythonProcess.waitFor(timeoutMillis, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(
-                    "Interrupt while waiting for the python process to stop.", e);
+    /** The cache key. It only considers the classloader. */
+    class CacheKey {
+        private final ReadableConfig config;
+        private final ClassLoader classLoader;
+
+        CacheKey(ReadableConfig config, ClassLoader classLoader) {
+            this.config = config;
+            this.classLoader = classLoader;
         }
-        if (pythonProcess.isAlive()) {
-            pythonProcess.destroyForcibly();
-        }
-    }
 
-    /** The shutdown hook used to destroy the Python process. */
-    class PythonProcessShutdownHook extends Thread {
-
-        private Process process;
-
-        public PythonProcessShutdownHook(Process process) {
-            this.process = process;
+        public static CacheKey of(ReadableConfig config, ClassLoader classLoader) {
+            return new CacheKey(config, classLoader);
         }
 
         @Override
-        public void run() {
-            shutdownPythonProcess(process, TIMEOUT_MILLIS);
+        public boolean equals(Object other) {
+            return other instanceof CacheKey && this.classLoader == ((CacheKey) other).classLoader;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(classLoader);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactory.java
@@ -30,6 +30,8 @@ import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
 import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
 import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
 
+import org.apache.flink.util.FileUtils;
+
 import py4j.GatewayServer;
 
 import java.io.Closeable;
@@ -144,7 +146,7 @@ public interface PythonFunctionFactory {
         if (getGatewayServer() == null) {
             GatewayServer gatewayServer = null;
             Process pythonProcess = null;
-            String tmpDir;
+            String tmpDir = null;
             try {
                 gatewayServer = startGatewayServer();
                 List<String> commands = new ArrayList<>();
@@ -191,6 +193,10 @@ public interface PythonFunctionFactory {
                 } catch (Throwable e3) {
                     // ignore, do not swallow the origin exception.
                 }
+                if (tmpDir != null) {
+                    FileUtils.deleteDirectoryQuietly(new File(tmpDir));
+                }
+
                 throw e;
             }
             shutdownHook = new PythonProcessShutdownHook(pythonProcess, gatewayServer, tmpDir);

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactoryImpl.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonFunctionFactoryImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.python;
+
+import org.apache.flink.table.functions.python.PythonFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+
+import static org.apache.flink.client.python.PythonEnvUtils.PythonProcessShutdownHook;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of PythonFunctionFactory. */
+public class PythonFunctionFactoryImpl implements PythonFunctionFactory, Closeable {
+
+    @Nonnull private final PythonFunctionFactory realPythonFunctionFactory;
+
+    @Nullable private final PythonProcessShutdownHook shutdownHook;
+
+    public PythonFunctionFactoryImpl(
+            PythonFunctionFactory realPythonFunctionFactory,
+            PythonProcessShutdownHook shutdownHook) {
+        this.realPythonFunctionFactory = checkNotNull(realPythonFunctionFactory);
+        this.shutdownHook = shutdownHook;
+    }
+
+    @Override
+    public PythonFunction getPythonFunction(String moduleName, String objectName) {
+        return realPythonFunctionFactory.getPythonFunction(moduleName, objectName);
+    }
+
+    @Override
+    public void close() {
+        if (shutdownHook != null) {
+            if (Runtime.getRuntime().removeShutdownHook(shutdownHook)) {
+                shutdownHook.run();
+            }
+        }
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonGatewayServer.java
@@ -29,8 +29,8 @@ import java.nio.file.Files;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-import static org.apache.flink.client.python.PythonFunctionFactory.CHECK_INTERVAL;
-import static org.apache.flink.client.python.PythonFunctionFactory.TIMEOUT_MILLIS;
+import static org.apache.flink.client.python.PythonEnvUtils.CHECK_INTERVAL;
+import static org.apache.flink.client.python.PythonEnvUtils.TIMEOUT_MILLIS;
 
 /** The Py4j Gateway Server provides RPC service for user's python process. */
 public class PythonGatewayServer {

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
@@ -154,10 +154,10 @@ public class PythonFunctionFactoryTest {
         Field field = clazz.getDeclaredField("hooks");
         field.setAccessible(true);
         Map<Thread, Thread> hooks = (Map<Thread, Thread>) field.get(null);
-        PythonFunctionFactory.PythonProcessShutdownHook shutdownHook = null;
+        PythonEnvUtils.PythonProcessShutdownHook shutdownHook = null;
         for (Thread t : hooks.keySet()) {
-            if (t instanceof PythonFunctionFactory.PythonProcessShutdownHook) {
-                shutdownHook = (PythonFunctionFactory.PythonProcessShutdownHook) t;
+            if (t instanceof PythonEnvUtils.PythonProcessShutdownHook) {
+                shutdownHook = (PythonEnvUtils.PythonProcessShutdownHook) t;
                 break;
             }
         }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/ExecutionContextTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.client.python.PythonFunctionFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -51,6 +52,11 @@ import org.apache.flink.util.StringUtils;
 
 import org.apache.commons.cli.Options;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.URL;
 import java.time.Duration;
@@ -69,8 +75,23 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /** Test for {@link ExecutionContext}. */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PythonFunctionFactory.class)
+@PowerMockIgnore({
+    "org.apache.hive.*",
+    "org.apache.hadoop.*",
+    "com.sun.org.apache.xerces.*",
+    "javax.xml.*",
+    "org.xml.*",
+    "javax.management.*",
+    "org.w3c.dom.*",
+    "org.datanucleus.*"
+})
 public class ExecutionContextTest {
 
     private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-client-defaults.yaml";
@@ -248,20 +269,19 @@ public class ExecutionContextTest {
 
     @Test
     public void testPythonFunction() throws Exception {
-        PythonFunctionFactory pythonFunctionFactory =
-                PythonFunctionFactory.PYTHON_FUNCTION_FACTORY_REF.get();
         PythonFunctionFactory testFunctionFactory =
                 (moduleName, objectName) ->
                         new PythonScalarFunction(null, null, null, null, null, false, false, null);
-        try {
-            PythonFunctionFactory.PYTHON_FUNCTION_FACTORY_REF.set(testFunctionFactory);
-            ExecutionContext context = createPythonFunctionExecutionContext();
-            final String[] expected = new String[] {"pythonudf"};
-            final String[] actual = context.getTableEnvironment().listUserDefinedFunctions();
-            assertArrayEquals(expected, actual);
-        } finally {
-            PythonFunctionFactory.PYTHON_FUNCTION_FACTORY_REF.set(pythonFunctionFactory);
-        }
+        PowerMockito.mockStatic(PythonFunctionFactory.class);
+        when(PythonFunctionFactory.getPythonFunction(
+                        anyString(), any(ReadableConfig.class), any(ClassLoader.class)))
+                .thenCallRealMethod();
+        when(PythonFunctionFactory.createPythonFunctionFactory(any(ReadableConfig.class)))
+                .thenReturn(testFunctionFactory);
+        ExecutionContext context = createPythonFunctionExecutionContext();
+        final String[] expected = new String[] {"pythonudf"};
+        final String[] actual = context.getTableEnvironment().listUserDefinedFunctions();
+        assertArrayEquals(expected, actual);
     }
 
     @Test

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
@@ -116,7 +116,9 @@ public class FunctionService {
             case FunctionDescriptorValidator.FROM_VALUE_PYTHON:
                 String fullyQualifiedName =
                         properties.getString(PythonFunctionValidator.FULLY_QUALIFIED_NAME);
-                instance = PythonFunctionUtils.getPythonFunction(fullyQualifiedName, config);
+                instance =
+                        PythonFunctionUtils.getPythonFunction(
+                                fullyQualifiedName, config, classLoader);
                 break;
             default:
                 throw new ValidationException(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -204,7 +204,7 @@ public final class UserDefinedFunctionHelper {
                     }
                     return (UserDefinedFunction)
                             PythonFunctionUtils.getPythonFunction(
-                                    catalogFunction.getClassName(), config);
+                                    catalogFunction.getClassName(), config, classLoader);
                 case JAVA:
                 case SCALA:
                     final Class<?> functionClass =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
@@ -22,32 +22,31 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.functions.python.PythonFunction;
 
-import java.lang.reflect.InvocationTargetException;
-
 /** Utilities for creating PythonFunction from the fully qualified name of a Python function. */
 @Internal
 public enum PythonFunctionUtils {
     ;
 
     public static PythonFunction getPythonFunction(
-            String fullyQualifiedName, ReadableConfig config) {
+            String fullyQualifiedName, ReadableConfig config, ClassLoader classLoader) {
         try {
             Class pythonFunctionFactory =
                     Class.forName(
                             "org.apache.flink.client.python.PythonFunctionFactory",
                             true,
-                            Thread.currentThread().getContextClassLoader());
+                            classLoader);
             return (PythonFunction)
                     pythonFunctionFactory
-                            .getMethod("getPythonFunction", String.class, ReadableConfig.class)
-                            .invoke(null, fullyQualifiedName, config);
-        } catch (IllegalAccessException
-                | ClassNotFoundException
-                | NoSuchMethodException
-                | InvocationTargetException e) {
+                            .getMethod(
+                                    "getPythonFunction",
+                                    String.class,
+                                    ReadableConfig.class,
+                                    ClassLoader.class)
+                            .invoke(null, fullyQualifiedName, config, classLoader);
+        } catch (Throwable t) {
             throw new IllegalStateException(
                     String.format("Instantiating python function '%s' failed.", fullyQualifiedName),
-                    e);
+                    t);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support to close PythonFunctionFactory manually.*

## Brief change log

  - *Introduce PythonFunctionFactoryImpl which allows to close PythonFunctionFactory*
  - *Introduce PYTHON_FUNCTION_FACTORY_CACHE which is responsible for closing inactive PythonFunctionFactory periodically.*

## Verifying this change

This change can be verified by the existing test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
