### PR TITLE
[FLINK-21208][python] Make Arrow Coder serialize schema info in every batch

### DIFF
--- a/flink-python/pyflink/fn_execution/ResettableIO.py
+++ b/flink-python/pyflink/fn_execution/ResettableIO.py
@@ -26,15 +26,15 @@ class ResettableIO(io.RawIOBase):
     def set_input_bytes(self, b):
         self._input_bytes = b
         self._input_offset = 0
+        self._size = len(b)
 
     def readinto(self, b):
         """
         Read up to len(b) bytes into the writable buffer *b* and return
         the number of bytes read. If no bytes are available, None is returned.
         """
-        input_len = len(self._input_bytes)
         output_buffer_len = len(b)
-        remaining = input_len - self._input_offset
+        remaining = self._size - self._input_offset
 
         if remaining >= output_buffer_len:
             b[:] = self._input_bytes[self._input_offset:self._input_offset + output_buffer_len]
@@ -42,7 +42,7 @@ class ResettableIO(io.RawIOBase):
             return output_buffer_len
         elif remaining > 0:
             b[:remaining] = self._input_bytes[self._input_offset:self._input_offset + remaining]
-            self._input_offset = input_len
+            self._input_offset = self._size
             return remaining
         else:
             return None
@@ -66,7 +66,7 @@ class ResettableIO(io.RawIOBase):
         return False
 
     def readable(self):
-        return True
+        return self._size - self._input_offset
 
     def writable(self):
         return True

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -620,13 +620,13 @@ class ArrowCoderImpl(StreamCoderImpl):
         self._timezone = timezone
         self._resettable_io = ResettableIO()
         self._batch_reader = ArrowCoderImpl._load_from_stream(self._resettable_io)
-        self._batch_writer = pa.RecordBatchStreamWriter(self._resettable_io, self._schema)
         self.data_out_stream = create_OutputStream()
         self._resettable_io.set_output_stream(self.data_out_stream)
 
     def encode_to_stream(self, cols, out_stream, nested):
         data_out_stream = self.data_out_stream
-        self._batch_writer.write_batch(
+        batch_writer = pa.RecordBatchStreamWriter(self._resettable_io, self._schema)
+        batch_writer.write_batch(
             pandas_to_arrow(self._schema, self._timezone, self._field_types, cols))
         out_stream.write_var_int64(data_out_stream.size())
         out_stream.write(data_out_stream.get())
@@ -638,9 +638,9 @@ class ArrowCoderImpl(StreamCoderImpl):
 
     @staticmethod
     def _load_from_stream(stream):
-        reader = pa.ipc.open_stream(stream)
-        for batch in reader:
-            yield batch
+        while stream.readable():
+            reader = pa.ipc.open_stream(stream)
+            yield reader.read_next_batch()
 
     def _decode_one_batch_from_stream(self, in_stream: create_InputStream, size: int) -> List:
         self._resettable_io.set_input_bytes(in_stream.read(size))

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -305,7 +305,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         expected = Row('Hi,Hi,hello,hello2', 'Hi', 'hello', 4, 5, 'Hi,Hi,hello2,hello',
                        'Hi|Hi|hello2|hello', 10, 11.0, 2, Decimal(3.0), 24, 28.0, 6, 7.0,
                        3.1622777, 3.6514838, 10.0, 13.333333)
-        expected.set_row_kind(RowKind.INSERT)
+        expected.set_row_kind(RowKind.UPDATE_AFTER)
         self.assertEqual(result[len(result) - 1], expected)
 
     def test_mixed_with_built_in_functions_without_retract(self):
@@ -338,7 +338,7 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
         result = [i for i in result_table.execute().collect()]
         expected = Row('Hi,Hi,hello,hello2', 'Hi', 'hello', 4, 5, 'Hi,Hi,hello2,hello',
                        'Hi|Hi|hello2|hello', 10, 11.0, 2, Decimal(3.0), 24, 28.0)
-        expected.set_row_kind(RowKind.INSERT)
+        expected.set_row_kind(RowKind.UPDATE_AFTER)
         self.assertEqual(result[len(result) - 1], expected)
 
     def test_using_decorator(self):

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -157,6 +157,8 @@ class PyFlinkStreamTableTestCase(PyFlinkTestCase):
             self.env,
             environment_settings=EnvironmentSettings.new_instance()
                 .in_streaming_mode().use_old_planner().build())
