### PR TITLE
[FLINK-21203]Don’t collect -U&+U Row When they are equals In the LastRowFunction

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -93,6 +93,7 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         GeneratedRecordEqualiser generatedEqualiser =
                 equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
 
+
         if (isMiniBatchEnabled) {
             TypeSerializer<RowData> rowSerializer =
                     rowTypeInfo.createSerializer(planner.getExecEnv().getConfig());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -85,10 +85,9 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                         .getConfiguration()
                         .getBoolean(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED);
 
-        RowType inputRowType = (RowType) inputNode.getOutputType();
         final EqualiserCodeGenerator equaliserCodeGen =
                 new EqualiserCodeGenerator(
-                        inputRowType.getFields().stream()
+                        rowTypeInfo.toRowType().getFields().stream()
                                 .map(RowType.RowField::getType)
                                 .toArray(LogicalType[]::new));
         GeneratedRecordEqualiser generatedEqualiser = equaliserCodeGen.generateRecordEqualiser(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -85,13 +85,12 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                         .getConfiguration()
                         .getBoolean(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED);
 
-        final EqualiserCodeGenerator equaliserCodeGen =
-                new EqualiserCodeGenerator(
-                        rowTypeInfo.toRowType().getFields().stream()
-                                .map(RowType.RowField::getType)
-                                .toArray(LogicalType[]::new));
         GeneratedRecordEqualiser generatedEqualiser =
-                equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
+                new EqualiserCodeGenerator(
+                                rowTypeInfo.toRowType().getFields().stream()
+                                        .map(RowType.RowField::getType)
+                                        .toArray(LogicalType[]::new))
+                        .generateRecordEqualiser("DeduplicateRowEqualiser");
 
         if (isMiniBatchEnabled) {
             TypeSerializer<RowData> rowSerializer =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -93,7 +93,6 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
         GeneratedRecordEqualiser generatedEqualiser =
                 equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
 
-
         if (isMiniBatchEnabled) {
             TypeSerializer<RowData> rowSerializer =
                     rowTypeInfo.createSerializer(planner.getExecEnv().getConfig());

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -41,7 +41,6 @@ import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigge
 import org.apache.flink.table.runtime.operators.deduplicate.ProcTimeDeduplicateKeepLastRowFunction;
 import org.apache.flink.table.runtime.operators.deduplicate.ProcTimeMiniBatchDeduplicateKeepLastRowFunction;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Collections;
@@ -86,10 +85,7 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                         .getBoolean(ExecutionConfigOptions.TABLE_EXEC_MINIBATCH_ENABLED);
 
         GeneratedRecordEqualiser generatedEqualiser =
-                new EqualiserCodeGenerator(
-                                rowTypeInfo.toRowType().getFields().stream()
-                                        .map(RowType.RowField::getType)
-                                        .toArray(LogicalType[]::new))
+                new EqualiserCodeGenerator(rowTypeInfo.toRowType())
                         .generateRecordEqualiser("DeduplicateRowEqualiser");
 
         if (isMiniBatchEnabled) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -90,9 +90,8 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                         rowTypeInfo.toRowType().getFields().stream()
                                 .map(RowType.RowField::getType)
                                 .toArray(LogicalType[]::new));
-        GeneratedRecordEqualiser generatedEqualiser = equaliserCodeGen.generateRecordEqualiser(
-                "DeduplicateRowEqualiser");
-
+        GeneratedRecordEqualiser generatedEqualiser =
+                equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
 
         if (isMiniBatchEnabled) {
             TypeSerializer<RowData> rowSerializer =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -103,8 +103,8 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                             stateIdleTime,
                             generateUpdateBefore,
                             true, // generateInsert
-                            false,
-                            generatedEqualiser); // inputInsertOnly
+                            false, // inputInsertOnly
+                            generatedEqualiser);
             CountBundleTrigger<RowData> trigger = AggregateUtil.createMiniBatchTrigger(tableConfig);
             operator = new KeyedMapBundleOperator<>(processFunction, trigger);
         } else {
@@ -114,8 +114,8 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                             stateIdleTime,
                             generateUpdateBefore,
                             true, // generateInsert
-                            false,
-                            generatedEqualiser); // inputInsertOnly
+                            false, // inputInsertOnly
+                            generatedEqualiser);
             operator = new KeyedProcessOperator<>(processFunction);
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -282,7 +282,6 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     .toArray(LogicalType[]::new));
             generatedEqualiser =
                     equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
