### PR TITLE
[FLINK-21254] Add Created state for DeclarativeScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Created.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Created.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+/** Initial state of the {@link DeclarativeScheduler}. */
+class Created implements State {
+
+    private final Context context;
+
+    private final Logger logger;
+
+    Created(Context context, Logger logger) {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    @Override
+    public void cancel() {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.CANCELED, null));
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.SUSPENDED, cause));
+    }
+
+    @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.INITIALIZING;
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        return context.getArchivedExecutionGraph(getJobStatus(), null);
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, cause));
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    /** Starts the scheduling by going into the {@link WaitingForResources} state. */
+    void startScheduling() {
+        context.goToWaitingForResources();
+    }
+
+    /** Context of the {@link Created} state. */
+    interface Context {
+
+        /**
+         * Transitions into the {@link Finished} state.
+         *
+         * @param archivedExecutionGraph archivedExecutionGraph is passed to the {@link Finished}
+         *     state
+         */
+        void goToFinished(ArchivedExecutionGraph archivedExecutionGraph);
+
+        /**
+         * Creates an {@link ArchivedExecutionGraph} for the given jobStatus and failure cause.
+         *
+         * @param jobStatus jobStatus to create the {@link ArchivedExecutionGraph} with
+         * @param cause cause represents the failure cause for the {@link ArchivedExecutionGraph};
+         *     {@code null} if there is no failure cause
+         * @return the created {@link ArchivedExecutionGraph}
+         */
+        ArchivedExecutionGraph getArchivedExecutionGraph(
+                JobStatus jobStatus, @Nullable Throwable cause);
+
+        /** Transitions into the {@link WaitingForResources} state. */
+        void goToWaitingForResources();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CreatedTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Consumer;
+
+import static org.apache.flink.runtime.scheduler.declarative.WaitingForResourcesTest.assertNonNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link Created} state. */
+public class CreatedTest extends TestLogger {
+    static final JobID testJobId = new JobID();
+
+    @Test
+    public void testCancel() throws Exception {
+        try (MockCreatedContext ctx = new MockCreatedContext()) {
+            Created created = new Created(ctx, log);
+
+            ctx.setExpectFinished(assertNonNull());
+
+            created.cancel();
+        }
+    }
+
+    @Test
+    public void testStartScheduling() throws Exception {
+        try (MockCreatedContext ctx = new MockCreatedContext()) {
+            Created created = new Created(ctx, log);
+
+            ctx.setExpectWaitingForResources();
+
+            created.startScheduling();
+        }
+    }
+
+    @Test
+    public void testSuspend() throws Exception {
+        try (MockCreatedContext ctx = new MockCreatedContext()) {
+            Created created = new Created(ctx, log);
+
+            ctx.setExpectFinished(
+                    archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
+                    });
+
+            created.suspend(new RuntimeException("Suspend"));
+        }
+    }
+
+    @Test
+    public void testFailure() throws Exception {
+        try (MockCreatedContext ctx = new MockCreatedContext()) {
+            Created created = new Created(ctx, log);
+
+            ctx.setExpectFinished(
+                    archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
+                    });
+
+            created.handleGlobalFailure(new RuntimeException("Global"));
+        }
+    }
+
+    @Test
+    public void testJobInformation() throws Exception {
+        try (MockCreatedContext ctx = new MockCreatedContext()) {
+            Created created = new Created(ctx, log);
+            ArchivedExecutionGraph job = created.getJob();
+            assertThat(job.getState(), is(JobStatus.INITIALIZING));
+        }
+    }
+
+    static class MockCreatedContext implements Created.Context, AutoCloseable {
+        private final StateValidator<ArchivedExecutionGraph> finishedStateValidator =
+                new StateValidator<>("finished");
+        private final StateValidator<Void> waitingForResourcesStateValidator =
+                new StateValidator<>("WaitingForResources");
+
+        public void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
+            finishedStateValidator.activate(asserter);
+        }
+
+        public void setExpectWaitingForResources() {
+            waitingForResourcesStateValidator.activate((none) -> {});
+        }
+
+        @Override
+        public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
+            finishedStateValidator.validateInput(archivedExecutionGraph);
+        }
+
+        @Override
+        public ArchivedExecutionGraph getArchivedExecutionGraph(
+                JobStatus jobStatus, @Nullable Throwable cause) {
+            return ArchivedExecutionGraph.createFromInitializingJob(
+                    testJobId, "testJob", jobStatus, cause, 0L);
+        }
+
+        @Override
+        public void goToWaitingForResources() {
+            waitingForResourcesStateValidator.validateInput(null);
+        }
+
+        @Override
+        public void close() throws Exception {
+            finishedStateValidator.close();
+            waitingForResourcesStateValidator.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CreatedTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link Created} state. */
 public class CreatedTest extends TestLogger {
-    static final JobID testJobId = new JobID();
 
     @Test
     public void testCancel() throws Exception {
@@ -103,11 +102,11 @@ public class CreatedTest extends TestLogger {
                 new StateValidator<>("WaitingForResources");
 
         public void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
-            finishedStateValidator.activate(asserter);
+            finishedStateValidator.expectInput(asserter);
         }
 
         public void setExpectWaitingForResources() {
-            waitingForResourcesStateValidator.activate((none) -> {});
+            waitingForResourcesStateValidator.expectInput((none) -> {});
         }
 
         @Override
@@ -119,7 +118,7 @@ public class CreatedTest extends TestLogger {
         public ArchivedExecutionGraph getArchivedExecutionGraph(
                 JobStatus jobStatus, @Nullable Throwable cause) {
             return ArchivedExecutionGraph.createFromInitializingJob(
-                    testJobId, "testJob", jobStatus, cause, 0L);
+                    new JobID(), "testJob", jobStatus, cause, 0L);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the default methods on the {@link State} interface, based on the {@link Created} state,
+ * as it is a simple state.
+ */
+public class StateTest extends TestLogger {
+    @Test
+    public void testEmptyAs() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            assertThat(state.as(WaitingForResources.class), is(Optional.empty()));
+        }
+    }
+
+    @Test
+    public void testCast() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            assertThat(state.as(Created.class), is(Optional.of(state)));
+        }
+    }
+
+    @Test
+    public void testTryRunNoRun() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            state.tryRun(
+                    WaitingForResources.class, (waiting -> fail("Unexpected execution")), "test");
+        }
+    }
+
+    @Test
+    public void testTryRun() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            Tuple1<Runnable> validate = Tuple1.of(() -> fail("Did not run"));
+            state.tryRun(Created.class, created -> validate.setFields(() -> {}), "test");
+            validate.f0.run();
+        }
+    }
+
+    @Test
+    public void testTryCallNoCall() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            Optional<String> result =
+                    state.tryCall(
+                            WaitingForResources.class,
+                            Waiting -> {
+                                fail("Unexpected execution");
+                                return "nope";
+                            },
+                            "test");
+            assertThat(result, is(Optional.empty()));
+        }
+    }
+
+    @Test
+    public void testTryCall() throws Exception {
+        try (CreatedTest.MockCreatedContext ctx = new CreatedTest.MockCreatedContext()) {
+            State state = new Created(ctx, log);
+            Tuple1<Runnable> validate = Tuple1.of(() -> fail("Did not run"));
+            Optional<String> result =
+                    state.tryCall(
+                            Created.class,
+                            created -> {
+                                validate.setFields(() -> {});
+                                return "yes";
+                            },
+                            "test");
+            validate.f0.run();
+            assertThat(result, is(Optional.of("yes")));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. This PR is based on #14852 (the first two commits are from #14852, remaining commits are to be reviewed here).

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.