+        self.t_env.get_config().get_configuration().set_string(
+            "python.fn-execution.bundle.size", "1")
 
 
 class PyFlinkBatchTableTestCase(PyFlinkTestCase):
@@ -169,6 +171,8 @@ class PyFlinkBatchTableTestCase(PyFlinkTestCase):
         self.env = ExecutionEnvironment.get_execution_environment()
         self.env.set_parallelism(2)
         self.t_env = BatchTableEnvironment.create(self.env, TableConfig())
+        self.t_env.get_config().get_configuration().set_string(
+            "python.fn-execution.bundle.size", "1")
 
     def collect(self, table):
         j_table = table._j_table
@@ -191,6 +195,8 @@ class PyFlinkBlinkStreamTableTestCase(PyFlinkTestCase):
         self.t_env = StreamTableEnvironment.create(
             self.env, environment_settings=EnvironmentSettings.new_instance()
                 .in_streaming_mode().use_blink_planner().build())
+        self.t_env.get_config().get_configuration().set_string(
+            "python.fn-execution.bundle.size", "1")
 
 
 class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
@@ -204,6 +210,8 @@ class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
             environment_settings=EnvironmentSettings.new_instance()
             .in_batch_mode().use_blink_planner().build())
         self.t_env._j_tenv.getPlanner().getExecEnv().setParallelism(2)