-
         }
 
         @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -275,13 +275,12 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                 boolean keepLastRow,
                 boolean generateUpdateBefore) {
             super(tableConfig, rowTypeInfo, typeSerializer, keepLastRow, generateUpdateBefore);
-            final EqualiserCodeGenerator equaliserCodeGen =
-                    new EqualiserCodeGenerator(
-                            inputRowType.getFields().stream()
-                                    .map(RowType.RowField::getType)
-                                    .toArray(LogicalType[]::new));
             generatedEqualiser =
-                    equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
+                    new EqualiserCodeGenerator(
+                                    inputRowType.getFields().stream()
+                                            .map(RowType.RowField::getType)
+                                            .toArray(LogicalType[]::new))
+                            .generateRecordEqualiser("DeduplicateRowEqualiser");
         }
 
         @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -29,12 +29,14 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.operators.bundle.KeyedMapBundleOperator;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountBundleTrigger;
@@ -46,6 +48,7 @@ import org.apache.flink.table.runtime.operators.deduplicate.RowTimeDeduplicateFu
 import org.apache.flink.table.runtime.operators.deduplicate.RowTimeMiniBatchDeduplicateFunction;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
@@ -106,6 +109,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         final TypeSerializer<RowData> rowSerializer =
                 rowTypeInfo.createSerializer(planner.getExecEnv().getConfig());
         final OneInputStreamOperator<RowData, RowData> operator;
+
         if (isRowtime) {
             operator =
                     new RowtimeDeduplicateOperatorTranslator(
@@ -122,6 +126,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     planner.getTableConfig(),
                                     rowTypeInfo,
                                     rowSerializer,
+                                    inputRowType,
                                     keepLastRow,
                                     generateUpdateBefore)
                             .createDeduplicateOperator();
@@ -260,14 +265,24 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
     /** Translator to create process time deduplicate operator. */
     private static class ProcTimeDeduplicateOperatorTranslator
             extends DeduplicateOperatorTranslator {
+        private final GeneratedRecordEqualiser generatedEqualiser;
 
         protected ProcTimeDeduplicateOperatorTranslator(
                 TableConfig tableConfig,
                 InternalTypeInfo<RowData> rowTypeInfo,
                 TypeSerializer<RowData> typeSerializer,
+                RowType inputRowType,
                 boolean keepLastRow,
                 boolean generateUpdateBefore) {
             super(tableConfig, rowTypeInfo, typeSerializer, keepLastRow, generateUpdateBefore);
+            final EqualiserCodeGenerator equaliserCodeGen =
+                    new EqualiserCodeGenerator(
+                            inputRowType.getFields().stream()
+                                    .map(RowType.RowField::getType)
+                                    .toArray(LogicalType[]::new));
+            generatedEqualiser = equaliserCodeGen.generateRecordEqualiser(
+                    "DeduplicateRowEqualiser");
+
         }
 
         @Override
@@ -282,7 +297,8 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     getMinRetentionTime(),
                                     generateUpdateBefore,
                                     generateInsert(),
-                                    true);
+                                    true,
+                                    generatedEqualiser);
                     return new KeyedMapBundleOperator<>(processFunction, trigger);
                 } else {
                     ProcTimeMiniBatchDeduplicateKeepFirstRowFunction processFunction =
@@ -298,7 +314,8 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     getMinRetentionTime(),
                                     generateUpdateBefore,
                                     generateInsert(),
-                                    true);
+                                    true,
+                                    generatedEqualiser);
                     return new KeyedProcessOperator<>(processFunction);
                 } else {
                     ProcTimeDeduplicateKeepFirstRowFunction processFunction =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -280,9 +280,8 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                             inputRowType.getFields().stream()
                                     .map(RowType.RowField::getType)
                                     .toArray(LogicalType[]::new));
-            generatedEqualiser = equaliserCodeGen.generateRecordEqualiser(
-                    "DeduplicateRowEqualiser");
-
+            generatedEqualiser =
+                    equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
         }
 
         @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -48,7 +48,6 @@ import org.apache.flink.table.runtime.operators.deduplicate.RowTimeDeduplicateFu
 import org.apache.flink.table.runtime.operators.deduplicate.RowTimeMiniBatchDeduplicateFunction;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
