### PR TITLE
[FLINK-21245][table-planner-blink] Support StreamExecCalc json serialization/deserialization

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
@@ -63,18 +63,33 @@ public abstract class EncodingUtils {
         return "`" + escapeBackticks(s) + "`";
     }
 
-    public static String encodeObjectToString(Serializable obj) {
+    public static String encodeObjectToString(Object serializable) {
         try {
-            final byte[] bytes = InstantiationUtil.serializeObject(obj);
+            final byte[] bytes = InstantiationUtil.serializeObject(serializable);
             return new String(BASE64_ENCODER.encode(bytes), UTF_8);
         } catch (Exception e) {
             throw new ValidationException(
                     "Unable to serialize object '"
-                            + obj.toString()
+                            + serializable.toString()
                             + "' of class '"
-                            + obj.getClass().getName()
+                            + serializable.getClass().getName()
                             + "'.",
                     e);
+        }
+    }
+
+    public static String encodeObjectToString(Serializable obj) {
+        return encodeObjectToString((Object) obj);
+    }
+
+    public static <T> T decodeStringToObject(String encodedStr, ClassLoader classLoader)
+            throws IOException {
+        final byte[] bytes = BASE64_DECODER.decode(encodedStr.getBytes(UTF_8));
+        try {
+            return InstantiationUtil.deserializeObject(bytes, classLoader);
+        } catch (ClassNotFoundException e) {
+            throw new ValidationException(
+                    "Unable to deserialize string '" + encodedStr + "' to object.", e);
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -101,7 +101,6 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
         return inputProperties;
     }
 
-    @JsonIgnore
     @Override
     public List<ExecEdge> getInputEdges() {
         return checkNotNull(
@@ -109,7 +108,6 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
                 "inputEdges should not null, please call `setInputEdges(List<ExecEdge>)` first.");
     }
 
-    @JsonIgnore
     @Override
     public void setInputEdges(List<ExecEdge> inputEdges) {
         checkNotNull(inputEdges, "inputEdges should not be null.");

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecCalc.java
@@ -25,21 +25,29 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 
 /** Batch {@link ExecNode} for Calc. */
 public class BatchExecCalc extends CommonExecCalc implements BatchExecNode<RowData> {
 
     public BatchExecCalc(
-            RexProgram calcProgram,
+            List<RexNode> projection,
+            @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(
-                calcProgram,
+                projection,
+                condition,
                 TableStreamOperator.class,
                 false, // retainHeader
-                inputProperty,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
                 outputType,
                 description);
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -32,27 +32,44 @@ import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexProgram;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Collections;
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
 import java.util.Optional;
 
 /** Base class for exec Calc. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class CommonExecCalc extends ExecNodeBase<RowData> {
-    private final RexProgram calcProgram;
-    private final Class<?> operatorBaseClass;
-    private final boolean retainHeader;
+    public static final String FIELD_NAME_PROJECTION = "projection";
+    public static final String FIELD_NAME_CONDITION = "condition";
 
-    public CommonExecCalc(
-            RexProgram calcProgram,
+    @JsonProperty(FIELD_NAME_PROJECTION)
+    private final List<RexNode> projection;
+
+    @JsonProperty(FIELD_NAME_CONDITION)
+    private final @Nullable RexNode condition;
+
+    @JsonIgnore private final Class<?> operatorBaseClass;
+    @JsonIgnore private final boolean retainHeader;
+
+    protected CommonExecCalc(
+            List<RexNode> projection,
+            @Nullable RexNode condition,
             Class<?> operatorBaseClass,
             boolean retainHeader,
-            InputProperty inputProperty,
+            int id,
+            List<InputProperty> inputProperties,
             RowType outputType,
             String description) {
-        super(Collections.singletonList(inputProperty), outputType, description);
-        this.calcProgram = calcProgram;
+        super(id, inputProperties, outputType, description);
+        this.projection = projection;
+        this.condition = condition;
         this.operatorBaseClass = operatorBaseClass;
         this.retainHeader = retainHeader;
     }
@@ -67,20 +84,13 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData> {
                 new CodeGeneratorContext(planner.getTableConfig())
                         .setOperatorBaseClass(operatorBaseClass);
 
-        final Optional<RexNode> condition;
-        if (calcProgram.getCondition() != null) {
-            condition = Optional.of(calcProgram.expandLocalRef(calcProgram.getCondition()));
-        } else {
-            condition = Optional.empty();
-        }
-
         final CodeGenOperatorFactory<RowData> substituteStreamOperator =
                 CalcCodeGenerator.generateCalcOperator(
                         ctx,
                         inputTransform,
                         (RowType) getOutputType(),
-                        calcProgram,
-                        JavaScalaConversionUtil.toScala(condition),
+                        JavaScalaConversionUtil.toScala(projection),
+                        JavaScalaConversionUtil.toScala(Optional.ofNullable(this.condition)),
                         retainHeader,
                         getClass().getSimpleName());
         final Transformation<RowData> transformation =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -103,4 +103,8 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData> {
             InputFormat<RowData, ?> inputFormat,
             InternalTypeInfo<RowData> outputTypeInfo,
             String name);
+
+    public DynamicTableSourceSpec getTableSourceSpec() {
+        return tableSourceSpec;
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkDeserializationContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/FlinkDeserializationContext.java
@@ -22,13 +22,17 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationConfig;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.InjectableValues;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.DeserializerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Custom JSON {@link DeserializationContext} which wraps a {@link SerdeContext}. */
 public class FlinkDeserializationContext extends DefaultDeserializationContext {
     private static final long serialVersionUID = 1L;
     private final SerdeContext serdeCtx;
+    private ObjectMapper objectMapper;
 
     public FlinkDeserializationContext(DefaultDeserializationContext src, SerdeContext serdeCtx) {
         super(src);
@@ -42,12 +46,14 @@ public class FlinkDeserializationContext extends DefaultDeserializationContext {
             InjectableValues values) {
         super(src, config, jp, values);
         this.serdeCtx = src.serdeCtx;
+        this.objectMapper = src.objectMapper;
     }
 
     protected FlinkDeserializationContext(
             FlinkDeserializationContext src, DeserializerFactory factory) {
         super(src, factory);
         this.serdeCtx = src.serdeCtx;
+        this.objectMapper = src.objectMapper;
     }
 
     @Override
@@ -63,5 +69,13 @@ public class FlinkDeserializationContext extends DefaultDeserializationContext {
 
     public SerdeContext getSerdeContext() {
         return serdeCtx;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return checkNotNull(objectMapper);
+    }
+
+    public void setObjectMapper(ObjectMapper mapper) {
+        this.objectMapper = mapper;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/JsonSerdeUtil.java
@@ -44,15 +44,17 @@ public class JsonSerdeUtil {
 
     /** Create an {@link ObjectMapper} which DeserializationContext wraps a {@link SerdeContext}. */
     public static ObjectMapper createObjectMapper(SerdeContext serdeCtx) {
+        FlinkDeserializationContext ctx =
+                new FlinkDeserializationContext(
+                        new DefaultDeserializationContext.Impl(BeanDeserializerFactory.instance),
+                        serdeCtx);
         ObjectMapper mapper =
                 new ObjectMapper(
                         null, // JsonFactory
                         null, // DefaultSerializerProvider
-                        new FlinkDeserializationContext(
-                                new DefaultDeserializationContext.Impl(
-                                        BeanDeserializerFactory.instance),
-                                serdeCtx));
+                        ctx);
         mapper.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
+        ctx.setObjectMapper(mapper);
         return mapper;
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ObjectIdentifierJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ObjectIdentifierJsonDeserializer.java
@@ -36,7 +36,7 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.ObjectIdentif
 public class ObjectIdentifierJsonDeserializer extends StdDeserializer<ObjectIdentifier> {
     private static final long serialVersionUID = 1L;
 
-    protected ObjectIdentifierJsonDeserializer() {
+    public ObjectIdentifierJsonDeserializer() {
         super(ObjectIdentifier.class);
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ObjectIdentifierJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ObjectIdentifierJsonSerializer.java
@@ -34,7 +34,7 @@ public class ObjectIdentifierJsonSerializer extends StdSerializer<ObjectIdentifi
     public static final String FIELD_NAME_DATABASE_NAME = "databaseName";
     public static final String FIELD_NAME_TABLE_NAME = "tableName";
 
-    protected ObjectIdentifierJsonSerializer() {
+    public ObjectIdentifierJsonSerializer() {
         super(ObjectIdentifier.class);
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonDeserializer.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.TextNode;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Util;
+
+import java.io.IOException;
+
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_ELEMENT;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_FIELDS;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_FILED_NAME;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_KEY;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_NULLABLE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_PRECISION;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_RAW_TYPE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_SCALE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_STRUCTURED_TYPE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_STRUCT_KIND;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_TIMESTAMP_KIND;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_TYPE_INFO;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_TYPE_NAME;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RelDataTypeJsonSerializer.FIELD_NAME_VALUE;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * JSON deserializer for {@link RelDataType}. refer to {@link RelDataTypeJsonSerializer} for
+ * serializer.
+ */
+public class RelDataTypeJsonDeserializer extends StdDeserializer<RelDataType> {
+    private static final long serialVersionUID = 1L;
+
+    public RelDataTypeJsonDeserializer() {
+        super(RelDataType.class);
+    }
+
+    @Override
+    public RelDataType deserialize(JsonParser jsonParser, DeserializationContext ctx)
+            throws IOException, JsonProcessingException {
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+        return deserialize(jsonNode, ((FlinkDeserializationContext) ctx));
+    }
+
+    private RelDataType deserialize(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws JsonProcessingException {
+        FlinkTypeFactory typeFactory = ctx.getSerdeContext().getTypeFactory();
+        if (jsonNode instanceof ObjectNode) {
+            ObjectNode objectNode = (ObjectNode) jsonNode;
+            if (objectNode.has(FIELD_NAME_TIMESTAMP_KIND)) {
+                boolean nullable = objectNode.get(FIELD_NAME_NULLABLE).booleanValue();
+                TimestampKind timestampKind =
+                        TimestampKind.valueOf(
+                                objectNode.get(FIELD_NAME_TIMESTAMP_KIND).asText().toUpperCase());
+                switch (timestampKind) {
+                    case ROWTIME:
+                        return typeFactory.createRowtimeIndicatorType(nullable);
+                    case PROCTIME:
+                        return typeFactory.createProctimeIndicatorType(nullable);
+                    default:
+                        throw new TableException(timestampKind + " is not supported.");
+                }
+            } else if (objectNode.has(FIELD_NAME_STRUCTURED_TYPE)) {
+                JsonNode structuredTypeNode = objectNode.get(FIELD_NAME_STRUCTURED_TYPE);
+                LogicalType structuredType =
+                        ctx.getObjectMapper()
+                                .readValue(structuredTypeNode.toPrettyString(), LogicalType.class);
+                checkArgument(structuredType instanceof StructuredType);
+                return ctx.getSerdeContext()
+                        .getTypeFactory()
+                        .createFieldTypeFromLogicalType(structuredType);
+            } else if (objectNode.has(FIELD_NAME_STRUCT_KIND)) {
+                ArrayNode arrayNode = (ArrayNode) objectNode.get(FIELD_NAME_FIELDS);
+                RelDataTypeFactory.Builder builder = typeFactory.builder();
+                for (JsonNode node : arrayNode) {
+                    builder.add(node.get(FIELD_NAME_FILED_NAME).asText(), deserialize(node, ctx));
+                }
+                StructKind structKind =
+                        StructKind.valueOf(
+                                objectNode.get(FIELD_NAME_STRUCT_KIND).asText().toUpperCase());
+                boolean nullable = objectNode.get(FIELD_NAME_NULLABLE).booleanValue();
+                return builder.kind(structKind).nullableRecord(nullable).build();
+            } else if (objectNode.has(FIELD_NAME_FIELDS)) {
+                JsonNode fields = objectNode.get(FIELD_NAME_FIELDS);
+                // Nested struct
+                return deserialize(fields, ctx);
+            } else {
+                SqlTypeName sqlTypeName =
+                        Util.enumVal(
+                                SqlTypeName.class, objectNode.get(FIELD_NAME_TYPE_NAME).asText());
+                boolean nullable = objectNode.get(FIELD_NAME_NULLABLE).booleanValue();
+                if (SqlTypeName.INTERVAL_TYPES.contains(sqlTypeName)) {
+                    TimeUnit startUnit = sqlTypeName.getStartUnit();
+                    TimeUnit endUnit = sqlTypeName.getEndUnit();
+                    return typeFactory.createTypeWithNullability(
+                            typeFactory.createSqlIntervalType(
+                                    new SqlIntervalQualifier(
+                                            startUnit, endUnit, SqlParserPos.ZERO)),
+                            nullable);
+                }
+                if (sqlTypeName == SqlTypeName.OTHER && objectNode.has(FIELD_NAME_RAW_TYPE)) {
+                    RawType<?> rawType =
+                            (RawType<?>)
+                                    LogicalTypeParser.parse(
+                                            objectNode.get(FIELD_NAME_RAW_TYPE).asText(),
+                                            ctx.getSerdeContext().getClassLoader());
+                    return typeFactory.createTypeWithNullability(
+                            typeFactory.createFieldTypeFromLogicalType(rawType), nullable);
+                }
+                if (sqlTypeName == SqlTypeName.ANY && objectNode.has(FIELD_NAME_RAW_TYPE)) {
+                    JsonNode rawTypeNode = objectNode.get(FIELD_NAME_RAW_TYPE);
+                    boolean nullableOfTypeInfo =
+                            rawTypeNode.get(FIELD_NAME_NULLABLE).booleanValue();
+                    TypeInformation<?> typeInfo =
+                            EncodingUtils.decodeStringToObject(
+                                    rawTypeNode.get(FIELD_NAME_TYPE_INFO).asText(),
+                                    TypeInformation.class,
+                                    ctx.getSerdeContext().getClassLoader());
+                    TypeInformationRawType<?> rawType =
+                            new TypeInformationRawType<>(nullableOfTypeInfo, typeInfo);
+                    return typeFactory.createTypeWithNullability(
+                            typeFactory.createFieldTypeFromLogicalType(rawType), nullable);
+                }
+
+                Integer precision =
+                        objectNode.has(FIELD_NAME_PRECISION)
+                                ? objectNode.get(FIELD_NAME_PRECISION).intValue()
+                                : null;
+                Integer scale =
+                        objectNode.has(FIELD_NAME_SCALE)
+                                ? objectNode.get(FIELD_NAME_SCALE).intValue()
+                                : null;
+                final RelDataType type;
+                if (sqlTypeName == SqlTypeName.ARRAY) {
+                    RelDataType elementType = deserialize(objectNode.get(FIELD_NAME_ELEMENT), ctx);
+                    type = typeFactory.createArrayType(elementType, -1);
+                } else if (sqlTypeName == SqlTypeName.MULTISET) {
+                    RelDataType elementType = deserialize(objectNode.get(FIELD_NAME_ELEMENT), ctx);
+                    type = typeFactory.createMultisetType(elementType, -1);
+                } else if (sqlTypeName == SqlTypeName.MAP) {
+                    RelDataType keyType = deserialize(objectNode.get(FIELD_NAME_KEY), ctx);
+                    RelDataType valueType = deserialize(objectNode.get(FIELD_NAME_VALUE), ctx);
+                    type = typeFactory.createMapType(keyType, valueType);
+                } else if (precision == null) {
+                    type = typeFactory.createSqlType(sqlTypeName);
+                } else if (scale == null) {
+                    type = typeFactory.createSqlType(sqlTypeName, precision);
+                } else {
+                    type = typeFactory.createSqlType(sqlTypeName, precision, scale);
+                }
+                return typeFactory.createTypeWithNullability(type, nullable);
+            }
+        } else if (jsonNode instanceof TextNode) {
+            SqlTypeName sqlTypeName = Util.enumVal(SqlTypeName.class, jsonNode.asText());
+            return typeFactory.createSqlType(sqlTypeName);
+        } else {
+            throw new TableException("Unknown type: " + jsonNode.toPrettyString());
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeJsonSerializer.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.planner.plan.schema.GenericRelDataType;
+import org.apache.flink.table.planner.plan.schema.RawRelDataType;
+import org.apache.flink.table.planner.plan.schema.StructuredRelDataType;
+import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.type.ArraySqlType;
+import org.apache.calcite.sql.type.MapSqlType;
+import org.apache.calcite.sql.type.MultisetSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.io.IOException;
+
+/**
+ * JSON serializer for {@link RelDataType}. refer to {@link RelDataTypeJsonDeserializer} for
+ * deserializer.
+ */
+public class RelDataTypeJsonSerializer extends StdSerializer<RelDataType> {
+    private static final long serialVersionUID = 1L;
+
+    public static final String FIELD_NAME_TYPE_NAME = "typeName";
+    public static final String FIELD_NAME_FILED_NAME = "fieldName";
+    public static final String FIELD_NAME_NULLABLE = "nullable";
+    public static final String FIELD_NAME_PRECISION = "precision";
+    public static final String FIELD_NAME_SCALE = "scale";
+    public static final String FIELD_NAME_FIELDS = "fields";
+    public static final String FIELD_NAME_STRUCT_KIND = "structKind";
+    public static final String FIELD_NAME_TIMESTAMP_KIND = "timestampKind";
+    public static final String FIELD_NAME_ELEMENT = "element";
+    public static final String FIELD_NAME_KEY = "key";
+    public static final String FIELD_NAME_VALUE = "value";
+    public static final String FIELD_NAME_TYPE_INFO = "typeInfo";
+    public static final String FIELD_NAME_RAW_TYPE = "rawType";
+    public static final String FIELD_NAME_STRUCTURED_TYPE = "structuredType";
+
+    public RelDataTypeJsonSerializer() {
+        super(RelDataType.class);
+    }
+
+    @Override
+    public void serialize(
+            RelDataType relDataType,
+            JsonGenerator jsonGenerator,
+            SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+        serialize(relDataType, jsonGenerator);
+        jsonGenerator.writeEndObject();
+    }
+
+    private void serialize(RelDataType relDataType, JsonGenerator gen) throws IOException {
+        if (relDataType instanceof TimeIndicatorRelDataType) {
+            TimeIndicatorRelDataType timeIndicatorType = (TimeIndicatorRelDataType) relDataType;
+            gen.writeStringField(
+                    FIELD_NAME_TIMESTAMP_KIND,
+                    timeIndicatorType.isEventTime()
+                            ? TimestampKind.ROWTIME.name()
+                            : TimestampKind.PROCTIME.name());
+            gen.writeBooleanField(FIELD_NAME_NULLABLE, relDataType.isNullable());
+        } else if (relDataType instanceof StructuredRelDataType) {
+            StructuredRelDataType structuredType = (StructuredRelDataType) relDataType;
+            gen.writeObjectField(FIELD_NAME_STRUCTURED_TYPE, structuredType.getStructuredType());
+        } else if (relDataType.isStruct()) {
+            gen.writeStringField(FIELD_NAME_STRUCT_KIND, relDataType.getStructKind().name());
+            gen.writeBooleanField(FIELD_NAME_NULLABLE, relDataType.isNullable());
+
+            gen.writeFieldName(FIELD_NAME_FIELDS);
+            gen.writeStartArray();
+            for (RelDataTypeField field : relDataType.getFieldList()) {
+                gen.writeStartObject();
+                serialize(field.getType(), gen);
+                gen.writeStringField(FIELD_NAME_FILED_NAME, field.getName());
+                gen.writeEndObject();
+            }
+            gen.writeEndArray();
+        } else if (relDataType.getSqlTypeName() == SqlTypeName.ARRAY) {
+            serializeCommon(relDataType, gen);
+            ArraySqlType arraySqlType = (ArraySqlType) relDataType;
+
+            gen.writeFieldName(FIELD_NAME_ELEMENT);
+            gen.writeStartObject();
+            serialize(arraySqlType.getComponentType(), gen);
+            gen.writeEndObject();
+        } else if (relDataType.getSqlTypeName() == SqlTypeName.MULTISET) {
+            assert relDataType instanceof MultisetSqlType;
+            serializeCommon(relDataType, gen);
+            MultisetSqlType multisetSqlType = (MultisetSqlType) relDataType;
+
+            gen.writeFieldName(FIELD_NAME_ELEMENT);
+            gen.writeStartObject();
+            serialize(multisetSqlType.getComponentType(), gen);
+            gen.writeEndObject();
+        } else if (relDataType.getSqlTypeName() == SqlTypeName.MAP) {
+            assert relDataType instanceof MapSqlType;
+            serializeCommon(relDataType, gen);
+            MapSqlType mapSqlType = (MapSqlType) relDataType;
+
+            gen.writeFieldName(FIELD_NAME_KEY);
+            gen.writeStartObject();
+            serialize(mapSqlType.getKeyType(), gen);
+            gen.writeEndObject();
+
+            gen.writeFieldName(FIELD_NAME_VALUE);
+            gen.writeStartObject();
+            serialize(mapSqlType.getValueType(), gen);
+            gen.writeEndObject();
+        } else if (relDataType instanceof GenericRelDataType) {
+            assert relDataType.getSqlTypeName() == SqlTypeName.ANY;
+            serializeCommon(relDataType, gen);
+            TypeInformationRawType<?> rawType = ((GenericRelDataType) relDataType).genericType();
+
+            gen.writeFieldName(FIELD_NAME_RAW_TYPE);
+            gen.writeStartObject();
+            gen.writeBooleanField(FIELD_NAME_NULLABLE, rawType.isNullable());
+            gen.writeStringField(
+                    FIELD_NAME_TYPE_INFO,
+                    EncodingUtils.encodeObjectToString(rawType.getTypeInformation()));
+            gen.writeEndObject();
+        } else if (relDataType instanceof RawRelDataType) {
+            assert relDataType.getSqlTypeName() == SqlTypeName.OTHER;
+            serializeCommon(relDataType, gen);
+            RawRelDataType rawType = (RawRelDataType) relDataType;
+            gen.writeStringField(FIELD_NAME_RAW_TYPE, rawType.getRawType().asSerializableString());
+        } else {
+            serializeCommon(relDataType, gen);
+        }
+    }
+
+    private void serializeCommon(RelDataType relDataType, JsonGenerator gen) throws IOException {
+        final SqlTypeName typeName = relDataType.getSqlTypeName();
+        gen.writeStringField(FIELD_NAME_TYPE_NAME, typeName.name());
+        gen.writeBooleanField(FIELD_NAME_NULLABLE, relDataType.isNullable());
+        if (relDataType.getSqlTypeName().allowsPrec()) {
+            gen.writeNumberField(FIELD_NAME_PRECISION, relDataType.getPrecision());
+        }
+        if (relDataType.getSqlTypeName().allowsScale()) {
+            gen.writeNumberField(FIELD_NAME_SCALE, relDataType.getScale());
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.module.CoreModule;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
+import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlNameMatchers;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.Sarg;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_LOWER;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_TYPE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_UPPER;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BRIDGING;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BUILT_IN;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CLASS;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CONTAINS_NULL;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_CORREL;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_DISPLAY_NAME;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_EXPR;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_FUNCTION_KIND;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_INPUT_INDEX;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_INSTANCE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_KIND;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_NAME;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_OPERANDS;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_OPERATOR;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_RANGES;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_SARG;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_SYNTAX;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_TYPE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_VALUE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_CORREL_VARIABLE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_FIELD_ACCESS;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_INPUT_REF;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_LITERAL;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_REX_CALL;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** JSON deserializer for {@link RexNode}. refer to {@link RexNodeJsonSerializer} for serializer. */
+public class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
+    private static final long serialVersionUID = 1L;
+
+    public RexNodeJsonDeserializer() {
+        super(RexNode.class);
+    }
+
+    @Override
+    public RexNode deserialize(JsonParser jsonParser, DeserializationContext ctx)
+            throws IOException, JsonProcessingException {
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+        return deserializeRexNode(jsonNode, ((FlinkDeserializationContext) ctx));
+    }
+
+    private RexNode deserializeRexNode(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws IOException {
+        String kind = jsonNode.get(FIELD_NAME_KIND).asText().toUpperCase();
+        switch (kind) {
+            case SQL_KIND_INPUT_REF:
+                return deserializeInputRef(jsonNode, ctx);
+            case SQL_KIND_LITERAL:
+                return deserializeLiteral(jsonNode, ctx);
+            case SQL_KIND_FIELD_ACCESS:
+                return deserializeFieldAccess(jsonNode, ctx);
+            case SQL_KIND_CORREL_VARIABLE:
+                return deserializeCorrelVariable(jsonNode, ctx);
+            case SQL_KIND_REX_CALL:
+                return deserializeCall(jsonNode, ctx);
+            default:
+                throw new TableException("Cannot convert to RexNode: " + jsonNode.toPrettyString());
+        }
+    }
+
+    private RexNode deserializeInputRef(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws JsonProcessingException {
+        int inputIndex = jsonNode.get(FIELD_NAME_INPUT_INDEX).intValue();
+        JsonNode typeNode = jsonNode.get(FIELD_NAME_TYPE);
+        RelDataType fieldType =
+                ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
+        return ctx.getSerdeContext().getRexBuilder().makeInputRef(fieldType, inputIndex);
+    }
+
+    private RexNode deserializeLiteral(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws IOException {
+        RexBuilder rexBuilder = ctx.getSerdeContext().getRexBuilder();
+        JsonNode typeNode = jsonNode.get(FIELD_NAME_TYPE);
+        RelDataType literalType =
+                ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
+        if (jsonNode.has(FIELD_NAME_SARG)) {
+            Sarg<?> sarg = toSarg(jsonNode.get(FIELD_NAME_SARG), literalType.getSqlTypeName(), ctx);
+            return rexBuilder.makeSearchArgumentLiteral(sarg, literalType);
+        } else if (jsonNode.has(FIELD_NAME_VALUE)) {
+            JsonNode literalNode = jsonNode.get(FIELD_NAME_VALUE);
+            if (literalNode.isNull()) {
+                return rexBuilder.makeNullLiteral(literalType);
+            }
+            Object literal = toLiteralValue(jsonNode, literalType.getSqlTypeName(), ctx);
+            return rexBuilder.makeLiteral(literal, literalType, true);
+        } else {
+            throw new TableException("Unknown literal: " + jsonNode.toPrettyString());
+        }
+    }
+
+    private Object toLiteralValue(
+            JsonNode literalNode, SqlTypeName sqlTypeName, FlinkDeserializationContext ctx)
+            throws IOException {
+        JsonNode valueNode = literalNode.get(FIELD_NAME_VALUE);
+        if (valueNode.isNull()) {
+            return null;
+        }
+
+        switch (sqlTypeName) {
+            case BOOLEAN:
+                return valueNode.booleanValue();
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case DOUBLE:
+            case FLOAT:
+            case DECIMAL:
+            case REAL:
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                return new BigDecimal(valueNode.asText());
+            case DATE:
+                return new DateString(valueNode.asText());
+            case TIME:
+            case TIME_WITH_LOCAL_TIME_ZONE:
+                return new TimeString(valueNode.asText());
+            case TIMESTAMP:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return new TimestampString(valueNode.asText());
+            case BINARY:
+            case VARBINARY:
+                return ByteString.ofBase64(valueNode.asText());
+            case CHAR:
+            case VARCHAR:
+                return ctx.getSerdeContext()
+                        .getRexBuilder()
+                        .makeLiteral(valueNode.asText())
+                        .getValue();
+            case SYMBOL:
+                JsonNode classNode = literalNode.get(FIELD_NAME_CLASS);
+                return getEnum(
+                        classNode.asText(),
+                        valueNode.asText(),
+                        ctx.getSerdeContext().getClassLoader());
+            case ROW:
+            case MULTISET:
+                ArrayNode valuesNode = (ArrayNode) valueNode;
+                List<RexNode> list = new ArrayList<>();
+                for (int i = 0; i < valuesNode.size(); ++i) {
+                    list.add(deserializeRexNode(valuesNode.get(i), ctx));
+                }
+                return list;
+            default:
+                throw new TableException("Unknown literal: " + valueNode);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Enum<T>> T getEnum(
+            String clazz, String name, ClassLoader classLoader) {
+        try {
+            Class<T> c = (Class<T>) Class.forName(clazz, true, classLoader);
+            return Enum.valueOf(c, name);
+        } catch (ClassNotFoundException e) {
+            throw new TableException("Unknown class: " + clazz);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked", "UnstableApiUsage"})
+    private Sarg<?> toSarg(
+            JsonNode jsonNode, SqlTypeName sqlTypeName, FlinkDeserializationContext ctx)
+            throws IOException {
+        ArrayNode rangesNode = (ArrayNode) jsonNode.get(FIELD_NAME_RANGES);
+        com.google.common.collect.ImmutableRangeSet.Builder builder =
+                com.google.common.collect.ImmutableRangeSet.builder();
+        for (JsonNode rangeNode : rangesNode) {
+            com.google.common.collect.Range<?> range = com.google.common.collect.Range.all();
+            if (rangeNode.has(FIELD_NAME_BOUND_LOWER)) {
+                JsonNode lowerNode = rangeNode.get(FIELD_NAME_BOUND_LOWER);
+                Comparable<?> boundValue =
+                        checkNotNull((Comparable<?>) toLiteralValue(lowerNode, sqlTypeName, ctx));
+                com.google.common.collect.BoundType boundType =
+                        com.google.common.collect.BoundType.valueOf(
+                                lowerNode.get(FIELD_NAME_BOUND_TYPE).asText().toUpperCase());
+                com.google.common.collect.Range r =
+                        boundType == com.google.common.collect.BoundType.OPEN
+                                ? com.google.common.collect.Range.greaterThan(boundValue)
+                                : com.google.common.collect.Range.atLeast(boundValue);
+                range = range.intersection(r);
+            }
+            if (rangeNode.has(FIELD_NAME_BOUND_UPPER)) {
+                JsonNode upperNode = rangeNode.get(FIELD_NAME_BOUND_UPPER);
+                Comparable<?> boundValue =
+                        checkNotNull((Comparable<?>) toLiteralValue(upperNode, sqlTypeName, ctx));
+                com.google.common.collect.BoundType boundType =
+                        com.google.common.collect.BoundType.valueOf(
+                                upperNode.get(FIELD_NAME_BOUND_TYPE).asText().toUpperCase());
+                com.google.common.collect.Range r =
+                        boundType == com.google.common.collect.BoundType.OPEN
+                                ? com.google.common.collect.Range.lessThan(boundValue)
+                                : com.google.common.collect.Range.atMost(boundValue);
+                range = range.intersection(r);
+            }
+            if (range.hasUpperBound() || range.hasLowerBound()) {
+                builder.add(range);
+            }
+        }
+        boolean containsNull = jsonNode.get(FIELD_NAME_CONTAINS_NULL).booleanValue();
+        return Sarg.of(containsNull, builder.build());
+    }
+
+    private RexNode deserializeFieldAccess(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws IOException {
+        String fieldName = jsonNode.get(FIELD_NAME_NAME).asText();
+        JsonNode exprNode = jsonNode.get(FIELD_NAME_EXPR);
+        RexNode refExpr = deserializeRexNode(exprNode, ctx);
+        return ctx.getSerdeContext().getRexBuilder().makeFieldAccess(refExpr, fieldName, true);
+    }
+
+    private RexNode deserializeCorrelVariable(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws JsonProcessingException {
+        String correl = jsonNode.get(FIELD_NAME_CORREL).asText();
+        JsonNode typeNode = jsonNode.get(FIELD_NAME_TYPE);
+        RelDataType fieldType =
+                ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
+        return ctx.getSerdeContext()
+                .getRexBuilder()
+                .makeCorrel(fieldType, new CorrelationId(correl));
+    }
+
+    private RexNode deserializeCall(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws IOException {
+        RexBuilder rexBuilder = ctx.getSerdeContext().getRexBuilder();
+        SqlOperator operator = toOperator(jsonNode.get(FIELD_NAME_OPERATOR), ctx.getSerdeContext());
+        ArrayNode operandNodes = (ArrayNode) jsonNode.get(FIELD_NAME_OPERANDS);
+        List<RexNode> rexOperands = new ArrayList<>();
+        for (JsonNode node : operandNodes) {
+            rexOperands.add(deserializeRexNode(node, ctx));
+        }
+        final RelDataType callType;
+        if (jsonNode.has(FIELD_NAME_TYPE)) {
+            JsonNode typeNode = jsonNode.get(FIELD_NAME_TYPE);
+            callType =
+                    ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
+        } else {
+            callType = rexBuilder.deriveReturnType(operator, rexOperands);
+        }
+        return rexBuilder.makeCall(callType, operator, rexOperands);
+    }
+
+    private SqlOperator toOperator(JsonNode jsonNode, SerdeContext ctx) throws IOException {
+        String name = jsonNode.get(FIELD_NAME_NAME).asText();
+        SqlKind sqlKind = SqlKind.valueOf(jsonNode.get(FIELD_NAME_KIND).asText());
+        SqlSyntax sqlSyntax = SqlSyntax.valueOf(jsonNode.get(FIELD_NAME_SYNTAX).asText());
+        List<SqlOperator> operators = new ArrayList<>();
+        ctx.getOperatorTable()
+                .lookupOperatorOverloads(
+                        new SqlIdentifier(name, new SqlParserPos(0, 0)),
+                        null, // category
+                        sqlSyntax,
+                        operators,
+                        SqlNameMatchers.liberal());
+        for (SqlOperator operator : operators) {
+            // in case different operator has the same kind, check with both name and kind.
+            if (operator.kind == sqlKind) {
+                return operator;
+            }
+        }
+
+        // built-in function
+        // TODO supports other module's built-in function
+        if (jsonNode.has(FIELD_NAME_BUILT_IN) && jsonNode.get(FIELD_NAME_BUILT_IN).booleanValue()) {
+            Optional<FunctionDefinition> function = CoreModule.INSTANCE.getFunctionDefinition(name);
+            Preconditions.checkArgument(function.isPresent());
+            return BridgingSqlFunction.of(
+                    ctx.getFlinkContext(),
+                    ctx.getTypeFactory(),
+                    FunctionIdentifier.of(name),
+                    function.get());
+        }
+
+        if (jsonNode.has(FIELD_NAME_FUNCTION_KIND) && jsonNode.has(FIELD_NAME_INSTANCE)) {
+            FunctionKind functionKind =
+                    FunctionKind.valueOf(
+                            jsonNode.get(FIELD_NAME_FUNCTION_KIND).asText().toUpperCase());
+            String instanceStr = jsonNode.get(FIELD_NAME_INSTANCE).asText();
+            if (functionKind != FunctionKind.SCALAR) {
+                throw new TableException("Unknown function kind: " + functionKind);
+            }
+            if (jsonNode.has(FIELD_NAME_BRIDGING)
+                    && jsonNode.get(FIELD_NAME_BRIDGING).booleanValue()) {
+                FunctionDefinition function =
+                        EncodingUtils.decodeStringToObject(instanceStr, ctx.getClassLoader());
+                return BridgingSqlFunction.of(
+                        ctx.getFlinkContext(),
+                        ctx.getTypeFactory(),
+                        FunctionIdentifier.of(name),
+                        function);
+            } else {
+                String displayName = jsonNode.get(FIELD_NAME_DISPLAY_NAME).asText();
+                ScalarFunction function =
+                        EncodingUtils.decodeStringToObject(instanceStr, ctx.getClassLoader());
+                return new ScalarSqlFunction(
+                        FunctionIdentifier.of(name),
+                        displayName,
+                        function,
+                        ctx.getTypeFactory(),
+                        JavaScalaConversionUtil.toScala(Optional.empty()));
+            }
+        }
+        throw new TableException("Unknown operator: " + jsonNode.toPrettyString());
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
+import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.Sarg;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * JSON serializer for {@link RexNode}. refer to {@link RexNodeJsonDeserializer} for deserializer.
+ */
+public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
+    private static final long serialVersionUID = 1L;
+
+    // common fields
+    public static final String FIELD_NAME_KIND = "kind";
+    public static final String FIELD_NAME_VALUE = "value";
+    public static final String FIELD_NAME_TYPE = "type";
+    public static final String FIELD_NAME_NAME = "name";
+    // RexInputRef fields
+    public static final String FIELD_NAME_INPUT_INDEX = "inputIndex";
+    // RexLiteral fields
+    public static final String FIELD_NAME_CLASS = "class";
+    // RexFieldAccess fields
+    public static final String FIELD_NAME_EXPR = "expr";
+    // RexCorrelVariable fields
+    public static final String FIELD_NAME_CORREL = "correl";
+    // RexCall fields
+    public static final String FIELD_NAME_OPERATOR = "operator";
+    public static final String FIELD_NAME_OPERANDS = "operands";
+    public static final String FIELD_NAME_SYNTAX = "syntax";
+    public static final String FIELD_NAME_DISPLAY_NAME = "displayName";
+    public static final String FIELD_NAME_FUNCTION_KIND = "functionKind";
+    public static final String FIELD_NAME_INSTANCE = "instance";
+    public static final String FIELD_NAME_BRIDGING = "bridging";
+    public static final String FIELD_NAME_BUILT_IN = "builtIn";
+
+    // Sarg fields and values
+    public static final String FIELD_NAME_SARG = "sarg";
+    public static final String FIELD_NAME_RANGES = "ranges";
+    public static final String FIELD_NAME_BOUND_LOWER = "lower";
+    public static final String FIELD_NAME_BOUND_UPPER = "upper";
+    public static final String FIELD_NAME_BOUND_TYPE = "boundType";
+    public static final String FIELD_NAME_CONTAINS_NULL = "containsNull";
+
+    // supported SqlKinds
+    public static final String SQL_KIND_INPUT_REF = "INPUT_REF";
+    public static final String SQL_KIND_LITERAL = "LITERAL";
+    public static final String SQL_KIND_FIELD_ACCESS = "FIELD_ACCESS";
+    public static final String SQL_KIND_CORREL_VARIABLE = "CORREL_VARIABLE";
+    public static final String SQL_KIND_REX_CALL = "REX_CALL";
+
+    public RexNodeJsonSerializer() {
+        super(RexNode.class);
+    }
+
+    @Override
+    public void serialize(
+            RexNode rexNode, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+
+        switch (rexNode.getKind()) {
+            case INPUT_REF:
+            case TABLE_INPUT_REF:
+                serialize((RexInputRef) rexNode, jsonGenerator);
+                break;
+            case LITERAL:
+                serialize((RexLiteral) rexNode, jsonGenerator);
+                break;
+            case FIELD_ACCESS:
+                serialize((RexFieldAccess) rexNode, jsonGenerator);
+                break;
+            case CORREL_VARIABLE:
+                serialize((RexCorrelVariable) rexNode, jsonGenerator);
+                break;
+            default:
+                if (rexNode instanceof RexCall) {
+                    serialize((RexCall) rexNode, jsonGenerator);
+                } else {
+                    throw new TableException("Unknown RexNode: " + rexNode);
+                }
+        }
+    }
+
+    private void serialize(RexInputRef inputRef, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_INPUT_REF);
+        gen.writeNumberField(FIELD_NAME_INPUT_INDEX, inputRef.getIndex());
+        gen.writeObjectField(FIELD_NAME_TYPE, inputRef.getType());
+        gen.writeEndObject();
+    }
+
+    private void serialize(RexLiteral literal, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_LITERAL);
+        Comparable<?> value = literal.getValueAs(Comparable.class);
+        serialize(value, literal.getTypeName(), literal.getType().getSqlTypeName(), gen);
+        gen.writeObjectField(FIELD_NAME_TYPE, literal.getType());
+        gen.writeEndObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void serialize(
+            Comparable<?> value,
+            SqlTypeName literalTypeName,
+            SqlTypeName elementTypeName,
+            JsonGenerator gen)
+            throws IOException {
+        if (value == null) {
+            gen.writeNullField(FIELD_NAME_VALUE);
+            return;
+        }
+        switch (literalTypeName) {
+            case BOOLEAN:
+                gen.writeBooleanField(FIELD_NAME_VALUE, (Boolean) value);
+                break;
+            case TINYINT:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).byteValue());
+                break;
+            case SMALLINT:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).shortValue());
+                break;
+            case INTEGER:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).intValue());
+                break;
+            case BIGINT:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).longValue());
+                break;
+            case DOUBLE:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).doubleValue());
+                break;
+            case FLOAT:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).floatValue());
+                break;
+            case DECIMAL:
+            case REAL:
+                // use String to make sure that no data is lost
+                gen.writeStringField(FIELD_NAME_VALUE, value.toString());
+                break;
+            case BINARY:
+            case VARBINARY:
+                gen.writeStringField(FIELD_NAME_VALUE, ((ByteString) value).toBase64String());
+                break;
+            case CHAR:
+            case VARCHAR:
+                gen.writeStringField(FIELD_NAME_VALUE, ((NlsString) value).getValue());
+                break;
+            case DATE:
+            case TIME:
+            case TIME_WITH_LOCAL_TIME_ZONE:
+            case TIMESTAMP:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                // store string value to avoid data lost
+                gen.writeStringField(FIELD_NAME_VALUE, value.toString());
+                break;
+            case INTERVAL_YEAR:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_MONTH:
+            case INTERVAL_DAY:
+            case INTERVAL_DAY_HOUR:
+            case INTERVAL_DAY_MINUTE:
+            case INTERVAL_DAY_SECOND:
+            case INTERVAL_HOUR:
+            case INTERVAL_HOUR_MINUTE:
+            case INTERVAL_HOUR_SECOND:
+            case INTERVAL_MINUTE:
+            case INTERVAL_MINUTE_SECOND:
+            case INTERVAL_SECOND:
+                gen.writeNumberField(FIELD_NAME_VALUE, ((BigDecimal) value).longValue());
+                break;
+            case SYMBOL:
+                gen.writeStringField(FIELD_NAME_VALUE, ((Enum<?>) value).name());
+                gen.writeStringField(FIELD_NAME_CLASS, value.getClass().getName());
+                break;
+            case SARG:
+                serialize((Sarg<?>) value, elementTypeName, gen);
+                break;
+            case ROW:
+            case MULTISET:
+                gen.writeFieldName(FIELD_NAME_VALUE);
+                gen.writeStartArray();
+                for (RexLiteral v : (FlatLists.ComparableList<RexLiteral>) value) {
+                    serialize(v, gen);
+                }
+                gen.writeEndArray();
+                break;
+            default:
+                // TODO support ARRAY, MAP
+                throw new TableException("Unknown value: " + value + ", type: " + literalTypeName);
+        }
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private void serialize(Sarg<?> value, SqlTypeName sqlTypeName, JsonGenerator gen)
+            throws IOException {
+        gen.writeFieldName(FIELD_NAME_SARG);
+        gen.writeStartObject();
+        gen.writeFieldName(FIELD_NAME_RANGES);
+        gen.writeStartArray();
+        for (com.google.common.collect.Range<?> range : value.rangeSet.asRanges()) {
+            gen.writeStartObject();
+            if (range.hasLowerBound()) {
+                gen.writeFieldName(FIELD_NAME_BOUND_LOWER);
+                gen.writeStartObject();
+                serialize(range.lowerEndpoint(), sqlTypeName, sqlTypeName, gen);
+                gen.writeStringField(FIELD_NAME_BOUND_TYPE, range.lowerBoundType().name());
+                gen.writeEndObject();
+            }
+            if (range.hasUpperBound()) {
+                gen.writeFieldName(FIELD_NAME_BOUND_UPPER);
+                gen.writeStartObject();
+                serialize(range.upperEndpoint(), sqlTypeName, sqlTypeName, gen);
+                gen.writeStringField(FIELD_NAME_BOUND_TYPE, range.upperBoundType().name());
+                gen.writeEndObject();
+            }
+            gen.writeEndObject();
+        }
+        gen.writeEndArray();
+        gen.writeBooleanField(FIELD_NAME_CONTAINS_NULL, value.containsNull);
+        gen.writeEndObject();
+    }
+
+    private void serialize(RexFieldAccess fieldAccess, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_FIELD_ACCESS);
+        gen.writeStringField(FIELD_NAME_NAME, fieldAccess.getField().getName());
+        gen.writeObjectField(FIELD_NAME_EXPR, fieldAccess.getReferenceExpr());
+        gen.writeEndObject();
+    }
+
+    private void serialize(RexCorrelVariable variable, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_CORREL_VARIABLE);
+        gen.writeStringField(FIELD_NAME_CORREL, variable.getName());
+        gen.writeObjectField(FIELD_NAME_TYPE, variable.getType());
+        gen.writeEndObject();
+    }
+
+    private void serialize(RexCall call, JsonGenerator gen) throws IOException {
+        if (!call.getClass().isAssignableFrom(RexCall.class)) {
+            throw new TableException("Unknown RexCall: " + call);
+        }
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_REX_CALL);
+        serialize(call.getOperator(), gen);
+        gen.writeFieldName(FIELD_NAME_OPERANDS);
+        gen.writeStartArray();
+        for (RexNode operand : call.getOperands()) {
+            gen.writeObject(operand);
+        }
+        gen.writeEndArray();
+        gen.writeObjectField(FIELD_NAME_TYPE, call.getType());
+        gen.writeEndObject();
+    }
+
+    private void serialize(SqlOperator operator, JsonGenerator gen) throws IOException {
+        gen.writeFieldName(FIELD_NAME_OPERATOR);
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_NAME, operator.getName());
+        gen.writeStringField(FIELD_NAME_KIND, operator.kind.name());
+        gen.writeStringField(FIELD_NAME_SYNTAX, operator.getSyntax().name());
+        // TODO if a udf is registered with class name, class name is recorded enough
+        if (operator instanceof ScalarSqlFunction) {
+            ScalarSqlFunction scalarSqlFunc = (ScalarSqlFunction) operator;
+            gen.writeStringField(FIELD_NAME_DISPLAY_NAME, scalarSqlFunc.displayName());
+            gen.writeStringField(FIELD_NAME_FUNCTION_KIND, FunctionKind.SCALAR.name());
+            gen.writeStringField(
+                    FIELD_NAME_INSTANCE,
+                    EncodingUtils.encodeObjectToString(scalarSqlFunc.scalarFunction()));
+        } else if (operator instanceof BridgingSqlFunction) {
+            BridgingSqlFunction bridgingSqlFunc = (BridgingSqlFunction) operator;
+            FunctionDefinition functionDefinition = bridgingSqlFunc.getDefinition();
+            if (functionDefinition instanceof BuiltInFunctionDefinition) {
+                // just record the flag, we can find it by name
+                gen.writeBooleanField(FIELD_NAME_BUILT_IN, true);
+            } else {
+                gen.writeStringField(FIELD_NAME_FUNCTION_KIND, functionDefinition.getKind().name());
+                gen.writeStringField(
+                        FIELD_NAME_INSTANCE,
+                        EncodingUtils.encodeObjectToString(functionDefinition));
+                gen.writeBooleanField(FIELD_NAME_BRIDGING, true);
+            }
+        }
+        gen.writeEndObject();
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SerdeContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SerdeContext.java
@@ -19,24 +19,55 @@
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.SqlOperatorTable;
 
 /**
  * A context to allow the store user-defined data within ExecNode serialization and deserialization.
  */
 public class SerdeContext {
-    private final Configuration configuration;
     private final ClassLoader classLoader;
+    private final FlinkContext flinkContext;
+    private final FlinkTypeFactory typeFactory;
+    private final SqlOperatorTable operatorTable;
+    private final RexBuilder rexBuilder;
 
-    public SerdeContext(Configuration configuration, ClassLoader classLoader) {
-        this.configuration = configuration;
+    public SerdeContext(
+            FlinkContext flinkContext,
+            ClassLoader classLoader,
+            FlinkTypeFactory typeFactory,
+            SqlOperatorTable operatorTable) {
         this.classLoader = classLoader;
+        this.flinkContext = flinkContext;
+        this.typeFactory = typeFactory;
+        this.operatorTable = operatorTable;
+        this.rexBuilder = new RexBuilder(typeFactory);
     }
 
     public Configuration getConfiguration() {
-        return configuration;
+        return flinkContext.getTableConfig().getConfiguration();
     }
 
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public FlinkContext getFlinkContext() {
+        return flinkContext;
+    }
+
+    public FlinkTypeFactory getTypeFactory() {
+        return typeFactory;
+    }
+
+    public SqlOperatorTable getOperatorTable() {
+        return operatorTable;
+    }
+
+    public RexBuilder getRexBuilder() {
+        return rexBuilder;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -25,21 +25,51 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecCalc;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rex.RexProgram;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 
 /** Stream {@link ExecNode} for Calc. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {
 
     public StreamExecCalc(
-            RexProgram calcProgram,
+            List<RexNode> projection,
+            @Nullable RexNode condition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
+        this(
+                projection,
+                condition,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecCalc(
+            @JsonProperty(FIELD_NAME_PROJECTION) List<RexNode> projection,
+            @JsonProperty(FIELD_NAME_CONDITION) @Nullable RexNode condition,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
-                calcProgram,
+                projection,
+                condition,
                 TableStreamOperator.class,
                 true, // retainHeader
-                inputProperty,
+                id,
+                inputProperties,
                 outputType,
                 description);
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -38,7 +38,7 @@ object CalcCodeGenerator {
       ctx: CodeGeneratorContext,
       inputTransform: Transformation[RowData],
       outputType: RowType,
-      calcProgram: RexProgram,
+      projection: Seq[RexNode],
       condition: Option[RexNode],
       retainHeader: Boolean = false,
       opName: String): CodeGenOperatorFactory[RowData] = {
@@ -52,7 +52,7 @@ object CalcCodeGenerator {
       inputType,
       outputType,
       classOf[BoxedWrapperRowData],
-      calcProgram,
+      projection,
       condition,
       eagerInputUnboxingCode = true,
       retainHeader = retainHeader,
@@ -75,7 +75,7 @@ object CalcCodeGenerator {
       name: String,
       returnType: RowType,
       outRowClass: Class[_ <: RowData],
-      calcProjection: RexProgram,
+      calcProjection: Seq[RexNode],
       calcCondition: Option[RexNode],
       config: TableConfig): GeneratedFunction[FlatMapFunction[RowData, RowData]] = {
     val ctx = CodeGeneratorContext(config)
@@ -109,7 +109,7 @@ object CalcCodeGenerator {
       inputType: RowType,
       outRowType: RowType,
       outRowClass: Class[_ <: RowData],
-      calcProgram: RexProgram,
+      projection: Seq[RexNode],
       condition: Option[RexNode],
       inputTerm: String = CodeGenUtils.DEFAULT_INPUT1_TERM,
       collectorTerm: String = CodeGenUtils.DEFAULT_OPERATOR_COLLECTOR_TERM,
@@ -117,8 +117,6 @@ object CalcCodeGenerator {
       retainHeader: Boolean = false,
       outputDirectly: Boolean = false,
       allowSplit: Boolean = false): String = {
-
-    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
 
     // according to the SQL standard, every table function should also be a scalar function
     // but we don't allow that for now
@@ -133,13 +131,13 @@ object CalcCodeGenerator {
         rexNode.isInstanceOf[RexInputRef] && rexNode.asInstanceOf[RexInputRef].getIndex == index
       }
 
-    def produceOutputCode(resultTerm: String) = if (outputDirectly) {
+    def produceOutputCode(resultTerm: String): String = if (outputDirectly) {
       s"$collectorTerm.collect($resultTerm);"
     } else {
       s"${OperatorCodeGenerator.generateCollect(resultTerm)}"
     }
 
-    def produceProjectionCode = {
+    def produceProjectionCode: String = {
       val projectionExprs = projection.map(exprGenerator.generateExpression)
       val projectionExpression = exprGenerator.generateResultExpression(
         projectionExprs,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -508,8 +508,9 @@ object LookupJoinCodeGenerator {
       calcProgram: Option[RexProgram],
       tableSourceRowType: RowType)
     : GeneratedFunction[FlatMapFunction[RowData, RowData]] = {
-
+    require(calcProgram.isDefined)
     val program = calcProgram.get
+    val projection = program.getProjectList.asScala.map(program.expandLocalRef)
     val condition = if (program.getCondition != null) {
       Some(program.expandLocalRef(program.getCondition))
     } else {
@@ -520,7 +521,7 @@ object LookupJoinCodeGenerator {
       "TableCalcMapFunction",
       FlinkTypeFactory.toLogicalRowType(program.getOutputRowType),
       classOf[GenericRowData],
-      program,
+      projection,
       condition,
       config)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -437,7 +437,13 @@ abstract class PlannerBase(
   }
 
   protected def createSerdeContext: SerdeContext = {
-    new SerdeContext(config.getConfiguration, getClassLoader)
+    val planner = createFlinkPlanner
+    new SerdeContext(
+      planner.config.getContext.asInstanceOf[FlinkContext],
+      getClassLoader,
+      plannerContext.getTypeFactory,
+      planner.operatorTable
+    )
   }
 
   private def getClassLoader: ClassLoader = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
@@ -45,7 +45,7 @@ import scala.collection.JavaConverters._
   */
 class ScalarSqlFunction(
     identifier: FunctionIdentifier,
-    displayName: String,
+    val displayName: String,
     val scalarFunction: ScalarFunction,
     typeFactory: FlinkTypeFactory,
     returnTypeInfer: Option[SqlReturnTypeInference] = None)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalCalc.scala
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rex.RexProgram
 
+import scala.collection.JavaConversions._
+
 /**
   * Batch physical RelNode for [[Calc]].
   */
@@ -44,8 +46,16 @@ class BatchPhysicalCalc(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
+    val projection = calcProgram.getProjectList.map(calcProgram.expandLocalRef)
+    val condition = if (calcProgram.getCondition != null) {
+      calcProgram.expandLocalRef(calcProgram.getCondition)
+    } else {
+      null
+    }
+
     new BatchExecCalc(
-      getProgram,
+      projection,
+      condition,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -19,8 +19,12 @@
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -51,7 +55,12 @@ public class DynamicTableSinkSpecSerdeTest {
     @Test
     public void testDynamicTableSinkSpecSerde() throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        SerdeContext serdeCtx = new SerdeContext(new Configuration(), classLoader);
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        new FlinkContextImpl(TableConfig.getDefault(), null, null, null),
+                        classLoader,
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
         ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
         SimpleModule module = new SimpleModule();
         module.addDeserializer(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -51,7 +54,12 @@ public class DynamicTableSourceSpecSerdeTest {
     @Test
     public void testDynamicTableSourceSpecSerde() throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        SerdeContext serdeCtx = new SerdeContext(new Configuration(), classLoader);
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        new FlinkContextImpl(TableConfig.getDefault(), null, null, null),
+                        classLoader,
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
         ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
         SimpleModule module = new SimpleModule();
         module.addDeserializer(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -21,9 +21,10 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.types.logical.ArrayType;
@@ -87,9 +88,8 @@ public class LogicalTypeSerdeTest {
     public void testLogicalTypeSerde() throws IOException {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new Configuration(),
+                        new FlinkContextImpl(TableConfig.getDefault(), null, null, null),
                         Thread.currentThread().getContextClassLoader(),
-                        null, // FlinkContext
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());
         ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -85,7 +87,11 @@ public class LogicalTypeSerdeTest {
     public void testLogicalTypeSerde() throws IOException {
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new Configuration(), Thread.currentThread().getContextClassLoader());
+                        new Configuration(),
+                        Thread.currentThread().getContextClassLoader(),
+                        null, // FlinkContext
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
         ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
         SimpleModule module = new SimpleModule();
 
@@ -115,12 +121,16 @@ public class LogicalTypeSerdeTest {
                         new DoubleType(),
                         new DecimalType(10),
                         new DecimalType(15, 5),
+                        CharType.ofEmptyLiteral(),
                         new CharType(),
                         new CharType(5),
+                        VarCharType.ofEmptyLiteral(),
                         new VarCharType(),
                         new VarCharType(5),
+                        BinaryType.ofEmptyLiteral(),
                         new BinaryType(),
                         new BinaryType(100),
+                        VarBinaryType.ofEmptyLiteral(),
                         new VarBinaryType(),
                         new VarBinaryType(100),
                         new DateType(),

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RelDataTypeSerdeTest.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.VoidSerializer;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/** Tests for serialization/deserialization of {@link RelDataType}. */
+@RunWith(Parameterized.class)
+public class RelDataTypeSerdeTest {
+    private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
+
+    @Parameterized.Parameters(name = "type = {0}")
+    public static Collection<RelDataType> parameters() {
+        // the values in the list do not care about nullable.
+        List<RelDataType> types =
+                Arrays.asList(
+                        FACTORY.createSqlType(SqlTypeName.BOOLEAN),
+                        FACTORY.createSqlType(SqlTypeName.TINYINT),
+                        FACTORY.createSqlType(SqlTypeName.SMALLINT),
+                        FACTORY.createSqlType(SqlTypeName.INTEGER),
+                        FACTORY.createSqlType(SqlTypeName.BIGINT),
+                        FACTORY.createSqlType(SqlTypeName.DECIMAL, 3, 10),
+                        FACTORY.createSqlType(SqlTypeName.DECIMAL, 0, 19),
+                        FACTORY.createSqlType(SqlTypeName.DECIMAL, -1, 19),
+                        FACTORY.createSqlType(SqlTypeName.FLOAT),
+                        FACTORY.createSqlType(SqlTypeName.REAL),
+                        FACTORY.createSqlType(SqlTypeName.DOUBLE),
+                        FACTORY.createSqlType(SqlTypeName.DATE),
+                        FACTORY.createSqlType(SqlTypeName.TIME),
+                        FACTORY.createSqlType(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE),
+                        FACTORY.createSqlType(SqlTypeName.TIMESTAMP),
+                        FACTORY.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.YEAR, TimeUnit.YEAR, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MONTH, TimeUnit.MONTH, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        FACTORY.createSqlIntervalType(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.SECOND, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        FACTORY.createSqlType(SqlTypeName.CHAR),
+                        FACTORY.createSqlType(SqlTypeName.CHAR, 0),
+                        FACTORY.createSqlType(SqlTypeName.CHAR, 32),
+                        FACTORY.createSqlType(SqlTypeName.VARCHAR),
+                        FACTORY.createSqlType(SqlTypeName.VARCHAR, 0),
+                        FACTORY.createSqlType(SqlTypeName.VARCHAR, 10),
+                        FACTORY.createSqlType(SqlTypeName.BINARY),
+                        FACTORY.createSqlType(SqlTypeName.BINARY, 0),
+                        FACTORY.createSqlType(SqlTypeName.BINARY, 100),
+                        FACTORY.createSqlType(SqlTypeName.VARBINARY),
+                        FACTORY.createSqlType(SqlTypeName.VARBINARY, 0),
+                        FACTORY.createSqlType(SqlTypeName.VARBINARY, 1000),
+                        FACTORY.createSqlType(SqlTypeName.NULL),
+                        FACTORY.createSqlType(SqlTypeName.ANY),
+                        FACTORY.createSqlType(SqlTypeName.SYMBOL),
+                        FACTORY.createMultisetType(FACTORY.createSqlType(SqlTypeName.VARCHAR), -1),
+                        FACTORY.createArrayType(FACTORY.createSqlType(SqlTypeName.VARCHAR, 16), -1),
+                        FACTORY.createArrayType(
+                                FACTORY.createArrayType(
+                                        FACTORY.createSqlType(SqlTypeName.VARCHAR, 16), -1),
+                                -1),
+                        FACTORY.createMapType(
+                                FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                FACTORY.createSqlType(SqlTypeName.VARCHAR, 10)),
+                        FACTORY.createMapType(
+                                FACTORY.createMapType(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                        FACTORY.createSqlType(SqlTypeName.VARCHAR, 10)),
+                                FACTORY.createArrayType(
+                                        FACTORY.createMapType(
+                                                FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                                FACTORY.createSqlType(SqlTypeName.VARCHAR, 10)),
+                                        -1)),
+                        FACTORY.createSqlType(SqlTypeName.DISTINCT),
+                        FACTORY.createSqlType(SqlTypeName.STRUCTURED),
+                        // simple struct type
+                        FACTORY.createStructType(
+                                StructKind.PEEK_FIELDS,
+                                Arrays.asList(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                        FACTORY.createSqlType(SqlTypeName.DECIMAL, 3, 10)),
+                                Arrays.asList("f1", "f2")),
+                        // struct type with array type
+                        FACTORY.createStructType(
+                                Arrays.asList(
+                                        FACTORY.createSqlType(SqlTypeName.VARCHAR),
+                                        FACTORY.createArrayType(
+                                                FACTORY.createSqlType(SqlTypeName.VARCHAR, 16),
+                                                -1)),
+                                Arrays.asList("f1", "f2")),
+                        // nested struct type
+                        FACTORY.createStructType(
+                                Arrays.asList(
+                                        FACTORY.createStructType(
+                                                Arrays.asList(
+                                                        FACTORY.createSqlType(
+                                                                SqlTypeName.VARCHAR, 5),
+                                                        FACTORY.createSqlType(
+                                                                SqlTypeName.VARCHAR, 10)),
+                                                Arrays.asList("f1", "f2")),
+                                        FACTORY.createArrayType(
+                                                FACTORY.createSqlType(SqlTypeName.VARCHAR, 16),
+                                                -1)),
+                                Arrays.asList("f3", "f4")),
+                        FACTORY.createSqlType(SqlTypeName.SARG),
+                        FACTORY.createRowtimeIndicatorType(true),
+                        FACTORY.createProctimeIndicatorType(true),
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new LegacyTypeInformationType<>(LogicalTypeRoot.RAW, Types.STRING)),
+                        FACTORY.createFieldTypeFromLogicalType(
+                                StructuredType.newBuilder(
+                                                ObjectIdentifier.of("cat", "db", "structuredType"),
+                                                LogicalTypeSerdeTest.PojoClass.class)
+                                        .attributes(
+                                                Arrays.asList(
+                                                        new StructuredType.StructuredAttribute(
+                                                                "f0", new IntType(true)),
+                                                        new StructuredType.StructuredAttribute(
+                                                                "f1", new BigIntType(true)),
+                                                        new StructuredType.StructuredAttribute(
+                                                                "f2",
+                                                                new VarCharType(200),
+                                                                "desc")))
+                                        .comparision(StructuredType.StructuredComparision.FULL)
+                                        .setFinal(false)
+                                        .setInstantiable(false)
+                                        .description("description for StructuredType")
+                                        .build()));
+
+        List<RelDataType> ret = new ArrayList<>(types.size() * 2);
+        for (RelDataType type : types) {
+            ret.add(FACTORY.createTypeWithNullability(type, true));
+            ret.add(FACTORY.createTypeWithNullability(type, false));
+        }
+
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new RawType<>(true, Void.class, VoidSerializer.INSTANCE)),
+                        true));
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new RawType<>(false, Void.class, VoidSerializer.INSTANCE)),
+                        false));
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new RawType<>(true, Void.class, VoidSerializer.INSTANCE)),
+                        false));
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new TypeInformationRawType<>(true, Types.STRING)),
+                        true));
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new TypeInformationRawType<>(false, Types.STRING)),
+                        false));
+        ret.add(
+                FACTORY.createTypeWithNullability(
+                        FACTORY.createFieldTypeFromLogicalType(
+                                new TypeInformationRawType<>(true, Types.STRING)),
+                        false));
+
+        return ret;
+    }
+
+    @Parameterized.Parameter public RelDataType relDataType;
+
+    @Test
+    public void testTypeSerde() throws Exception {
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        new FlinkContextImpl(TableConfig.getDefault(), null, null, null),
+                        Thread.currentThread().getContextClassLoader(),
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
+        ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
+        SimpleModule module = new SimpleModule();
+
+        module.addSerializer(new RelDataTypeJsonSerializer());
+        module.addSerializer(new LogicalTypeJsonSerializer());
+        module.addSerializer(new ObjectIdentifierJsonSerializer());
+        module.addDeserializer(RelDataType.class, new RelDataTypeJsonDeserializer());
+        module.addDeserializer(LogicalType.class, new LogicalTypeJsonDeserializer());
+        module.addDeserializer(ObjectIdentifier.class, new ObjectIdentifierJsonDeserializer());
+        mapper.registerModule(module);
+        StringWriter writer = new StringWriter(100);
+        try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
+            gen.writeObject(relDataType);
+        }
+
+        String json = writer.toString();
+        RelDataType actual = mapper.readValue(json, RelDataType.class);
+        // type system will fill the default precision if the precision is not defined
+        if (relDataType.toString().equals("DECIMAL")) {
+            assertEquals(SqlTypeName.DECIMAL, actual.getSqlTypeName());
+            assertEquals(relDataType.getScale(), actual.getScale());
+            assertEquals(
+                    serdeCtx.getTypeFactory()
+                            .getTypeSystem()
+                            .getDefaultPrecision(SqlTypeName.DECIMAL),
+                    actual.getPrecision());
+        } else {
+            assertSame(relDataType, actual);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.StructKind;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.fun.SqlTrimFunction;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.Sarg;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for serialization/deserialization of {@link RexNode}. */
+@RunWith(Parameterized.class)
+public class RexNodeSerdeTest {
+    private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
+
+    @SuppressWarnings({"rawtypes", "unchecked", "UnstableApiUsage"})
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[][] parameters() {
+        TableConfig tableConfig = TableConfig.getDefault();
+        CatalogManager catalogManager =
+                CatalogManager.newBuilder()
+                        .classLoader(Thread.currentThread().getContextClassLoader())
+                        .config(tableConfig.getConfiguration())
+                        .defaultCatalog("default_catalog", new GenericInMemoryCatalog("default_db"))
+                        .build();
+        FlinkContext flinkContext =
+                new FlinkContextImpl(
+                        tableConfig,
+                        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+                        catalogManager,
+                        null); // toRexFactory
+        RexBuilder rexBuilder = new RexBuilder(FACTORY);
+        RelDataType inputType =
+                FACTORY.createStructType(
+                        StructKind.PEEK_FIELDS,
+                        Arrays.asList(
+                                FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                FACTORY.createSqlType(SqlTypeName.BIGINT),
+                                FACTORY.createStructType(
+                                        StructKind.PEEK_FIELDS,
+                                        Arrays.asList(
+                                                FACTORY.createSqlType(SqlTypeName.VARCHAR),
+                                                FACTORY.createSqlType(SqlTypeName.VARCHAR)),
+                                        Arrays.asList("n1", "n2"))),
+                        Arrays.asList("f1", "f2", "f3"));
+
+        Random random = new Random();
+        List<RexNode> rexNodes =
+                Arrays.asList(
+                        rexBuilder.makeNullLiteral(FACTORY.createSqlType(SqlTypeName.VARCHAR)),
+                        rexBuilder.makeLiteral(random.nextBoolean()),
+                        rexBuilder.makeExactLiteral(
+                                new BigDecimal((byte) random.nextInt()),
+                                FACTORY.createSqlType(SqlTypeName.TINYINT)),
+                        rexBuilder.makeExactLiteral(
+                                new BigDecimal((short) random.nextInt()),
+                                FACTORY.createSqlType(SqlTypeName.SMALLINT)),
+                        rexBuilder.makeExactLiteral(
+                                new BigDecimal(random.nextInt()),
+                                FACTORY.createSqlType(SqlTypeName.INTEGER)),
+                        rexBuilder.makeExactLiteral(
+                                new BigDecimal(random.nextLong()),
+                                FACTORY.createSqlType(SqlTypeName.BIGINT)),
+                        rexBuilder.makeExactLiteral(
+                                BigDecimal.valueOf(random.nextDouble()),
+                                FACTORY.createSqlType(SqlTypeName.DOUBLE)),
+                        rexBuilder.makeApproxLiteral(
+                                BigDecimal.valueOf(random.nextFloat()),
+                                FACTORY.createSqlType(SqlTypeName.FLOAT)),
+                        rexBuilder.makeExactLiteral(BigDecimal.valueOf(random.nextDouble())),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.YEAR, TimeUnit.YEAR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(100),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.YEAR, TimeUnit.YEAR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MONTH, TimeUnit.MONTH, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MONTH, TimeUnit.MONTH, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.HOUR, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.HOUR, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.MINUTE, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.MINUTE, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                new SqlIntervalQualifier(
+                                        TimeUnit.SECOND, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeIntervalLiteral(
+                                BigDecimal.valueOf(3),
+                                new SqlIntervalQualifier(
+                                        TimeUnit.SECOND, TimeUnit.SECOND, SqlParserPos.ZERO)),
+                        rexBuilder.makeDateLiteral(DateString.fromDaysSinceEpoch(10)),
+                        rexBuilder.makeDateLiteral(new DateString("2000-12-12")),
+                        rexBuilder.makeTimeLiteral(TimeString.fromMillisOfDay(1234), 3),
+                        rexBuilder.makeTimeLiteral(TimeString.fromMillisOfDay(123456), 6),
+                        rexBuilder.makeTimeLiteral(new TimeString("01:01:01.000000001"), 9),
+                        rexBuilder.makeTimeWithLocalTimeZoneLiteral(
+                                TimeString.fromMillisOfDay(1234), 3),
+                        rexBuilder.makeTimestampLiteral(
+                                TimestampString.fromMillisSinceEpoch(1234), 3),
+                        rexBuilder.makeTimestampLiteral(
+                                TimestampString.fromMillisSinceEpoch(123456789), 9),
+                        rexBuilder.makeTimestampLiteral(
+                                new TimestampString("0001-01-01 01:01:01.000000001"), 9),
+                        rexBuilder.makeTimestampLiteral(
+                                new TimestampString("2000-12-12 12:30:57.1234"), 4),
+                        rexBuilder.makeBinaryLiteral(ByteString.EMPTY),
+                        rexBuilder.makeBinaryLiteral(
+                                ByteString.ofBase64(EncodingUtils.encodeObjectToString("abc"))),
+                        rexBuilder.makeLiteral(""),
+                        rexBuilder.makeLiteral("abc"),
+                        rexBuilder.makeFlag(SqlTrimFunction.Flag.BOTH),
+                        rexBuilder.makeFlag(TimeUnitRange.DAY),
+                        rexBuilder.makeLiteral(
+                                Arrays.<Object>asList(1, 2L),
+                                FACTORY.createStructType(
+                                        Arrays.asList(
+                                                FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                                FACTORY.createSqlType(SqlTypeName.BIGINT)),
+                                        Arrays.asList("f1", "f2")),
+                                false),
+                        rexBuilder.makeSearchArgumentLiteral(
+                                Sarg.of(
+                                        false,
+                                        com.google.common.collect.ImmutableRangeSet.<Comparable>of(
+                                                com.google.common.collect.Range.closed(
+                                                        BigDecimal.valueOf(1),
+                                                        BigDecimal.valueOf(10)))),
+                                FACTORY.createSqlType(SqlTypeName.INTEGER)),
+                        rexBuilder.makeSearchArgumentLiteral(
+                                Sarg.of(
+                                        false,
+                                        com.google.common.collect.ImmutableRangeSet.<Comparable>of(
+                                                com.google.common.collect.Range.range(
+                                                        BigDecimal.valueOf(1),
+                                                        com.google.common.collect.BoundType.OPEN,
+                                                        BigDecimal.valueOf(10),
+                                                        com.google.common.collect.BoundType
+                                                                .CLOSED))),
+                                FACTORY.createSqlType(SqlTypeName.INTEGER)),
+                        rexBuilder.makeSearchArgumentLiteral(
+                                Sarg.of(
+                                        false,
+                                        com.google.common.collect.TreeRangeSet.<Comparable>create(
+                                                Arrays.asList(
+                                                        com.google.common.collect.Range.closed(
+                                                                BigDecimal.valueOf(1),
+                                                                BigDecimal.valueOf(1)),
+                                                        com.google.common.collect.Range.closed(
+                                                                BigDecimal.valueOf(3),
+                                                                BigDecimal.valueOf(3)),
+                                                        com.google.common.collect.Range.closed(
+                                                                BigDecimal.valueOf(6),
+                                                                BigDecimal.valueOf(6))))),
+                                FACTORY.createSqlType(SqlTypeName.INTEGER)),
+                        rexBuilder.makeInputRef(FACTORY.createSqlType(SqlTypeName.BIGINT), 0),
+                        rexBuilder.makeCorrel(inputType, new CorrelationId("$cor1")),
+                        rexBuilder.makeFieldAccess(
+                                rexBuilder.makeCorrel(inputType, new CorrelationId("$cor2")),
+                                "f2",
+                                true),
+                        // cast($1 as smallint)
+                        rexBuilder.makeCast(
+                                FACTORY.createSqlType(SqlTypeName.SMALLINT),
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 1)),
+                        // $1 in (1, 3, 5)
+                        rexBuilder.makeIn(
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 1),
+                                Arrays.asList(
+                                        rexBuilder.makeExactLiteral(new BigDecimal(1)),
+                                        rexBuilder.makeExactLiteral(new BigDecimal(3)),
+                                        rexBuilder.makeExactLiteral(new BigDecimal(5)))),
+                        // null or $1 is null
+                        rexBuilder.makeCall(
+                                SqlStdOperatorTable.OR,
+                                rexBuilder.makeNullLiteral(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER)),
+                                rexBuilder.makeCall(
+                                        SqlStdOperatorTable.IS_NOT_NULL,
+                                        rexBuilder.makeInputRef(
+                                                FACTORY.createSqlType(SqlTypeName.INTEGER), 1))),
+                        // $1 >= 10
+                        rexBuilder.makeCall(
+                                SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 1),
+                                rexBuilder.makeExactLiteral(new BigDecimal(10))),
+                        // hash_code($1)
+                        rexBuilder.makeCall(
+                                FlinkSqlOperatorTable.HASH_CODE,
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 1)),
+                        // MyUdf($0)
+                        rexBuilder.makeCall(
+                                new ScalarSqlFunction(
+                                        FunctionIdentifier.of("MyUdf"),
+                                        "MyUdf",
+                                        new ScalarFunc1(),
+                                        FACTORY,
+                                        JavaScalaConversionUtil.toScala(Optional.empty())),
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 0)),
+                        // MyUdf($0)
+                        rexBuilder.makeCall(
+                                BridgingSqlFunction.of(
+                                        flinkContext,
+                                        FACTORY,
+                                        null, // identifier
+                                        new ScalarFunc1()),
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 0)),
+                        // type_of($0)
+                        rexBuilder.makeCall(
+                                BridgingSqlFunction.of(
+                                        flinkContext,
+                                        FACTORY,
+                                        FunctionIdentifier.of(
+                                                BuiltInFunctionDefinitions.TYPE_OF.getName()),
+                                        BuiltInFunctionDefinitions.TYPE_OF),
+                                rexBuilder.makeInputRef(
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 0)));
+        return rexNodes.stream().map(n -> new Object[] {n, flinkContext}).toArray(Object[][]::new);
+    }
+
+    @Parameterized.Parameter public RexNode rexNode;
+
+    @Parameterized.Parameter(1)
+    public FlinkContext flinkContext;
+
+    @Test
+    public void testRexNodeSerde() throws Exception {
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        flinkContext,
+                        Thread.currentThread().getContextClassLoader(),
+                        FACTORY,
+                        FlinkSqlOperatorTable.instance());
+        ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
+        SimpleModule module = new SimpleModule();
+
+        module.addSerializer(new RexNodeJsonSerializer());
+        module.addSerializer(new RelDataTypeJsonSerializer());
+        module.addDeserializer(RexNode.class, new RexNodeJsonDeserializer());
+        module.addDeserializer(RelDataType.class, new RelDataTypeJsonDeserializer());
+        mapper.registerModule(module);
+        StringWriter writer = new StringWriter(100);
+        try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
+            gen.writeObject(rexNode);
+        }
+        String json = writer.toString();
+        RexNode actual = mapper.readValue(json, RexNode.class);
+        assertEquals(rexNode, actual);
+    }
+
+    /** Testing ScalarFunction. */
+    public static class ScalarFunc1 extends ScalarFunction {
+        public int eval(int i) {
+            return i + 1;
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc1;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc2;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc5;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.UdfWithOpen;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization/deserialization for calc. */
+public class CalcJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  a bigint,\n"
+                        + "  b int not null,\n"
+                        + "  c varchar,\n"
+                        + "  d timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableDdl);
+    }
+
+    @Test
+    public void testSimpleProject() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b int\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan("insert into MySink select a, b from MyTable");
+    }
+
+    @Test
+    public void testSimpleFilter() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b int,\n"
+                        + "  c varchar,\n"
+                        + "  d timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan("insert into MySink select * from MyTable where b > 0");
+    }
+
+    @Test
+    public void testComplexCalc() {
+        tEnv.createTemporaryFunction("udf1", new JavaFunc0());
+        tEnv.createTemporaryFunction("udf2", JavaFunc1.class);
+        tEnv.createTemporarySystemFunction("udf3", new JavaFunc2());
+        tEnv.createTemporarySystemFunction("udf4", UdfWithOpen.class);
+        tEnv.createFunction("udf5", JavaFunc5.class);
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  a1 varchar,\n"
+                        + "  b int,\n"
+                        + "  b1 varchar,\n"
+                        + "  c1 varchar,\n"
+                        + "  c2 varchar,\n"
+                        + "  d1 timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan(
+                "insert into MySink select "
+                        + "a, "
+                        + "cast(a as varchar) as a1, "
+                        + "b, "
+                        + "udf2(b, b, d) as b1, "
+                        + "udf3(c, b) as c1, "
+                        + "udf4(substring(c, 1, 5)) as c2, "
+                        + "udf5(d, 1000) as d1 "
+                        + "from MyTable where "
+                        + "(udf1(a) > 0 or (a * b) < 100) and b > 10");
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -63,7 +63,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecCorrelate",
                     "StreamExecPythonCorrelate",
                     "StreamExecRank",
-                    "StreamExecCalc",
                     "StreamExecPythonCalc",
                     "StreamExecLimit",
                     "StreamExecSortLimit",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CalcJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CalcJsonPlanITCase.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc2;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.UdfWithOpen;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+/** Test for calc json plan. */
+public class CalcJsonPlanITCase extends JsonPlanTestBase {
+
+    @Test
+    public void testCalcJsonPlan() throws Exception {
+        tableEnv.createTemporaryFunction("udf1", new JavaFunc0());
+        tableEnv.createTemporarySystemFunction("udf2", new JavaFunc2());
+        tableEnv.createFunction("udf3", UdfWithOpen.class);
+
+        List<String> data = Arrays.asList("1,1,hi", "2,1,hello", "3,2,hello world");
+        createTestCsvSourceTable("MyTable", data, "a bigint", "b int not null", "c varchar");
+        File sinkPath =
+                createTestCsvSinkTable(
+                        "MySink", "a bigint", "a1 varchar", "b int", "c1 varchar", "c2 varchar");
+
+        String jsonPlan =
+                tableEnv.getJsonPlan(
+                        "insert into MySink select "
+                                + "a, "
+                                + "cast(a as varchar) as a1, "
+                                + "b, "
+                                + "udf2(c, b) as c1, "
+                                + "udf3(substring(c, 1, 8)) as c2 "
+                                + "from MyTable where "
+                                + "(udf1(a) > 2 or (a * b) > 1) and b > 0");
+        tableEnv.executeJsonPlan(jsonPlan).await();
+
+        assertResult(
+                Arrays.asList("2,2,1,hello1,$hello", "3,3,2,hello world2,$hello wo"), sinkPath);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -49,7 +49,7 @@ public class JavaUserDefinedScalarFunctions {
 
     /** Concatenate inputs as strings. */
     public static class JavaFunc1 extends ScalarFunction {
-        public String eval(Integer a, int b, TimestampData c) {
+        public String eval(Integer a, int b, @DataTypeHint("TIMESTAMP(3)") TimestampData c) {
             Long ts = (c == null) ? null : c.getMillisecond();
             return a + " and " + b + " and " + ts;
         }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+
+/** The base class for json plan testing. */
+public abstract class JsonPlanTestBase {
+
+    @Rule public ExpectedException exception = ExpectedException.none();
+
+    @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    protected TableEnvironmentInternal tableEnv;
+
+    @Before
+    public void setup() {
+        EnvironmentSettings settings =
+                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+        tableEnv = (TableEnvironmentInternal) TableEnvironment.create(settings);
+    }
+
+    protected void createTestCsvSourceTable(
+            String tableName, List<String> data, String... fieldNameAndTypes) throws IOException {
+        checkArgument(fieldNameAndTypes.length > 0);
+        File sourceFile = tmpFolder.newFile();
+        Collections.shuffle(data);
+        Files.write(sourceFile.toPath(), String.join("\n", data).getBytes());
+        String srcTableDdl =
+                String.format(
+                        "CREATE TABLE %s (\n"
+                                + "%s\n"
+                                + ") with (\n"
+                                + "  'connector' = 'filesystem',\n"
+                                + "  'path' = '%s',\n"
+                                + "  'format' = 'testcsv')",
+                        tableName,
+                        String.join(",\n", fieldNameAndTypes),
+                        sourceFile.getAbsolutePath());
+        tableEnv.executeSql(srcTableDdl);
+    }
+
+    protected File createTestCsvSinkTable(String tableName, String... fieldNameAndTypes)
+            throws IOException {
+        checkArgument(fieldNameAndTypes.length > 0);
+        File sinkPath = tmpFolder.newFolder();
+        String srcTableDdl =
+                String.format(
+                        "CREATE TABLE %s (\n"
+                                + "%s\n"
+                                + ") with (\n"
+                                + "  'connector' = 'filesystem',\n"
+                                + "  'path' = '%s',\n"
+                                + "  'format' = 'testcsv')",
+                        tableName,
+                        String.join(",\n", fieldNameAndTypes),
+                        sinkPath.getAbsolutePath());
+        tableEnv.executeSql(srcTableDdl);
+        return sinkPath;
+    }
+
+    protected void assertResult(List<String> expected, File resultFile) throws IOException {
+        List<String> actual = readLines(resultFile);
+        Collections.sort(expected);
+        Collections.sort(actual);
+        assertEquals(expected, actual);
+    }
+
+    protected List<String> readLines(File path) throws IOException {
+        List<String> result = new ArrayList<>();
+        for (File file : checkNotNull(path.listFiles())) {
+            if (file.isFile()) {
+                String value = new String(Files.readAllBytes(file.toPath()));
+                result.addAll(Arrays.asList(value.split("\n")));
+            }
+        }
+        return result;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testComplexCalc.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testComplexCalc.out
@@ -1,0 +1,417 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      }
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[a, b, c, d])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "CAST",
+        "kind" : "CAST",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 0,
+        "type" : {
+          "typeName" : "BIGINT",
+          "nullable" : true
+        }
+      } ],
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "udf2",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION",
+        "functionKind" : "SCALAR",
+        "instance" : "rO0ABXNyAFVvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnBsYW5uZXIucnVudGltZS51dGlscy5KYXZhVXNlckRlZmluZWRTY2FsYXJGdW5jdGlvbnMkSmF2YUZ1bmMxrxQXjaFRP3gCAAB4cgAvb3JnLmFwYWNoZS5mbGluay50YWJsZS5mdW5jdGlvbnMuU2NhbGFyRnVuY3Rpb26383IwrjqOqQIAAHhyADRvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5Vc2VyRGVmaW5lZEZ1bmN0aW9uWWgLCLtDDxYCAAB4cA",
+        "bridging" : true
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      }, {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      }, {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : {
+          "typeName" : "TIMESTAMP",
+          "nullable" : true,
+          "precision" : 3
+        }
+      } ],
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "udf3",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION",
+        "functionKind" : "SCALAR",
+        "instance" : "rO0ABXNyAFVvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnBsYW5uZXIucnVudGltZS51dGlscy5KYXZhVXNlckRlZmluZWRTY2FsYXJGdW5jdGlvbnMkSmF2YUZ1bmMyuMiwuSv_y2cCAAB4cgAvb3JnLmFwYWNoZS5mbGluay50YWJsZS5mdW5jdGlvbnMuU2NhbGFyRnVuY3Rpb26383IwrjqOqQIAAHhyADRvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5Vc2VyRGVmaW5lZEZ1bmN0aW9uWWgLCLtDDxYCAAB4cA",
+        "bridging" : true
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 2,
+        "type" : {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2147483647
+        }
+      }, {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "udf4",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION",
+        "functionKind" : "SCALAR",
+        "instance" : "rO0ABXNyAFdvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnBsYW5uZXIucnVudGltZS51dGlscy5KYXZhVXNlckRlZmluZWRTY2FsYXJGdW5jdGlvbnMkVWRmV2l0aE9wZW7kOoTYwUYYKQIAAVoACGlzT3BlbmVkeHIAL29yZy5hcGFjaGUuZmxpbmsudGFibGUuZnVuY3Rpb25zLlNjYWxhckZ1bmN0aW9ut_NyMK46jqkCAAB4cgA0b3JnLmFwYWNoZS5mbGluay50YWJsZS5mdW5jdGlvbnMuVXNlckRlZmluZWRGdW5jdGlvblloCwi7Qw8WAgAAeHAA",
+        "bridging" : true
+      },
+      "operands" : [ {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : "SUBSTRING",
+          "kind" : "OTHER_FUNCTION",
+          "syntax" : "FUNCTION"
+        },
+        "operands" : [ {
+          "kind" : "INPUT_REF",
+          "inputIndex" : 2,
+          "type" : {
+            "typeName" : "VARCHAR",
+            "nullable" : true,
+            "precision" : 2147483647
+          }
+        }, {
+          "kind" : "LITERAL",
+          "value" : "1",
+          "type" : {
+            "typeName" : "INTEGER",
+            "nullable" : false
+          }
+        }, {
+          "kind" : "LITERAL",
+          "value" : "5",
+          "type" : {
+            "typeName" : "INTEGER",
+            "nullable" : false
+          }
+        } ],
+        "type" : {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2147483647
+        }
+      } ],
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "udf5",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION",
+        "functionKind" : "SCALAR",
+        "instance" : "rO0ABXNyAFVvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnBsYW5uZXIucnVudGltZS51dGlscy5KYXZhVXNlckRlZmluZWRTY2FsYXJGdW5jdGlvbnMkSmF2YUZ1bmM1-8VMtBhUOQMCAAB4cgAvb3JnLmFwYWNoZS5mbGluay50YWJsZS5mdW5jdGlvbnMuU2NhbGFyRnVuY3Rpb26383IwrjqOqQIAAHhyADRvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5Vc2VyRGVmaW5lZEZ1bmN0aW9uWWgLCLtDDxYCAAB4cA",
+        "bridging" : true
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : {
+          "typeName" : "TIMESTAMP",
+          "nullable" : true,
+          "precision" : 3
+        }
+      }, {
+        "kind" : "LITERAL",
+        "value" : "1000",
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    } ],
+    "condition" : {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "AND",
+        "kind" : "AND",
+        "syntax" : "BINARY"
+      },
+      "operands" : [ {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : "OR",
+          "kind" : "OR",
+          "syntax" : "BINARY"
+        },
+        "operands" : [ {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : ">",
+            "kind" : "GREATER_THAN",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "REX_CALL",
+            "operator" : {
+              "name" : "org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$JavaFunc0$ea91f94853664692cdbdcd38ac065769",
+              "kind" : "OTHER_FUNCTION",
+              "syntax" : "FUNCTION",
+              "functionKind" : "SCALAR",
+              "instance" : "rO0ABXNyAFVvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLnBsYW5uZXIucnVudGltZS51dGlscy5KYXZhVXNlckRlZmluZWRTY2FsYXJGdW5jdGlvbnMkSmF2YUZ1bmMwn3sBX4kzBu8CAAB4cgAvb3JnLmFwYWNoZS5mbGluay50YWJsZS5mdW5jdGlvbnMuU2NhbGFyRnVuY3Rpb26383IwrjqOqQIAAHhyADRvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmZ1bmN0aW9ucy5Vc2VyRGVmaW5lZEZ1bmN0aW9uWWgLCLtDDxYCAAB4cA",
+              "bridging" : true
+            },
+            "operands" : [ {
+              "kind" : "INPUT_REF",
+              "inputIndex" : 0,
+              "type" : {
+                "typeName" : "BIGINT",
+                "nullable" : true
+              }
+            } ],
+            "type" : {
+              "typeName" : "BIGINT",
+              "nullable" : false
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "0",
+            "type" : {
+              "typeName" : "INTEGER",
+              "nullable" : false
+            }
+          } ],
+          "type" : {
+            "typeName" : "BOOLEAN",
+            "nullable" : false
+          }
+        }, {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "<",
+            "kind" : "LESS_THAN",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "REX_CALL",
+            "operator" : {
+              "name" : "*",
+              "kind" : "TIMES",
+              "syntax" : "BINARY"
+            },
+            "operands" : [ {
+              "kind" : "INPUT_REF",
+              "inputIndex" : 0,
+              "type" : {
+                "typeName" : "BIGINT",
+                "nullable" : true
+              }
+            }, {
+              "kind" : "INPUT_REF",
+              "inputIndex" : 1,
+              "type" : {
+                "typeName" : "INTEGER",
+                "nullable" : false
+              }
+            } ],
+            "type" : {
+              "typeName" : "BIGINT",
+              "nullable" : true
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "100",
+            "type" : {
+              "typeName" : "INTEGER",
+              "nullable" : false
+            }
+          } ],
+          "type" : {
+            "typeName" : "BOOLEAN",
+            "nullable" : true
+          }
+        } ],
+        "type" : {
+          "typeName" : "BOOLEAN",
+          "nullable" : true
+        }
+      }, {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : ">",
+          "kind" : "GREATER_THAN",
+          "syntax" : "BINARY"
+        },
+        "operands" : [ {
+          "kind" : "INPUT_REF",
+          "inputIndex" : 1,
+          "type" : {
+            "typeName" : "INTEGER",
+            "nullable" : false
+          }
+        }, {
+          "kind" : "LITERAL",
+          "value" : "10",
+          "type" : {
+            "typeName" : "INTEGER",
+            "nullable" : false
+          }
+        } ],
+        "type" : {
+          "typeName" : "BOOLEAN",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "BOOLEAN",
+        "nullable" : true
+      }
+    },
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a1` VARCHAR(2147483647), `b` INT NOT NULL, `b1` VARCHAR(2147483647), `c1` VARCHAR(2147483647), `c2` VARCHAR(2147483647), `d1` TIMESTAMP(3)>",
+    "description" : "Calc(select=[a, CAST(a) AS a1, b, udf2(b, b, d) AS b1, udf3(c, b) AS c1, udf4(SUBSTRING(c, 1, 5)) AS c2, udf5(d, 1000) AS d1], where=[(((org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$JavaFunc0$ea91f94853664692cdbdcd38ac065769(a) > 0) OR ((a * b) < 100)) AND (b > 10))])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "schema.5.name" : "c2",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "b",
+        "schema.1.name" : "a1",
+        "schema.6.data-type" : "TIMESTAMP(3)",
+        "schema.4.name" : "c1",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "VARCHAR(2147483647)",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "INT",
+        "schema.3.name" : "b1",
+        "connector" : "values",
+        "schema.6.name" : "d1",
+        "schema.5.data-type" : "VARCHAR(2147483647)",
+        "schema.4.data-type" : "VARCHAR(2147483647)",
+        "schema.0.name" : "a"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a1` VARCHAR(2147483647), `b` INT NOT NULL, `b1` VARCHAR(2147483647), `c1` VARCHAR(2147483647), `c2` VARCHAR(2147483647), `d1` TIMESTAMP(3)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a1, b, b1, c1, c2, d1])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testSimpleFilter.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testSimpleFilter.out
@@ -1,0 +1,146 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      }
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[a, b, c, d])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    } ],
+    "condition" : {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : ">",
+        "kind" : "GREATER_THAN",
+        "syntax" : "BINARY"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      }, {
+        "kind" : "LITERAL",
+        "value" : "0",
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "BOOLEAN",
+        "nullable" : false
+      }
+    },
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "description" : "Calc(select=[a, b, c, d], where=[(b > 0)])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c, d])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testSimpleProject.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest/testSimpleProject.out
@@ -1,0 +1,65 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      }
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "table-sink-class" : "DEFAULT",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1675,15 +1675,15 @@ object TableTestUtil {
    * ExecNode {id} is ignored, because id keeps incrementing in test class.
    */
   def replaceExecNodeId(s: String): String = {
-    s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\":")
-      .replaceAll("\"source\"\\s*:\\s*\\d+", "\"source\":")
-      .replaceAll("\"target\"\\s*:\\s*\\d+", "\"target\":")
+    s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\": 0")
+      .replaceAll("\"source\"\\s*:\\s*\\d+", "\"source\": 0")
+      .replaceAll("\"target\"\\s*:\\s*\\d+", "\"target\": 0")
   }
 
   /**
    * Ignore flink version value.
    */
   def replaceFlinkVersion(s: String): String = {
-    s.replaceAll("\"flinkVersion\"\\s*:\\s*\"\\d+.\\d+(-SNAPSHOT)?\"", "\"flinkVersion\":\"\"")
+    s.replaceAll("\"flinkVersion\":\"[\\w.-]*\"", "\"flinkVersion\":\"\"")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -69,13 +69,14 @@ import org.apache.calcite.avatica.util.TimeUnit
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.sql.{SqlExplainLevel, SqlIntervalQualifier}
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Assert.{assertEquals, assertTrue, fail}
 import org.junit.Rule
 import org.junit.rules.{ExpectedException, TemporaryFolder, TestName}
 
 import _root_.java.math.{BigDecimal => JBigDecimal}
 import _root_.java.util
-import java.io.IOException
+import java.io.{File, IOException}
+import java.nio.file.{Files, Paths}
 import java.time.Duration
 
 import _root_.scala.collection.JavaConversions._
@@ -730,6 +731,31 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
     doVerifyExplain(
       stmtSet.explain(extraDetails: _*),
       extraDetails.contains(ExplainDetail.ESTIMATED_COST))
+  }
+
+  /**
+   * Verify the json plan for the given insert statement.
+   */
+  def verifyJsonPlan(insert: String): Unit = {
+    val jsonPlan = getTableEnv.asInstanceOf[TableEnvironmentInternal].getJsonPlan(insert)
+    val jsonPlanWithoutFlinkVersion = TableTestUtil.replaceFlinkVersion(jsonPlan)
+    val path = test.getClass.getName.replaceAll("\\.", "/")
+    val fileName = test.testName.getMethodName + ".out"
+    val file = new File(s"./src/test/resources/$path/$fileName")
+    if (file.exists()) {
+      val expected = TableTestUtil.readFromResource(s"/$path/$fileName")
+      assertEquals(
+        TableTestUtil.replaceExecNodeId(
+          TableTestUtil.getFormattedJson(expected)),
+        TableTestUtil.replaceExecNodeId(
+          TableTestUtil.getFormattedJson(jsonPlanWithoutFlinkVersion)))
+    } else {
+      file.getParentFile.mkdirs()
+      assertTrue(file.createNewFile())
+      val prettyJson = TableTestUtil.getPrettyJson(jsonPlanWithoutFlinkVersion)
+      Files.write(Paths.get(file.toURI), prettyJson.getBytes)
+      fail(s"$fileName does not exist.")
+    }
   }
 
   /**
@@ -1618,6 +1644,13 @@ object TableTestUtil {
     jsonNode.toString
   }
 
+  @throws[IOException]
+  def getPrettyJson(json: String): String = {
+    val parser = new ObjectMapper().getFactory.createParser(json)
+    val jsonNode: JsonNode = parser.readValueAsTree[JsonNode]
+    jsonNode.toPrettyString
+  }
+
   def readFromResourceAndRemoveLastLinkBreak(path: String): String = {
     readFromResource(path).stripSuffix("\n")
   }
@@ -1642,15 +1675,15 @@ object TableTestUtil {
    * ExecNode {id} is ignored, because id keeps incrementing in test class.
    */
   def replaceExecNodeId(s: String): String = {
-    s.replaceAll("\"id\":\\d+", "\"id\" :")
-      .replaceAll("\"source\":\\d+", "\"source\" :")
-      .replaceAll("\"target\":\\d+", "\"target\" :")
+    s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\":")
+      .replaceAll("\"source\"\\s*:\\s*\\d+", "\"source\":")
+      .replaceAll("\"target\"\\s*:\\s*\\d+", "\"target\":")
   }
 
   /**
    * Ignore flink version value.
    */
   def replaceFlinkVersion(s: String): String = {
-    s.replaceAll("\"flinkVersion\":\"\\d+.\\d+(-SNAPSHOT)?\"", "\"flinkVersion\":\"\"")
+    s.replaceAll("\"flinkVersion\"\\s*:\\s*\"\\d+.\\d+(-SNAPSHOT)?\"", "\"flinkVersion\":\"\"")
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1481,8 +1481,7 @@ under the License.
 						<exclude>flink-formats/flink-avro/src/test/resources/avro/*.avsc</exclude>
 						<exclude>out/test/flink-avro/avro/user.avsc</exclude>
 						<exclude>flink-table/flink-table-planner/src/test/scala/resources/*.out</exclude>
-						<exclude>flink-table/flink-table-planner-blink/src/test/resources/digest/*.out</exclude>
-						<exclude>flink-table/flink-table-planner-blink/src/test/resources/explain/**</exclude>
+						<exclude>flink-table/flink-table-planner-blink/src/test/resources/**/*.out</exclude>
 						<exclude>flink-table/flink-table-planner-blink/src/test/resources/jsonplan/*</exclude>
 						<exclude>flink-yarn/src/test/resources/krb5.keytab</exclude>
 						<exclude>flink-end-to-end-tests/test-scripts/test-data/**</exclude>


### PR DESCRIPTION


## What is the purpose of the change

*This pr aims to support StreamExecCalc json serialization/deserialization. now we can get json plan for sql like: select a, b from MyTable where c > 0, and execute the json plan.*


## Brief change log

  - *LogicalType's serializer and deserializer should consider empty Char/VarChar/Binary/VarBinary*
  - *Support RexNode and RelDataType json serialization/deserialization*
  - *Support StreamExecCalc json serialization/deserialization*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended LogicalTypeSerdeTest test for empty Char/VarChar/Binary/VarBinary json serialization/deserialization*
  - *Added RelDataTypeSerdeTest to verify RelDataType json serialization/deserialization*
  - *Added RexNodeSerdeTest to verify RexNode json serialization/deserialization*
  - *Added CalcJsonPlanTest to verify the json plan of calc query, Added CalcJsonPlanITCase to execute the json plan of calc query.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