+        self.t_env.get_config().get_configuration().set_string(
+            "python.fn-execution.bundle.size", "1")
 
 
 class PythonAPICompletenessTestCase(object):

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
@@ -73,12 +73,20 @@ public abstract class ArrowSerializer<T> {
     /** Writer which is responsible for convert the arrow format data into byte array. */
     private transient ArrowStreamWriter arrowStreamWriter;
 
+    /** Reusable InputStream used to holding the execution results to be deserialized. */
+    private transient InputStream bais;
+
+    /** Reusable OutputStream used to holding the serialized input elements. */
+    private transient OutputStream baos;
+
     public ArrowSerializer(RowType inputType, RowType outputType) {
         this.inputType = inputType;
         this.outputType = outputType;
     }
 
     public void open(InputStream bais, OutputStream baos) throws Exception {
+        this.bais = bais;
+        this.baos = baos;
         allocator = ArrowUtils.getRootAllocator().newChildAllocator("allocator", 0, Long.MAX_VALUE);
         arrowStreamReader = new ArrowStreamReader(bais, allocator);
 
@@ -127,13 +135,13 @@ public abstract class ArrowSerializer<T> {
         arrowWriter.reset();
     }
 
-    public void resetReader(InputStream bais) throws IOException {
+    public void resetReader() throws IOException {
         arrowReader = null;
         arrowStreamReader.close();
         arrowStreamReader = new ArrowStreamReader(bais, allocator);
     }
 
-    public void resetWriter(OutputStream baos) throws IOException {
+    public void resetWriter() throws IOException {
         arrowStreamWriter = new ArrowStreamWriter(rootWriter, null, baos);
         arrowStreamWriter.start();
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
@@ -80,10 +80,12 @@ public abstract class ArrowSerializer<T> {
 
     public void open(InputStream bais, OutputStream baos) throws Exception {
         allocator = ArrowUtils.getRootAllocator().newChildAllocator("allocator", 0, Long.MAX_VALUE);
-        initializeReader(bais);
+        arrowStreamReader = new ArrowStreamReader(bais, allocator);
+
         rootWriter = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(inputType), allocator);
         arrowWriter = createArrowWriter();
-        initializeWriter(baos);
+        arrowStreamWriter = new ArrowStreamWriter(rootWriter, null, baos);
+        arrowStreamWriter.start();
     }
 
     public int load() throws IOException {
@@ -125,21 +127,13 @@ public abstract class ArrowSerializer<T> {
         arrowWriter.reset();
     }
 
-    public void reinitializeReader(InputStream bais) throws IOException {
+    public void resetReader(InputStream bais) throws IOException {
         arrowReader = null;
         arrowStreamReader.close();
-        initializeReader(bais);
-    }
-
-    public void reInitializeWriter(OutputStream baos) throws IOException {
-        initializeWriter(baos);
-    }
-
-    private void initializeReader(InputStream bais) {
         arrowStreamReader = new ArrowStreamReader(bais, allocator);
     }
 
-    private void initializeWriter(OutputStream baos) throws IOException {
+    public void resetWriter(OutputStream baos) throws IOException {
         arrowStreamWriter = new ArrowStreamWriter(rootWriter, null, baos);
         arrowStreamWriter.start();
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/serializers/ArrowSerializer.java
@@ -80,12 +80,10 @@ public abstract class ArrowSerializer<T> {
 
     public void open(InputStream bais, OutputStream baos) throws Exception {
         allocator = ArrowUtils.getRootAllocator().newChildAllocator("allocator", 0, Long.MAX_VALUE);
-        arrowStreamReader = new ArrowStreamReader(bais, allocator);
-
+        initializeReader(bais);
         rootWriter = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(inputType), allocator);
         arrowWriter = createArrowWriter();
-        arrowStreamWriter = new ArrowStreamWriter(rootWriter, null, baos);
-        arrowStreamWriter.start();
+        initializeWriter(baos);
     }
 
     public int load() throws IOException {
@@ -125,5 +123,24 @@ public abstract class ArrowSerializer<T> {
         arrowWriter.finish();
         arrowStreamWriter.writeBatch();
         arrowWriter.reset();
+    }
+
+    public void reinitializeReader(InputStream bais) throws IOException {
+        arrowReader = null;
+        arrowStreamReader.close();
+        initializeReader(bais);
+    }
+
+    public void reInitializeWriter(OutputStream baos) throws IOException {
+        initializeWriter(baos);
+    }
+
+    private void initializeReader(InputStream bais) {
+        arrowStreamReader = new ArrowStreamReader(bais, allocator);
+    }
+
+    private void initializeWriter(OutputStream baos) throws IOException {
+        arrowStreamWriter = new ArrowStreamWriter(rootWriter, null, baos);
+        arrowStreamWriter.start();
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
@@ -92,6 +92,7 @@ public final class ArrowPythonScalarFunctionFlatMap extends AbstractPythonScalar
         for (int i = 0; i < rowCount; i++) {
             resultCollector.collect(Row.join(forwardedInputQueue.poll(), arrowSerializer.read(i)));
         }
+        arrowSerializer.resetReader(bais);
     }
 
     @Override
@@ -121,6 +122,7 @@ public final class ArrowPythonScalarFunctionFlatMap extends AbstractPythonScalar
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
+            arrowSerializer.resetWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
@@ -92,7 +92,7 @@ public final class ArrowPythonScalarFunctionFlatMap extends AbstractPythonScalar
         for (int i = 0; i < rowCount; i++) {
             resultCollector.collect(Row.join(forwardedInputQueue.poll(), arrowSerializer.read(i)));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     @Override
@@ -122,7 +122,7 @@ public final class ArrowPythonScalarFunctionFlatMap extends AbstractPythonScalar
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
@@ -71,7 +71,7 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
-            arrowSerializer.reInitializeWriter(baos);
+            arrowSerializer.resetWriter(baos);
         }
     }
 
@@ -107,6 +107,6 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             RowData result = arrowSerializer.read(i);
             rowDataWrapper.collect(reuseJoinedRow.replace(key, result));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
@@ -71,6 +71,7 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
+            arrowSerializer.reInitializeWriter(baos);
         }
     }
 
@@ -106,5 +107,6 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             RowData result = arrowSerializer.read(i);
             rowDataWrapper.collect(reuseJoinedRow.replace(key, result));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperator.java
@@ -71,7 +71,7 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
     }
 
@@ -107,6 +107,6 @@ public class BatchArrowPythonGroupAggregateFunctionOperator
             RowData result = arrowSerializer.read(i);
             rowDataWrapper.collect(reuseJoinedRow.replace(key, result));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -175,7 +175,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     private void triggerWindowProcess() throws Exception {
@@ -196,7 +196,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
-                arrowSerializer.resetWriter(baos);
+                arrowSerializer.resetWriter();
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -175,6 +175,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     private void triggerWindowProcess() throws Exception {
@@ -195,6 +196,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
+                arrowSerializer.reInitializeWriter(baos);
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -175,7 +175,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     private void triggerWindowProcess() throws Exception {
@@ -196,7 +196,7 @@ public class BatchArrowPythonGroupWindowAggregateFunctionOperator
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
-                arrowSerializer.reInitializeWriter(baos);
+                arrowSerializer.resetWriter(baos);
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
@@ -225,6 +225,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
+            arrowSerializer.reInitializeWriter(baos);
         }
         lastKeyDataStartPos = forwardedInputQueue.size();
     }
@@ -248,6 +249,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
@@ -225,7 +225,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
-            arrowSerializer.reInitializeWriter(baos);
+            arrowSerializer.resetWriter(baos);
         }
         lastKeyDataStartPos = forwardedInputQueue.size();
     }
@@ -249,7 +249,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperator.java
@@ -225,7 +225,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             elementCount += currentBatchCount;
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
         lastKeyDataStartPos = forwardedInputQueue.size();
     }
@@ -249,7 +249,7 @@ public class BatchArrowPythonOverWindowAggregateFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
@@ -125,7 +125,7 @@ public abstract class AbstractStreamArrowPythonBoundedRangeOperator<K>
                 rowDataWrapper.collect(reuseJoinedRow.replace(ele, data));
             }
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     void registerCleanupTimer(long timestamp, TimeDomain domain) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
@@ -125,6 +125,7 @@ public abstract class AbstractStreamArrowPythonBoundedRangeOperator<K>
                 rowDataWrapper.collect(reuseJoinedRow.replace(ele, data));
             }
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     void registerCleanupTimer(long timestamp, TimeDomain domain) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRangeOperator.java
@@ -125,7 +125,7 @@ public abstract class AbstractStreamArrowPythonBoundedRangeOperator<K>
                 rowDataWrapper.collect(reuseJoinedRow.replace(ele, data));
             }
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     void registerCleanupTimer(long timestamp, TimeDomain domain) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
@@ -154,7 +154,7 @@ public abstract class AbstractStreamArrowPythonBoundedRowsOperator<K>
             reuseJoinedRow.setRowKind(key.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(key, data));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     void registerProcessingCleanupTimer(long currentTime) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
@@ -154,7 +154,7 @@ public abstract class AbstractStreamArrowPythonBoundedRowsOperator<K>
             reuseJoinedRow.setRowKind(key.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(key, data));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     void registerProcessingCleanupTimer(long currentTime) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonBoundedRowsOperator.java
@@ -154,6 +154,7 @@ public abstract class AbstractStreamArrowPythonBoundedRowsOperator<K>
             reuseJoinedRow.setRowKind(key.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(key, data));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     void registerProcessingCleanupTimer(long currentTime) throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
@@ -127,7 +127,7 @@ public abstract class AbstractStreamArrowPythonOverWindowAggregateFunctionOperat
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
             baos.reset();
-            arrowSerializer.reInitializeWriter(baos);
+            arrowSerializer.resetWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
@@ -127,6 +127,7 @@ public abstract class AbstractStreamArrowPythonOverWindowAggregateFunctionOperat
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
             baos.reset();
+            arrowSerializer.reInitializeWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/AbstractStreamArrowPythonOverWindowAggregateFunctionOperator.java
@@ -127,7 +127,7 @@ public abstract class AbstractStreamArrowPythonOverWindowAggregateFunctionOperat
             checkInvokeFinishBundleByCount();
             currentBatchCount = 0;
             baos.reset();
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -235,7 +235,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     @Override
@@ -314,7 +314,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
-                arrowSerializer.resetWriter(baos);
+                arrowSerializer.resetWriter();
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -235,7 +235,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     @Override
@@ -314,7 +314,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
-                arrowSerializer.reInitializeWriter(baos);
+                arrowSerializer.resetWriter(baos);
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperator.java
@@ -235,6 +235,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
             windowAggResult.replace(key, arrowSerializer.read(i));
             rowDataWrapper.collect(reuseJoinedRow.replace(windowAggResult, windowProperty));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     @Override
@@ -313,6 +314,7 @@ public class StreamArrowPythonGroupWindowAggregateFunctionOperator<K, W extends 
                 checkInvokeFinishBundleByCount();
                 currentBatchCount = 0;
                 baos.reset();
+                arrowSerializer.reInitializeWriter(baos);
             }
         }
     }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -102,7 +102,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             cRowWrapper.setChange(input.change());
             cRowWrapper.collect(Row.join(input.row(), arrowSerializer.read(i)));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
