### PR TITLE
[FLINK-21102] Add ScaleUpController for declarative scheduler

### DIFF
--- a/docs/_includes/generated/all_jobmanager_section.html
+++ b/docs/_includes/generated/all_jobmanager_section.html
@@ -15,6 +15,12 @@
             <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.declarative-scheduler.min-parallelism-increase</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>Configure the minimum increase in parallelism for a job to scale up.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/docs/_includes/generated/expert_scheduling_section.html
+++ b/docs/_includes/generated/expert_scheduling_section.html
@@ -15,6 +15,12 @@
             <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.declarative-scheduler.min-parallelism-increase</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>Configure the minimum increase in parallelism for a job to scale up.</td>
+        </tr>
+        <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -21,6 +21,12 @@
             <td>The local address of the network interface that the job manager binds to. If not configured, '0.0.0.0' will be used.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.declarative-scheduler.min-parallelism-increase</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>Configure the minimum increase in parallelism for a job to scale up.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -358,6 +358,17 @@ public class JobManagerOptions {
                                     .list(text("'ng': new generation scheduler"))
                                     .build());
 
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Integer> MIN_PARALLELISM_INCREASE =
+            key("jobmanager.declarative-scheduler.min-parallelism-increase")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            "Configure the minimum increase in parallelism for a job to scale up.");
+
     /**
      * Config parameter controlling whether partitions should already be released during the job
      * execution.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ReactiveScaleUpController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ReactiveScaleUpController.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative.scalingpolicy;
+
+import org.apache.flink.configuration.Configuration;
+
+import static org.apache.flink.configuration.JobManagerOptions.MIN_PARALLELISM_INCREASE;
+
+/**
+ * Simple scaling policy for a reactive mode. The user can configure a minimum cumulative
+ * parallelism increase to allow a scale up.
+ */
+public class ReactiveScaleUpController implements ScaleUpController {
+
+    private final int minParallelismIncrease;
+
+    public ReactiveScaleUpController(Configuration configuration) {
+        minParallelismIncrease = configuration.get(MIN_PARALLELISM_INCREASE);
+    }
+
+    @Override
+    public boolean canScaleUp(int currentCumulativeParallelism, int newCumulativeParallelism) {
+        return newCumulativeParallelism - currentCumulativeParallelism >= minParallelismIncrease;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ScaleUpController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ScaleUpController.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative.scalingpolicy;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Simple policy for controlling the scale up behavior of the {@link
+ * org.apache.flink.runtime.scheduler.declarative.DeclarativeScheduler}.
+ */
+@Internal
+public interface ScaleUpController {
+
+    /**
+     * This method gets called whenever new resources are available to the scheduler to scale up.
+     *
+     * @param currentCumulativeParallelism Cumulative parallelism of the currently running job
+     *     graph.
+     * @param newCumulativeParallelism Potential new cumulative parallelism with the additional
+     *     resources.
+     * @return true if the policy decided to scale up based on the provided information.
+     */
+    boolean canScaleUp(int currentCumulativeParallelism, int newCumulativeParallelism);
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ScaleUpControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/scalingpolicy/ScaleUpControllerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative.scalingpolicy;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link ScaleUpController}. */
+public class ScaleUpControllerTest extends TestLogger {
+    private static final Configuration TEST_CONFIG = new Configuration();
+
+    static {
+        TEST_CONFIG.set(JobManagerOptions.MIN_PARALLELISM_INCREASE, 2);
+    }
+
+    @Test
+    public void testScaleUp() {
+        ScaleUpController suc = new ReactiveScaleUpController(TEST_CONFIG);
+        assertThat(suc.canScaleUp(1, 4), is(true));
+    }
+
+    @Test
+    public void testNoScaleUp() {
+        ScaleUpController suc = new ReactiveScaleUpController(TEST_CONFIG);
+        assertThat(suc.canScaleUp(2, 3), is(false));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the ScaleUpController according to the definition in FLIP-160.

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler)


## Verifying this change

Added a new test

## Does this pull request potentially affect one of the following parts:

No existing code has been touched.

## Documentation

There will be a separate PR for the Declarative Scheduler Docs.
