### PR TITLE
[FLINK-21088][runtime][checkpoint] Pass the flag about whether a task is finished on restore on recovery

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -60,6 +60,11 @@ final class SavepointTaskStateManager implements TaskStateManager {
     public void reportIncompleteTaskStateSnapshots(
             CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {}
 
+    @Override
+    public boolean isFinishedOnRestore() {
+        return false;
+    }
+
     @Nonnull
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -56,8 +56,12 @@ public class TaskStateSnapshot implements CompositeStateHandle {
 
     private static final long serialVersionUID = 1L;
 
+    public static final TaskStateSnapshot FINISHED = new TaskStateSnapshot(new HashMap<>(), true);
+
     /** Mapping from an operator id to the state of one subtask of this operator. */
     private final Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID;
+
+    private final boolean isFinished;
 
     public TaskStateSnapshot() {
         this(10);
@@ -68,7 +72,18 @@ public class TaskStateSnapshot implements CompositeStateHandle {
     }
 
     public TaskStateSnapshot(Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID) {
+        this(subtaskStatesByOperatorID, false);
+    }
+
+    private TaskStateSnapshot(
+            Map<OperatorID, OperatorSubtaskState> subtaskStatesByOperatorID, boolean isFinished) {
         this.subtaskStatesByOperatorID = Preconditions.checkNotNull(subtaskStatesByOperatorID);
+        this.isFinished = isFinished;
+    }
+
+    /** Returns whether all the operators of the task are finished. */
+    public boolean isFinished() {
+        return isFinished;
     }
 
     /** Returns the subtask state for the given operator id (or null if not contained). */
@@ -102,7 +117,7 @@ public class TaskStateSnapshot implements CompositeStateHandle {
                 return true;
             }
         }
-        return false;
+        return isFinished;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
@@ -71,6 +71,9 @@ public interface TaskStateManager extends CheckpointListener, AutoCloseable {
     void reportIncompleteTaskStateSnapshots(
             CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics);
 
+    /** Whether all the operators of the task are finished on restore. */
+    boolean isFinishedOnRestore();
+
     /**
      * Returns means to restore previously reported state of an operator running in the owning task.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -155,6 +155,14 @@ public class TaskStateManagerImpl implements TaskStateManager {
         return jobManagerTaskRestore.getTaskStateSnapshot().getOutputRescalingDescriptor();
     }
 
+    public boolean isFinishedOnRestore() {
+        if (jobManagerTaskRestore == null) {
+            return false;
+        }
+
+        return jobManagerTaskRestore.getTaskStateSnapshot().isFinished();
+    }
+
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -268,6 +268,23 @@ public class TaskStateManagerImplTest extends TestLogger {
         }
     }
 
+    @Test
+    public void testStateRetrievingWithFinishedOperator() {
+        TaskStateSnapshot taskStateSnapshot = TaskStateSnapshot.FINISHED;
+
+        JobManagerTaskRestore jobManagerTaskRestore =
+                new JobManagerTaskRestore(2, taskStateSnapshot);
+        TaskStateManagerImpl stateManager =
+                new TaskStateManagerImpl(
+                        new JobID(),
+                        new ExecutionAttemptID(),
+                        new TestTaskLocalStateStore(),
+                        null,
+                        jobManagerTaskRestore,
+                        new TestCheckpointResponder());
+        Assert.assertTrue(stateManager.isFinishedOnRestore());
+    }
+
     public static TaskStateManager taskStateManager(
             JobID jobID,
             ExecutionAttemptID executionAttemptID,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -132,6 +132,16 @@ public class TestTaskStateManager implements TaskStateManager {
         reportedCheckpointId = checkpointMetaData.getCheckpointId();
     }
 
+    @Override
+    public boolean isFinishedOnRestore() {
+        TaskStateSnapshot jmTaskStateSnapshot = getLastJobManagerTaskStateSnapshot();
+        if (jmTaskStateSnapshot != null) {
+            return jmTaskStateSnapshot.isFinished();
+        }
+
+        return false;
+    }
+
     @Nonnull
     @Override
     public PrioritizedOperatorSubtaskState prioritizedOperatorState(OperatorID operatorID) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -555,7 +555,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         closedOperators = false;
         LOG.debug("Initializing {}.", getName());
 
-        operatorChain = new OperatorChain<>(this, recordWriter);
+        operatorChain =
+                new OperatorChain<>(
+                        this,
+                        recordWriter,
+                        getEnvironment().getTaskStateManager().isFinishedOnRestore());
         mainOperator = operatorChain.getMainOperator();
 
         // task specific initialization

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -280,7 +280,7 @@ public class StreamOperatorChainingTest {
     private <IN, OT extends StreamOperator<IN>> OperatorChain<IN, OT> createOperatorChain(
             StreamConfig streamConfig, Environment environment, StreamTask<IN, OT> task) {
         return new OperatorChain<>(
-                task, StreamTask.createRecordWriterDelegate(streamConfig, environment));
+                task, StreamTask.createRecordWriterDelegate(streamConfig, environment), false);
     }
 
     private <IN, OT extends StreamOperator<IN>> StreamTask<IN, OT> createMockTask(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -186,8 +186,8 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
                 new OperatorChain<>(
                         operator.getContainingTask(),
                         StreamTask.createRecordWriterDelegate(
-                                operator.getOperatorConfig(),
-                                new MockEnvironmentBuilder().build()));
+                                operator.getOperatorConfig(), new MockEnvironmentBuilder().build()),
+                        false);
         try {
             operator.run(new Object(), new CollectorOutput<>(output), operatorChain);
             operator.finish();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -116,7 +116,7 @@ public class StreamTaskExecutionDecorationTest {
                     @Override
                     protected void processInput(MailboxDefaultAction.Controller controller) {}
                 };
-        task.operatorChain = new OperatorChain<>(task, new NonRecordWriter<>());
+        task.operatorChain = new OperatorChain<>(task, new NonRecordWriter<>(), false);
     }
 
     @After

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -160,7 +160,8 @@ public class SubtaskCheckpointCoordinatorTest {
             final OperatorChain<?, ?> operatorChain =
                     new OperatorChain(
                             new MockStreamTaskBuilder(mockEnvironment).build(),
-                            new NonRecordWriter<>()) {
+                            new NonRecordWriter<>(),
+                            false) {
                         @Override
                         public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
                                 throws IOException {
@@ -196,7 +197,8 @@ public class SubtaskCheckpointCoordinatorTest {
             final OperatorChain<?, ?> operatorChain =
                     new OperatorChain(
                             new MockStreamTaskBuilder(mockEnvironment).build(),
-                            new NonRecordWriter<>()) {
+                            new NonRecordWriter<>(),
+                            false) {
                         @Override
                         public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
                                 throws IOException {
@@ -244,7 +246,9 @@ public class SubtaskCheckpointCoordinatorTest {
                             SAVEPOINT, CheckpointStorageLocationReference.getDefault()),
                     new CheckpointMetricsBuilder(),
                     new OperatorChain<>(
-                            new NoOpStreamTask<>(new DummyEnvironment()), new NonRecordWriter<>()),
+                            new NoOpStreamTask<>(new DummyEnvironment()),
+                            new NonRecordWriter<>(),
+                            false),
                     () -> true);
         }
     }
@@ -347,7 +351,8 @@ public class SubtaskCheckpointCoordinatorTest {
             OperatorChain<String, OneInputStreamOperator<String, String>> operatorChain =
                     new OperatorChain<>(
                             task,
-                            StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment));
+                            StreamTask.createRecordWriterDelegate(streamConfig, mockEnvironment),
+                            false);
             long checkpointId = 42L;
             // notify checkpoint aborted before execution.
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
@@ -454,7 +459,7 @@ public class SubtaskCheckpointCoordinatorTest {
 
     private OperatorChain<?, ?> getOperatorChain(MockEnvironment mockEnvironment) throws Exception {
         return new OperatorChain<>(
-                new MockStreamTaskBuilder(mockEnvironment).build(), new NonRecordWriter<>());
+                new MockStreamTaskBuilder(mockEnvironment).build(), new NonRecordWriter<>(), false);
     }
 
     private <T> OperatorChain<T, AbstractStreamOperator<T>> operatorChain(


### PR DESCRIPTION
## What is the purpose of the change

For checkpoints after tasks finished, if some operators are fully finished, it would store a special state content in the checkpoint metadata. After recovery, the flag of whether the operator is fully finished should be passed to the task side so that these operator could skip execution (which would be implemented in the next PR).

## Brief change log

- 213102836a80edeb968a37566f174b501de36028 passes the flag to the task.


## Verifying this change


This change added tests and can be verified via added ut.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
