### PR TITLE
[FLINK-21078] Add DeclarativeSlotPoolService which encapsulates a DeclarativeSlotPool

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -27,32 +27,19 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
-import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
-import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
-import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
-import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.slots.ResourceRequirement;
-import org.apache.flink.runtime.slots.ResourceRequirements;
-import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.clock.Clock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,29 +53,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** {@link SlotPool} implementation which uses the {@link DeclarativeSlotPool} to allocate slots. */
-public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
-
-    private static final Logger LOG = LoggerFactory.getLogger(DeclarativeSlotPoolBridge.class);
-
-    private final JobID jobId;
+public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implements SlotPool {
 
     private final Map<SlotRequestId, PendingRequest> pendingRequests;
     private final Map<SlotRequestId, AllocationID> fulfilledRequests;
-    private final DeclarativeSlotPool declarativeSlotPool;
-    private final Set<ResourceID> registeredTaskManagers;
+    private final Time idleSlotTimeout;
 
     @Nullable private ComponentMainThreadExecutor componentMainThreadExecutor;
 
-    @Nullable private String jobManagerAddress;
-
-    @Nullable private JobMasterId jobMasterId;
-
-    private DeclareResourceRequirementServiceConnectionManager
-            declareResourceRequirementServiceConnectionManager;
-
-    private final Clock clock;
-    private final Time rpcTimeout;
-    private final Time idleSlotTimeout;
     private final Time batchSlotTimeout;
     private boolean isBatchSlotRequestTimeoutCheckDisabled;
 
@@ -99,37 +71,30 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             Time rpcTimeout,
             Time idleSlotTimeout,
             Time batchSlotTimeout) {
-        this.jobId = Preconditions.checkNotNull(jobId);
-        this.clock = Preconditions.checkNotNull(clock);
-        this.rpcTimeout = Preconditions.checkNotNull(rpcTimeout);
-        this.idleSlotTimeout = Preconditions.checkNotNull(idleSlotTimeout);
+        super(jobId, declarativeSlotPoolFactory, clock, idleSlotTimeout, rpcTimeout);
+
+        this.idleSlotTimeout = idleSlotTimeout;
         this.batchSlotTimeout = Preconditions.checkNotNull(batchSlotTimeout);
         this.isBatchSlotRequestTimeoutCheckDisabled = false;
 
         this.pendingRequests = new LinkedHashMap<>();
         this.fulfilledRequests = new HashMap<>();
-        this.registeredTaskManagers = new HashSet<>();
-        this.declareResourceRequirementServiceConnectionManager =
-                NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
-        this.declarativeSlotPool =
-                declarativeSlotPoolFactory.create(
-                        jobId, this::declareResourceRequirements, idleSlotTimeout, rpcTimeout);
-        this.declarativeSlotPool.registerNewSlotsListener(this::newSlotsAreAvailable);
     }
 
     @Override
