### PR TITLE
[FLINK-21255] Add WaitingForResources state for DeclarativeScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/ResourceCounter.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * <p>ResourceCounter contains a set of {@link ResourceProfile ResourceProfiles} and their
  * associated counts. The counts are always positive (> 0).
  */
-final class ResourceCounter {
+public final class ResourceCounter {
 
     private final Map<ResourceProfile, Integer> resources;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ResourceConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/ResourceConsumer.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+/** Interface which denotes that {@link State} can react to newly available resource (slots). */
+interface ResourceConsumer {
+
+    /** Notifies that new resources are available. */
+    void notifyNewResourcesAvailable();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * State abstraction of the {@link DeclarativeScheduler}. This interface contains all methods every
+ * state implementation must support.
+ */
+interface State {
+
+    /** This method is called whenever one transitions into this state. */
+    default void onEnter() {}
+
+    /**
+     * This method is called whenever one transitions out of this state.
+     *
+     * @param newState newState is the state into which the scheduler transitions
+     */
+    default void onLeave(State newState) {}
+
+    /** Cancels the job execution. */
+    void cancel();
+
+    /**
+     * Suspends the job execution.
+     *
+     * @param cause cause for the suspension
+     */
+    void suspend(Throwable cause);
+
+    /**
+     * Gets the current {@link JobStatus}.
+     *
+     * @return the current {@link JobStatus}
+     */
+    JobStatus getJobStatus();
+
+    /**
+     * Gets the current {@link ArchivedExecutionGraph}.
+     *
+     * @return the current {@link ArchivedExecutionGraph}
+     */
+    ArchivedExecutionGraph getJob();
+
+    /**
+     * Handles a global failure.
+     *
+     * @param cause cause describes the global failure
+     */
+    void handleGlobalFailure(Throwable cause);
+
+    /**
+     * Gets the logger.
+     *
+     * @return the logger
+     */
+    Logger getLogger();
+
+    /**
+     * Tries to cast this state into a type of the given clazz.
+     *
+     * @param clazz clazz describes the target type
+     * @param <T> target type
+     * @return {@link Optional#of} target type if the underlying type can be cast into clazz;
+     *     otherwise {@link Optional#empty()}
+     */
+    default <T> Optional<T> as(Class<? extends T> clazz) {
+        if (clazz.isAssignableFrom(this.getClass())) {
+            return Optional.of(clazz.cast(this));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Tries to run the action if this state is of type clazz.
+     *
+     * @param clazz clazz describes the target type
+     * @param action action to run if this state is of the target type
+     * @param debugMessage debugMessage which is printed if this state is not the target type
+     * @param <T> target type
+     * @param <E> error type
+     * @throws E an exception if the action fails
+     */
+    default <T, E extends Exception> void tryRun(
+            Class<? extends T> clazz, ThrowingConsumer<T, E> action, String debugMessage) throws E {
+        final Optional<? extends T> asOptional = as(clazz);
+
+        if (asOptional.isPresent()) {
+            action.accept(asOptional.get());
+        } else {
+            getLogger()
+                    .debug(
+                            "Cannot run '{}' because the actual state is {} and not {}.",
+                            debugMessage,
+                            this.getClass().getSimpleName(),
+                            clazz.getSimpleName());
+        }
+    }
+
+    /**
+     * Tries to run the action if this state is of type clazz.
+     *
+     * @param clazz clazz describes the target type
+     * @param action action to run if this state is of the target type
+     * @param debugMessage debugMessage which is printed if this state is not the target type
+     * @param <T> target type
+     * @param <V> value type
+     * @param <E> error type
+     * @return {@link Optional#of} the action result if it is successfully executed; otherwise
+     *     {@link Optional#empty()}
+     * @throws E an exception if the action fails
+     */
+    default <T, V, E extends Exception> Optional<V> tryCall(
+            Class<? extends T> clazz, FunctionWithException<T, V, E> action, String debugMessage)
+            throws E {
+        final Optional<? extends T> asOptional = as(clazz);
+
+        if (asOptional.isPresent()) {
+            return Optional.of(action.apply(asOptional.get()));
+        } else {
+            getLogger()
+                    .debug(
+                            "Cannot run '{}' because the actual state is {} and not {}.",
+                            debugMessage,
+                            this.getClass().getSimpleName(),
+                            clazz.getSimpleName());
+            return Optional.empty();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
@@ -36,13 +36,6 @@ interface State {
     /** This method is called whenever one transitions into this state. */
     default void onEnter() {}
 
-    /**
-     * This method is called whenever one transitions out of this state.
-     *
-     * @param newState newState is the state into which the scheduler transitions
-     */
-    default void onLeave(State newState) {}
-
     /** Cancels the job execution. */
     void cancel();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
@@ -74,7 +74,7 @@ class WaitingForResources implements State, ResourceConsumer {
 
     @Override
     public void handleGlobalFailure(Throwable cause) {
-        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.INITIALIZING, cause));
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResources.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/**
+ * State which describes that the scheduler is waiting for resources in order to execute the job.
+ */
+class WaitingForResources implements State, ResourceConsumer {
+
+    private final Context context;
+
+    private final Logger logger;
+
+    private final ResourceCounter desiredResources;
+
+    WaitingForResources(Context context, Logger logger, ResourceCounter desiredResources) {
+        this.context = context;
+        this.logger = logger;
+        this.desiredResources = desiredResources;
+    }
+
+    @Override
+    public void onEnter() {
+        context.runIfState(this, this::resourceTimeout, Duration.ofSeconds(10L));
+        notifyNewResourcesAvailable();
+    }
+
+    @Override
+    public void cancel() {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.CANCELED, null));
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
+    }
+
+    @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.INITIALIZING;
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        return context.getArchivedExecutionGraph(getJobStatus(), null);
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.INITIALIZING, cause));
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    public void notifyNewResourcesAvailable() {
+        if (context.hasEnoughResources(desiredResources)) {
+            createExecutionGraphWithAvailableResources();
+        }
+    }
+
+    private void resourceTimeout() {
+        createExecutionGraphWithAvailableResources();
+    }
+
+    private void createExecutionGraphWithAvailableResources() {
+        try {
+            final ExecutionGraph executionGraph =
+                    context.createExecutionGraphWithAvailableResources();
+
+            context.goToExecuting(executionGraph);
+        } catch (Exception exception) {
+            logger.error("handling initialization failure", exception);
+            context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, exception));
+        }
+    }
+
+    /** Context of the {@link WaitingForResources} state. */
+    interface Context {
+
+        /**
+         * Transitions into the {@link Finished} state.
+         *
+         * @param archivedExecutionGraph archivedExecutionGraph representing the final job state
+         */
+        void goToFinished(ArchivedExecutionGraph archivedExecutionGraph);
+
+        /**
+         * Transitions into the {@link Executing} state.
+         *
+         * @param executionGraph executionGraph which is passed to the {@link Executing} state
+         */
+        void goToExecuting(ExecutionGraph executionGraph);
+
+        /**
+         * Creates the {@link ArchivedExecutionGraph} for the given job status and cause. Cause can
+         * be null if there is no failure.
+         *
+         * @param jobStatus jobStatus to initialize the {@link ArchivedExecutionGraph} with
+         * @param cause cause describing a failure cause; {@code null} if there is none
+         * @return the created {@link ArchivedExecutionGraph}
+         */
+        ArchivedExecutionGraph getArchivedExecutionGraph(
+                JobStatus jobStatus, @Nullable Throwable cause);
+
+        /**
+         * Checks whether we have enough resources to fulfill the desired resources.
+         *
+         * @param desiredResources desiredResources describing the desired resources
+         * @return {@code true} if we have enough resources; otherwise {@code false}
+         */
+        boolean hasEnoughResources(ResourceCounter desiredResources);
+
+        /**
+         * Creates an {@link ExecutionGraph} with the available resources.
+         *
+         * @return the created {@link ExecutionGraph}
+         * @throws Exception if the creation of the {@link ExecutionGraph} fails
+         */
+        ExecutionGraph createExecutionGraphWithAvailableResources() throws Exception;
+
+        /**
+         * Runs the given action after a delay if the state at this time equals the expected state.
+         *
+         * @param expectedState expectedState describes the required state at the time of running
+         *     the action
+         * @param action action to run if the expected state equals the actual state
+         * @param delay delay after which to run the action
+         */
+        void runIfState(State expectedState, Runnable action, Duration delay);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateValidator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.util.Preconditions;
+
+import java.util.function.Consumer;
+
+/**
+ * Utility for state test classes (e.g. {@link WaitingForResourcesTest}) to track if correct input
+ * has been presented and if the state transition happened.
+ *
+ * @param <T> Type of the state to validate.
+ */
+public class StateValidator<T> {
+
+    private Runnable trap = () -> {};
+    private Consumer<T> consumer = null;
+    private final String stateName;
+
+    public StateValidator(String stateName) {
+        this.stateName = stateName;
+    }
+
+    /**
+     * Activate this validator (if the state transition hasn't been validated, it will fail in the
+     * close method).
+     *
+     * @param asserter Consumer which validates the input to the state transition.
+     */
+    public void activate(Consumer<T> asserter) {
+        consumer = Preconditions.checkNotNull(asserter);
+        trap =
+                () -> {
+                    throw new AssertionError("no transition to " + stateName);
+                };
+    }
+
+    /**
+     * Call this method on the state transition, to register the transition, and validate the passed
+     * arguments.
+     *
+     * @param input Argument(s) of the state transition.
+     * @throws NullPointerException If no comsumer has been set (an unexpected state transition
+     *     occurred)
+     */
+    public void validateInput(T input) {
+        Preconditions.checkNotNull(consumer, "No consumer set. Unexpected state transition?");
+        trap = () -> {};
+        consumer.accept(input);
+    }
+
+    /**
+     * If the validator has been activated, check if input has been provided (e.g. a state
+     * transition happened).
+     */
+    public void close() {
+        trap.run();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/WaitingForResourcesTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.jobmaster.slotpool.ResourceCounter;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the WaitingForResources state. */
+public class WaitingForResourcesTest extends TestLogger {
+    private static final ResourceCounter RESOURCE_COUNTER =
+            ResourceCounter.withResource(ResourceProfile.ANY, 1);
+
+    /** WaitingForResources is transitioning to Executing if there are enough resources. */
+    @Test
+    public void testTransitionToExecuting() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> true);
+
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+            ctx.setExpectExecuting(assertNonNull());
+            wfr.onEnter();
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedOnFailure() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> true);
+            ctx.setCreateExecutionGraphWithAvailableResources(
+                    () -> {
+                        throw new RuntimeException("Test exception");
+                    });
+
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+            ctx.setExpectFinished(
+                    (archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
+                    }));
+            wfr.onEnter();
+        }
+    }
+
+    @Test
+    public void testNotEnoughResources() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false);
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+
+            // we expect no state transition.
+            wfr.onEnter();
+            wfr.notifyNewResourcesAvailable();
+        }
+    }
+
+    @Test
+    public void testNotifyNewResourcesAvailable() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false); // initially, not enough resources
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+            wfr.onEnter();
+            ctx.setExpectExecuting(assertNonNull());
+            ctx.setHasEnoughResources(() -> true); // make resources available
+            wfr.notifyNewResourcesAvailable(); // .. and notify
+        }
+    }
+
+    @Test
+    public void testResourceTimeout() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false);
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+
+            ctx.setExpectExecuting(assertNonNull());
+            wfr.onEnter();
+
+            // immediately execute all scheduled runnables
+            assertThat(ctx.getScheduledRunnables().size(), greaterThan(0));
+            for (ScheduledRunnable scheduledRunnable : ctx.getScheduledRunnables()) {
+                if (scheduledRunnable.getExpectedState() == wfr) {
+                    scheduledRunnable.runAction();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedOnGlobalFailure() throws Exception {
+        final String testExceptionString = "This is a test exception";
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false);
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+
+            ctx.setExpectFinished(
+                    archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
+                        assertThat(archivedExecutionGraph.getFailureInfo(), notNullValue());
+                        assertTrue(
+                                archivedExecutionGraph
+                                        .getFailureInfo()
+                                        .getExceptionAsString()
+                                        .contains(testExceptionString));
+                    });
+            wfr.onEnter();
+
+            wfr.handleGlobalFailure(new RuntimeException(testExceptionString));
+        }
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false);
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+
+            ctx.setExpectFinished(
+                    (archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.CANCELED));
+                    }));
+            wfr.onEnter();
+            wfr.cancel();
+        }
+    }
+
+    @Test
+    public void testSuspend() throws Exception {
+        try (MockContext ctx = new MockContext()) {
+            ctx.setHasEnoughResources(() -> false);
+            WaitingForResources wfr = new WaitingForResources(ctx, log, RESOURCE_COUNTER);
+
+            ctx.setExpectFinished(
+                    (archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
+                        assertThat(archivedExecutionGraph.getFailureInfo(), notNullValue());
+                    }));
+            wfr.onEnter();
+            wfr.suspend(new RuntimeException("suspend"));
+        }
+    }
+
+    private static class MockContext implements WaitingForResources.Context, AutoCloseable {
+
+        private final StateValidator<ExecutionGraph> executingStateValidator =
+                new StateValidator<>("executing");
+        private final StateValidator<ArchivedExecutionGraph> finishingStateValidator =
+                new StateValidator<>("finishing");
+
+        private Supplier<Boolean> hasEnoughResourcesSupplier = () -> false;
+        private SupplierWithException<ExecutionGraph, FlinkException>
+                createExecutionGraphWithAvailableResources =
+                        () -> TestingExecutionGraphBuilder.newBuilder().build();
+        private final List<ScheduledRunnable> scheduledRunnables = new ArrayList<>();
+
+        public List<ScheduledRunnable> getScheduledRunnables() {
+            return scheduledRunnables;
+        }
+
+        public void setHasEnoughResources(Supplier<Boolean> sup) {
+            hasEnoughResourcesSupplier = sup;
+        }
+
+        public void setCreateExecutionGraphWithAvailableResources(
+                SupplierWithException<ExecutionGraph, FlinkException> sup) {
+            this.createExecutionGraphWithAvailableResources = sup;
+        }
+
+        void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
+            finishingStateValidator.activate(asserter);
+        }
+
+        void setExpectExecuting(Consumer<ExecutionGraph> asserter) {
+            executingStateValidator.activate(asserter);
+        }
+
+        @Override
+        public void close() throws Exception {
+            executingStateValidator.close();
+            finishingStateValidator.close();
+        }
+
+        @Override
+        public ArchivedExecutionGraph getArchivedExecutionGraph(
+                JobStatus jobStatus, @Nullable Throwable cause) {
+            return new ArchivedExecutionGraphBuilder()
+                    .setState(jobStatus)
+                    .setFailureCause(cause == null ? null : new ErrorInfo(cause, 1337))
+                    .build();
+        }
+
+        @Override
+        public boolean hasEnoughResources(ResourceCounter desiredResources) {
+            return hasEnoughResourcesSupplier.get();
+        }
+
+        @Override
+        public ExecutionGraph createExecutionGraphWithAvailableResources() throws FlinkException {
+            return createExecutionGraphWithAvailableResources.get();
+        }
+
+        @Override
+        public void runIfState(State expectedState, Runnable action, Duration delay) {
+            scheduledRunnables.add(new ScheduledRunnable(expectedState, action, delay));
+        }
+
+        @Override
+        public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
+            finishingStateValidator.validateInput(archivedExecutionGraph);
+        }
+
+        @Override
+        public void goToExecuting(ExecutionGraph executionGraph) {
+            executingStateValidator.validateInput(executionGraph);
+        }
+    }
+
+    private static final class ScheduledRunnable {
+        private final Runnable action;
+        private final State expectedState;
+        private final Duration delay;
+
+        private ScheduledRunnable(State expectedState, Runnable action, Duration delay) {
+            this.expectedState = expectedState;
+            this.action = action;
+            this.delay = delay;
+        }
+
+        public void runAction() {
+            action.run();
+        }
+
+        public State getExpectedState() {
+            return expectedState;
+        }
+    }
+
+    static <T> Consumer<T> assertNonNull() {
+        return (item) -> assertThat(item, notNullValue());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. This PR is adding the first state of the new scheduler to Flink.

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.