### PR TITLE
[FLINK-11838][flink-gs-fs-hadoop] Add GCS FileSystem with RecoverableWriter

### DIFF
--- a/docs/dev/connectors/file_sink.md
+++ b/docs/dev/connectors/file_sink.md
@@ -774,8 +774,8 @@ Given this, when trying to restore from an old checkpoint/savepoint which assume
 by subsequent successful checkpoints, the `FileSink` will refuse to resume and will throw an exception as it cannot locate the 
 in-progress file.
 
-<span class="label label-danger">Important Note 4</span>: Currently, the `FileSink` only supports three filesystems: 
-HDFS, S3, and Local. Flink will throw an exception when using an unsupported filesystem at runtime.
+<span class="label label-danger">Important Note 4</span>: Currently, the `FileSink` only supports four filesystems: 
+HDFS, S3, Google Storage (GS), and Local. Flink will throw an exception when using an unsupported filesystem at runtime.
 
 ### BATCH-specific
 
@@ -809,5 +809,12 @@ that don't complete within a specified number of days after being initiated. Thi
 aggressively and take a savepoint with some part-files being not fully uploaded, their associated MPUs may time-out
 before the job is restarted. This will result in your job not being able to restore from that savepoint as the
 pending part-files are no longer there and Flink will fail with an exception as it tries to fetch them and fails.
