### PR TITLE
[FLINK-21087][runtime][checkpoint] StreamTask waits for all the pending checkpoints to finish before finished

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -163,6 +163,8 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                         taskName,
                         checkpointMetaData.getCheckpointId());
             }
+
+            finishedFuture.complete(null);
         } catch (Exception e) {
             LOG.info(
                     "{} - asynchronous part of checkpoint {} could not be completed.",
@@ -170,10 +172,10 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
                     checkpointMetaData.getCheckpointId(),
                     e);
             handleExecutionException(e);
+            finishedFuture.completeExceptionally(e);
         } finally {
             unregisterConsumer.accept(this);
             FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
-            finishedFuture.complete(null);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -760,6 +760,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         // make sure all buffered data is flushed
         operatorChain.flushOutputs();
 
+        // No new checkpoints could be triggered since mailbox has been drained.
+        subtaskCheckpointCoordinator.waitForPendingCheckpoints();
+        LOG.debug("All pending checkpoints are finished");
+
         // make an attempt to dispose the operators such that failures in the dispose call
         // still let the computation fail
         closeAllOperators();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -91,4 +91,7 @@ public interface SubtaskCheckpointCoordinator extends Closeable {
     void notifyCheckpointAborted(
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning)
             throws Exception;
+
+    /** Waits for all the pending checkpoints to finish their asynchronous step. */
+    void waitForPendingCheckpoints() throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -563,22 +563,17 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         env,
                         asyncExceptionHandler,
                         isRunning);
-        registerConsumer().accept(asyncCheckpointRunnable);
+
+        try {
+            registerAsyncCheckpointRunnable(
+                    asyncCheckpointRunnable.getCheckpointId(), asyncCheckpointRunnable);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
         // we are transferring ownership over snapshotInProgressList for cleanup to the thread,
         // active on submit
         asyncOperationsThreadPool.execute(asyncCheckpointRunnable);
-    }
-
-    private Consumer<AsyncCheckpointRunnable> registerConsumer() {
-        return asyncCheckpointRunnable -> {
-            try {
-                registerAsyncCheckpointRunnable(
-                        asyncCheckpointRunnable.getCheckpointId(), asyncCheckpointRunnable);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
     }
 
     private Consumer<AsyncCheckpointRunnable> unregisterConsumer() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -421,7 +421,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                     try {
                         ar.getFinishedFuture().get();
                     } catch (Exception e) {
-                        LOG.error(
+                        LOG.debug(
                                 "Async runnable for checkpoint "
                                         + ar.getCheckpointId()
                                         + " throws exception and exit",

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -551,7 +550,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Map<OperatorID, OperatorSnapshotFutures> snapshotFutures,
             CheckpointMetaData metadata,
             CheckpointMetricsBuilder metrics,
-            Supplier<Boolean> isRunning) {
+            Supplier<Boolean> isRunning)
+            throws IOException {
         AsyncCheckpointRunnable asyncCheckpointRunnable =
                 new AsyncCheckpointRunnable(
                         snapshotFutures,
@@ -564,12 +564,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         asyncExceptionHandler,
                         isRunning);
 
-        try {
-            registerAsyncCheckpointRunnable(
-                    asyncCheckpointRunnable.getCheckpointId(), asyncCheckpointRunnable);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        registerAsyncCheckpointRunnable(
+                asyncCheckpointRunnable.getCheckpointId(), asyncCheckpointRunnable);
 
         // we are transferring ownership over snapshotInProgressList for cleanup to the thread,
         // active on submit

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -54,7 +54,6 @@ public class AsyncCheckpointRunnableTest {
                         0,
                         "Task Name",
                         r -> {},
-                        r -> {},
                         env,
                         (msg, ex) -> {},
                         () -> true)
@@ -135,7 +134,6 @@ public class AsyncCheckpointRunnableTest {
                 new CheckpointMetricsBuilder(),
                 1L,
                 "Task Name",
-                r -> {},
                 r -> {},
                 environment,
                 (msg, ex) -> {},

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -123,7 +123,6 @@ public class LocalStateForwardingTest extends TestLogger {
                         0L,
                         testStreamTask.getName(),
                         asyncCheckpointRunnable -> {},
-                        asyncCheckpointRunnable -> {},
                         testStreamTask.getEnvironment(),
                         testStreamTask,
                         () -> true);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -311,10 +311,10 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                 });
 
                 // The checkpoint 4 would be triggered successfully.
-                // TODO: Would also check the checkpoint succeed after we also waiting
-                // for the asynchronous step to finish on finish.
                 testHarness.finishProcessing();
                 assertTrue(checkpointFuture.isDone());
+                testHarness.getTaskStateManager().getWaitForReportLatch().await();
+                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
 
                 // Each result partition should have emitted 2 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -910,10 +910,10 @@ public class MultipleInputStreamTaskTest {
                                 });
 
                 // The checkpoint 6 would be triggered successfully.
-                // TODO: Would also check the checkpoint succeed after we also waiting
-                // for the asynchronous step to finish on finish.
                 testHarness.finishProcessing();
                 assertTrue(checkpointFuture.isDone());
+                testHarness.getTaskStateManager().getWaitForReportLatch().await();
+                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
 
                 // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TestSubtaskCheckpointCoordinator.java
@@ -93,5 +93,8 @@ public class TestSubtaskCheckpointCoordinator implements SubtaskCheckpointCoordi
             long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning) {}
 
     @Override
+    public void waitForPendingCheckpoints() throws Exception {}
+
+    @Override
     public void close() {}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR makes `StreamTask` to wait for all the pending checkpoints to finish before finished. Previously checkpoints after tasks finished is not supported, and aborting all the pending checkpoints when finished is reasonable. However, after this feature is considering, it would be normal to have tasks finished when taking checkpoints, and it should be more reasonable to wait for the pending checkpoints to finish.

Since for each checkpoint, the synchronous part is done immediately when triggered, thus we need only wait for all the pending `AsyncCheckpointRunnable` to finish.

## Brief change log

- 56e89104538519e2a74f3276149da0b1372bd024 implements the waiting for StreamTask.

## Verifying this change

This change added tests and can be verified via added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive):  **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