@@ -276,10 +275,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                 boolean generateUpdateBefore) {
             super(tableConfig, rowTypeInfo, typeSerializer, keepLastRow, generateUpdateBefore);
             generatedEqualiser =
-                    new EqualiserCodeGenerator(
-                                    inputRowType.getFields().stream()
-                                            .map(RowType.RowField::getType)
-                                            .toArray(LogicalType[]::new))
+                    new EqualiserCodeGenerator(inputRowType)
                             .generateRecordEqualiser("DeduplicateRowEqualiser");
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -282,6 +282,7 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     .toArray(LogicalType[]::new));
             generatedEqualiser =
                     equaliserCodeGen.generateRecordEqualiser("DeduplicateRowEqualiser");
+
         }
 
         @Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.runtime.generated.{GeneratedRecordEqualiser, Recor
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{getFieldTypes, isCompositeType}
-import org.apache.flink.table.types.logical.{DistinctType, LogicalType}
+import org.apache.flink.table.types.logical.{DistinctType, LogicalType, RowType}
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -35,6 +35,10 @@ class EqualiserCodeGenerator(fieldTypes: Array[LogicalType]) {
   private val RECORD_EQUALISER = className[RecordEqualiser]
   private val LEFT_INPUT = "left"
   private val RIGHT_INPUT = "right"
+
+  def this(rowType: RowType) = {
+    this(rowType.getChildren.asScala.toArray)
+  }
 
   def generateRecordEqualiser(name: String): GeneratedRecordEqualiser = {
     // ignore time zone

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -36,6 +36,8 @@ class DeduplicateFunctionHelper {
      * @param generateUpdateBefore whether need to send UPDATE_BEFORE message for updates
      * @param state state of function, null if generateUpdateBefore is false
      * @param out underlying collector
+     * @param isStateTtlEnabled whether state ttl is disabled
+     * @param equaliser the record equaliser used to equal RowData.
      */
     static void processLastRowOnProcTime(
             RowData currentRow,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -58,8 +58,6 @@ class DeduplicateFunctionHelper {
                 currentRow.setRowKind(RowKind.INSERT);
                 out.collect(currentRow);
             } else {
-                boolean isEqualsWithPrevious = preRow.equals(currentRow);
-
                 if (!isStateTTLEnabled && equaliser.equals(preRow, currentRow)) {
                     // currentRow is the same as preRow and state cleaning is not enabled.
                     // We do not emit retraction and update message.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -43,7 +43,7 @@ class DeduplicateFunctionHelper {
             boolean generateInsert,
             ValueState<RowData> state,
             Collector<RowData> out,
-            boolean isStateTTLEnabled,
+            boolean isStateTtlEnabled,
             RecordEqualiser equaliser)
             throws Exception {
 
@@ -58,7 +58,7 @@ class DeduplicateFunctionHelper {
                 currentRow.setRowKind(RowKind.INSERT);
                 out.collect(currentRow);
             } else {
-                if (!isStateTTLEnabled && equaliser.equals(preRow, currentRow)) {
+                if (!isStateTtlEnabled && equaliser.equals(preRow, currentRow)) {
                     // currentRow is the same as preRow and state cleaning is not enabled.
                     // We do not emit retraction and update message.
                     // If state cleaning is enabled, we have to emit messages to prevent too early
@@ -98,7 +98,7 @@ class DeduplicateFunctionHelper {
             boolean generateUpdateBefore,
             ValueState<RowData> state,
             Collector<RowData> out,
-            boolean isStateTTLEnabled,
+            boolean isStateTtlEnabled,
             RecordEqualiser equaliser)
             throws Exception {
         RowData preRow = state.value();
@@ -109,7 +109,7 @@ class DeduplicateFunctionHelper {
                 currentRow.setRowKind(RowKind.INSERT);
                 out.collect(currentRow);
             } else {
-                if (!isStateTTLEnabled && equaliser.equals(preRow, currentRow)) {
+                if (!isStateTtlEnabled && equaliser.equals(preRow, currentRow)) {
                     // currentRow is the same as preRow and state cleaning is not enabled.
                     // We do not emit retraction and update message.
                     // If state cleaning is enabled, we have to emit messages to prevent too early

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -36,13 +36,17 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     private final boolean generateUpdateBefore;
     private final boolean generateInsert;
     private final boolean inputIsInsertOnly;
-    // function used to equal RowData
-    private transient RecordEqualiser equaliser = null;
+    /**
+     * function used to equal RowData.
+     */
+    private transient RecordEqualiser equaliser;
 
-    // The code generated equaliser used to equal RowData.
-    private transient GeneratedRecordEqualiser genRecordEqualiser = null;
+    /**
+     * The code generated equaliser used to equal RowData.
+     */
+    private final GeneratedRecordEqualiser genRecordEqualiser;
 
-    private transient boolean isStateTTLEnabled = false;
+    private final boolean isStateTtlEnabled;
 
     public ProcTimeDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
@@ -56,6 +60,8 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.generateInsert = generateInsert;
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
+        isStateTtlEnabled = stateRetentionTime > 0;
+
     }
 
     @Override
@@ -68,11 +74,11 @@ public class ProcTimeDeduplicateKeepLastRowFunction
                     generateInsert,
                     state,
                     out,
-                    isStateTTLEnabled,
+                    isStateTtlEnabled,
                     equaliser);
         } else {
             processLastRowOnChangelog(
-                    input, generateUpdateBefore, state, out, isStateTTLEnabled, equaliser);
+                    input, generateUpdateBefore, state, out, isStateTtlEnabled, equaliser);
         }
     }
 
@@ -80,6 +86,5 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     public void open(Configuration configure) throws Exception {
         super.open(configure);
         equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
-        isStateTTLEnabled = this.stateRetentionTime > 0;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -36,14 +36,10 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     private final boolean generateUpdateBefore;
     private final boolean generateInsert;
     private final boolean inputIsInsertOnly;
-    /**
-     * function used to equal RowData.
-     */
+    /** function used to equal RowData. */
     private transient RecordEqualiser equaliser;
 
-    /**
-     * The code generated equaliser used to equal RowData.
-     */
+    /** The code generated equaliser used to equal RowData. */
     private final GeneratedRecordEqualiser genRecordEqualiser;
 
     private final boolean isStateTtlEnabled;
@@ -61,7 +57,6 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
         isStateTtlEnabled = stateRetentionTime > 0;
-
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -56,7 +56,7 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.generateInsert = generateInsert;
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
-        isStateTtlEnabled = stateRetentionTime > 0;
+        this.isStateTtlEnabled = stateRetentionTime > 0;
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -36,13 +36,12 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     private final boolean generateUpdateBefore;
     private final boolean generateInsert;
     private final boolean inputIsInsertOnly;
-    /** function used to equal RowData. */
-    private transient RecordEqualiser equaliser;
-
+    private final boolean isStateTtlEnabled;
     /** The code generated equaliser used to equal RowData. */
     private final GeneratedRecordEqualiser genRecordEqualiser;
 
-    private final boolean isStateTtlEnabled;
+    /** The record equaliser used to equal RowData. */
+    private transient RecordEqualiser equaliser;
 
     public ProcTimeDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
@@ -57,6 +56,12 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
         this.isStateTtlEnabled = stateRetentionTime > 0;
+    }
+
+    @Override
+    public void open(Configuration configure) throws Exception {
+        super.open(configure);
+        equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
     }
 
     @Override
@@ -75,11 +80,5 @@ public class ProcTimeDeduplicateKeepLastRowFunction
             processLastRowOnChangelog(
                     input, generateUpdateBefore, state, out, isStateTtlEnabled, equaliser);
         }
-    }
-
-    @Override
-    public void open(Configuration configure) throws Exception {
-        super.open(configure);
-        equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.table.runtime.operators.deduplicate;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.Collector;
 
@@ -33,26 +36,50 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     private final boolean generateUpdateBefore;
     private final boolean generateInsert;
     private final boolean inputIsInsertOnly;
+    // function used to equal RowData
+    private transient RecordEqualiser equaliser = null;
+
+    // The code generated equaliser used to equal RowData.
+    private transient GeneratedRecordEqualiser genRecordEqualiser = null;
+
+    private transient boolean isStateTTLEnabled = false;
 
     public ProcTimeDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
             long stateRetentionTime,
             boolean generateUpdateBefore,
             boolean generateInsert,
-            boolean inputInsertOnly) {
+            boolean inputInsertOnly,
+            GeneratedRecordEqualiser genRecordEqualiser) {
         super(typeInfo, null, stateRetentionTime);
         this.generateUpdateBefore = generateUpdateBefore;
         this.generateInsert = generateInsert;
         this.inputIsInsertOnly = inputInsertOnly;
+        this.genRecordEqualiser = genRecordEqualiser;
     }
 
     @Override
     public void processElement(RowData input, Context ctx, Collector<RowData> out)
             throws Exception {
         if (inputIsInsertOnly) {
-            processLastRowOnProcTime(input, generateUpdateBefore, generateInsert, state, out);
+            processLastRowOnProcTime(
+                    input,
+                    generateUpdateBefore,
+                    generateInsert,
+                    state,
+                    out,
+                    isStateTTLEnabled,
+                    equaliser);
         } else {
-            processLastRowOnChangelog(input, generateUpdateBefore, state, out);
+            processLastRowOnChangelog(
+                    input, generateUpdateBefore, state, out, isStateTTLEnabled, equaliser);
         }
+    }
+
+    @Override
+    public void open(Configuration configure) throws Exception {
+        super.open(configure);
+        equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
+        isStateTTLEnabled = this.stateRetentionTime > 0;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
@@ -43,12 +43,12 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
     private final boolean generateInsert;
     private final boolean inputInsertOnly;
     // function used to equal RowData
-    private transient RecordEqualiser equaliser = null;
+    private transient RecordEqualiser equaliser;
 
     // The code generated equaliser used to equal RowData.
-    private transient GeneratedRecordEqualiser genRecordEqualiser = null;
+    private final GeneratedRecordEqualiser genRecordEqualiser;
 
-    private transient boolean isStateTTLEnabled = false;
+    private final boolean isStateTtlEnabled;
 
     public ProcTimeMiniBatchDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
@@ -64,6 +64,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
         this.generateInsert = generateInsert;
         this.inputInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
+        this.isStateTtlEnabled = minRetentionTime > 0;
     }
 
     @Override
@@ -86,11 +87,11 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
                         generateInsert,
                         state,
                         out,
-                        isStateTTLEnabled,
+                        isStateTtlEnabled,
                         equaliser);
             } else {
                 processLastRowOnChangelog(
-                        currentRow, generateUpdateBefore, state, out, isStateTTLEnabled, equaliser);
+                        currentRow, generateUpdateBefore, state, out, isStateTtlEnabled, equaliser);
             }
         }
     }
@@ -100,6 +101,5 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
         super.open(ctx);
         equaliser =
                 genRecordEqualiser.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
-        isStateTTLEnabled = this.minRetentionTime > 0;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
@@ -20,6 +20,9 @@ package org.apache.flink.table.runtime.operators.deduplicate;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.context.ExecutionContext;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.Collector;
 
@@ -39,6 +42,13 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
     private final boolean generateUpdateBefore;
     private final boolean generateInsert;
     private final boolean inputInsertOnly;
+    // function used to equal RowData
+    private transient RecordEqualiser equaliser = null;
+
+    // The code generated equaliser used to equal RowData.
+    private transient GeneratedRecordEqualiser genRecordEqualiser = null;
+
+    private transient boolean isStateTTLEnabled = false;
 
     public ProcTimeMiniBatchDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
@@ -46,12 +56,14 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
             long stateRetentionTime,
             boolean generateUpdateBefore,
             boolean generateInsert,
-            boolean inputInsertOnly) {
+            boolean inputInsertOnly,
+            GeneratedRecordEqualiser genRecordEqualiser) {
         super(typeInfo, stateRetentionTime);
         this.serializer = serializer;
         this.generateUpdateBefore = generateUpdateBefore;
         this.generateInsert = generateInsert;
         this.inputInsertOnly = inputInsertOnly;
+        this.genRecordEqualiser = genRecordEqualiser;
     }
 
     @Override
@@ -69,10 +81,25 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
             ctx.setCurrentKey(currentKey);
             if (inputInsertOnly) {
                 processLastRowOnProcTime(
-                        currentRow, generateUpdateBefore, generateInsert, state, out);
+                        currentRow,
+                        generateUpdateBefore,
+                        generateInsert,
+                        state,
+                        out,
+                        isStateTTLEnabled,
+                        equaliser);
             } else {
-                processLastRowOnChangelog(currentRow, generateUpdateBefore, state, out);
+                processLastRowOnChangelog(
+                        currentRow, generateUpdateBefore, state, out, isStateTTLEnabled, equaliser);
             }
         }