-    public void start(
-            JobMasterId jobMasterId,
-            String newJobManagerAddress,
-            ComponentMainThreadExecutor jmMainThreadScheduledExecutor)
-            throws Exception {
-        this.componentMainThreadExecutor =
-                Preconditions.checkNotNull(jmMainThreadScheduledExecutor);
-        this.jobManagerAddress = Preconditions.checkNotNull(newJobManagerAddress);
-        this.jobMasterId = Preconditions.checkNotNull(jobMasterId);
-        this.declareResourceRequirementServiceConnectionManager =
-                DefaultDeclareResourceRequirementServiceConnectionManager.create(
-                        componentMainThreadExecutor);
+    public <T> Optional<T> castInto(Class<T> clazz) {
+        if (clazz.isAssignableFrom(getClass())) {
+            return Optional.of(clazz.cast(this));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected void onStart(ComponentMainThreadExecutor componentMainThreadExecutor) {
+        this.componentMainThreadExecutor = componentMainThreadExecutor;
+
+        getDeclarativeSlotPool().registerNewSlotsListener(this::newSlotsAreAvailable);
 
         componentMainThreadExecutor.schedule(
                 this::checkIdleSlotTimeout,
@@ -144,23 +109,20 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     @Override
     public void suspend() {
         assertRunningInMainThread();
-        LOG.info("Suspending slot pool.");
+        log.info("Suspending slot pool.");
 
         cancelPendingRequests(request -> true, new FlinkException("Suspending slot pool."));
-        clearState();
     }
 
     @Override
-    public void close() {
-        LOG.info("Closing slot pool.");
+    protected void onClose() {
         final FlinkException cause = new FlinkException("Closing slot pool");
         cancelPendingRequests(request -> true, cause);
-        releaseAllTaskManagers(new FlinkException("Closing slot pool."));
-        clearState();
     }
 
     private void cancelPendingRequests(
             Predicate<PendingRequest> requestPredicate, FlinkException cancelCause) {
+
         ResourceCounter decreasedResourceRequirements = ResourceCounter.empty();
 
         // need a copy since failing a request could trigger another request to be issued
@@ -178,85 +140,12 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             }
         }
 
-        declarativeSlotPool.decreaseResourceRequirementsBy(decreasedResourceRequirements);
-    }
-
-    private void clearState() {
-        declareResourceRequirementServiceConnectionManager.close();
-        declareResourceRequirementServiceConnectionManager =
-                NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
-        registeredTaskManagers.clear();
-        jobManagerAddress = null;
-        jobMasterId = null;
+        getDeclarativeSlotPool().decreaseResourceRequirementsBy(decreasedResourceRequirements);
     }
 
     @Override
-    public void connectToResourceManager(ResourceManagerGateway resourceManagerGateway) {
-        assertRunningInMainThread();
-        Preconditions.checkNotNull(resourceManagerGateway);
-
-        declareResourceRequirementServiceConnectionManager.connect(
-                resourceRequirements ->
-                        resourceManagerGateway.declareRequiredResources(
-                                jobMasterId, resourceRequirements, rpcTimeout));
-        declareResourceRequirements(declarativeSlotPool.getResourceRequirements());
-    }
-
-    @Override
-    public void disconnectResourceManager() {
-        assertRunningInMainThread();
-        this.declareResourceRequirementServiceConnectionManager.disconnect();
-    }
-
-    @Override
-    public boolean registerTaskManager(ResourceID resourceID) {
-        assertRunningInMainThread();
-
-        LOG.debug("Register new TaskExecutor {}.", resourceID);
-        return registeredTaskManagers.add(resourceID);
-    }
-
-    @Override
-    public boolean releaseTaskManager(ResourceID resourceId, Exception cause) {
-        assertRunningInMainThread();
-
-        if (registeredTaskManagers.remove(resourceId)) {
-            internalReleaseTaskManager(resourceId, cause);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private void releaseAllTaskManagers(FlinkException cause) {
-        for (ResourceID registeredTaskManager : registeredTaskManagers) {
-            internalReleaseTaskManager(registeredTaskManager, cause);
-        }
-
-        registeredTaskManagers.clear();
-    }
-
-    private void internalReleaseTaskManager(ResourceID resourceId, Exception cause) {
-        ResourceCounter previouslyFulfilledRequirement =
-                declarativeSlotPool.releaseSlots(resourceId, cause);
-        declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
-    }
-
-    @Override
-    public Collection<SlotOffer> offerSlots(
-            TaskManagerLocation taskManagerLocation,
-            TaskManagerGateway taskManagerGateway,
-            Collection<SlotOffer> offers) {
-        assertRunningInMainThread();
-        Preconditions.checkNotNull(taskManagerGateway);
-        Preconditions.checkNotNull(offers);
-
-        if (!registeredTaskManagers.contains(taskManagerLocation.getResourceID())) {
-            return Collections.emptyList();
-        }
-
-        return declarativeSlotPool.offerSlots(
-                offers, taskManagerLocation, taskManagerGateway, clock.relativeTimeMillis());
+    protected void onReleaseTaskManager(ResourceCounter previouslyFulfilledRequirement) {
+        getDeclarativeSlotPool().decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
     }
 
     @VisibleForTesting
@@ -294,8 +183,8 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             SlotRequestId slotRequestId,
             AllocationID allocationId,
             ResourceProfile resourceProfile) {
-        LOG.debug("Reserve slot {} for slot request id {}", allocationId, slotRequestId);
-        declarativeSlotPool.reserveFreeSlot(allocationId, resourceProfile);
+        log.debug("Reserve slot {} for slot request id {}", allocationId, slotRequestId);
+        getDeclarativeSlotPool().reserveFreeSlot(allocationId, resourceProfile);
         fulfilledRequests.put(slotRequestId, allocationId);
     }
 
@@ -304,11 +193,11 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
 
         for (PendingRequest pendingRequest : pendingRequests.values()) {
             if (resourceProfile.isMatching(pendingRequest.getResourceProfile())) {
-                LOG.debug("Matched slot {} to pending request {}.", slot, pendingRequest);
+                log.debug("Matched slot {} to pending request {}.", slot, pendingRequest);
                 return Optional.of(pendingRequest);
             }
         }
-        LOG.debug("Could not match slot {} to any pending request.", slot);
+        log.debug("Could not match slot {} to any pending request.", slot);
 
         return Optional.empty();
     }
@@ -321,7 +210,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
         assertRunningInMainThread();
         Preconditions.checkNotNull(requirementProfile, "The requiredSlotProfile must not be null.");
 
-        LOG.debug(
+        log.debug(
                 "Reserving free slot {} for slot request id {} and profile {}.",
                 allocationID,
                 slotRequestId,
@@ -335,10 +224,11 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             SlotRequestId slotRequestId,
             AllocationID allocationId,
             ResourceProfile requiredSlotProfile) {
-        declarativeSlotPool.increaseResourceRequirementsBy(
-                ResourceCounter.withResource(requiredSlotProfile, 1));
+        getDeclarativeSlotPool()
+                .increaseResourceRequirementsBy(
+                        ResourceCounter.withResource(requiredSlotProfile, 1));
         final PhysicalSlot physicalSlot =
-                declarativeSlotPool.reserveFreeSlot(allocationId, requiredSlotProfile);
+                getDeclarativeSlotPool().reserveFreeSlot(allocationId, requiredSlotProfile);
         fulfilledRequests.put(slotRequestId, allocationId);
 
         return physicalSlot;
@@ -352,7 +242,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             @Nullable Time timeout) {
         assertRunningInMainThread();
 
-        LOG.debug(
+        log.debug(
                 "Request new allocated slot with slot request id {} and resource profile {}",
                 slotRequestId,
                 resourceProfile);
@@ -369,7 +259,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             @Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
         assertRunningInMainThread();
 
-        LOG.debug(
+        log.debug(
                 "Request new allocated batch slot with slot request id {} and resource profile {}",
                 slotRequestId,
                 resourceProfile);
@@ -410,15 +300,9 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     private void internalRequestNewAllocatedSlot(PendingRequest pendingRequest) {
         pendingRequests.put(pendingRequest.getSlotRequestId(), pendingRequest);
 
-        declarativeSlotPool.increaseResourceRequirementsBy(
-                ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
-    }
-
-    private void declareResourceRequirements(Collection<ResourceRequirement> resourceRequirements) {
-        assertRunningInMainThread();
-
-        declareResourceRequirementServiceConnectionManager.declareResourceRequirements(
-                ResourceRequirements.create(jobId, jobManagerAddress, resourceRequirements));
+        getDeclarativeSlotPool()
+                .increaseResourceRequirementsBy(
+                        ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
     }
 
     @Override
@@ -428,36 +312,21 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     }
 
     @Override
-    public Optional<ResourceID> failAllocation(
-            @Nullable ResourceID resourceId, AllocationID allocationID, Exception cause) {
-        assertRunningInMainThread();
-
-        Preconditions.checkNotNull(allocationID);
-        Preconditions.checkNotNull(
-                resourceId,
-                "This slot pool only supports failAllocation calls coming from the TaskExecutor.");
-
-        ResourceCounter previouslyFulfilledRequirements =
-                declarativeSlotPool.releaseSlot(allocationID, cause);
-        declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirements);
-
-        if (declarativeSlotPool.containsSlots(resourceId)) {
-            return Optional.empty();
-        } else {
-            return Optional.of(resourceId);
-        }
+    protected void onFailAllocation(ResourceCounter previouslyFulfilledRequirements) {
+        getDeclarativeSlotPool().decreaseResourceRequirementsBy(previouslyFulfilledRequirements);
     }
 
     @Override
     public void releaseSlot(@Nonnull SlotRequestId slotRequestId, @Nullable Throwable cause) {
-        LOG.debug("Release slot with slot request id {}", slotRequestId);
+        log.debug("Release slot with slot request id {}", slotRequestId);
         assertRunningInMainThread();
 
         final PendingRequest pendingRequest = pendingRequests.remove(slotRequestId);
 
         if (pendingRequest != null) {
-            declarativeSlotPool.decreaseResourceRequirementsBy(
-                    ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
+            getDeclarativeSlotPool()
+                    .decreaseResourceRequirementsBy(
+                            ResourceCounter.withResource(pendingRequest.getResourceProfile(), 1));
             pendingRequest.failRequest(
                     new FlinkException(
                             String.format(
@@ -469,11 +338,12 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
 
             if (allocationId != null) {
                 ResourceCounter previouslyFulfilledRequirement =
-                        declarativeSlotPool.freeReservedSlot(
-                                allocationId, cause, clock.relativeTimeMillis());
-                declarativeSlotPool.decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
+                        getDeclarativeSlotPool()
+                                .freeReservedSlot(allocationId, cause, getRelativeTimeMillis());
+                getDeclarativeSlotPool()
+                        .decreaseResourceRequirementsBy(previouslyFulfilledRequirement);
             } else {
-                LOG.debug(
+                log.debug(
                         "Could not find slot which has fulfilled slot request {}. Ignoring the release operation.",
                         slotRequestId);
             }
@@ -501,34 +371,13 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     }
 
     @Override
-    public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
-        assertRunningInMainThread();
-        Preconditions.checkNotNull(taskManagerId);
-
-        final Collection<? extends SlotInfo> allocatedSlotsInformation =
-                declarativeSlotPool.getAllSlotsInformation();
-
-        final Collection<AllocatedSlotInfo> allocatedSlotInfos = new ArrayList<>();
-
-        for (SlotInfo slotInfo : allocatedSlotsInformation) {
-            if (slotInfo.getTaskManagerLocation().getResourceID().equals(taskManagerId)) {
-                allocatedSlotInfos.add(
-                        new AllocatedSlotInfo(
-                                slotInfo.getPhysicalSlotNumber(), slotInfo.getAllocationId()));
-            }
-        }
-
-        return new AllocatedSlotReport(jobId, allocatedSlotInfos);
-    }
-
-    @Override
     public Collection<SlotInfo> getAllocatedSlotsInformation() {
         assertRunningInMainThread();
 
         final Collection<? extends SlotInfo> allSlotsInformation =
-                declarativeSlotPool.getAllSlotsInformation();
+                getDeclarativeSlotPool().getAllSlotsInformation();
         final Set<AllocationID> freeSlots =
-                declarativeSlotPool.getFreeSlotsInformation().stream()
+                getDeclarativeSlotPool().getFreeSlotsInformation().stream()
                         .map(SlotInfoWithUtilization::getAllocationId)
                         .collect(Collectors.toSet());
 
@@ -542,7 +391,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     public Collection<SlotInfoWithUtilization> getAvailableSlotsInformation() {
         assertRunningInMainThread();
 
-        return declarativeSlotPool.getFreeSlotsInformation();
+        return getDeclarativeSlotPool().getFreeSlotsInformation();
     }
 
     @Override
@@ -559,7 +408,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
     }
 
     private void checkIdleSlotTimeout() {
-        declarativeSlotPool.releaseIdleSlots(clock.relativeTimeMillis());
+        getDeclarativeSlotPool().releaseIdleSlots(getRelativeTimeMillis());
 
         if (componentMainThreadExecutor != null) {
             componentMainThreadExecutor.schedule(
@@ -590,7 +439,7 @@ public class DeclarativeSlotPoolBridge implements SlotPool, SlotPoolService {
             final List<PendingRequest> unfulfillableRequests =
                     fulfillableAndUnfulfillableRequests.get(false);
 
-            final long currentTimestamp = clock.relativeTimeMillis();
+            final long currentTimestamp = getRelativeTimeMillis();
 
             for (PendingRequest fulfillableRequest : fulfillableRequests) {
                 fulfillableRequest.markFulfillable();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.clock.Clock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/** {@link SlotPoolService} implementation for the {@link DeclarativeSlotPool}. */
+public class DeclarativeSlotPoolService implements SlotPoolService {
+
+    private final JobID jobId;
+
+    private final Time rpcTimeout;
+
+    private final DeclarativeSlotPool declarativeSlotPool;
+
+    private final Clock clock;
+
+    private final Set<ResourceID> registeredTaskManagers;
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private DeclareResourceRequirementServiceConnectionManager
+            resourceRequirementServiceConnectionManager =
+                    NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
+
+    @Nullable private JobMasterId jobMasterId;
+
+    @Nullable private String jobManagerAddress;
+
+    private State state = State.CREATED;
+
+    public DeclarativeSlotPoolService(
+            JobID jobId,
+            DeclarativeSlotPoolFactory declarativeSlotPoolFactory,
+            Clock clock,
+            Time idleSlotTimeout,
+            Time rpcTimeout) {
+        this.jobId = jobId;
+        this.clock = clock;
+        this.rpcTimeout = rpcTimeout;
+        this.registeredTaskManagers = new HashSet<>();
+
+        this.declarativeSlotPool =
+                declarativeSlotPoolFactory.create(
+                        jobId, this::declareResourceRequirements, idleSlotTimeout, rpcTimeout);
+    }
+
+    protected DeclarativeSlotPool getDeclarativeSlotPool() {
+        return declarativeSlotPool;
+    }
+
+    protected long getRelativeTimeMillis() {
+        return clock.relativeTimeMillis();
+    }
+
+    @Override
+    public <T> Optional<T> castInto(Class<T> clazz) {
+        if (clazz.isAssignableFrom(declarativeSlotPool.getClass())) {
+            return Optional.of(clazz.cast(declarativeSlotPool));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public final void start(
+            JobMasterId jobMasterId, String address, ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {
+        Preconditions.checkState(
+                state == State.CREATED, "The DeclarativeSlotPoolService can only be started once.");
+
+        this.jobMasterId = Preconditions.checkNotNull(jobMasterId);
+        this.jobManagerAddress = Preconditions.checkNotNull(address);
+
+        this.resourceRequirementServiceConnectionManager =
+                DefaultDeclareResourceRequirementServiceConnectionManager.create(
+                        mainThreadExecutor);
+
+        onStart(mainThreadExecutor);
+
+        state = State.STARTED;
+    }
+
+    /**
+     * This method is called when the slot pool service is started. It can be overridden by
+     * subclasses.
+     *
+     * @param componentMainThreadExecutor componentMainThreadExecutor used by this slot pool service
+     */
+    protected void onStart(ComponentMainThreadExecutor componentMainThreadExecutor) {}
+
+    protected void assertHasBeenStarted() {
+        Preconditions.checkState(
+                state == State.STARTED, "The DeclarativeSlotPoolService has to be started.");
+    }
+
+    @Override
+    public void suspend() {
+        throw new UnsupportedOperationException("This method should not be needed.");
+    }
+
+    @Override
+    public final void close() {
+        if (state != State.CLOSED) {
+
+            onClose();
+
+            resourceRequirementServiceConnectionManager.close();
+            resourceRequirementServiceConnectionManager =
+                    NoOpDeclareResourceRequirementServiceConnectionManager.INSTANCE;
+
+            releaseAllTaskManagers(
+                    new FlinkException("The DeclarativeSlotPoolService is being closed."));
+
+            state = State.CLOSED;
+        }
+    }
+
+    /**
+     * This method is called when the slot pool service is closed. It can be overridden by
+     * subclasses.
+     */
+    protected void onClose() {}
+
+    @Override
+    public Collection<SlotOffer> offerSlots(
+            TaskManagerLocation taskManagerLocation,
+            TaskManagerGateway taskManagerGateway,
+            Collection<SlotOffer> offers) {
+        assertHasBeenStarted();
+
+        if (!isTaskManagerRegistered(taskManagerLocation.getResourceID())) {
+            log.debug(
+                    "Ignoring offered slots from unknown task manager {}.",
+                    taskManagerLocation.getResourceID());
+            return Collections.emptyList();
+        }
+
+        return declarativeSlotPool.offerSlots(
+                offers, taskManagerLocation, taskManagerGateway, clock.relativeTimeMillis());
+    }
+
+    boolean isTaskManagerRegistered(ResourceID taskManagerId) {
+        return registeredTaskManagers.contains(taskManagerId);
+    }
+
+    @Override
+    public Optional<ResourceID> failAllocation(
+            @Nullable ResourceID taskManagerId, AllocationID allocationId, Exception cause) {
+        assertHasBeenStarted();
+        Preconditions.checkNotNull(allocationId);
+        Preconditions.checkNotNull(
+                taskManagerId,
+                "This slot pool only supports failAllocation calls coming from the TaskExecutor.");
+
+        final ResourceCounter previouslyFulfilledRequirements =
+                declarativeSlotPool.releaseSlot(allocationId, cause);
+
+        onFailAllocation(previouslyFulfilledRequirements);
+
+        if (declarativeSlotPool.containsSlots(taskManagerId)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(taskManagerId);
+        }
+    }
+
+    /**
+     * This method is called when an allocation fails. It can be overridden by subclasses.
+     *
+     * @param previouslyFulfilledRequirements previouslyFulfilledRequirements by the failed
+     *     allocation
+     */
+    protected void onFailAllocation(ResourceCounter previouslyFulfilledRequirements) {}
+
+    @Override
+    public boolean registerTaskManager(ResourceID taskManagerId) {
+        assertHasBeenStarted();
+
+        log.debug("Register new TaskExecutor {}.", taskManagerId);
+        return registeredTaskManagers.add(taskManagerId);
+    }
+
+    @Override
+    public boolean releaseTaskManager(ResourceID taskManagerId, Exception cause) {
+        assertHasBeenStarted();
+
+        if (registeredTaskManagers.remove(taskManagerId)) {
+            internalReleaseTaskManager(taskManagerId, cause);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void releaseAllTaskManagers(Exception cause) {
+        for (ResourceID registeredTaskManager : registeredTaskManagers) {
+            internalReleaseTaskManager(registeredTaskManager, cause);
+        }
+
+        registeredTaskManagers.clear();
+    }
+
+    private void internalReleaseTaskManager(ResourceID taskManagerId, Exception cause) {
+        assertHasBeenStarted();
+
+        final ResourceCounter previouslyFulfilledRequirement =
+                declarativeSlotPool.releaseSlots(taskManagerId, cause);
+
+        onReleaseTaskManager(previouslyFulfilledRequirement);
+    }
+
+    /**
+     * This method is called when a TaskManager is released. It can be overridden by subclasses.
+     *
+     * @param previouslyFulfilledRequirement previouslyFulfilledRequirement by the released
+     *     TaskManager
+     */
+    protected void onReleaseTaskManager(ResourceCounter previouslyFulfilledRequirement) {}
+
+    @Override
+    public void connectToResourceManager(ResourceManagerGateway resourceManagerGateway) {
+        assertHasBeenStarted();
+
+        resourceRequirementServiceConnectionManager.connect(
+                resourceRequirements ->
+                        resourceManagerGateway.declareRequiredResources(
+                                jobMasterId, resourceRequirements, rpcTimeout));
+
+        declareResourceRequirements(declarativeSlotPool.getResourceRequirements());
+    }
+
+    private void declareResourceRequirements(Collection<ResourceRequirement> resourceRequirements) {
+        assertHasBeenStarted();
+
+        resourceRequirementServiceConnectionManager.declareResourceRequirements(
+                ResourceRequirements.create(jobId, jobManagerAddress, resourceRequirements));
+    }
+
+    @Override
+    public void disconnectResourceManager() {
+        assertHasBeenStarted();
+
+        resourceRequirementServiceConnectionManager.disconnect();
+    }
+
+    @Override
+    public AllocatedSlotReport createAllocatedSlotReport(ResourceID taskManagerId) {
+        assertHasBeenStarted();
+
+        final Collection<AllocatedSlotInfo> allocatedSlotInfos = new ArrayList<>();
+
+        for (SlotInfo slotInfo : declarativeSlotPool.getAllSlotsInformation()) {
+            if (slotInfo.getTaskManagerLocation().getResourceID().equals(taskManagerId)) {
+                allocatedSlotInfos.add(
+                        new AllocatedSlotInfo(
+                                slotInfo.getPhysicalSlotNumber(), slotInfo.getAllocationId()));
+            }
+        }
+        return new AllocatedSlotReport(jobId, allocatedSlotInfos);
+    }
+
+    private enum State {
+        CREATED,
+        STARTED,
+        CLOSED,
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.clock.Clock;
+
+import javax.annotation.Nonnull;
+
+/** Factory for the {@link DeclarativeSlotPoolService}. */
+public class DeclarativeSlotPoolServiceFactory implements SlotPoolServiceFactory {
+
+    private final Clock clock;
+    private final Time idleSlotTimeout;
+    private final Time rpcTimeout;
+
+    public DeclarativeSlotPoolServiceFactory(Clock clock, Time idleSlotTimeout, Time rpcTimeout) {
+        this.clock = clock;
+        this.idleSlotTimeout = idleSlotTimeout;
+        this.rpcTimeout = rpcTimeout;
+    }
+
+    @Nonnull
+    @Override
+    public SlotPoolService createSlotPoolService(@Nonnull JobID jobId) {
+        return new DeclarativeSlotPoolService(
+                jobId, new DefaultDeclarativeSlotPoolFactory(), clock, idleSlotTimeout, rpcTimeout);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeResourceDeclarationTest.java
@@ -73,10 +73,8 @@ public class DeclarativeSlotPoolBridgeResourceDeclarationTest extends TestLogger
                                 (allocationID, e) ->
                                         ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1));
 
-        final DeclarativeSlotPoolBridgeTest.TestingDeclarativeSlotPoolFactory
-                declarativeSlotPoolFactory =
-                        new DeclarativeSlotPoolBridgeTest.TestingDeclarativeSlotPoolFactory(
-                                slotPoolBuilder);
+        final TestingDeclarativeSlotPoolFactory declarativeSlotPoolFactory =
+                new TestingDeclarativeSlotPoolFactory(slotPoolBuilder);
         declarativeSlotPoolBridge = createDeclarativeSlotPoolBridge(declarativeSlotPoolFactory);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridgeTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableExceptio
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
-import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.util.TestLogger;
@@ -42,12 +41,10 @@ import javax.annotation.Nonnull;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -216,23 +213,5 @@ public class DeclarativeSlotPoolBridgeTest extends TestLogger {
                 new RpcTaskManagerGateway(
                         new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(),
                         JobMasterId.generate()));
-    }
-
-    static final class TestingDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFactory {
-
-        final TestingDeclarativeSlotPoolBuilder builder;
-
-        public TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPoolBuilder builder) {
-            this.builder = builder;
-        }
-
-        @Override
-        public DeclarativeSlotPool create(
-                JobID jobId,
-                Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
-                Time idleSlotTimeout,
-                Time rpcTimeout) {
-            return builder.build();
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolServiceTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.instance.SimpleSlotContext;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotContext;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+import org.apache.flink.runtime.slots.ResourceRequirements;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.clock.SystemClock;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link DeclarativeSlotPoolService}. */
+public class DeclarativeSlotPoolServiceTest extends TestLogger {
+
+    private static final JobID jobId = new JobID();
+    private static final JobMasterId jobMasterId = JobMasterId.generate();
+    private final ComponentMainThreadExecutor mainThreadExecutor =
+            ComponentMainThreadExecutorServiceAdapter.forMainThread();
+    private static final String address = "localhost";
+
+    @Test
+    public void testUnknownTaskManagerRegistration() throws Exception {
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService()) {
+            final ResourceID unknownTaskManager = ResourceID.generate();
+
+            assertFalse(
+                    declarativeSlotPoolService.isTaskManagerRegistered(
+                            unknownTaskManager.getResourceID()));
+        }
+    }
+
+    @Test
+    public void testKnownTaskManagerRegistration() throws Exception {
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService()) {
+            final ResourceID knownTaskManager = ResourceID.generate();
+            declarativeSlotPoolService.registerTaskManager(knownTaskManager);
+
+            assertTrue(
+                    declarativeSlotPoolService.isTaskManagerRegistered(
+                            knownTaskManager.getResourceID()));
+        }
+    }
+
+    @Test
+    public void testReleaseTaskManager() throws Exception {
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService()) {
+            final ResourceID knownTaskManager = ResourceID.generate();
+            declarativeSlotPoolService.registerTaskManager(knownTaskManager);
+            declarativeSlotPoolService.releaseTaskManager(
+                    knownTaskManager, new FlinkException("Test cause"));
+
+            assertFalse(
+                    declarativeSlotPoolService.isTaskManagerRegistered(
+                            knownTaskManager.getResourceID()));
+        }
+    }
+
+    @Test
+    public void testSlotOfferingOfUnknownTaskManagerIsIgnored() throws Exception {
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService()) {
+            final Collection<SlotOffer> slotOffers =
+                    Collections.singletonList(
+                            new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY));
+
+            final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+            final Collection<SlotOffer> acceptedSlots =
+                    declarativeSlotPoolService.offerSlots(
+                            taskManagerLocation,
+                            new RpcTaskManagerGateway(
+                                    new TestingTaskExecutorGatewayBuilder()
+                                            .createTestingTaskExecutorGateway(),
+                                    jobMasterId),
+                            slotOffers);
+
+            assertThat(acceptedSlots, is(empty()));
+        }
+    }
+
+    @Test
+    public void testSlotOfferingOfKnownTaskManager() throws Exception {
+        final AtomicReference<Collection<? extends SlotOffer>> receivedSlotOffers =
+                new AtomicReference<>();
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService(
+                        new TestingDeclarativeSlotPoolFactory(
+                                new TestingDeclarativeSlotPoolBuilder()
+                                        .setOfferSlotsFunction(
+                                                (slotOffers,
+                                                        taskManagerLocation,
+                                                        taskManagerGateway,
+                                                        aLong) -> {
+                                                    receivedSlotOffers.set(slotOffers);
+                                                    return new ArrayList<>(slotOffers);
+                                                })))) {
+            final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+
+            declarativeSlotPoolService.registerTaskManager(taskManagerLocation.getResourceID());
+
+            final Collection<SlotOffer> slotOffers =
+                    Collections.singletonList(
+                            new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY));
+
+            declarativeSlotPoolService.offerSlots(
+                    taskManagerLocation,
+                    new RpcTaskManagerGateway(
+                            new TestingTaskExecutorGatewayBuilder()
+                                    .createTestingTaskExecutorGateway(),
+                            jobMasterId),
+                    slotOffers);
+
+            assertThat(receivedSlotOffers.get(), is(slotOffers));
+        }
+    }
+
+    @Test
+    public void testConnectToResourceManagerDeclaresRequiredResources() throws Exception {
+        final Collection<ResourceRequirement> requiredResources =
+                Arrays.asList(
+                        ResourceRequirement.create(ResourceProfile.ANY, 2),
+                        ResourceRequirement.create(ResourceProfile.ZERO, 4));
+
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService(
+                        new TestingDeclarativeSlotPoolFactory(
+                                new TestingDeclarativeSlotPoolBuilder()
+                                        .setGetResourceRequirementsSupplier(
+                                                () -> requiredResources)))) {
+            final TestingResourceManagerGateway resourceManagerGateway =
+                    new TestingResourceManagerGateway();
+
+            final CompletableFuture<ResourceRequirements> declaredResourceRequirements =
+                    new CompletableFuture<>();
+
+            resourceManagerGateway.setDeclareRequiredResourcesFunction(
+                    (jobMasterId, resourceRequirements) -> {
+                        declaredResourceRequirements.complete(resourceRequirements);
+                        return CompletableFuture.completedFuture(Acknowledge.get());
+                    });
+
+            declarativeSlotPoolService.connectToResourceManager(resourceManagerGateway);
+
+            final ResourceRequirements resourceRequirements = declaredResourceRequirements.join();
+
+            assertThat(resourceRequirements.getResourceRequirements(), is(requiredResources));
+            assertThat(resourceRequirements.getJobId(), is(jobId));
+            assertThat(resourceRequirements.getTargetAddress(), is(address));
+        }
+    }
+
+    @Test
+    public void testCreateAllocatedSlotReport() throws Exception {
+        final LocalTaskManagerLocation taskManagerLocation1 = new LocalTaskManagerLocation();
+        final LocalTaskManagerLocation taskManagerLocation2 = new LocalTaskManagerLocation();
+        final SimpleSlotContext simpleSlotContext2 = createSimpleSlotContext(taskManagerLocation2);
+        final Collection<SlotInfo> slotInfos =
+                Arrays.asList(createSimpleSlotContext(taskManagerLocation1), simpleSlotContext2);
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService(
+                        new TestingDeclarativeSlotPoolFactory(
+                                new TestingDeclarativeSlotPoolBuilder()
+                                        .setGetAllSlotsInformationSupplier(() -> slotInfos)))) {
+
+            final AllocatedSlotReport allocatedSlotReport =
+                    declarativeSlotPoolService.createAllocatedSlotReport(
+                            taskManagerLocation2.getResourceID());
+
+            assertThat(
+                    allocatedSlotReport.getAllocatedSlotInfos(),
+                    contains(matchesWithSlotContext(simpleSlotContext2)));
+        }
+    }
+
+    @Test
+    public void testFailAllocationReleasesSlot() throws Exception {
+        final CompletableFuture<AllocationID> releasedSlot = new CompletableFuture<>();
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService(
+                        new TestingDeclarativeSlotPoolFactory(
+                                new TestingDeclarativeSlotPoolBuilder()
+                                        .setReleaseSlotFunction(
+                                                (allocationID, exception) -> {
+                                                    releasedSlot.complete(allocationID);
+                                                    return ResourceCounter.empty();
+                                                })))) {
+            final ResourceID taskManagerId = ResourceID.generate();
+            final AllocationID allocationId = new AllocationID();
+
+            declarativeSlotPoolService.registerTaskManager(taskManagerId);
+
+            declarativeSlotPoolService.failAllocation(
+                    taskManagerId, allocationId, new FlinkException("Test cause"));
+
+            assertThat(releasedSlot.join(), is(allocationId));
+        }
+    }
+
+    @Test
+    public void testFailLastAllocationOfTaskManagerReturnsIt() throws Exception {
+        try (DeclarativeSlotPoolService declarativeSlotPoolService =
+                createDeclarativeSlotPoolService()) {
+            final ResourceID taskManagerId = ResourceID.generate();
+
+            declarativeSlotPoolService.registerTaskManager(taskManagerId);
+            final Optional<ResourceID> emptyTaskManager =
+                    declarativeSlotPoolService.failAllocation(
+                            taskManagerId, new AllocationID(), new FlinkException("Test cause"));
+
+            assertThat(
+                    emptyTaskManager.orElseThrow(
+                            () -> new Exception("Expected empty task manager")),
+                    is(taskManagerId));
+        }
+    }
+
+    private DeclarativeSlotPoolService createDeclarativeSlotPoolService() throws Exception {
+        return createDeclarativeSlotPoolService(new DefaultDeclarativeSlotPoolFactory());
+    }
+
+    private DeclarativeSlotPoolService createDeclarativeSlotPoolService(
+            DeclarativeSlotPoolFactory declarativeSlotPoolFactory) throws Exception {
+        final DeclarativeSlotPoolService declarativeSlotPoolService =
+                new DeclarativeSlotPoolService(
+                        jobId,
+                        declarativeSlotPoolFactory,
+                        SystemClock.getInstance(),
+                        Time.seconds(20L),
+                        Time.seconds(20L));
+
+        declarativeSlotPoolService.start(jobMasterId, address, mainThreadExecutor);
+
+        return declarativeSlotPoolService;
+    }
+
+    private Matcher<AllocatedSlotInfo> matchesWithSlotContext(SimpleSlotContext simpleSlotContext) {
+        return new AllocatedSlotInfoMatcher(simpleSlotContext);
+    }
+
+    private static final class AllocatedSlotInfoMatcher extends TypeSafeMatcher<AllocatedSlotInfo> {
+
+        private final SlotContext slotContext;
+
+        private AllocatedSlotInfoMatcher(SlotContext slotContext) {
+            this.slotContext = slotContext;
+        }
+
+        @Override
+        protected boolean matchesSafely(AllocatedSlotInfo item) {
+            return item.getAllocationId().equals(slotContext.getAllocationId())
+                    && item.getSlotIndex() == slotContext.getPhysicalSlotNumber();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description
+                    .appendText("expect allocated slot info with allocation id ")
+                    .appendValue(slotContext.getAllocationId())
+                    .appendText(" and slot index ")
+                    .appendValue(slotContext.getPhysicalSlotNumber());
+        }
+    }
+
+    @Nonnull
+    private SimpleSlotContext createSimpleSlotContext(
+            LocalTaskManagerLocation taskManagerLocation1) {
+        return new SimpleSlotContext(
+                new AllocationID(),
+                taskManagerLocation1,
+                0,
+                new RpcTaskManagerGateway(
+                        new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(),
+                        jobMasterId));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingDeclarativeSlotPoolFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/** Factory for creating a {@link TestingDeclarativeSlotPool}. */
+final class TestingDeclarativeSlotPoolFactory implements DeclarativeSlotPoolFactory {
+
+    final TestingDeclarativeSlotPoolBuilder builder;
+
+    TestingDeclarativeSlotPoolFactory(TestingDeclarativeSlotPoolBuilder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public TestingDeclarativeSlotPool create(
+            JobID jobId,
+            Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements,
+            Time idleSlotTimeout,
+            Time rpcTimeout) {
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the `DeclarativeSlotPoolService` which encapsulates the `DeclarativeSlotPool` and makes it usable by the `JobMaster`.

## Verifying this change

Added `DeclarativeSlotPoolServiceTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
