### PR TITLE
[FLINK-21269] Introduce runtime interfaces for specifying SlotSharingGroup-based resource requirements

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/SlotSharingGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager.scheduler;
 
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
@@ -45,7 +46,10 @@ public class SlotSharingGroup implements java.io.Serializable {
      * Represents resources of all tasks in the group. Default to be zero. Any task with UNKNOWN
      * resources will turn it to be UNKNOWN.
      */
-    private ResourceSpec resourceSpec = ResourceSpec.ZERO;
+    @Deprecated private ResourceSpec resourceSpec = ResourceSpec.ZERO;
+
+    // Represents resources of all tasks in the group. Default to be UNKNOWN.
+    private ResourceProfile resourceProfile = ResourceProfile.UNKNOWN;
 
     // --------------------------------------------------------------------------------------------
 
@@ -67,6 +71,15 @@ public class SlotSharingGroup implements java.io.Serializable {
         return slotSharingGroupId;
     }
 
+    public void setResourceProfile(ResourceProfile resourceProfile) {
+        this.resourceProfile = checkNotNull(resourceProfile);
+    }
+
+    public ResourceProfile getResourceProfile() {
+        return resourceProfile;
+    }
+
+    @Deprecated
     public ResourceSpec getResourceSpec() {
         return resourceSpec;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -70,6 +71,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -119,6 +121,7 @@ public class StreamGraph implements Pipeline {
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
     private InternalTimeServiceManager.Provider timerServiceProvider;
     private JobType jobType = JobType.STREAMING;
+    private Map<String, ResourceProfile> slotSharingGroupResources;
 
     public StreamGraph(
             ExecutionConfig executionConfig,
@@ -142,6 +145,7 @@ public class StreamGraph implements Pipeline {
         iterationSourceSinkPairs = new HashSet<>();
         sources = new HashSet<>();
         sinks = new HashSet<>();
+        slotSharingGroupResources = new HashMap<>();
     }
 
     public ExecutionConfig getExecutionConfig() {
@@ -227,6 +231,15 @@ public class StreamGraph implements Pipeline {
 
     public void setGlobalDataExchangeMode(GlobalDataExchangeMode globalDataExchangeMode) {
         this.globalDataExchangeMode = globalDataExchangeMode;
+    }
+
+    public void setSlotSharingGroupResource(
+            Map<String, ResourceProfile> slotSharingGroupResources) {
+        this.slotSharingGroupResources.putAll(slotSharingGroupResources);
+    }
+
+    public Optional<ResourceProfile> getSlotSharingGroupResource(String groupId) {
+        return Optional.ofNullable(slotSharingGroupResources.get(groupId));
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -966,7 +966,14 @@ public class StreamingJobGraphGenerator {
             } else {
                 effectiveSlotSharingGroup =
                         specifiedSlotSharingGroups.computeIfAbsent(
-                                slotSharingGroupKey, k -> new SlotSharingGroup());
+                                slotSharingGroupKey,
+                                k -> {
+                                    SlotSharingGroup ssg = new SlotSharingGroup();
+                                    streamGraph
+                                            .getSlotSharingGroupResource(k)
+                                            .ifPresent(ssg::setResourceProfile);
+                                    return ssg;
+                                });
             }
 
             vertex.setSlotSharingGroup(effectiveSlotSharingGroup);
@@ -981,6 +988,9 @@ public class StreamingJobGraphGenerator {
     private Map<JobVertexID, SlotSharingGroup> buildVertexRegionSlotSharingGroups() {
         final Map<JobVertexID, SlotSharingGroup> vertexRegionSlotSharingGroups = new HashMap<>();
         final SlotSharingGroup defaultSlotSharingGroup = new SlotSharingGroup();
+        streamGraph
+                .getSlotSharingGroupResource(StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)
+                .ifPresent(defaultSlotSharingGroup::setResourceProfile);
 
         final boolean allRegionsInSameSlotSharingGroup =
                 streamGraph.isAllVerticesInSameSlotSharingGroupByDefault();
@@ -993,6 +1003,10 @@ public class StreamingJobGraphGenerator {
                 regionSlotSharingGroup = defaultSlotSharingGroup;
             } else {
                 regionSlotSharingGroup = new SlotSharingGroup();
+                streamGraph
+                        .getSlotSharingGroupResource(
+                                StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)
+                        .ifPresent(regionSlotSharingGroup::setResourceProfile);
             }
 
             for (JobVertexID jobVertexID : region.getVertexIDs()) {


### PR DESCRIPTION
## What is the purpose of the change

Introduce runtime interfaces for specifying SlotSharingGroup-based resource requirements and the specified resource requirements will be passed on all the way to the corresponding SlotSharingGroup in ExecutionGraph.

