### PR TITLE
backport [FLINK-21215][task] Do not overwrite the original CheckpointFailureReason in AsyncCheckpointRunnable

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -37,22 +37,21 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /** Tests for {@link AsyncCheckpointRunnable}. */
 public class AsyncCheckpointRunnableTest {
 
     @Test
     public void testDeclineWithAsyncCheckpointExceptionWhenRunning() {
-        testAsyncCheckpointException(() -> true);
+        testAsyncCheckpointException(true);
     }
 
     @Test
     public void testDeclineWithAsyncCheckpointExceptionWhenNotRunning() {
-        testAsyncCheckpointException(() -> false);
+        testAsyncCheckpointException(false);
     }
 
-    private void testAsyncCheckpointException(Supplier<Boolean> isTaskRunning) {
+    private void testAsyncCheckpointException(boolean isTaskRunning) {
         final Map<OperatorID, OperatorSnapshotFutures> snapshotsInProgress = new HashMap<>();
         snapshotsInProgress.put(
                 new OperatorID(),
@@ -67,20 +66,10 @@ public class AsyncCheckpointRunnableTest {
 
         final TestEnvironment environment = new TestEnvironment();
         final AsyncCheckpointRunnable runnable =
-                new AsyncCheckpointRunnable(
-                        snapshotsInProgress,
-                        new CheckpointMetaData(1, 1L),
-                        new CheckpointMetrics(),
-                        1L,
-                        "Task Name",
-                        r -> {},
-                        r -> {},
-                        environment,
-                        (msg, ex) -> {},
-                        isTaskRunning);
+                createAsyncRunnable(snapshotsInProgress, environment, isTaskRunning);
         runnable.run();
 
-        if (isTaskRunning.get()) {
+        if (isTaskRunning) {
             Assert.assertTrue(environment.getCause() instanceof CheckpointException);
             Assert.assertSame(
                     ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
@@ -88,6 +77,49 @@ public class AsyncCheckpointRunnableTest {
         } else {
             Assert.assertNull(environment.getCause());
         }
+    }
+
+    @Test
+    public void testDeclineAsyncCheckpoint() {
+        CheckpointFailureReason originalReason =
+                CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM;
+
+        final Map<OperatorID, OperatorSnapshotFutures> snapshotsInProgress = new HashMap<>();
+        snapshotsInProgress.put(
+                new OperatorID(),
+                new OperatorSnapshotFutures(
+                        DoneFuture.of(SnapshotResult.empty()),
+                        DoneFuture.of(SnapshotResult.empty()),
+                        DoneFuture.of(SnapshotResult.empty()),
+                        DoneFuture.of(SnapshotResult.empty()),
+                        ExceptionallyDoneFuture.of(new CheckpointException(originalReason)),
+                        DoneFuture.of(SnapshotResult.empty())));
+
+        final TestEnvironment environment = new TestEnvironment();
+        final AsyncCheckpointRunnable runnable =
+                createAsyncRunnable(snapshotsInProgress, environment, true);
+        runnable.run();
+
+        Assert.assertSame(
+                ((CheckpointException) environment.getCause()).getCheckpointFailureReason(),
+                originalReason);
+    }
+
+    private AsyncCheckpointRunnable createAsyncRunnable(
+            Map<OperatorID, OperatorSnapshotFutures> snapshotsInProgress,
+            TestEnvironment environment,
+            boolean isTaskRunning) {
+        return new AsyncCheckpointRunnable(
+                snapshotsInProgress,
+                new CheckpointMetaData(1, 1L),
+                new CheckpointMetrics(),
+                1L,
+                "Task Name",
+                r -> {},
+                r -> {},
+                environment,
+                (msg, ex) -> {},
+                () -> isTaskRunning);
     }
 
     private static class TestEnvironment extends StreamMockEnvironment {


### PR DESCRIPTION
backport part of FLINK-21215. Original fix had two fixes (or one fix and one optimisation, depending how you look at it). As the code has changed too much, I'm back-porting to release-1.11 just one of those fixes (skipping optimisation which I don't see how it can be easily implemented)