-            arrowSerializer.reInitializeWriter(baos);
+            arrowSerializer.resetWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -102,6 +102,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             cRowWrapper.setChange(input.change());
             cRowWrapper.collect(Row.join(input.row(), arrowSerializer.read(i)));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     @Override
@@ -125,6 +126,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
+            arrowSerializer.reInitializeWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -102,7 +102,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             cRowWrapper.setChange(input.change());
             cRowWrapper.collect(Row.join(input.row(), arrowSerializer.read(i)));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     @Override
@@ -126,7 +126,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
@@ -103,6 +103,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
+        arrowSerializer.reinitializeReader(bais);
     }
 
     @Override
@@ -126,6 +127,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
+            arrowSerializer.reInitializeWriter(baos);
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
@@ -103,7 +103,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
-        arrowSerializer.resetReader(bais);
+        arrowSerializer.resetReader();
     }
 
     @Override
@@ -127,7 +127,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
-            arrowSerializer.resetWriter(baos);
+            arrowSerializer.resetWriter();
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
@@ -103,7 +103,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             reuseJoinedRow.setRowKind(input.getRowKind());
             rowDataWrapper.collect(reuseJoinedRow.replace(input, arrowSerializer.read(i)));
         }
-        arrowSerializer.reinitializeReader(bais);
+        arrowSerializer.resetReader(bais);
     }
 
     @Override
