### PR TITLE
[FLINK-21047][coordination] Fix the incorrect registered/free resourc…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -296,7 +296,10 @@ public class DeclarativeSlotManager implements SlotManager {
             return false;
         } else {
             if (!taskExecutorManager.registerTaskManager(
-                    taskExecutorConnection, initialSlotReport)) {
+                    taskExecutorConnection,
+                    initialSlotReport,
+                    totalResourceProfile,
+                    defaultSlotResourceProfile)) {
                 LOG.debug(
                         "Task executor {} could not be registered.",
                         taskExecutorConnection.getResourceID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -230,30 +230,38 @@ public class SlotManagerImpl implements SlotManager {
 
     @Override
     public ResourceProfile getRegisteredResource() {
-        return getResourceFromNumSlots(getNumberRegisteredSlots());
+        return taskManagerRegistrations.values().stream()
+                .map(TaskManagerRegistration::getTotalResource)
+                .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
     }
 
     @Override
     public ResourceProfile getRegisteredResourceOf(InstanceID instanceID) {
-        return getResourceFromNumSlots(getNumberRegisteredSlotsOf(instanceID));
+        return Optional.ofNullable(taskManagerRegistrations.get(instanceID))
+                .map(TaskManagerRegistration::getTotalResource)
+                .orElse(ResourceProfile.ZERO);
     }
 
     @Override
     public ResourceProfile getFreeResource() {
-        return getResourceFromNumSlots(getNumberFreeSlots());
+        return taskManagerRegistrations.values().stream()
+                .map(
+                        taskManagerRegistration ->
+                                taskManagerRegistration
+                                        .getDefaultSlotResourceProfile()
+                                        .multiply(taskManagerRegistration.getNumberFreeSlots()))
+                .reduce(ResourceProfile.ZERO, ResourceProfile::merge);
     }
 
     @Override
     public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
-        return getResourceFromNumSlots(getNumberFreeSlotsOf(instanceID));
-    }
-
-    private ResourceProfile getResourceFromNumSlots(int numSlots) {
-        if (numSlots < 0 || defaultSlotResourceProfile == null) {
-            return ResourceProfile.UNKNOWN;
-        } else {
-            return defaultSlotResourceProfile.multiply(numSlots);
-        }
+        return Optional.ofNullable(taskManagerRegistrations.get(instanceID))
+                .map(
+                        taskManagerRegistration ->
+                                taskManagerRegistration
+                                        .getDefaultSlotResourceProfile()
+                                        .multiply(taskManagerRegistration.getNumberFreeSlots()))
+                .orElse(ResourceProfile.ZERO);
     }
 
     @VisibleForTesting
@@ -497,7 +505,11 @@ public class SlotManagerImpl implements SlotManager {
             }
 
             TaskManagerRegistration taskManagerRegistration =
-                    new TaskManagerRegistration(taskExecutorConnection, reportedSlots);
+                    new TaskManagerRegistration(
+                            taskExecutorConnection,
+                            reportedSlots,
+                            totalResourceProfile,
+                            defaultSlotResourceProfile);
 
             taskManagerRegistrations.put(
                     taskExecutorConnection.getInstanceID(), taskManagerRegistration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerRegistration.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
@@ -30,6 +31,10 @@ public class TaskManagerRegistration {
 
     private final TaskExecutorConnection taskManagerConnection;
 
+    private final ResourceProfile defaultSlotResourceProfile;
+
+    private final ResourceProfile totalResource;
+
     private final HashSet<SlotID> slots;
 
     private int numberFreeSlots;
@@ -38,11 +43,17 @@ public class TaskManagerRegistration {
     private long idleSince;
 
     public TaskManagerRegistration(
-            TaskExecutorConnection taskManagerConnection, Collection<SlotID> slots) {
+            TaskExecutorConnection taskManagerConnection,
+            Collection<SlotID> slots,
+            ResourceProfile totalResourceProfile,
+            ResourceProfile defaultSlotResourceProfile) {
 
         this.taskManagerConnection =
                 Preconditions.checkNotNull(taskManagerConnection, "taskManagerConnection");
         Preconditions.checkNotNull(slots, "slots");
+
+        this.totalResource = Preconditions.checkNotNull(totalResourceProfile);
+        this.defaultSlotResourceProfile = Preconditions.checkNotNull(defaultSlotResourceProfile);
 
         this.slots = new HashSet<>(slots);
 
@@ -65,6 +76,14 @@ public class TaskManagerRegistration {
 
     public int getNumberFreeSlots() {
         return numberFreeSlots;
+    }
+
+    public ResourceProfile getDefaultSlotResourceProfile() {
+        return defaultSlotResourceProfile;
+    }
+
+    public ResourceProfile getTotalResource() {
+        return totalResource;
     }
 
     public void freeSlot() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -1504,6 +1504,69 @@ public class SlotManagerImplTest extends TestLogger {
         }
     }
 
+    @Test
+    public void testGetResourceOverview() throws Exception {
+        final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+        final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
+
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+        final ResourceID resourceId1 = ResourceID.generate();
+        final ResourceID resourceId2 = ResourceID.generate();
+        final TaskExecutorConnection taskManagerConnection1 =
+                new TaskExecutorConnection(resourceId1, taskExecutorGateway);
+        final TaskExecutorConnection taskManagerConnection2 =
+                new TaskExecutorConnection(resourceId2, taskExecutorGateway);
+
+        final SlotID slotId1 = new SlotID(resourceId1, 0);
+        final SlotID slotId2 = new SlotID(resourceId1, 1);
+        final SlotID slotId3 = new SlotID(resourceId2, 0);
+        final SlotID slotId4 = new SlotID(resourceId2, 1);
+        final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1, 10);
+        final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2, 20);
+        final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile1);
+        final SlotStatus slotStatus2 =
+                new SlotStatus(slotId2, resourceProfile1, new JobID(), new AllocationID());
+        final SlotStatus slotStatus3 = new SlotStatus(slotId3, resourceProfile2);
+        final SlotStatus slotStatus4 =
+                new SlotStatus(slotId4, resourceProfile2, new JobID(), new AllocationID());
+        final SlotReport slotReport1 = new SlotReport(Arrays.asList(slotStatus1, slotStatus2));
+        final SlotReport slotReport2 = new SlotReport(Arrays.asList(slotStatus3, slotStatus4));
+
+        try (SlotManagerImpl slotManager =
+                createSlotManager(resourceManagerId, resourceManagerActions)) {
+            slotManager.registerTaskManager(
+                    taskManagerConnection1,
+                    slotReport1,
+                    resourceProfile1.multiply(2),
+                    resourceProfile1);
+            slotManager.registerTaskManager(
+                    taskManagerConnection2,
+                    slotReport2,
+                    resourceProfile2.multiply(2),
+                    resourceProfile2);
+
+            assertThat(
+                    slotManager.getFreeResource(),
+                    equalTo(resourceProfile1.merge(resourceProfile2)));
+            assertThat(
+                    slotManager.getFreeResourceOf(taskManagerConnection1.getInstanceID()),
+                    equalTo(resourceProfile1));
+            assertThat(
+                    slotManager.getFreeResourceOf(taskManagerConnection2.getInstanceID()),
+                    equalTo(resourceProfile2));
+            assertThat(
+                    slotManager.getRegisteredResource(),
+                    equalTo(resourceProfile1.merge(resourceProfile2).multiply(2)));
+            assertThat(
+                    slotManager.getRegisteredResourceOf(taskManagerConnection1.getInstanceID()),
+                    equalTo(resourceProfile1.multiply(2)));
+            assertThat(
+                    slotManager.getRegisteredResourceOf(taskManagerConnection2.getInstanceID()),
+                    equalTo(resourceProfile2.multiply(2)));
+        }
+    }
+
     private Set<AllocationID> extractFailedAllocationsForJob(
             JobID jobId2,
             Map<JobID, List<Tuple2<JobID, AllocationID>>> job2AndJob3FailedAllocationInfo) {


### PR DESCRIPTION
…es information exposed by SlotManager

## What is the purpose of the change

In FLINK-16640, we extend ResourceOverview and TaskManager(Details)Info for registered/free resources. However, the implementation is based on the assumption that all the registered task executors are homogeneous with the default resource spec. This assumption will be broken in standalone mode when user manually starts heterogeneous task executors.

We need to calculate the registered/free resources according to the exact defaultSlotResourceProfile and totalResourceProfile of TaskExecutorRegistrations.

## Brief change log

Calculate the registered/free resources according to the exact defaultSlotResourceProfile and totalResourceProfile of TaskExecutorRegistrations.