+
+### Google-Storage-specific
+
+<span class="label label-danger">Important Note 1</span>: To guarantee exactly-once semantics while
+being efficient, the `StreamingFileSink` uses the [Resumable Upload](https://cloud.google.com/storage/docs/resumable-uploads)
+feature of Google Storage. A resumable upload must be completed within one week of being initiated; attempts to resume uploads 
+beyond one week will fail, and savepoints that reference such in-progress, timed-out uploads not be usable.
 
 {% top %}

--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -770,8 +770,8 @@ Given this, when trying to restore from an old checkpoint/savepoint which assume
 by subsequent successful checkpoints, the `StreamingFileSink` will refuse to resume and it will throw an exception as it cannot locate the 
 in-progress file.
 
-<span class="label label-danger">Important Note 4</span>: Currently, the `StreamingFileSink` only supports three filesystems: 
-HDFS, S3, and Local. Flink will throw an exception when using an unsupported filesystem at runtime.
+<span class="label label-danger">Important Note 4</span>: Currently, the `StreamingFileSink` only supports four filesystems: 
+HDFS, S3, Google Storage (GS), and Local. Flink will throw an exception when using an unsupported filesystem at runtime.
 
 ### S3-specific
 
@@ -793,4 +793,14 @@ aggressively and take a savepoint with some part-files being not fully uploaded,
 before the job is restarted. This will result in your job not being able to restore from that savepoint as the
 pending part-files are no longer there and Flink will fail with an exception as it tries to fetch them and fails.
 
+### Google-Storage-specific
+
+<span class="label label-danger">Important Note 1</span>: To guarantee exactly-once semantics while
+being efficient, the `StreamingFileSink` uses the [Resumable Upload](https://cloud.google.com/storage/docs/resumable-uploads)
+feature of Google Storage. A resumable upload must be completed within one week of being initiated; attempts to resume uploads
+beyond one week will fail, and savepoints that reference such in-progress, timed-out uploads not be usable.
+
+
 {% top %}
+
+

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-filesystems</artifactId>
+		<version>1.13-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-gs-fs-hadoop</artifactId>
+	<name>Flink : FileSystems : Google Storage FS Hadoop</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<fs.gs.gcs.version>1.113.9</fs.gs.gcs.version>
+		<fs.gs.gcs.connector.version>hadoop2-2.2.0</fs.gs.gcs.connector.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Override the flink-parent dependencyManagement definition for hadoop-common to ensure
+				${fs.hadoopshaded.version} is used for this file system -->
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-common</artifactId>
+				<version>${fs.hadoopshaded.version}</version>
+			</dependency>
+
+			<dependency>
+				<!-- Bumped for security purposes -->
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<dependencies>
+
+		<!-- Flink's file system abstraction (compiled against, not bundled) -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Hadoop's file system abstraction (bundled) -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>${fs.hadoopshaded.version}</version>
+
+			<exclusions>
+				<exclusion>
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.jcraft</groupId>
+					<artifactId>jsch</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-servlet</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-json</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>jersey-server</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.avro</groupId>
+					<artifactId>avro</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-server</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-util</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-servlet</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-webapp</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.servlet.jsp</groupId>
+					<artifactId>jsp-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.kerby</groupId>
+					<artifactId>kerb-simplekdc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-framework</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-recipes</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-net</groupId>
+					<artifactId>commons-net</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-cli</groupId>
+					<artifactId>commons-cli</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-math3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.nimbusds</groupId>
+					<artifactId>nimbus-jose-jwt</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- The Hadoop file system adapter classes (bundled) -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-fs</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<!-- Hadoop requires jaxb-api for javax.xml.bind.JAXBException -->
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb.api.version}</version>
+			<!-- packaged as an optional dependency that is only accessible on Java 11+ -->
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Google dependencies, for cloud storage and hadoop filesystem -->
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-storage</artifactId>
+			<version>${fs.gs.gcs.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.cloud.bigdataoss</groupId>
+			<artifactId>gcs-connector</artifactId>
+			<version>${fs.gs.gcs.connector.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-fs</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<!-- jaxb-api is packaged as an optional dependency that is only accessible on Java 11 -->
+							<Multi-Release>true</Multi-Release>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-javax-jars</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>javax.xml.bind</groupId>
+							<artifactId>jaxb-api</artifactId>
+							<version>${jaxb.api.version}</version>
+							<type>jar</type>
+							<overWrite>true</overWrite>
+						</artifactItem>
+					</artifactItems>
+					<outputDirectory>${project.build.directory}/temporary</outputDirectory>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>unpack-javax-libraries</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<echo message="unpacking javax jars"/>
+								<unzip dest="${project.build.directory}/classes/META-INF/versions/11">
+									<fileset dir="${project.build.directory}/temporary">
+										<include name="*"/>
+									</fileset>
+								</unzip>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<!-- shade Flink's Hadoop FS adapter classes, forces plugin classloader for them -->
+								<relocation>
+									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>
+									<shadedPattern>org.apache.flink.fs.gshadoop.common</shadedPattern>
+								</relocation>
+								<!-- shade Flink's Hadoop FS utility classes, forces plugin classloader for them -->
+								<relocation>
+									<pattern>org.apache.flink.runtime.util</pattern>
+									<shadedPattern>org.apache.flink.fs.gshadoop.common</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>.gitkeep</exclude>
+										<exclude>mime.types</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>META-INF/maven/**</exclude>
+										<exclude>META-INF/LICENSE.txt</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>properties.dtd</exclude>
+										<exclude>PropertyList-1.0.dtd</exclude>
+										<exclude>META-INF/maven/**</exclude>
+										<exclude>META-INF/services/javax.xml.stream.*</exclude>
+										<exclude>META-INF/LICENSE.txt</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/DefaultGSFileSystemHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/DefaultGSFileSystemHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.fs.gshadoop.writer.DefaultGSRecoverableWriterHelper;
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableWriterHelper;
+
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.apache.hadoop.fs.FileSystem;
+
+/**
+ * The default implementation of the file system helper, which provides access to the real {@link
+ * com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem} and {@link
+ * com.google.cloud.storage.Storage} implementations.
+ */
+class DefaultGSFileSystemHelper implements GSFileSystemHelper {
+
+    private final GSRecoverableWriterHelper recoverableWriterHelper;
+
+    /** Construct the file system helper. */
+    public DefaultGSFileSystemHelper() {
+        Storage storage = StorageOptions.getDefaultInstance().getService();
+        this.recoverableWriterHelper = new DefaultGSRecoverableWriterHelper(storage);
+    }
+
+    @Override
+    public FileSystem createHadoopFileSystem() {
+        return new GoogleHadoopFileSystem();
+    }
+
+    @Override
+    public GSRecoverableWriterHelper getRecoverableWriterHelper() {
+        return recoverableWriterHelper;
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystem.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystem.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableOptions;
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableWriter;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * Implementation of the Flink {@link org.apache.flink.core.fs.FileSystem} interface for Google
+ * Storage.
+ */
+public class GSFileSystem extends HadoopFileSystem {
+
+    @VisibleForTesting final org.apache.hadoop.fs.FileSystem hadoopFileSystem;
+
+    @VisibleForTesting final GSRecoverableOptions options;
+
+    /**
+     * Creates a GSFileSystem based on the given Hadoop GS file system. The given Hadoop file system
+     * object is expected to be initialized already.
+     *
+     * @param hadoopFileSystem The hadoop filesystem
+     * @param options The {@link org.apache.flink.fs.gshadoop.writer.GSRecoverableOptions} for this
+     *     file system instance.
+     */
+    public GSFileSystem(
+            org.apache.hadoop.fs.FileSystem hadoopFileSystem, GSRecoverableOptions options) {
+        super(hadoopFileSystem);
+        this.hadoopFileSystem = Preconditions.checkNotNull(hadoopFileSystem);
+        this.options = Preconditions.checkNotNull(options);
+    }
+
+    @Override
+    public RecoverableWriter createRecoverableWriter() throws IOException {
+        return new GSRecoverableWriter(options);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemFactory.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemFactory.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableOptions;
+import org.apache.flink.runtime.util.HadoopConfigLoader;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+
+/**
+ * Implementation of the Flink {@link org.apache.flink.core.fs.FileSystemFactory} interface for
+ * Google Storage.
+ */
+public class GSFileSystemFactory implements FileSystemFactory {
+
+    private static final String[] FLINK_CONFIG_PREFIXES = {"gs.", "fs.gs."};
+
+    private static final String[][] MIRRORED_CONFIG_KEYS = {};
+
+    @VisibleForTesting
+    public static final String DEFAULT_UPLOAD_CONTENT_TYPE = "application/octet-stream";
+
+    @VisibleForTesting public static final String DEFAULT_UPLOAD_TEMP_PREFIX = ".inprogress";
+
+    private static final ConfigOption<String> UPLOAD_CONTENT_TYPE =
+            ConfigOptions.key("gs.upload.content.type")
+                    .stringType()
+                    .defaultValue(DEFAULT_UPLOAD_CONTENT_TYPE)
+                    .withDescription("This option sets content type for uploaded files");
+
+    private static final ConfigOption<String> UPLOAD_TEMP_BUCKET =
+            ConfigOptions.key("gs.upload.temp.bucket")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "This option sets the bucket for temporary files for the recoverable writer. If empty, the same bucket of the file to upload is used.");
+
+    private static final ConfigOption<String> UPLOAD_TEMP_PREFIX =
+            ConfigOptions.key("gs.upload.temp.prefix")
+                    .stringType()
+                    .defaultValue(DEFAULT_UPLOAD_TEMP_PREFIX)
+                    .withDescription(
+                            "This option sets the prefix for temporary files for the recoverable writer");
+
+    private static final ConfigOption<Integer> UPLOAD_CHUNK_SIZE =
+            ConfigOptions.key("gs.upload.chunk.size")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "This option sets a custom chunk size for resumable uploads. A zero value (the default) means the chunk size will not be set and Google's default value will be used.");
+
+    private static HadoopConfigLoader createDefaultHadoopConfigLoader() {
+        return new HadoopConfigLoader(
+                FLINK_CONFIG_PREFIXES,
+                MIRRORED_CONFIG_KEYS,
+                "fs.gs.",
+                Collections.emptySet(),
+                Collections.emptySet(),
+                "");
+    }
+
+    private final GSFileSystemHelper fileSystemHelper;
+
+    private final HadoopConfigLoader hadoopConfigLoader;
+
+    private Configuration flinkConfig;
+
+    /**
+     * Constructs a GSFileSystemFactory.
+     *
+     * @param fileSystemHelper The {@link org.apache.flink.fs.gshadoop.GSFileSystemHelper} instance
+     * @param hadoopConfigLoader The hadoop configuration loader
+     */
+    private GSFileSystemFactory(
+            GSFileSystemHelper fileSystemHelper, HadoopConfigLoader hadoopConfigLoader) {
+        this.fileSystemHelper = Preconditions.checkNotNull(fileSystemHelper);
+        this.hadoopConfigLoader = Preconditions.checkNotNull(hadoopConfigLoader);
+
+        // assign an empty flink config so that we have an empty configuration in the event that
+        // the configure method (below) is not called for whatever reason
+        this.flinkConfig = new Configuration();
+    }
+
+    @VisibleForTesting
+    GSFileSystemFactory(GSFileSystemHelper fileSystemHelper) {
+        this(fileSystemHelper, createDefaultHadoopConfigLoader());
+    }
+
+    /** Constructs the factory using the default helper. */
+    public GSFileSystemFactory() {
+        this(new DefaultGSFileSystemHelper());
+    }
+
+    @Override
+    public String getScheme() {
+        return "gs";
+    }
+
+    @Override
+    public void configure(Configuration config) {
+        Preconditions.checkNotNull(config);
+
+        flinkConfig = config;
+        hadoopConfigLoader.setFlinkConfig(config);
+    }
+
+    @Override
+    public FileSystem create(URI fsUri) throws IOException {
+        Preconditions.checkNotNull(fsUri);
+
+        // configure the hadoop filesystem
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                hadoopConfigLoader.getOrLoadHadoopConfig();
+        org.apache.hadoop.fs.FileSystem hadoopFileSystem =
+                fileSystemHelper.createHadoopFileSystem();
+        hadoopFileSystem.initialize(fsUri, hadoopConfig);
+
+        // read options and construct options instance
+        GSRecoverableOptions options =
+                new GSRecoverableOptions(
+                        fileSystemHelper.getRecoverableWriterHelper(),
+                        flinkConfig.getString(UPLOAD_CONTENT_TYPE),
+                        flinkConfig.getString(UPLOAD_TEMP_BUCKET),
+                        flinkConfig.getString(UPLOAD_TEMP_PREFIX),
+                        flinkConfig.getInteger(UPLOAD_CHUNK_SIZE));
+
+        return new org.apache.flink.fs.gshadoop.GSFileSystem(hadoopFileSystem, options);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemFactory.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemFactory.java
@@ -45,7 +45,7 @@ public class GSFileSystemFactory implements FileSystemFactory {
     @VisibleForTesting
     public static final String DEFAULT_UPLOAD_CONTENT_TYPE = "application/octet-stream";
 
-    @VisibleForTesting public static final String DEFAULT_UPLOAD_TEMP_PREFIX = ".inprogress";
+    @VisibleForTesting public static final String DEFAULT_UPLOAD_TEMP_PREFIX = ".inprogress/";
 
     private static final ConfigOption<String> UPLOAD_CONTENT_TYPE =
             ConfigOptions.key("gs.upload.content.type")
@@ -65,7 +65,7 @@ public class GSFileSystemFactory implements FileSystemFactory {
                     .stringType()
                     .defaultValue(DEFAULT_UPLOAD_TEMP_PREFIX)
                     .withDescription(
-                            "This option sets the prefix for temporary files for the recoverable writer");
+                            "This option sets the prefix for temporary files for the recoverable writer. This should not start with a slash.");
 
     private static final ConfigOption<Integer> UPLOAD_CHUNK_SIZE =
             ConfigOptions.key("gs.upload.chunk.size")

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/GSFileSystemHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableWriterHelper;
+
+/** Abstracts away the implementations of Google Hadoop file system and storage. */
+public interface GSFileSystemHelper {
+    /**
+     * Creates a new instance of the hadoop file system.
+     *
+     * @return The file system, uninitialized
+     */
+    org.apache.hadoop.fs.FileSystem createHadoopFileSystem();
+
+    /**
+     * Accessor for the associated {@link
+     * org.apache.flink.fs.gshadoop.writer.GSRecoverableWriterHelper}, to be used with recoverable
+     * writers.
+     *
+     * @return The recoverable writer helper
+     */
+    GSRecoverableWriterHelper getRecoverableWriterHelper();
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/DefaultGSRecoverableWriterHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/DefaultGSRecoverableWriterHelper.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import com.google.cloud.RestorableState;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * The default implementation of the recoverable writer helper, which uses Google Storage directly.
+ */
+public class DefaultGSRecoverableWriterHelper extends GSRecoverableWriterHelper {
+
+    private final Storage storage;
+
+    /**
+     * Constructs a recoverable writer helper.
+     *
+     * @param storage The {@link com.google.cloud.storage.Storage} instance
+     */
+    public DefaultGSRecoverableWriterHelper(com.google.cloud.storage.Storage storage) {
+        this.storage = new Storage(storage);
+    }
+
+    @Override
+    public GSRecoverableWriterHelper.Storage getStorage() {
+        return storage;
+    }
+
+    /**
+     * Implements the Storage interface by delegating calls to a true {@link
+     * com.google.cloud.storage.Storage} instance.
+     */
+    static class Storage implements GSRecoverableWriterHelper.Storage {
+
+        private final com.google.cloud.storage.Storage storage;
+
+        /**
+         * Constructs the storage wrapper.
+         *
+         * @param storage The underlying Google {@link com.google.cloud.storage.Storage} instance
+         */
+        public Storage(com.google.cloud.storage.Storage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        public GSRecoverableWriterHelper.Writer createWriter(
+                BlobId blobId, String contentType, int chunkSize) {
+
+            BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType(contentType).build();
+            WriteChannel writeChannel = storage.writer(blobInfo);
+            if (chunkSize > 0) {
+                writeChannel.setChunkSize(chunkSize);
+            }
+            return new Writer(writeChannel);
+        }
+
+        @Override
+        public boolean exists(BlobId blobId) {
+            Blob blob = storage.get(blobId);
+            return blob != null;
+        }
+
+        @Override
+        public void copy(BlobId source, BlobId target) {
+            storage.get(source).copyTo(target).getResult();
+        }
+
+        @Override
+        public boolean delete(BlobId blobId) {
+            return storage.delete(blobId);
+        }
+    }
+
+    /**
+     * Implements the Writer interface by delegating calls to a true {@link
+     * com.google.cloud.WriteChannel} instance.
+     */
+    static class Writer implements GSRecoverableWriterHelper.Writer {
+
+        private final WriteChannel writeChannel;
+
+        /**
+         * Constructs the Writer wrapper.
+         *
+         * @param writeChannel The underlying {@link com.google.cloud.WriteChannel} instance
+         */
+        public Writer(WriteChannel writeChannel) {
+            this.writeChannel = writeChannel;
+        }
+
+        @Override
+        public int write(ByteBuffer byteBuffer) throws IOException {
+            return writeChannel.write(byteBuffer);
+        }
+
+        @Override
+        public void close() throws IOException {
+            writeChannel.close();
+        }
+
+        @Override
+        public GSRecoverableWriterHelper.WriterState capture() {
+            RestorableState<WriteChannel> restorableState = writeChannel.capture();
+            return new WriterState(restorableState);
+        }
+    }
+
+    /**
+     * Implements the WriterState interface by delegating calls to a true {@link
+     * com.google.cloud.RestorableState} instance.
+     *
+     * <p>This is serializable because the RestorableState it wraps is serializable, and this is the
+     * only way to serialize/deserialize it.
+     */
+    static class WriterState implements GSRecoverableWriterHelper.WriterState {
+
+        private static final long serialVersionUID = 1L;
+
+        private final RestorableState<WriteChannel> restorableState;
+
+        /**
+         * Constructs the WriterState wrapper.
+         *
+         * @param restorableState The {@link com.google.cloud.RestorableState} instance
+         */
+        public WriterState(RestorableState<WriteChannel> restorableState) {
+            this.restorableState = restorableState;
+        }
+
+        @Override
+        public GSRecoverableWriterHelper.Writer restore() {
+            WriteChannel writeChannel = restorableState.restore();
+            return new Writer(writeChannel);
+        }
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverable.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverable.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.util.Preconditions;
+
+/** Data structure that holds the recoverable state of a resumable upload. */
+class GSRecoverable implements RecoverableWriter.ResumeRecoverable {
+
+    /** The upload plan associated with this upload. */
+    public final GSRecoverablePlan plan;
+
+    /** The writer state associated with this upload. */
+    public final GSRecoverableWriterHelper.WriterState writerState;
+
+    /** The write position associated with this upload, i.e. number of bytes written. */
+    public final long position;
+
+    /**
+     * Constructs a GSRecoverable.
+     *
+     * @param plan The plan
+     * @param writerState The writer state
+     * @param position The write position
+     */
+    public GSRecoverable(
+            GSRecoverablePlan plan,
+            GSRecoverableWriterHelper.WriterState writerState,
+            long position) {
+        this.plan = Preconditions.checkNotNull(plan);
+        this.writerState = Preconditions.checkNotNull(writerState);
+        this.position = position;
+        Preconditions.checkArgument(position >= 0, "position must be non-negative: %s", position);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableCommitter.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableCommitter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.util.Preconditions;
+
+/** A committer for a recoverable upload to Google Storage. */
+class GSRecoverableCommitter implements RecoverableFsDataOutputStream.Committer {
+
+    private final GSRecoverableOptions options;
+
+    private final GSRecoverable recoverable;
+
+    GSRecoverableCommitter(GSRecoverableOptions options, GSRecoverable recoverable) {
+        this.options = Preconditions.checkNotNull(options);
+        this.recoverable = Preconditions.checkNotNull(recoverable);
+    }
+
+    private void deleteTempBlob() {
+        // this call returns a boolean which would be false to indicate the referenced blob
+        // doesn't exist; we disregard that result here, as either true or false means that
+        // the temp blob is gone
+        options.helper.getStorage().delete(recoverable.plan.tempBlobId);
+    }
+
+    @Override
+    public void commit() {
+        // copy from the temp blob to the final one
+        options.helper.getStorage().copy(recoverable.plan.tempBlobId, recoverable.plan.finalBlobId);
+
+        // delete the temp blob
+        deleteTempBlob();
+    }
+
+    @Override
+    public void commitAfterRecovery() {
+        // is the final blob in place?
+        if (options.helper.getStorage().exists(recoverable.plan.finalBlobId)) {
+            // yes, so just make sure that the temp blob is deleted
+            deleteTempBlob();
+        } else {
+            // no, so do the full commit
+            commit();
+        }
+    }
+
+    @Override
+    public RecoverableWriter.CommitRecoverable getRecoverable() {
+        return recoverable;
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableFsDataOutputStream.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Implementation of {@link org.apache.flink.core.fs.RecoverableFsDataOutputStream} for Google
+ * Storage.
+ */
+class GSRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
+
+    private final GSRecoverableOptions options;
+
+    @VisibleForTesting final GSRecoverablePlan plan;
+
+    private final GSRecoverableWriterHelper.Writer writer;
+
+    private long position;
+
+    GSRecoverableFsDataOutputStream(
+            GSRecoverableOptions options,
+            GSRecoverablePlan plan,
+            GSRecoverableWriterHelper.Writer writer,
+            long position) {
+        this.options = Preconditions.checkNotNull(options);
+        this.plan = Preconditions.checkNotNull(plan);
+        this.writer = Preconditions.checkNotNull(writer);
+        this.position = position;
+        Preconditions.checkArgument(position >= 0, "position must be non-negative: %s", position);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return position;
+    }
+
+    @Override
+    public void write(byte[] bytes, int start, int length) throws IOException {
+        Preconditions.checkNotNull(bytes);
+        Preconditions.checkArgument(start >= 0, "start must be non-negative: %s", start);
+        Preconditions.checkArgument(length >= 0, "length must be non-negative: %s", length);
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes, start, length);
+        int writtenCount = writer.write(buffer);
+
+        // we have no way to inform the caller of (or otherwise handle) a partial write, so if the
+        // number of bytes written doesn't match the number of bytes that were requested to
+        // be written, throw an exception
+        if (length != writtenCount) {
+            throw new IOException(
+                    String.format(
+                            "Only %s of %s bytes were written to the write channel",
+                            writtenCount, length));
+        }
+
+        // adjust the position to account for the successful write
+        position += writtenCount;
+    }
+
+    @Override
+    public void write(byte[] bytes) throws IOException {
+        Preconditions.checkNotNull(bytes);
+
+        write(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void write(int byteValue) throws IOException {
+        byte[] bytes = new byte[] {(byte) byteValue};
+        write(bytes);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // flush is not supported by WriteChannel
+    }
+
+    @Override
+    public void sync() throws IOException {
+        // sync is not supported by WriteChannel
+    }
+
+    @Override
+    public RecoverableWriter.ResumeRecoverable persist() throws IOException {
+        GSRecoverableWriterHelper.WriterState writerState = writer.capture();
+        return new GSRecoverable(plan, writerState, position);
+    }
+
+    @Override
+    public void close() throws IOException {
+        writer.close();
+    }
+
+    @Override
+    public Committer closeForCommit() throws IOException {
+        GSRecoverable recoverable = (GSRecoverable) persist();
+        close();
+        return new GSRecoverableCommitter(options, recoverable);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableOptions.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableOptions.java
@@ -60,8 +60,8 @@ public class GSRecoverableOptions {
      * @param uploadContentType The upload content type
      * @param uploadTempBucket The bucket to use for temporary upload files. If null, the bucket of
      *     the target file is used.
-     * @param uploadTempPrefix The prefix to use for uploaded files, which must not have leading or
-     *     trailing slashes.
+     * @param uploadTempPrefix The prefix to use for uploaded files, which must not have leading
+     *     slash.
      * @param uploadChunkSize The chunk size to use for uploads
      */
     public GSRecoverableOptions(
@@ -78,10 +78,6 @@ public class GSRecoverableOptions {
         Preconditions.checkArgument(
                 !uploadTempPrefix.startsWith(Path.SEPARATOR),
                 "Upload temp prefix must not start with a separator: %s",
-                uploadTempPrefix);
-        Preconditions.checkArgument(
-                !uploadTempPrefix.endsWith(Path.SEPARATOR),
-                "Upload temp prefix must not end with a separator: %s",
                 uploadTempPrefix);
 
         this.uploadChunkSize = uploadChunkSize;
@@ -110,12 +106,8 @@ public class GSRecoverableOptions {
 
         UUID tempUniqueId = UUID.randomUUID();
         String tempObjectName =
-                String.join(
-                        org.apache.flink.core.fs.Path.SEPARATOR,
-                        uploadTempPrefix,
-                        finalObjectName,
-                        tempUniqueId.toString());
-
+                String.format(
+                        "%s%s/%s", uploadTempPrefix, finalObjectName, tempUniqueId.toString());
         BlobId tempBlobId = BlobId.of(tempBucketName, tempObjectName);
         BlobId finalBlobId = BlobId.of(finalBucketName, finalObjectName);
         return new GSRecoverablePlan(tempBlobId, finalBlobId);

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableOptions.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableOptions.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
+import com.google.cloud.storage.BlobId;
+import org.apache.hadoop.fs.Path;
+
+import javax.annotation.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Data structure holding options for the Google Storage recoverable writer. These options are
+ * determined by the factory and are common to all instances of the recoverable writer.
+ */
+public class GSRecoverableOptions {
+
+    /** The recoverable writer helper to use. */
+    public final GSRecoverableWriterHelper helper;
+
+    /** The content type for uploaded blobs. */
+    public final String uploadContentType;
+
+    /**
+     * The bucket to use for temporary blobs; if null, temporary blobs are put into the same bucket
+     * as the "final" blobs being uploaded.
+     */
+    @Nullable public final String uploadTempBucket;
+
+    /** The prefix to use in constructing temporary blob names. */
+    public final String uploadTempPrefix;
+
+    /** The minimum chunk size to use when uploading files; this controls flushing. */
+    public final int uploadChunkSize;
+
+    /**
+     * Creates a GSRecoverableOptions object.
+     *
+     * @param helper The helper, which wraps the interactions with Google Storage or a mock
+     * @param uploadContentType The upload content type
+     * @param uploadTempBucket The bucket to use for temporary upload files. If null, the bucket of
+     *     the target file is used.
+     * @param uploadTempPrefix The prefix to use for uploaded files, which must not have leading or
+     *     trailing slashes.
+     * @param uploadChunkSize The chunk size to use for uploads
+     */
+    public GSRecoverableOptions(
+            GSRecoverableWriterHelper helper,
+            String uploadContentType,
+            @Nullable String uploadTempBucket,
+            String uploadTempPrefix,
+            int uploadChunkSize) {
+
+        this.helper = Preconditions.checkNotNull(helper);
+        this.uploadContentType = Preconditions.checkNotNull(Strings.emptyToNull(uploadContentType));
+        this.uploadTempBucket = Strings.emptyToNull(uploadTempBucket);
+        this.uploadTempPrefix = Preconditions.checkNotNull(Strings.emptyToNull(uploadTempPrefix));
+        Preconditions.checkArgument(
+                !uploadTempPrefix.startsWith(Path.SEPARATOR),
+                "Upload temp prefix must not start with a separator: %s",
+                uploadTempPrefix);
+        Preconditions.checkArgument(
+                !uploadTempPrefix.endsWith(Path.SEPARATOR),
+                "Upload temp prefix must not end with a separator: %s",
+                uploadTempPrefix);
+
+        this.uploadChunkSize = uploadChunkSize;
+        Preconditions.checkArgument(
+                uploadChunkSize >= 0,
+                "upload chunk size must be non-negative: %s",
+                uploadChunkSize);
+    }
+
+    /**
+     * Helper method to create a {@link org.apache.flink.fs.gshadoop.writer.GSRecoverablePlan} for a
+     * given final bucket and object name, taking into account the options.
+     *
+     * @param finalBucketName The name of the bucket for the final uploaded blob
+     * @param finalObjectName The name of the object for the final uploaded blob
+     * @return The plan
+     */
+    GSRecoverablePlan createPlan(String finalBucketName, String finalObjectName) {
+        Preconditions.checkNotNull(Strings.emptyToNull(finalBucketName));
+        Preconditions.checkNotNull(Strings.emptyToNull(finalObjectName));
+
+        String tempBucketName = uploadTempBucket;
+        if (Strings.isNullOrEmpty(tempBucketName)) {
+            tempBucketName = finalBucketName;
+        }
+
+        UUID tempUniqueId = UUID.randomUUID();
+        String tempObjectName =
+                String.join(
+                        org.apache.flink.core.fs.Path.SEPARATOR,
+                        uploadTempPrefix,
+                        finalObjectName,
+                        tempUniqueId.toString());
+
+        BlobId tempBlobId = BlobId.of(tempBucketName, tempObjectName);
+        BlobId finalBlobId = BlobId.of(finalBucketName, finalObjectName);
+        return new GSRecoverablePlan(tempBlobId, finalBlobId);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverablePlan.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverablePlan.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.util.Preconditions;
+
+import com.google.cloud.storage.BlobId;
+
+/**
+ * Data structure holding the upload plan for a single blob, including the temporary blob id used
+ * for the resumable upload, and the final blob id that will be copied to upon commit.
+ */
+class GSRecoverablePlan {
+
+    /** The temporary blob id. */
+    public final BlobId tempBlobId;
+
+    /** The final blob id. */
+    public final BlobId finalBlobId;
+
+    /**
+     * Constructs a plan object.
+     *
+     * @param tempBlobId The temporary blob id
+     * @param finalBlobId The final blob id
+     */
+    GSRecoverablePlan(BlobId tempBlobId, BlobId finalBlobId) {
+        this.tempBlobId = Preconditions.checkNotNull(tempBlobId);
+        this.finalBlobId = Preconditions.checkNotNull(finalBlobId);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableSerializer.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableSerializer.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+
+import com.google.cloud.storage.BlobId;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Serializer for {@link org.apache.flink.fs.gshadoop.writer.GSRecoverable}.
+ *
+ * <p>Note that this deliberately breaks the Flink project guidance to never use Java serialization;
+ * the {@link com.google.cloud.RestorableState} instance that is used to persist states of the
+ * {@link com.google.cloud.WriteChannel} is an opaque object that supports Java serialization, so
+ * there seems to be no other way to serde it.
+ */
+class GSRecoverableSerializer implements SimpleVersionedSerializer<GSRecoverable> {
+
+    private static final int SERIALIZER_VERSION = 0;
+
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+    static final GSRecoverableSerializer INSTANCE = new GSRecoverableSerializer();
+
+    /**
+     * Helper to serialize a blob id, using the package name and object name directly.
+     *
+     * @param blobId The blob id
+     * @return The serialized bytes
+     */
+    private static byte[] serializeBlobId(BlobId blobId) {
+        byte[] bucketBytes = blobId.getBucket().getBytes(CHARSET);
+        byte[] nameBytes = blobId.getName().getBytes(CHARSET);
+
+        int bufferLength = 2 * Integer.BYTES + bucketBytes.length + nameBytes.length;
+        ByteBuffer buffer = ByteBuffer.allocate(bufferLength);
+        buffer.putInt(bucketBytes.length);
+        buffer.put(bucketBytes);
+        buffer.putInt(nameBytes.length);
+        buffer.put(nameBytes);
+
+        return buffer.array();
+    }
+
+    /**
+     * Helper to deserializer a blob id.
+     *
+     * @param bytes The serialized bytes
+     * @return The blob id
+     */
+    private static BlobId deserializeBlobId(byte[] bytes, int initialOffset, int length) {
+        int offset = initialOffset;
+        int bucketLength = ByteBuffer.wrap(bytes, offset, Integer.BYTES).getInt();
+        offset += Integer.BYTES;
+        String bucketName = CHARSET.decode(ByteBuffer.wrap(bytes, offset, bucketLength)).toString();
+        offset += bucketLength;
+        int objectNameLength = ByteBuffer.wrap(bytes, offset, Integer.BYTES).getInt();
+        offset += Integer.BYTES;
+        String objectName =
+                CHARSET.decode(ByteBuffer.wrap(bytes, offset, objectNameLength)).toString();
+        return BlobId.of(bucketName, objectName);
+    }
+
+    /**
+     * Helper to serialize a GSWriterStateAdapter. This adapter wraps an opaque serializable object
+     * from Google Storage, so we have to use Java serialization.
+     *
+     * @param writerState The writer state to serialize
+     * @return Serialized byte array
+     * @throws IOException On serialization failure
+     */
+    private static byte[] serializeWriterState(GSRecoverableWriterHelper.WriterState writerState)
+            throws IOException {
+        Preconditions.checkNotNull(writerState);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+                objectOutputStream.writeObject(writerState);
+                objectOutputStream.flush();
+                return outputStream.toByteArray();
+            }
+        }
+    }
+
+    /**
+     * Helper to deserialize a GSWriterStateAdapter. This adapter wraps an opaque serializable
+     * object from Google Storage, so we have to use Java serialization.
+     *
+     * @param bytes The serialized bytes
+     * @param offset The start point in the serialized bytes
+     * @param length The length of the serialized data
+     * @return The serializable object
+     * @throws IOException If deserialization fails
+     */
+    private static GSRecoverableWriterHelper.WriterState deserializeWriterState(
+            byte[] bytes, int offset, int length) throws IOException {
+        Preconditions.checkNotNull(bytes);
+        Preconditions.checkArgument(offset >= 0, "offset must be non-negative: %s", offset);
+        Preconditions.checkArgument(length >= 0, "length must be non-negative: %s", length);
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes, offset, length)) {
+            try (ObjectInputStream objectInputStream = new ObjectInputStream(inputStream)) {
+                try {
+                    return (GSRecoverableWriterHelper.WriterState) objectInputStream.readObject();
+                } catch (ClassNotFoundException ex) {
+                    throw new IOException(ex);
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getVersion() {
+        return SERIALIZER_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(GSRecoverable recoverable) throws IOException {
+        Preconditions.checkNotNull(recoverable);
+
+        // serialize these objects from the Google API
+        byte[] tempBlobIdBytes = serializeBlobId(recoverable.plan.tempBlobId);
+        byte[] finalBlobIdBytes = serializeBlobId(recoverable.plan.finalBlobId);
+        byte[] writeStateBytes = serializeWriterState(recoverable.writerState);
+
+        // total length is sum of lengths of:
+        // 1) serialized temp blob id, length(int) + serialized length
+        // 2) serialized final blob id, length(int) + serialized length
+        // 3) serialized restorable state, length(int) + serialized length
+        // 4) position (long)
+        int serializedLength =
+                Integer.BYTES * 3
+                        + tempBlobIdBytes.length
+                        + finalBlobIdBytes.length
+                        + writeStateBytes.length
+                        + Long.BYTES;
+
+        ByteBuffer buffer = ByteBuffer.allocate(serializedLength);
+
+        // tempBlobId
+        buffer.putInt(tempBlobIdBytes.length);
+        buffer.put(tempBlobIdBytes);
+
+        // finalBlobId
+        buffer.putInt(finalBlobIdBytes.length);
+        buffer.put(finalBlobIdBytes);
+
+        // writeState
+        buffer.putInt(writeStateBytes.length);
+        buffer.put(writeStateBytes);
+
+        // position
+        buffer.putLong(recoverable.position);
+
+        return buffer.array();
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public GSRecoverable deserialize(int version, byte[] bytes) throws IOException {
+        Preconditions.checkNotNull(bytes);
+        // only support version 0 for now
+        Preconditions.checkArgument(version == 0, "serialized version must be 0");
+
+        // the current offset in the serialized byte array
+        int offset = 0;
+
+        // tempBlobId
+        int tempBlobIdBytesLength = ByteBuffer.wrap(bytes, offset, Integer.BYTES).getInt();
+        offset += Integer.BYTES;
+        BlobId tempBlobId = (BlobId) deserializeBlobId(bytes, offset, tempBlobIdBytesLength);
+        offset += tempBlobIdBytesLength;
+
+        // finalBlobId
+        int finalBlobIdBytesLength = ByteBuffer.wrap(bytes, offset, Integer.BYTES).getInt();
+        offset += Integer.BYTES;
+        BlobId finalBlobId = (BlobId) deserializeBlobId(bytes, offset, finalBlobIdBytesLength);
+        offset += finalBlobIdBytesLength;
+
+        // writeState
+        int writerStateLength = ByteBuffer.wrap(bytes, offset, Integer.BYTES).getInt();
+        offset += Integer.BYTES;
+        GSRecoverableWriterHelper.WriterState writerState =
+                deserializeWriterState(bytes, offset, writerStateLength);
+        offset += writerStateLength;
+
+        // position
+        long position = ByteBuffer.wrap(bytes, offset, Long.BYTES).getLong();
+
+        GSRecoverablePlan plan = new GSRecoverablePlan(tempBlobId, finalBlobId);
+        return new GSRecoverable(plan, writerState, position);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriter.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriter.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.net.URI;
+
+/** Implementation of {@link org.apache.flink.core.fs.RecoverableWriter} for Google Storage. */
+public class GSRecoverableWriter implements RecoverableWriter {
+
+    private final GSRecoverableOptions options;
+
+    /**
+     * Construct a Google Storage recoverable writer.
+     *
+     * @param options The {@link org.apache.flink.fs.gshadoop.writer.GSRecoverableOptions} to use
+     *     for this recoverable writer.
+     */
+    public GSRecoverableWriter(GSRecoverableOptions options) {
+        this.options = Preconditions.checkNotNull(options);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream open(Path path) throws IOException {
+        Preconditions.checkNotNull(path);
+
+        URI pathUri = path.toUri();
+        String finalBucketName = pathUri.getAuthority();
+        String finalObjectName = pathUri.getPath().substring(1); // remove leading forward slash
+
+        GSRecoverablePlan plan = options.createPlan(finalBucketName, finalObjectName);
+        GSRecoverableWriterHelper.Writer writer =
+                options.helper
+                        .getStorage()
+                        .createWriter(
+                                plan.tempBlobId,
+                                options.uploadContentType,
+                                options.uploadChunkSize);
+        return new GSRecoverableFsDataOutputStream(options, plan, writer, 0);
+    }
+
+    @Override
+    public boolean supportsResume() {
+        return true;
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream recover(ResumeRecoverable resumable) {
+        Preconditions.checkNotNull(resumable);
+
+        GSRecoverable recoverable = (GSRecoverable) resumable;
+        GSRecoverableWriterHelper.Writer writer = recoverable.writerState.restore();
+        return new GSRecoverableFsDataOutputStream(
+                options, recoverable.plan, writer, recoverable.position);
+    }
+
+    @Override
+    public boolean requiresCleanupOfRecoverableState() {
+        return true;
+    }
+
+    @Override
+    public boolean cleanupRecoverableState(ResumeRecoverable resumable) {
+        Preconditions.checkNotNull(resumable);
+
+        GSRecoverable recoverable = (GSRecoverable) resumable;
+        return options.helper.getStorage().delete(recoverable.plan.tempBlobId);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream.Committer recoverForCommit(CommitRecoverable resumable)
+            throws IOException {
+        Preconditions.checkNotNull(resumable);
+
+        GSRecoverable recoverable = (GSRecoverable) resumable;
+        RecoverableFsDataOutputStream outputStream = recover(recoverable);
+        return outputStream.closeForCommit();
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public SimpleVersionedSerializer<CommitRecoverable> getCommitRecoverableSerializer() {
+        return (SimpleVersionedSerializer) GSRecoverableSerializer.INSTANCE;
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public SimpleVersionedSerializer<ResumeRecoverable> getResumeRecoverableSerializer() {
+        return (SimpleVersionedSerializer) GSRecoverableSerializer.INSTANCE;
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterHelper.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import com.google.cloud.storage.BlobId;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+/** This class abstracts away the Google Storage implementation details, allowing for mocking. */
+public abstract class GSRecoverableWriterHelper {
+
+    /**
+     * Provides access to the inner storage interface.
+     *
+     * @return Storage interface.
+     */
+    public abstract Storage getStorage();
+
+    /**
+     * Wraps the operations performed against the {@link com.google.cloud.storage.Storage} class.
+     */
+    public interface Storage {
+
+        /**
+         * Creates a writer object for a resumable upload.
+         *
+         * @param blobId The blob id to write to
+         * @param contentType The content type for the upload
+         * @param chunkSize The min chunk size for the upload; if zero, the default value will be
+         *     used
+         * @return The writer interface
+         */
+        Writer createWriter(BlobId blobId, String contentType, int chunkSize);
+
+        /**
+         * Determines whether a given blob exists.
+         *
+         * @param blobId The blob id to check
+         * @return True if the blob exists; false otherwise
+         */
+        boolean exists(BlobId blobId);
+
+        /**
+         * Copies a blob from one location to another. Note this does not delete the source blob, it
+         * is a copy, not a move.
+         *
+         * @param sourceBlobId The source blob id
+         * @param targetBlobId The target blob id
+         */
+        void copy(BlobId sourceBlobId, BlobId targetBlobId);
+
+        /**
+         * Deletes a blob. Note that this does not fail if the blob doesn't exist.
+         *
+         * @param blobId The blob id to delete
+         * @return True if the blob did exist and was deleted; false if the blob didn't exist
+         */
+        boolean delete(BlobId blobId);
+    }
+
+    /** Wraps the operations performed by the {@link com.google.cloud.WriteChannel} interface. */
+    public interface Writer {
+
+        /**
+         * Writes a buffer of bytes.
+         *
+         * @param byteBuffer The bytes to write
+         * @return The number of bytes written, this can be less than the entire buffer size
+         * @throws IOException On failure of the underlying write
+         */
+        int write(ByteBuffer byteBuffer) throws IOException;
+
+        /**
+         * Closes the writer.
+         *
+         * @throws IOException On failure of the underlying close
+         */
+        void close() throws IOException;
+
+        /**
+         * Captures the state of the writer so that it can be restored later.
+         *
+         * @return The writer state
+         */
+        WriterState capture();
+    }
+
+    /**
+     * Wraps the operations performed by the {@link com.google.cloud.RestorableState} interface. for
+     * a {@link com.google.cloud.WriteChannel}.
+     *
+     * <p>This is serializable because, in the default implementation of this helper, the writer
+     * state is represented by an instance of {@link com.google.cloud.RestorableState}, which is an
+     * opaque object that is serializable, and Java serialization must be used to persist it.
+     */
+    public interface WriterState extends Serializable {
+
+        /**
+         * Restores a previously captured writer.
+         *
+         * @return The restored writer
+         */
+        Writer restore();
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,49 @@
+flink-s3-fs-hadoop
+Copyright 2014-2021 The Apache Software Foundation
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.amazonaws:aws-java-sdk-core:1.11.788
+- com.amazonaws:aws-java-sdk-dynamodb:1.11.788
+- com.amazonaws:aws-java-sdk-kms:1.11.788
+- com.amazonaws:aws-java-sdk-s3:1.11.788
+- com.amazonaws:aws-java-sdk-sts:1.11.788
+- com.amazonaws:jmespath-java:1.11.788
+- com.fasterxml.jackson.core:jackson-annotations:2.12.1
+- com.fasterxml.jackson.core:jackson-core:2.12.1
+- com.fasterxml.jackson.core:jackson-databind:2.12.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.1
+- com.fasterxml.woodstox:woodstox-core:5.0.3
+- com.google.guava:guava:11.0.2
+- commons-beanutils:commons-beanutils:1.9.4
+- commons-codec:commons-codec:1.13
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.7
+- commons-lang:commons-lang:2.6
+- commons-logging:commons-logging:1.1.3
+- joda-time:joda-time:2.5
+- org.apache.commons:commons-configuration2:2.1.1
+- org.apache.commons:commons-lang3:3.3.2
+- org.apache.hadoop:hadoop-auth:3.1.0
+- org.apache.hadoop:hadoop-annotations:3.1.0
+- org.apache.hadoop:hadoop-aws:3.1.0
+- org.apache.hadoop:hadoop-common:3.1.0
+- org.apache.htrace:htrace-core4:4.1.0-incubating
+- org.apache.httpcomponents:httpcore:4.4.6
+- org.apache.httpcomponents:httpclient:4.5.9
+- software.amazon.ion:ion-java:1.0.2
+
+This project bundles the following dependencies under the CDDL 1.1 license.
+See bundled license files for details.
+
+- javax.xml.bind:jaxb-api:2.3.1
+
+This project bundles the following dependencies under the Go License (https://golang.org/LICENSE).
+See bundled license files for details.
+
+- com.google.re2j:re2j:1.1
+
+This project bundles the following dependencies under BSD License (https://opensource.org/licenses/bsd-license.php).
+See bundled license files for details.
+
+- org.codehaus.woodstox:stax2-api:3.1.4 (https://github.com/FasterXML/stax2-api/tree/stax2-api-3.1.4)

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE-re2j
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE-re2j
@@ -1,0 +1,32 @@
+This is a work derived from Russ Cox's RE2 in Go, whose license
+http://golang.org/LICENSE is as follows:
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Google Inc. nor the names of its contributors
+     may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE-stax2api
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE-stax2api
@@ -1,0 +1,22 @@
+Copyright woodstox stax2api contributors.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE.jaxb
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/licenses/LICENSE.jaxb
@@ -1,0 +1,135 @@
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)Version 1.1
+
+1. Definitions.
+
+     1.1. "Contributor" means each individual or entity that creates or contributes to the creation of Modifications.
+
+     1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
+
+     1.3. "Covered Software" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
+
+     1.4. "Executable" means the Covered Software in any form other than Source Code.
+
+     1.5. "Initial Developer" means the individual or entity that first makes Original Software available under this License.
+
+     1.6. "Larger Work" means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.
+
+     1.7. "License" means this document.
+
+     1.8. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
+
+     1.9. "Modifications" means the Source Code and Executable form of any of the following:
+
+     A. Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
+
+     B. Any new file that contains any part of the Original Software or previous Modification; or
+
+     C. Any new file that is contributed or otherwise made available under the terms of this License.
+
+     1.10. "Original Software" means the Source Code and Executable form of computer software code that is originally released under this License.
+
+     1.11. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
+
+     1.12. "Source Code" means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.
+
+     1.13. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants.
+
+     2.1. The Initial Developer Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
+
+     (c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
+
+     (d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
+
+     2.2. Contributor Grant.
+
+     Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+     (a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
+
+     (b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
+
+     (c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the date Contributor first distributes or otherwise makes the Modifications available to a third party.
+
+     (d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1) for any code that Contributor has deleted from the Contributor Version; (2) for infringements caused by: (i) third party modifications of Contributor Version, or (ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or (3) under Patent Claims infringed by Covered Software in the absence of Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+     3.1. Availability of Source Code.
+
+     Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.
+
+     3.2. Modifications.
+
+     The Modifications that You create or to which You contribute are governed by the terms of this License. You represent that You believe Your Modifications are Your original creation(s) and/or You have sufficient rights to grant the rights conveyed by this License.
+
+     3.3. Required Notices.
+
+     You must include a notice in each of Your Modifications that identifies You as the Contributor of the Modification. You may not remove or alter any copyright, patent or trademark notices contained within the Covered Software, or any notices of licensing or any descriptive text giving attribution to any Contributor or the Initial Developer.
+
+     3.4. Application of Additional Terms.
+
+     You may not offer or impose any terms on any Covered Software in Source Code form that alters or restricts the applicable version of this License or the recipients' rights hereunder. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, you may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear that any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.5. Distribution of Executable Versions.
+
+     You may distribute the Executable form of the Covered Software under the terms of this License or under the terms of a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable form does not attempt to limit or alter the recipient's rights in the Source Code form from the rights set forth in this License. If You distribute the Covered Software in Executable form under a different license, You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.6. Larger Works.
+
+     You may create a Larger Work by combining Covered Software with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Software.
+
+4. Versions of the License.
+
+     4.1. New Versions.
+
+     Oracle is the initial license steward and may publish revised and/or new versions of this License from time to time. Each version will be given a distinguishing version number. Except as provided in Section 4.3, no one other than the license steward has the right to modify this License.
+
+     4.2. Effect of New Versions.
+
+     You may always continue to use, distribute or otherwise make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. If the Initial Developer includes a notice in the Original Software prohibiting it from being distributed or otherwise made available under any subsequent version of the License, You must distribute and make the Covered Software available under the terms of the version of the License under which You originally received the Covered Software. Otherwise, You may also choose to use, distribute or otherwise make the Covered Software available under the terms of any subsequent version of the License published by the license steward.
+
+     4.3. Modified Versions.
+
+     When You are an Initial Developer and You want to create a new license for Your Original Software, You may create and use a modified version of this License if You: (a) rename the license and remove any references to the name of the license steward (except to note that the license differs from this License); and (b) otherwise make it clear that the license contains terms which differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+     COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+6. TERMINATION.
+
+     6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+     6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as "Participant") alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.
+
+     6.3. If You assert a patent infringement claim against Participant alleging that the Participant Software directly or indirectly infringes any patent where such claim is resolved (such as by license or settlement) prior to the initiation of patent infringement litigation, then the reasonable value of the licenses granted by such Participant under Sections 2.1 or 2.2 shall be taken into account in determining the amount or value of any payment or license.
+
+     6.4. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+     UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+     The Covered Software is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" (as that term is defined at 48 C.F.R. ? 252.227-7014(a)(1)) and "commercial computer software documentation" as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Software with only those rights set forth herein. This U.S. Government Rights clause is in lieu of, and supersedes, any other FAR, DFAR, or other clause or provision that addresses Government rights in computer software under this License.
+
+9. MISCELLANEOUS.
+
+     This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by the law of the jurisdiction specified in a notice contained within the Original Software (except to the extent applicable law, if any, provides otherwise), excluding such jurisdiction's conflict-of-law provisions. Any litigation relating to this License shall be subject to the jurisdiction of the courts located in the jurisdiction and venue specified in a notice contained within the Original Software, with the losing party responsible for costs, including, without limitation, court costs and reasonable attorneys' fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License. You agree that You alone are responsible for compliance with the United States export administration regulations (and the export control laws and regulation of any other countries) when You use, distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+     As between Initial Developer and the Contributors, each party is responsible for claims and damages arising, directly or indirectly, out of its utilization of rights under this License and You agree to work with Initial Developer and Contributors to distribute such responsibility on an equitable basis. Nothing herein is intended or shall be deemed to constitute any admission of liability.
+
+----------
+NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
+The code released under the CDDL shall be governed by the laws of the State of California (excluding conflict-of-law provisions). Any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California and the state courts of the State of California, with venue lying in Santa Clara County, California.

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.gshadoop.GSFileSystemFactory

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/GSFileSystemTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/GSFileSystemTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/** Tests the GS file system factory. */
+public class GSFileSystemTest extends TestLogger {
+
+    private static final URI FS_URI = URI.create("gs://bucket/name");
+
+    private GSFileSystemFactory fileSystemFactory;
+
+    @Before
+    public void setup() {
+        MockGSFileSystemHelper fileSystemHelper = new MockGSFileSystemHelper();
+        fileSystemFactory = new GSFileSystemFactory(fileSystemHelper);
+    }
+
+    @Test
+    public void testScheme() {
+        assertEquals("gs", fileSystemFactory.getScheme());
+    }
+
+    @Test
+    public void testCreateWithDefaultOptions() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        fileSystemFactory.configure(flinkConfig);
+        GSFileSystem fileSystem = (GSFileSystem) fileSystemFactory.create(FS_URI);
+
+        assertNotNull(fileSystem);
+        assertEquals(FS_URI, fileSystem.hadoopFileSystem.getUri());
+
+        assertEquals(
+                GSFileSystemFactory.DEFAULT_UPLOAD_CONTENT_TYPE,
+                fileSystem.options.uploadContentType);
+        assertNull(fileSystem.options.uploadTempBucket);
+        assertEquals(
+                GSFileSystemFactory.DEFAULT_UPLOAD_TEMP_PREFIX,
+                fileSystem.options.uploadTempPrefix);
+    }
+
+    @Test
+    public void testCreateWithNonDefaultOptions() throws IOException {
+        final String specifiedBucket = "BUCKET";
+        final String specifiedPrefix = "PREFIX";
+        final String specifiedContentTypE = "CONTENT_TYPE";
+
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.temp.bucket", specifiedBucket);
+        flinkConfig.setString("gs.upload.temp.prefix", specifiedPrefix);
+        flinkConfig.setString("gs.upload.content.type", specifiedContentTypE);
+        fileSystemFactory.configure(flinkConfig);
+        GSFileSystem fileSystem = (GSFileSystem) fileSystemFactory.create(FS_URI);
+
+        assertNotNull(fileSystem);
+        assertNotNull(fileSystem.hadoopFileSystem);
+        assertNotNull(fileSystem.options);
+        assertEquals(FS_URI, fileSystem.hadoopFileSystem.getUri());
+
+        assertEquals(specifiedBucket, fileSystem.options.uploadTempBucket);
+        assertEquals(specifiedPrefix, fileSystem.options.uploadTempPrefix);
+        assertEquals(specifiedContentTypE, fileSystem.options.uploadContentType);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithEmptyPrefix() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.temp.prefix", "");
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithNullPrefix() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.temp.prefix", null);
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateWithLeadingSeparatorPrefix() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.temp.prefix", "/prefix");
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateWithTrailingSeparatorPrefix() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.temp.prefix", "prefix/");
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithEmptyContentType() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.content.type", "");
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithNullContentType() throws IOException {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("gs.upload.content.type", null);
+        fileSystemFactory.configure(flinkConfig);
+        fileSystemFactory.create(FS_URI);
+    }
+
+    @Test
+    public void testHadoopOptionsPassThrough() throws IOException {
+        final String projectId = "PROJECT_ID";
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString("fs.gs.project.id", projectId);
+        fileSystemFactory.configure(flinkConfig);
+        org.apache.flink.fs.gshadoop.GSFileSystem fileSystem =
+                (org.apache.flink.fs.gshadoop.GSFileSystem) fileSystemFactory.create(FS_URI);
+        assertEquals(projectId, fileSystem.hadoopFileSystem.getConf().get("fs.gs.project.id"));
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/GSFileSystemTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/GSFileSystemTest.java
@@ -70,7 +70,7 @@ public class GSFileSystemTest extends TestLogger {
     @Test
     public void testCreateWithNonDefaultOptions() throws IOException {
         final String specifiedBucket = "BUCKET";
-        final String specifiedPrefix = "PREFIX";
+        final String specifiedPrefix = "PREFIX/";
         final String specifiedContentTypE = "CONTENT_TYPE";
 
         Configuration flinkConfig = new Configuration();
@@ -110,14 +110,6 @@ public class GSFileSystemTest extends TestLogger {
     public void testCreateWithLeadingSeparatorPrefix() throws IOException {
         Configuration flinkConfig = new Configuration();
         flinkConfig.setString("gs.upload.temp.prefix", "/prefix");
-        fileSystemFactory.configure(flinkConfig);
-        fileSystemFactory.create(FS_URI);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testCreateWithTrailingSeparatorPrefix() throws IOException {
-        Configuration flinkConfig = new Configuration();
-        flinkConfig.setString("gs.upload.temp.prefix", "prefix/");
         fileSystemFactory.configure(flinkConfig);
         fileSystemFactory.create(FS_URI);
     }

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/MockGSFileSystemHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/MockGSFileSystemHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.flink.fs.gshadoop.writer.GSRecoverableWriterHelper;
+import org.apache.flink.fs.gshadoop.writer.MockGSRecoverableWriterHelper;
+
+import org.apache.hadoop.fs.FileSystem;
+
+/** Mock implementation of the file system helper. */
+public class MockGSFileSystemHelper implements GSFileSystemHelper {
+
+    private final MockGSRecoverableWriterHelper recoverableWriterHelper;
+
+    /** Constructs a mock file system helper. */
+    public MockGSFileSystemHelper() {
+        this.recoverableWriterHelper = new MockGSRecoverableWriterHelper();
+    }
+
+    @Override
+    public FileSystem createHadoopFileSystem() {
+        return new MockHadoopFileSystem();
+    }
+
+    @Override
+    public GSRecoverableWriterHelper getRecoverableWriterHelper() {
+        return recoverableWriterHelper;
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/MockHadoopFileSystem.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/MockHadoopFileSystem.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+
+/** Mock implementation of a hadoop file system. */
+class MockHadoopFileSystem extends FileSystem {
+
+    private URI uri;
+    Configuration conf;
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public Configuration getConf() {
+        return conf;
+    }
+
+    @Override
+    public void initialize(URI uri, Configuration conf) throws IOException {
+        this.uri = uri;
+        this.conf = conf;
+    }
+
+    @Override
+    public FSDataInputStream open(Path path, int i) throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public FSDataOutputStream create(
+            Path path,
+            FsPermission fsPermission,
+            boolean b,
+            int i,
+            short i1,
+            long l,
+            Progressable progressable)
+            throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public FSDataOutputStream append(Path path, int i, Progressable progressable)
+            throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean rename(Path path, Path path1) throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean delete(Path path, boolean b) throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path path) throws FileNotFoundException, IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void setWorkingDirectory(Path path) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean mkdirs(Path path, FsPermission fsPermission) throws IOException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path) throws IOException {
+        throw new NotImplementedException();
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableCommitterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableCommitterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/** Test commit functionality. */
+public class GSRecoverableCommitterTest extends GSRecoverableWriterTestBase {
+
+    @Test(expected = RuntimeException.class)
+    public void testDuplicateCommit() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableFsDataOutputStream.Committer committer = outputStream.closeForCommit();
+        committer.commit();
+
+        // try to commit again, this should fail
+        committer.commit();
+    }
+
+    @Test
+    public void testCommitAfterRecoveryWithNothingToDo() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableFsDataOutputStream.Committer committer = outputStream.closeForCommit();
+        committer.commit();
+
+        // this should succeed as it tolerates the temp file not being present
+        committer.commitAfterRecovery();
+
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+        assertNotNull(recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId));
+    }
+
+    @Test
+    public void testCommitAfterRecoveryWithEverythingToDo() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableFsDataOutputStream.Committer committer = outputStream.closeForCommit();
+
+        // this should succeed and perform the entire commit
+        committer.commitAfterRecovery();
+
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+        assertNotNull(recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId));
+    }
+
+    @Test
+    public void testCommitAfterRecoveryWithDeleteTempToDo() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableFsDataOutputStream.Committer committer = outputStream.closeForCommit();
+        committer.commit();
+
+        // add back the temp blob, to simulate the situation where the copy has occurred but the
+        // temp blob still needs to be deleted
+        recoverableWriterHelper.getBlob(outputStream.plan.tempBlobId);
+
+        // this should succeed, deleting the temp blob
+        committer.commitAfterRecovery();
+
+        // we should have just the final blob
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+        assertNotNull(recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testInvalidCommitAfterRecovery() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableFsDataOutputStream.Committer committer = outputStream.closeForCommit();
+        committer.commit();
+
+        // simulate the situation where both the temp and final blobs are missing, as would be the
+        // case
+        // if the temp blob upload timed out (i.e. took longer than a week)
+        recoverableWriterHelper.blobs.remove(outputStream.plan.finalBlobId);
+        assertEquals(0, recoverableWriterHelper.blobs.size());
+
+        // this should fail, as there is no temp blob to copy but the final blob isn't in place
+        committer.commitAfterRecovery();
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableSerializerTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableSerializerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests the GS recoverable serializer. */
+public class GSRecoverableSerializerTest extends GSRecoverableWriterTestBase {
+
+    @Test
+    public void testResumeRecoverableSerde() throws IOException {
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableWriter.ResumeRecoverable resumeRecoverable1 = outputStream.persist();
+
+        SimpleVersionedSerializer<RecoverableWriter.ResumeRecoverable> serializer =
+                recoverableWriter.getResumeRecoverableSerializer();
+        byte[] bytes = serializer.serialize(resumeRecoverable1);
+        RecoverableWriter.ResumeRecoverable resumeRecoverable2 =
+                serializer.deserialize(serializer.getVersion(), bytes);
+
+        GSRecoverable recoverable1 = (GSRecoverable) resumeRecoverable1;
+        GSRecoverable recoverable2 = (GSRecoverable) resumeRecoverable2;
+
+        assertEquals(recoverable1.position, recoverable2.position);
+        assertEquals(recoverable1.plan.tempBlobId, recoverable2.plan.tempBlobId);
+        assertEquals(recoverable1.plan.finalBlobId, recoverable2.plan.finalBlobId);
+    }
+
+    @Test
+    public void testCommitRecoverableSerde() throws IOException {
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        RecoverableWriter.CommitRecoverable commitRecoverable1 =
+                outputStream.closeForCommit().getRecoverable();
+
+        SimpleVersionedSerializer<RecoverableWriter.CommitRecoverable> serializer =
+                recoverableWriter.getCommitRecoverableSerializer();
+        byte[] bytes = serializer.serialize(commitRecoverable1);
+        RecoverableWriter.CommitRecoverable commitRecoverable2 =
+                serializer.deserialize(serializer.getVersion(), bytes);
+
+        GSRecoverable recoverable1 = (GSRecoverable) commitRecoverable1;
+        GSRecoverable recoverable2 = (GSRecoverable) commitRecoverable2;
+
+        assertEquals(recoverable1.position, recoverable2.position);
+        assertEquals(recoverable1.plan.tempBlobId, recoverable2.plan.tempBlobId);
+        assertEquals(recoverable1.plan.finalBlobId, recoverable2.plan.finalBlobId);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests recoverable writer operations, i.e. write, commit, persist, restore, etc. */
+public class GSRecoverableWriterTest extends GSRecoverableWriterTestBase {
+
+    @Test
+    public void testSupportResume() {
+        assertTrue(recoverableWriter.supportsResume());
+    }
+
+    @Test
+    public void testRequiresCleanupOfRecoverableState() {
+        assertTrue(recoverableWriter.requiresCleanupOfRecoverableState());
+    }
+
+    @Test
+    public void testTempObjectBucketAndName() throws IOException {
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        String tempBucketName = outputStream.plan.tempBlobId.getBucket();
+        String tempObjectName = outputStream.plan.tempBlobId.getName();
+
+        assertEquals(TEMP_BUCKET_NAME, tempBucketName);
+
+        // should be like .inprogress/FINAL_OBJECT_NAME/000ec763-72d7-4359-9d84-119eb5425691, except
+        // different uuid
+        String expectedStartsWith =
+                String.format("%s/%s/", recoverableOptions.uploadTempPrefix, FINAL_OBJECT_NAME);
+        assertTrue(tempObjectName.startsWith(expectedStartsWith));
+
+        // the remainder should be a UUID, make sure we can parse it, UUID.fromString throws an
+        // exception if invalid format
+        String uuidString = tempObjectName.substring(expectedStartsWith.length());
+        UUID.fromString(uuidString);
+    }
+
+    @Test
+    public void testSimpleWrite() throws IOException {
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes);
+        outputStream.closeForCommit().commit();
+
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        assertArrayEquals(bytes, finalBlob.toByteArray());
+    }
+
+    @Test
+    public void testCompoundWrite() throws IOException {
+        byte[] bytes1 = new byte[1024];
+        byte[] bytes2 = new byte[1024];
+        RANDOM.nextBytes(bytes1);
+        RANDOM.nextBytes(bytes2);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes1);
+        outputStream.write(bytes2);
+        outputStream.closeForCommit().commit();
+
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        bytes.write(bytes1);
+        bytes.write(bytes2);
+
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        assertArrayEquals(bytes.toByteArray(), finalBlob.toByteArray());
+    }
+
+    @Test
+    public void testCompoundWriteWithRestore() throws IOException {
+        byte[] bytes1 = new byte[1024];
+        byte[] bytes2 = new byte[1024];
+        RANDOM.nextBytes(bytes1);
+        RANDOM.nextBytes(bytes2);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes1);
+        RecoverableWriter.ResumeRecoverable recoverable = outputStream.persist();
+
+        outputStream.write(bytes2);
+
+        // assume some sort of failure here, such that we have to restore to the prior recovery
+        // point
+        // and write the bytes againt
+        outputStream = (GSRecoverableFsDataOutputStream) recoverableWriter.recover(recoverable);
+        outputStream.write(bytes2);
+        outputStream.closeForCommit().commit();
+
+        assertEquals(1, recoverableWriterHelper.blobs.size());
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        bytes.write(bytes1);
+        bytes.write(bytes2);
+
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        assertArrayEquals(bytes.toByteArray(), finalBlob.toByteArray());
+    }
+
+    @Test
+    public void testCleanup() throws IOException {
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes);
+        RecoverableWriter.ResumeRecoverable recoverable = outputStream.persist();
+        recoverableWriter.cleanupRecoverableState(recoverable);
+
+        assertEquals(0, recoverableWriterHelper.blobs.size());
+    }
+
+    @Test(expected = ClosedChannelException.class)
+    public void testWriteAfterClose() throws IOException {
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes);
+        outputStream.close();
+        outputStream.write(bytes);
+    }
+
+    @Test
+    public void testWriteByteAndPosition() throws IOException {
+        final int byteValue = 27;
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(byteValue);
+        assertEquals(1, outputStream.getPos());
+
+        outputStream.closeForCommit().commit();
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        assertArrayEquals(new byte[] {byteValue}, finalBlob.toByteArray());
+    }
+
+    @Test
+    public void testWriteArrayAndPosition() throws IOException {
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes);
+        assertEquals(bytes.length, outputStream.getPos());
+
+        outputStream.closeForCommit().commit();
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        assertArrayEquals(bytes, finalBlob.toByteArray());
+    }
+
+    @Test
+    public void testWritePartialArrayAndPosition() throws IOException {
+        final int start = 512;
+        final int length = 256;
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes, start, length);
+        assertEquals(length, outputStream.getPos());
+
+        outputStream.closeForCommit().commit();
+        MockGSBlob finalBlob = recoverableWriterHelper.blobs.get(outputStream.plan.finalBlobId);
+        byte[] expectedBytes = Arrays.copyOfRange(bytes, start, start + length);
+        assertArrayEquals(expectedBytes, finalBlob.toByteArray());
+    }
+
+    @Test(expected = IOException.class)
+    public void testIncompleteWrite() throws IOException {
+        byte[] bytes = new byte[1024];
+        RANDOM.nextBytes(bytes);
+
+        // configure the mock to only write 512 bytes even though 1024 was requested
+        // WriteChannel can do this (write less than requested), and the
+        // RecoverableFsDataOutputStream
+        // interface doesn't support this, so we throw an exception in this case
+        recoverableWriterHelper.maxWriteBytes = 512;
+
+        GSRecoverableFsDataOutputStream outputStream =
+                (GSRecoverableFsDataOutputStream) recoverableWriter.open(FINAL_PATH);
+        outputStream.write(bytes);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTest.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTest.java
@@ -57,7 +57,7 @@ public class GSRecoverableWriterTest extends GSRecoverableWriterTestBase {
         // should be like .inprogress/FINAL_OBJECT_NAME/000ec763-72d7-4359-9d84-119eb5425691, except
         // different uuid
         String expectedStartsWith =
-                String.format("%s/%s/", recoverableOptions.uploadTempPrefix, FINAL_OBJECT_NAME);
+                String.format("%s%s/", recoverableOptions.uploadTempPrefix, FINAL_OBJECT_NAME);
         assertTrue(tempObjectName.startsWith(expectedStartsWith));
 
         // the remainder should be a UUID, make sure we can parse it, UUID.fromString throws an

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTestBase.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/GSRecoverableWriterTestBase.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.fs.gshadoop.GSFileSystemFactory;
+import org.apache.flink.fs.gshadoop.MockGSFileSystemHelper;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+
+import java.net.URI;
+import java.util.Random;
+
+/** Base class for GS tests. */
+class GSRecoverableWriterTestBase extends TestLogger {
+
+    protected static final Random RANDOM = new Random();
+
+    protected static final String FINAL_BUCKET_NAME = "FINAL_BUCKET_NAME";
+    protected static final String FINAL_OBJECT_NAME = "FINAL_OBJECT_NAME";
+    protected static final String TEMP_BUCKET_NAME = "TEMP_BUCKET_NAME";
+    protected static final URI FINAL_URI =
+            URI.create(String.format("gs://%s/%s", FINAL_BUCKET_NAME, FINAL_OBJECT_NAME));
+    protected static final Path FINAL_PATH = new Path(FINAL_URI);
+
+    // mocks
+    protected MockGSFileSystemHelper fileSystemHelper;
+    protected MockGSRecoverableWriterHelper recoverableWriterHelper;
+
+    // the options to use for tests
+    protected GSRecoverableOptions recoverableOptions;
+
+    // the recoverable writer being tested
+    protected GSRecoverableWriter recoverableWriter;
+
+    @Before
+    public void setup() {
+        fileSystemHelper = new MockGSFileSystemHelper();
+        recoverableWriterHelper =
+                (MockGSRecoverableWriterHelper) fileSystemHelper.getRecoverableWriterHelper();
+        recoverableOptions =
+                new GSRecoverableOptions(
+                        fileSystemHelper.getRecoverableWriterHelper(),
+                        GSFileSystemFactory.DEFAULT_UPLOAD_CONTENT_TYPE,
+                        TEMP_BUCKET_NAME,
+                        GSFileSystemFactory.DEFAULT_UPLOAD_TEMP_PREFIX,
+                        0);
+        recoverableWriter = new GSRecoverableWriter(recoverableOptions);
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/MockGSBlob.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/MockGSBlob.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import org.apache.flink.shaded.guava18.com.google.common.io.ByteArrayDataOutput;
+import org.apache.flink.shaded.guava18.com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+
+/** A mocked implementation of a file in cloud storage. */
+class MockGSBlob {
+
+    private ByteArrayDataOutput data;
+    private boolean closed;
+
+    MockGSBlob() {
+        data = ByteStreams.newDataOutput();
+        closed = false;
+    }
+
+    void setPosition(int position) throws IOException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
+        byte[] bytes = data.toByteArray();
+        if (bytes.length > position) {
+
+            // reconstruct the data output up to the specified position
+            data = ByteStreams.newDataOutput();
+            data.write(bytes, 0, position);
+
+        } else if (bytes.length < position) {
+
+            // this is an error state, we can't move forward
+            throw new IOException(
+                    String.format(
+                            "Position %d is invalid in output of length %d",
+                            position, bytes.length));
+        }
+    }
+
+    void write(byte[] bytes, int start, int length) throws IOException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
+        data.write(bytes, start, length);
+    }
+
+    void close() throws IOException {
+        closed = true;
+    }
+
+    byte[] toByteArray() {
+        return data.toByteArray();
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/MockGSRecoverableWriterHelper.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/java/org/apache/flink/fs/gshadoop/writer/MockGSRecoverableWriterHelper.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.gshadoop.writer;
+
+import com.google.cloud.storage.BlobId;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mocked implementation of the recoverable writer adapter, which tracks files as maps of {@link
+ * org.apache.flink.fs.gshadoop.writer.MockGSBlob} instances and enables test assertions.
+ */
+public class MockGSRecoverableWriterHelper extends GSRecoverableWriterHelper {
+
+    private final Storage storage;
+
+    public int maxWriteBytes;
+
+    Map<BlobId, MockGSBlob> blobs;
+
+    public MockGSRecoverableWriterHelper() {
+        this.storage = new Storage(this);
+        this.maxWriteBytes = Integer.MAX_VALUE;
+        this.blobs = new HashMap<>();
+    }
+
+    @Override
+    public Storage getStorage() {
+        return storage;
+    }
+
+    MockGSBlob getBlob(BlobId blobId) {
+        return blobs.computeIfAbsent(blobId, k -> new MockGSBlob());
+    }
+
+    static class Child {
+
+        protected final transient MockGSRecoverableWriterHelper parent;
+
+        protected Child(MockGSRecoverableWriterHelper parent) {
+            this.parent = parent;
+        }
+
+        // for deserialization of WriteState
+        protected Child() {
+            this(null);
+        }
+    }
+
+    static class Storage extends Child implements GSRecoverableWriterHelper.Storage {
+
+        Storage(MockGSRecoverableWriterHelper parent) {
+            super(parent);
+        }
+
+        @Override
+        public GSRecoverableWriterHelper.Writer createWriter(
+                BlobId blobId, String contentType, int chunkSize) {
+
+            // force creation of the blob
+            parent.getBlob(blobId);
+
+            return new Writer(parent, blobId, 0);
+        }
+
+        @Override
+        public boolean exists(BlobId blobId) {
+            return parent.blobs.containsKey(blobId);
+        }
+
+        @Override
+        public void copy(BlobId sourceBlobId, BlobId targetBlobId) {
+            MockGSBlob blob = parent.blobs.get(sourceBlobId);
+            if (blob == null) {
+                throw new RuntimeException();
+            }
+            parent.blobs.put(targetBlobId, blob);
+        }
+
+        @Override
+        public boolean delete(BlobId blobId) {
+            Object removedBlob = parent.blobs.remove(blobId);
+            return removedBlob != null;
+        }
+    }
+
+    static class Writer extends Child implements GSRecoverableWriterHelper.Writer {
+
+        private final BlobId blobId;
+
+        private int position;
+
+        Writer(MockGSRecoverableWriterHelper parent, BlobId blobId, int position) {
+            super(parent);
+            this.blobId = blobId;
+            this.position = position;
+        }
+
+        @Override
+        public int write(ByteBuffer byteBuffer) throws IOException {
+            MockGSBlob blob = parent.getBlob(blobId);
+            blob.setPosition(position);
+
+            int writeCount = Math.min(byteBuffer.remaining(), parent.maxWriteBytes);
+            blob.write(byteBuffer.array(), byteBuffer.position(), writeCount);
+
+            position += writeCount;
+            return writeCount;
+        }
+
+        @Override
+        public void close() throws IOException {
+            parent.getBlob(blobId).close();
+        }
+
+        @Override
+        public WriterState capture() {
+            return new WriteState(parent, blobId, position);
+        }
+    }
+
+    static class WriteState extends Child implements GSRecoverableWriterHelper.WriterState {
+
+        private static final long serialVersionUID = 1L;
+
+        private final BlobId blobId;
+
+        private final int position;
+
+        WriteState(MockGSRecoverableWriterHelper parent, BlobId blobId, int position) {
+            super(parent);
+            this.blobId = blobId;
+            this.position = position;
+        }
+
+        @Override
+        public GSRecoverableWriterHelper.Writer restore() {
+            return new Writer(parent, blobId, position);
+        }
+    }
+}

--- a/flink-filesystems/flink-gs-fs-hadoop/src/test/resources/log4j2-test.properties
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -42,6 +42,7 @@ under the License.
 		<module>flink-hadoop-fs</module>
 		<module>flink-mapr-fs</module>
 		<module>flink-fs-hadoop-shaded</module>
+		<module>flink-gs-fs-hadoop</module>
 		<module>flink-s3-fs-base</module>
 		<module>flink-s3-fs-hadoop</module>
 		<module>flink-s3-fs-presto</module>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add a FileSystem implementation with associated RecoverableWriter implementation for Google Cloud Storage, in order to be able to write to GCS via a StreamingFileSink. 

## Brief change log
- Add GSFileSystemFactory and register with SPI under org.apache.flink.core.fs.FileSystemFactory. This factory supports the ```gs``` scheme.
- GSFileSystemFactory creates instances of GSFileSystem, which extends HadoopFileSystem. An instance of [GoogleHadoopFileSystem ](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java) (i.e. the standard Hadoop connector for GCS) is used to construct HadoopFileSystem.
- GSFileSystem creates instances of GSRecoverableWriter via ```createRecoverableWriter```
- GSRecoverableWriter writes files to GCS in a two-step process, by first writing to a temporary blob, using the [resumable upload](https://cloud.google.com/storage/docs/resumable-uploads) feature, and then copying the temp blob to the final blob on commit (and deleting the temp file). Resumable uploads can be active for up to one week.
- Recoverability during the resumable upload process is provided by the ```capture``` method on [WriteChannel](https://googleapis.dev/java/google-cloud-clients/0.90.0-alpha/com/google/cloud/WriteChannel.html) and the ```restore``` method on [RestorableState<WriteChannel>](https://googleapis.dev/java/google-cloud-clients/0.90.0-alpha/com/google/cloud/RestorableState.html). GSRecoverable holds the recoverable state, which includes:
  - The opaque RestorableState object returned from [WriteChannel.capture](https://googleapis.dev/java/google-cloud-clients/0.90.0-alpha/com/google/cloud/WriteChannel.html#capture--) (which is Java serializable)
  - The position in the write stream
  - The "plan", i.e. an instance of GSRecoverablePlan, which includes the temporary and final blob ids, to be used for eventual commit or cleanup
 
Four new Flink options are added:
- **gs.upload.content.type**. This is the content type to use when writing blobs. Default: ```application/octet-stream```.
- **gs.upload.temp.bucket**. The bucket to use for temporary blobs. There is no default; if unspecified, temporary blobs are written to the same bucket as the final blobs. Specifying this option would allow one to put temporary blobs in their own bucket.
- **gs.upload.temp.prefix**. The prefix to apply to the final object name to generate the temporary object name. A UUID string is also appended to the temporary object name to avoid collisions during the resumable upload process. Default value: ```.inprogress```
- **gs.upload.chunk.size**. The chunk size to set for uploads. If zero (the default), no chunk size is set and the Google default value is used.

So, for example -- if a write were initiated to ```gs://bucket-name/foo/bar```, the following would happen (assuming default values for the options above):
- A temporary blob would be created at, say, ```gs://bucket-name/.inprogress/foo/bar/e202b566-150f-4784-9025-136cf351fcfe```
- Writes would be performed against this blob via resumable upload for up to a week, with support for saving and restoring the upload state
- Upon commit, the temporary blob would be copied to ```gs://bucket-name/foo/bar``` and the temporary blob would be deleted
- Upon failure, the temporary blob would be deleted (via [RecoverableWriter.cleanupRecoverableState](https://ci.apache.org/projects/flink/flink-docs-master/api/java/org/apache/flink/core/fs/RecoverableWriter.html#cleanupRecoverableState-org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable-))

A few important implementation notes:
- The GSRecoverableWriterHelper class and its child interfaces -- Storage, Writer, and WriterState -- abstract away the interactions with the underlying GCS interfaces. DefaultGSRecoverableWriterHelper implements GSRecoverableWriterHelper against the underlying GCS interfaces; for unit-testing purposes, MockGSRecoverableWriterHelper implements GSRecoverableWriterHelper against in-memory objects.
- GSRecoverableWriterHelper.WriterState implements Serializable, as it wraps an instance of the opaque [RestorableState<WriteChannel>](https://googleapis.dev/java/google-cloud-clients/0.90.0-alpha/com/google/cloud/RestorableState.html) returned from the GCS API. RestorableState instances are required to be Java serializable, and this would seem to be the only way to serialize/deserialze them. **So, GSRecoverableSerializer uses Java serialization for WriteState**. I'm aware this goes against the guidance not to use Java serialization, but, in this case, I don't see an alternative (but I'm open to suggestions).

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

**This change added tests and can be verified as follows**:
- Added unit tests in GSFileSystem test to verify the proper function of GSFileSystemFactory and GSFileSystem, including Flink options and passthrough of options to Hadoop. No validation of the external [GoogleHadoopFileSystem](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java) is performed.
- Added unit tests in GSRecoverableWriterTest to test scenarios related to writing, persist/restore, and cleanup.
- Added unit tests in GSRecoverableSerializerTest to test serialization of GSRecoverable.
- Added unit tests in GSRecoverableCommitterTest to test commit scenarios, including commit after recovery.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
    - Adds a new project -- **flink-gs-fs-hadoop** -- which includes dependencies [google-cloud-storage](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage) and [gcs-connector](https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector). I have a question about the proper scope for gcs-connector which I'll ask in a follow-up comment.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
    - Adds GSRecoverableSerializer, to serialize instances of GSRecoverable
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