@@ -127,7 +127,7 @@ public class RowDataArrowPythonScalarFunctionOperator
             pythonFunctionRunner.process(baos.toByteArray());
             checkInvokeFinishBundleByCount();
             baos.reset();
-            arrowSerializer.reInitializeWriter(baos);
+            arrowSerializer.resetWriter(baos);
         }
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -127,13 +127,16 @@ public class PassThroughPythonAggregateFunctionRunner
                             RowData firstData = arrowSerializer.read(lowerBoundary);
                             arrowSerializer.write(firstData);
                         }
+                        arrowSerializer.reinitializeReader(bais);
                     } else {
                         arrowSerializer.load();
                         arrowSerializer.write(arrowSerializer.read(0));
+                        arrowSerializer.reinitializeReader(bais);
                     }
                     arrowSerializer.finishCurrentBatch();
                     buffer.add(baos.toByteArray());
                     baos.reset();
+                    arrowSerializer.reInitializeWriter(baos);
                 };
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -127,16 +127,16 @@ public class PassThroughPythonAggregateFunctionRunner
                             RowData firstData = arrowSerializer.read(lowerBoundary);
                             arrowSerializer.write(firstData);
                         }
-                        arrowSerializer.resetReader(bais);
+                        arrowSerializer.resetReader();
                     } else {
                         arrowSerializer.load();
                         arrowSerializer.write(arrowSerializer.read(0));
-                        arrowSerializer.resetReader(bais);
+                        arrowSerializer.resetReader();
                     }
                     arrowSerializer.finishCurrentBatch();
                     buffer.add(baos.toByteArray());
                     baos.reset();
-                    arrowSerializer.resetWriter(baos);
+                    arrowSerializer.resetWriter();
                 };
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonAggregateFunctionRunner.java
@@ -127,16 +127,16 @@ public class PassThroughPythonAggregateFunctionRunner
                             RowData firstData = arrowSerializer.read(lowerBoundary);
                             arrowSerializer.write(firstData);
                         }
-                        arrowSerializer.reinitializeReader(bais);
+                        arrowSerializer.resetReader(bais);
                     } else {
                         arrowSerializer.load();
                         arrowSerializer.write(arrowSerializer.read(0));
-                        arrowSerializer.reinitializeReader(bais);
+                        arrowSerializer.resetReader(bais);
                     }
                     arrowSerializer.finishCurrentBatch();
                     buffer.add(baos.toByteArray());
                     baos.reset();
-                    arrowSerializer.reInitializeWriter(baos);
+                    arrowSerializer.resetWriter(baos);
                 };
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will make Arrow Coder serialize schema info in every batch*


## Brief change log

  - *make Arrow Coder serialize schema info in every batch*


## Verifying this change

This change added tests and can be verified as follows:

  - *original tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