+    }
+
+    @Override
+    public void open(ExecutionContext ctx) throws Exception {
+        super.open(ctx);
+        equaliser =
+                genRecordEqualiser.newInstance(ctx.getRuntimeContext().getUserCodeClassLoader());
+        isStateTTLEnabled = this.minRetentionTime > 0;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunction.java
@@ -64,7 +64,7 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunction
         this.generateInsert = generateInsert;
         this.inputInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
-        this.isStateTtlEnabled = minRetentionTime > 0;
+        this.isStateTtlEnabled = stateRetentionTime > 0;
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateFunctionTestBase.java
@@ -20,10 +20,13 @@ package org.apache.flink.table.runtime.operators.deduplicate;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
 import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.runtime.util.RowDataRecordEqualiser;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -45,4 +48,15 @@ abstract class ProcTimeDeduplicateFunctionTestBase {
                     inputRowType.toRowFieldTypes(),
                     new GenericRowRecordSortComparator(
                             rowKeyIdx, inputRowType.toRowFieldTypes()[rowKeyIdx]));
+
+    static GeneratedRecordEqualiser generatedEqualiser =
+            new GeneratedRecordEqualiser("", "", new Object[0]) {
+
+                private static final long serialVersionUID = 8932260133849746733L;
+
+                @Override
+                public RecordEqualiser newInstance(ClassLoader classLoader) {
+                    return new RowDataRecordEqualiser();
+                }
+            };
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateFunctionTestBase.java
@@ -52,7 +52,7 @@ abstract class ProcTimeDeduplicateFunctionTestBase {
     static GeneratedRecordEqualiser generatedEqualiser =
             new GeneratedRecordEqualiser("", "", new Object[0]) {
 
-                private static final long serialVersionUID = 8932260133849746733L;
+                private static final long serialVersionUID = 1L;
 
                 @Override
                 public RecordEqualiser newInstance(ClassLoader classLoader) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
@@ -39,7 +39,12 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     private ProcTimeDeduplicateKeepLastRowFunction createFunction(
             boolean generateUpdateBefore, boolean generateInsert) {
         return new ProcTimeDeduplicateKeepLastRowFunction(
-                inputRowType, minTime.toMilliseconds(), generateUpdateBefore, generateInsert, true);
+                inputRowType,
+                minTime.toMilliseconds(),
+                generateUpdateBefore,
+                generateInsert,
+                true,
+                generatedEqualiser);
     }
 
     private OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
@@ -115,7 +115,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     }
 
     @Test
-    public void testDeduplicateWithGenerateUpdateBefore() throws Exception {
+    public void testWithStateTtlDisabled() throws Exception {
         ProcTimeDeduplicateKeepLastRowFunction func = createFunctionWithoutStateTtl(true, true);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunctionTest.java
@@ -38,12 +38,7 @@ public class ProcTimeDeduplicateKeepLastRowFunctionTest
     private ProcTimeDeduplicateKeepLastRowFunction createFunctionWithoutStateTtl(
             boolean generateUpdateBefore, boolean generateInsert) {
         return new ProcTimeDeduplicateKeepLastRowFunction(
-                inputRowType,
-                0,
-                generateUpdateBefore,
-                generateInsert,
-                true,
-                generatedEqualiser);
+                inputRowType, 0, generateUpdateBefore, generateInsert, true, generatedEqualiser);
     }
 
     private ProcTimeDeduplicateKeepLastRowFunction createFunction(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest.java
@@ -46,13 +46,15 @@ public class ProcTimeMiniBatchDeduplicateKeepLastRowFunctionTest
 
     private ProcTimeMiniBatchDeduplicateKeepLastRowFunction createFunction(
             boolean generateUpdateBefore, boolean generateInsert, long minRetentionTime) {
+
         return new ProcTimeMiniBatchDeduplicateKeepLastRowFunction(
                 inputRowType,
                 typeSerializer,
                 minRetentionTime,
                 generateUpdateBefore,
                 generateInsert,
-                true);
+                true,
+                generatedEqualiser);
     }
 
     private OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the  LastRowFunction , the -U&+U Row will be collected even if they are the same, which will  increase calculation pressure of the next Operator.

 

To avoid this, we can optimize the logic of DeduplicateFunctionHelper. Also, a config to enable the optimization will be added.




## Brief change log
- add `equaliser` and `isStateTtlEnabled` in ProcTimeDeduplicateKeepLastRowFunction
- optimize the logic of DeduplicateFunctionHelper#processLastRowOnProcTime and  DeduplicateFunctionHelper#processLastRowOnChangelog  by `equaliser` and `isStateTtlEnabled`
- add unit test in ProcTimeDeduplicateKeepLastRowFunctionTest


## Verifying this change

This change added tests and can be verified as follows:
- Added test that validates that Duplicate row is Deduplicated when state ttl disabled In  ProcTimeDeduplicateKeepLastRowFunctionTest#testDeduplicateWithGenerateUpdateBefore


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (/no)
  - If yes, how is the feature documented? (not documented)
