### PR TITLE
[FLINK-21272][checkpointing] Report incomplete metrics when aborted

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
@@ -29,6 +29,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class CheckpointMetrics implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    public static final long UNSET = -1L;
 
     private final long bytesProcessedDuringAlignment;
 
@@ -52,7 +53,7 @@ public class CheckpointMetrics implements Serializable {
 
     @VisibleForTesting
     public CheckpointMetrics() {
-        this(-1L, -1L, -1L, -1L, -1L, -1L, false, 0L);
+        this(UNSET, UNSET, UNSET, UNSET, UNSET, UNSET, false, 0L);
     }
 
     public CheckpointMetrics(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetricsBuilder.java
@@ -139,4 +139,16 @@ public class CheckpointMetricsBuilder {
                 unalignedCheckpoint,
                 totalBytesPersisted);
     }
+
+    public CheckpointMetrics buildIncomplete() {
+        return new CheckpointMetrics(
+                bytesProcessedDuringAlignment.getNow(CheckpointMetrics.UNSET),
+                bytesPersistedDuringAlignment,
+                alignmentDurationNanos.getNow(CheckpointMetrics.UNSET),
+                syncDurationMillis,
+                asyncDurationMillis,
+                checkpointStartDelayNanos,
+                unalignedCheckpoint,
+                totalBytesPersisted);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -119,7 +119,9 @@ public class TestTaskStateManager implements TaskStateManager {
 
     @Override
     public void reportIncompleteTaskStateSnapshots(
-            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {}
+            CheckpointMetaData checkpointMetaData, CheckpointMetrics checkpointMetrics) {
+        reportedCheckpointId = checkpointMetaData.getCheckpointId();
+    }
 
     @Nonnull
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -221,7 +221,8 @@ final class AsyncCheckpointRunnable implements Runnable, Closeable {
     }
 
     private void reportAbortedSnapshotStats(long stateSize) {
-        CheckpointMetrics metrics = checkpointMetrics.setTotalBytesPersisted(stateSize).build();
+        CheckpointMetrics metrics =
+                checkpointMetrics.setTotalBytesPersisted(stateSize).buildIncomplete();
         LOG.trace(
                 "{} - report failed checkpoint stats: {} {}",
                 taskName,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -38,8 +38,31 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
+
 /** Tests for {@link AsyncCheckpointRunnable}. */
 public class AsyncCheckpointRunnableTest {
+
+    @Test
+    public void testReportIncompleteStats() {
+        long checkpointId = 1000L;
+        TestEnvironment env = new TestEnvironment();
+        new AsyncCheckpointRunnable(
+                        new HashMap<>(),
+                        new CheckpointMetaData(checkpointId, 1),
+                        new CheckpointMetricsBuilder(),
+                        0,
+                        "Task Name",
+                        r -> {},
+                        r -> {},
+                        env,
+                        (msg, ex) -> {},
+                        () -> true)
+                .close();
+        assertEquals(
+                checkpointId,
+                ((TestTaskStateManager) env.getTaskStateManager()).getReportedCheckpointId());
+    }
 
     @Test
     public void testDeclineWithAsyncCheckpointExceptionWhenRunning() {


### PR DESCRIPTION
## What is the purpose of the change

When a checkpoint is aborted, `AsyncCheckpointRunnable` still tries to send metrics.
But because some values are not known the validation fails.
The failure is only logged but warnging fails e2e tests.

## Verifying this change

- Added unit test: `AsyncCheckpointRunnableTest.testReportIncompleteStats`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
