### PR TITLE
[FLINK-21256][FLINK-21257] Add Restarting and Executing state for declarative scheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
@@ -124,7 +125,8 @@ public class ExecutionJobVertex
 
     private InputSplitAssigner splitAssigner;
 
-    ExecutionJobVertex(
+    @VisibleForTesting
+    public ExecutionJobVertex(
             ExecutionGraph graph,
             JobVertex jobVertex,
             int defaultParallelism,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -105,7 +105,8 @@ public class ExecutionVertex
      * @param maxPriorExecutionHistoryLength The number of prior Executions (= execution attempts)
      *     to keep.
      */
-    ExecutionVertex(
+    @VisibleForTesting
+    public ExecutionVertex(
             ExecutionJobVertex jobVertex,
             int subTaskIndex,
             IntermediateResult[] producedDataSets,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -141,13 +140,8 @@ public class OperatorCoordinatorHolder
         this.operatorMaxParallelism = operatorMaxParallelism;
     }
 
-    public void lazyInitialize(
-            SchedulerNG scheduler, ComponentMainThreadExecutor mainThreadExecutor) {
-        lazyInitialize(scheduler::handleGlobalFailure, mainThreadExecutor);
-    }
-
     @VisibleForTesting
-    void lazyInitialize(
+    public void lazyInitialize(
             Consumer<Throwable> globalFailureHandler,
             ComponentMainThreadExecutor mainThreadExecutor) {
         this.globalFailureHandler = globalFailureHandler;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -140,7 +140,6 @@ public class OperatorCoordinatorHolder
         this.operatorMaxParallelism = operatorMaxParallelism;
     }
 
-    @VisibleForTesting
     public void lazyInitialize(
             Consumer<Throwable> globalFailureHandler,
             ComponentMainThreadExecutor mainThreadExecutor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionGraphHandler.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+/** Handler for the {@link ExecutionGraph} which offers some common operations. */
+public class ExecutionGraphHandler {
+
+    private final ExecutionGraph executionGraph;
+
+    private final Logger log;
+
+    private final Executor ioExecutor;
+
+    private final ComponentMainThreadExecutor mainThreadExecutor;
+
+    public ExecutionGraphHandler(
+            ExecutionGraph executionGraph,
+            Logger log,
+            Executor ioExecutor,
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        this.executionGraph = executionGraph;
+        this.log = log;
+        this.ioExecutor = ioExecutor;
+        this.mainThreadExecutor = mainThreadExecutor;
+    }
+
+    public void reportCheckpointMetrics(
+            ExecutionAttemptID attemptId, long id, CheckpointMetrics metrics) {
+        processCheckpointCoordinatorMessage(
+                "ReportCheckpointStats",
+                coordinator -> coordinator.reportStats(id, attemptId, metrics));
+    }
+
+    public void acknowledgeCheckpoint(
+            final JobID jobID,
+            final ExecutionAttemptID executionAttemptID,
+            final long checkpointId,
+            final CheckpointMetrics checkpointMetrics,
+            final TaskStateSnapshot checkpointState) {
+        processCheckpointCoordinatorMessage(
+                "AcknowledgeCheckpoint",
+                coordinator ->
+                        coordinator.receiveAcknowledgeMessage(
+                                new AcknowledgeCheckpoint(
+                                        jobID,
+                                        executionAttemptID,
+                                        checkpointId,
+                                        checkpointMetrics,
+                                        checkpointState),
+                                retrieveTaskManagerLocation(executionAttemptID)));
+    }
+
+    public void declineCheckpoint(final DeclineCheckpoint decline) {
+        processCheckpointCoordinatorMessage(
+                "DeclineCheckpoint",
+                coordinator ->
+                        coordinator.receiveDeclineMessage(
+                                decline,
+                                retrieveTaskManagerLocation(decline.getTaskExecutionId())));
+    }
+
+    private void processCheckpointCoordinatorMessage(
+            String messageType, ThrowingConsumer<CheckpointCoordinator, Exception> process) {
+        mainThreadExecutor.assertRunningInMainThread();
+
+        final CheckpointCoordinator checkpointCoordinator =
+                executionGraph.getCheckpointCoordinator();
+
+        if (checkpointCoordinator != null) {
+            ioExecutor.execute(
+                    () -> {
+                        try {
+                            process.accept(checkpointCoordinator);
+                        } catch (Exception t) {
+                            log.warn("Error while processing " + messageType + " message", t);
+                        }
+                    });
+        } else {
+            String errorMessage =
+                    "Received " + messageType + " message for job {} with no CheckpointCoordinator";
+            if (executionGraph.getState() == JobStatus.RUNNING) {
+                log.error(errorMessage, executionGraph.getJobID());
+            } else {
+                log.debug(errorMessage, executionGraph.getJobID());
+            }
+        }
+    }
+
+    private String retrieveTaskManagerLocation(ExecutionAttemptID executionAttemptID) {
+        final Optional<Execution> currentExecution =
+                Optional.ofNullable(
+                        executionGraph.getRegisteredExecutions().get(executionAttemptID));
+
+        return currentExecution
+                .map(Execution::getAssignedResourceLocation)
+                .map(TaskManagerLocation::toString)
+                .orElse("Unknown location");
+    }
+
+    public ExecutionState requestPartitionState(
+            final IntermediateDataSetID intermediateResultId,
+            final ResultPartitionID resultPartitionId)
+            throws PartitionProducerDisposedException {
+
+        final Execution execution =
+                executionGraph.getRegisteredExecutions().get(resultPartitionId.getProducerId());
+        if (execution != null) {
+            return execution.getState();
+        } else {
+            final IntermediateResult intermediateResult =
+                    executionGraph.getAllIntermediateResults().get(intermediateResultId);
+
+            if (intermediateResult != null) {
+                // Try to find the producing execution
+                Execution producerExecution =
+                        intermediateResult
+                                .getPartitionById(resultPartitionId.getPartitionId())
+                                .getProducer()
+                                .getCurrentExecutionAttempt();
+
+                if (producerExecution.getAttemptId().equals(resultPartitionId.getProducerId())) {
+                    return producerExecution.getState();
+                } else {
+                    throw new PartitionProducerDisposedException(resultPartitionId);
+                }
+            } else {
+                throw new IllegalArgumentException(
+                        "Intermediate data set with ID " + intermediateResultId + " not found.");
+            }
+        }
+    }
+
+    public SerializedInputSplit requestNextInputSplit(
+            JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+
+        final Execution execution = executionGraph.getRegisteredExecutions().get(executionAttempt);
+        if (execution == null) {
+            // can happen when JobManager had already unregistered this execution upon on task
+            // failure,
+            // but TaskManager get some delay to aware of that situation
+            if (log.isDebugEnabled()) {
+                log.debug("Can not find Execution for attempt {}.", executionAttempt);
+            }
+            // but we should TaskManager be aware of this
+            throw new IllegalArgumentException(
+                    "Can not find Execution for attempt " + executionAttempt);
+        }
+
+        final ExecutionJobVertex vertex = executionGraph.getJobVertex(vertexID);
+        if (vertex == null) {
+            throw new IllegalArgumentException(
+                    "Cannot find execution vertex for vertex ID " + vertexID);
+        }
+
+        if (vertex.getSplitAssigner() == null) {
+            throw new IllegalStateException("No InputSplitAssigner for vertex ID " + vertexID);
+        }
+
+        final InputSplit nextInputSplit = execution.getNextInputSplit();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Send next input split {}.", nextInputSplit);
+        }
+
+        try {
+            final byte[] serializedInputSplit = InstantiationUtil.serializeObject(nextInputSplit);
+            return new SerializedInputSplit(serializedInputSplit);
+        } catch (Exception ex) {
+            IOException reason =
+                    new IOException(
+                            "Could not serialize the next input split of class "
+                                    + nextInputSplit.getClass()
+                                    + ".",
+                            ex);
+            vertex.fail(reason);
+            throw reason;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/KvStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/KvStateHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.KvStateLocationRegistry;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+
+/** Handler for common queryable state logic. */
+public class KvStateHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KvStateHandler.class);
+
+    private final ExecutionGraph executionGraph;
+
+    public KvStateHandler(ExecutionGraph executionGraph) {
+        this.executionGraph = executionGraph;
+    }
+
+    public KvStateLocation requestKvStateLocation(final JobID jobId, final String registrationName)
+            throws UnknownKvStateLocation, FlinkJobNotFoundException {
+
+        // sanity check for the correct JobID
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Lookup key-value state for job {} with registration " + "name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            final KvStateLocationRegistry registry = executionGraph.getKvStateLocationRegistry();
+            final KvStateLocation location = registry.getKvStateLocation(registrationName);
+            if (location != null) {
+                return location;
+            } else {
+                throw new UnknownKvStateLocation(registrationName);
+            }
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Request of key-value state location for unknown job {} received.", jobId);
+            }
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+
+    public void notifyKvStateRegistered(
+            final JobID jobId,
+            final JobVertexID jobVertexId,
+            final KeyGroupRange keyGroupRange,
+            final String registrationName,
+            final KvStateID kvStateId,
+            final InetSocketAddress kvStateServerAddress)
+            throws FlinkJobNotFoundException {
+
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Key value state registered for job {} under name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            try {
+                executionGraph
+                        .getKvStateLocationRegistry()
+                        .notifyKvStateRegistered(
+                                jobVertexId,
+                                keyGroupRange,
+                                registrationName,
+                                kvStateId,
+                                kvStateServerAddress);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+
+    public void notifyKvStateUnregistered(
+            final JobID jobId,
+            final JobVertexID jobVertexId,
+            final KeyGroupRange keyGroupRange,
+            final String registrationName)
+            throws FlinkJobNotFoundException {
+
+        if (executionGraph.getJobID().equals(jobId)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Key value state unregistered for job {} under name {}.",
+                        executionGraph.getJobID(),
+                        registrationName);
+            }
+
+            try {
+                executionGraph
+                        .getKvStateLocationRegistry()
+                        .notifyKvStateUnregistered(jobVertexId, keyGroupRange, registrationName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new FlinkJobNotFoundException(jobId);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.IOUtils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/** Handler for the {@link OperatorCoordinator OperatorCoordinators}. */
+public class OperatorCoordinatorHandler {
+    private final ExecutionGraph executionGraph;
+
+    private final Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap;
+
+    private final Consumer<Throwable> globalFailureHandler;
+
+    public OperatorCoordinatorHandler(
+            ExecutionGraph executionGraph, Consumer<Throwable> globalFailureHandler) {
+        this.executionGraph = executionGraph;
+
+        this.coordinatorMap = createCoordinatorMap(executionGraph);
+        this.globalFailureHandler = globalFailureHandler;
+    }
+
+    private Map<OperatorID, OperatorCoordinatorHolder> createCoordinatorMap(
+            ExecutionGraph executionGraph) {
+        Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
+        for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
+            for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
+                coordinatorMap.put(holder.operatorId(), holder);
+            }
+        }
+        return coordinatorMap;
+    }
+
+    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
+        for (OperatorCoordinatorHolder coordinatorHolder : coordinatorMap.values()) {
+            coordinatorHolder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        }
+    }
+
+    public void startAllOperatorCoordinators() {
+        final Collection<OperatorCoordinatorHolder> coordinators = coordinatorMap.values();
+        try {
+            for (OperatorCoordinatorHolder coordinator : coordinators) {
+                coordinator.start();
+            }
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            coordinators.forEach(IOUtils::closeQuietly);
+            throw new FlinkRuntimeException("Failed to start the operator coordinators", t);
+        }
+    }
+
+    public void disposeAllOperatorCoordinators() {
+        coordinatorMap.values().forEach(IOUtils::closeQuietly);
+    }
+
+    public void deliverOperatorEventToCoordinator(
+            final ExecutionAttemptID taskExecutionId,
+            final OperatorID operatorId,
+            final OperatorEvent evt)
+            throws FlinkException {
+
+        // Failure semantics (as per the javadocs of the method):
+        // If the task manager sends an event for a non-running task or an non-existing operator
+        // coordinator, then respond with an exception to the call. If task and coordinator exist,
+        // then we assume that the call from the TaskManager was valid, and any bubbling exception
+        // needs to cause a job failure.
+
+        final Execution exec = executionGraph.getRegisteredExecutions().get(taskExecutionId);
+        if (exec == null || exec.getState() != ExecutionState.RUNNING) {
+            // This situation is common when cancellation happens, or when the task failed while the
+            // event was just being dispatched asynchronously on the TM side.
+            // It should be fine in those expected situations to just ignore this event, but, to be
+            // on the safe, we notify the TM that the event could not be delivered.
+            throw new TaskNotRunningException(
+                    "Task is not known or in state running on the JobManager.");
+        }
+
+        final OperatorCoordinatorHolder coordinator = coordinatorMap.get(operatorId);
+        if (coordinator == null) {
+            throw new FlinkException("No coordinator registered for operator " + operatorId);
+        }
+
+        try {
+            coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            globalFailureHandler.accept(t);
+        }
+    }
+
+    public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+            OperatorID operator, CoordinationRequest request) throws FlinkException {
+
+        final OperatorCoordinatorHolder coordinatorHolder = coordinatorMap.get(operator);
+        if (coordinatorHolder == null) {
+            throw new FlinkException("Coordinator of operator " + operator + " does not exist");
+        }
+
+        final OperatorCoordinator coordinator = coordinatorHolder.coordinator();
+        if (coordinator instanceof CoordinationRequestHandler) {
+            return ((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request);
+        } else {
+            throw new FlinkException(
+                    "Coordinator of operator " + operator + " cannot handle client event");
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -1055,7 +1055,7 @@ public abstract class SchedulerBase implements SchedulerNG {
         Map<OperatorID, OperatorCoordinatorHolder> coordinatorMap = new HashMap<>();
         for (ExecutionJobVertex vertex : executionGraph.getAllVertices().values()) {
             for (OperatorCoordinatorHolder holder : vertex.getOperatorCoordinators()) {
-                holder.lazyInitialize(this, mainThreadExecutor);
+                holder.lazyInitialize(this::handleGlobalFailure, mainThreadExecutor);
                 coordinatorMap.put(holder.operatorId(), holder);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
@@ -104,7 +104,7 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
     }
 
     @Override
-    void onGloballyTerminalState(JobStatus terminalState) {
+    void onGloballyTerminalState(JobStatus globallyTerminalState) {
         context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
@@ -104,7 +104,7 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
     }
 
     @Override
-    void onTerminalState(JobStatus terminalState) {
+    void onGloballyTerminalState(JobStatus terminalState) {
         context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
@@ -109,9 +109,8 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
     }
 
     private void deploy() {
-        final ExecutionGraph executionGraph = getExecutionGraph();
-        executionGraph.transitionToRunning();
-        for (ExecutionJobVertex executionJobVertex : executionGraph.getVerticesTopologically()) {
+        for (ExecutionJobVertex executionJobVertex :
+                getExecutionGraph().getVerticesTopologically()) {
             for (ExecutionVertex executionVertex : executionJobVertex.getTaskVertices()) {
                 deploySafely(executionVertex);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.InternalFailuresListener;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/** State which represents a running job with an {@link ExecutionGraph} and assigned slots. */
+class Executing extends StateWithExecutionGraph
+        implements ResourceConsumer, InternalFailuresListener {
+
+    private final Context context;
+
+    private final ClassLoader userCodeClassLoader;
+
+    Executing(
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            Logger logger,
+            Context context,
+            ClassLoader userCodeClassLoader) {
+        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+        this.context = context;
+        this.userCodeClassLoader = userCodeClassLoader;
+    }
+
+    @Override
+    public void onEnter() {
+        deploy();
+    }
+
+    @Override
+    public void cancel() {
+        context.goToCanceling(
+                getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        handleAnyFailure(cause);
+    }
+
+    @Override
+    public void notifyTaskFailure(
+            ExecutionAttemptID attemptId,
+            Throwable cause,
+            boolean cancelTask,
+            boolean releasePartitions) {
+        handleAnyFailure(cause);
+    }
+
+    @Override
+    public void notifyGlobalFailure(Throwable cause) {
+        handleAnyFailure(cause);
+    }
+
+    private void handleAnyFailure(Throwable cause) {
+        final FailureResult failureResult = context.howToHandleFailure(cause);
+
+        if (failureResult.canRestart()) {
+            context.goToRestarting(
+                    getExecutionGraph(),
+                    getExecutionGraphHandler(),
+                    getOperatorCoordinatorHandler(),
+                    failureResult.getBackoffTime());
+        } else {
+            context.goToFailing(
+                    getExecutionGraph(),
+                    getExecutionGraphHandler(),
+                    getOperatorCoordinatorHandler(),
+                    failureResult.getFailureCause());
+        }
+    }
+
+    @Override
+    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionState) {
+        final boolean successfulUpdate = getExecutionGraph().updateState(taskExecutionState);
+
+        if (successfulUpdate) {
+            if (taskExecutionState.getExecutionState() == ExecutionState.FAILED) {
+                Throwable cause = taskExecutionState.getError(userCodeClassLoader);
+                handleAnyFailure(cause);
+            }
+        }
+
+        return successfulUpdate;
+    }
+
+    @Override
+    void onTerminalState(JobStatus terminalState) {
+        context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
+    }
+
+    private void deploy() {
+        final ExecutionGraph executionGraph = getExecutionGraph();
+        executionGraph.setInternalTaskFailuresListener(this);
+        for (ExecutionJobVertex executionJobVertex : executionGraph.getVerticesTopologically()) {
+            for (ExecutionVertex executionVertex : executionJobVertex.getTaskVertices()) {
+                deploySafely(executionVertex);
+            }
+        }
+    }
+
+    private void deploySafely(ExecutionVertex executionVertex) {
+        try {
+            executionVertex.deploy();
+        } catch (JobException e) {
+            handleDeploymentFailure(executionVertex, e);
+        }
+    }
+
+    private void handleDeploymentFailure(ExecutionVertex executionVertex, JobException e) {
+        executionVertex.markFailed(e);
+    }
+
+    @Override
+    public void notifyNewResourcesAvailable() {
+        if (context.canScaleUp(getExecutionGraph())) {
+            getLogger().info("New resources are available. Restarting job to scale up.");
+            context.goToRestarting(
+                    getExecutionGraph(),
+                    getExecutionGraphHandler(),
+                    getOperatorCoordinatorHandler(),
+                    Duration.ofMillis(0L));
+        }
+    }
+
+    /** Context of the {@link Executing} state. */
+    interface Context extends StateWithExecutionGraph.Context {
+
+        /**
+         * Transitions into the {@link Canceling} state.
+         *
+         * @param executionGraph executionGraph to pass to the {@link Canceling} state
+         * @param executionGraphHandler executionGraphHandler to pass to the {@link Canceling} state
+         * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
+         *     Canceling} state
+         */
+        void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler);
+
+        /**
+         * Asks how to handle the failure.
+         *
+         * @param failure failure describing the failure cause
+         * @return {@link FailureResult} which describes how to handle the failure
+         */
+        FailureResult howToHandleFailure(Throwable failure);
+
+        /**
+         * Asks if we can scale up the currently executing job.
+         *
+         * @param executionGraph executionGraph for making the scaling decision.
+         * @return true, if we can scale up
+         */
+        boolean canScaleUp(ExecutionGraph executionGraph);
+
+        /**
+         * Transitions into the {@link Restarting} state.
+         *
+         * @param executionGraph executionGraph to pass to the {@link Restarting} state
+         * @param executionGraphHandler executionGraphHandler to pass to the {@link Restarting}
+         *     state
+         * @param operatorCoordinatorHandler operatorCoordinatorHandler to pas to the {@link
+         *     Restarting} state
+         * @param backoffTime backoffTime to wait before transitioning to the {@link Restarting}
+         *     state
+         */
+        void goToRestarting(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Duration backoffTime);
+
+        /**
+         * Transitions into the {@link Failing} state.
+         *
+         * @param executionGraph executionGraph to pass to the {@link Failing} state
+         * @param executionGraphHandler executionGraphHandler to pass to the {@link Failing} state
+         * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
+         *     Failing} state
+         * @param failureCause failureCause describing why the job execution failed
+         */
+        void goToFailing(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Throwable failureCause);
+    }
+
+    /**
+     * The {@link FailureResult} describes how a failure shall be handled. Currently, there are two
+     * alternatives: Either restarting the job or failing it.
+     */
+    static final class FailureResult {
+        @Nullable private final Duration backoffTime;
+
+        @Nullable private final Throwable failureCause;
+
+        private FailureResult(@Nullable Duration backoffTime, @Nullable Throwable failureCause) {
+            this.backoffTime = backoffTime;
+            this.failureCause = failureCause;
+        }
+
+        boolean canRestart() {
+            return backoffTime != null;
+        }
+
+        Duration getBackoffTime() {
+            Preconditions.checkState(
+                    canRestart(), "Failure result must be restartable to return a backoff time.");
+            return backoffTime;
+        }
+
+        Throwable getFailureCause() {
+            Preconditions.checkState(
+                    failureCause != null,
+                    "Failure result must not be restartable to return a failure cause.");
+            return failureCause;
+        }
+
+        /**
+         * Creates a FailureResult which allows to restart the job.
+         *
+         * @param backoffTime backoffTime to wait before restarting the job
+         * @return FailureResult which allows to restart the job
+         */
+        static FailureResult canRestart(Duration backoffTime) {
+            return new FailureResult(backoffTime, null);
+        }
+
+        /**
+         * Creates FailureResult which does not allow to restart the job.
+         *
+         * @param failureCause failureCause describes the reason why the job cannot be restarted
+         * @return FailureResult which does not allow to restart the job
+         */
+        static FailureResult canNotRestart(Throwable failureCause) {
+            return new FailureResult(null, failureCause);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.scheduler.declarative;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
@@ -76,21 +75,8 @@ class Restarting extends StateWithExecutionGraph {
 
     @Override
     void onTerminalState(JobStatus terminalState) {
-        // TODO revisit this
-        switch (terminalState) {
-            case CANCELED:
-                context.runIfState(this, context::goToWaitingForResources, backoffTime);
-                break;
-            case SUSPENDED:
-                context.runIfState(
-                        this,
-                        () ->
-                                context.goToFinished(
-                                        ArchivedExecutionGraph.createFrom(getExecutionGraph())),
-                        Duration.ZERO);
-                break;
-            default:
-                throw new IllegalArgumentException("Unexpected terminal state " + terminalState);
+        if (terminalState == JobStatus.CANCELED) {
+            context.runIfState(this, context::goToWaitingForResources, backoffTime);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
@@ -74,8 +74,8 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     @Override
-    void onGloballyTerminalState(JobStatus terminalState) {
-        if (terminalState == JobStatus.CANCELED) {
+    void onGloballyTerminalState(JobStatus globallyTerminalState) {
+        if (globallyTerminalState == JobStatus.CANCELED) {
             context.runIfState(this, context::goToWaitingForResources, backoffTime);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+
+import org.slf4j.Logger;
+
+import java.time.Duration;
+
+/** State which describes a job which is currently being restarted. */
+class Restarting extends StateWithExecutionGraph {
+
+    private final Context context;
+
+    private final Duration backoffTime;
+
+    Restarting(
+            Context context,
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            Logger logger,
+            Duration backoffTime) {
+        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+        this.context = context;
+        this.backoffTime = backoffTime;
+    }
+
+    @Override
+    public void onEnter() {
+        getExecutionGraph().cancel();
+    }
+
+    @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.RESTARTING;
+    }
+
+    @Override
+    public void cancel() {
+        context.goToCanceling(
+                getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        // don't do anything
+    }
+
+    @Override
+    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
+        return getExecutionGraph().updateState(taskExecutionStateTransition);
+    }
+
+    @Override
+    void onTerminalState(JobStatus terminalState) {
+        // TODO revisit this
+        switch (terminalState) {
+            case CANCELED:
+                context.runIfState(this, context::goToWaitingForResources, backoffTime);
+                break;
+            case SUSPENDED:
+                context.runIfState(
+                        this,
+                        () ->
+                                context.goToFinished(
+                                        ArchivedExecutionGraph.createFrom(getExecutionGraph())),
+                        Duration.ZERO);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected terminal state " + terminalState);
+        }
+    }
+
+    /** Context of the {@link Restarting} state. */
+    interface Context extends StateWithExecutionGraph.Context {
+
+        /**
+         * Transitions into the {@link Canceling} state.
+         *
+         * @param executionGraph executionGraph which is passed to the {@link Canceling} state
+         * @param executionGraphHandler executionGraphHandler which is passed to the {@link
+         *     Canceling} state
+         * @param operatorCoordinatorHandler operatorCoordinatorHandler which is passed to the
+         *     {@link Canceling} state
+         */
+        void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler);
+
+        /** Transitions into the {@link WaitingForResources} state. */
+        void goToWaitingForResources();
+
+        /**
+         * Runs the given action after the specified delay if the state is the expected state at
+         * this time.
+         *
+         * @param expectedState expectedState describes the required state to run the action after
+         *     the delay
+         * @param action action to run if the state equals the expected state
+         * @param delay delay after which the action should be executed
+         */
+        void runIfState(State expectedState, Runnable action, Duration delay);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Restarting.java
@@ -74,7 +74,7 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     @Override
-    void onTerminalState(JobStatus terminalState) {
+    void onGloballyTerminalState(JobStatus terminalState) {
         if (terminalState == JobStatus.CANCELED) {
             context.runIfState(this, context::goToWaitingForResources, backoffTime);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
@@ -41,7 +41,7 @@ interface State {
      *
      * @param newState newState is the state into which the scheduler transitions
      */
-    default void onLeave(State newState) {}
+    default void onLeave(Class<? extends State> newState) {}
 
     /** Cancels the job execution. */
     void cancel();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/State.java
@@ -36,6 +36,13 @@ interface State {
     /** This method is called whenever one transitions into this state. */
     default void onEnter() {}
 
+    /**
+     * This method is called whenever one transitions out of this state.
+     *
+     * @param newState newState is the state into which the scheduler transitions
+     */
+    default void onLeave(State newState) {}
+
     /** Cancels the job execution. */
     void cancel();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -98,8 +98,9 @@ abstract class StateWithExecutionGraph implements State {
                         .getTerminationFuture()
                         .thenAcceptAsync(
                                 jobStatus -> {
-                                    if (jobStatus.isTerminalState()) {
-                                        context.runIfState(this, () -> onTerminalState(jobStatus));
+                                    if (jobStatus.isGloballyTerminalState()) {
+                                        context.runIfState(
+                                                this, () -> onGloballyTerminalState(jobStatus));
                                     }
                                 },
                                 context.getMainThreadExecutor()));
@@ -308,7 +309,7 @@ abstract class StateWithExecutionGraph implements State {
      *
      * @param terminalState terminalState which the execution graph reached
      */
-    abstract void onTerminalState(JobStatus terminalState);
+    abstract void onGloballyTerminalState(JobStatus terminalState);
 
     /** Context of the {@link StateWithExecutionGraph} state. */
     interface Context {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.KvStateHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.util.FlinkException;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * Abstract state class which contains an {@link ExecutionGraph} and the required handlers to
+ * execute common operations.
+ */
+abstract class StateWithExecutionGraph implements State {
+    private final Context context;
+
+    private final ExecutionGraph executionGraph;
+
+    private final ExecutionGraphHandler executionGraphHandler;
+
+    private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+
+    private final KvStateHandler kvStateHandler;
+
+    private final Logger logger;
+
+    StateWithExecutionGraph(
+            Context context,
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            Logger logger) {
+        this.context = context;
+        this.executionGraph = executionGraph;
+        this.executionGraphHandler = executionGraphHandler;
+        this.operatorCoordinatorHandler = operatorCoordinatorHandler;
+        this.kvStateHandler = new KvStateHandler(executionGraph);
+        this.logger = logger;
+
+        FutureUtils.assertNoException(
+                executionGraph
+                        .getTerminationFuture()
+                        .thenAcceptAsync(
+                                jobStatus -> {
+                                    operatorCoordinatorHandler.disposeAllOperatorCoordinators();
+                                    context.runIfState(this, () -> onTerminalState(jobStatus));
+                                },
+                                context.getMainThreadExecutor()));
+    }
+
+    ExecutionGraph getExecutionGraph() {
+        return executionGraph;
+    }
+
+    OperatorCoordinatorHandler getOperatorCoordinatorHandler() {
+        return operatorCoordinatorHandler;
+    }
+
+    ExecutionGraphHandler getExecutionGraphHandler() {
+        return executionGraphHandler;
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        return ArchivedExecutionGraph.createFrom(executionGraph);
+    }
+
+    @Override
+    public JobStatus getJobStatus() {
+        return executionGraph.getState();
+    }
+
+    @Override
+    public void suspend(Throwable cause) {
+        executionGraph.suspend(
+                cause); // suspend will call the onTerminalState(JobStatus) callback, triggering a
+        // state transition.
+        // Preconditions.checkState(executionGraph.getState() == JobStatus.SUSPENDED);
+        // context.goToFinished(ArchivedExecutionGraph.createFrom(executionGraph));
+    }
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    void notifyPartitionDataAvailable(ResultPartitionID partitionID) {
+        executionGraph.notifyPartitionDataAvailable(partitionID);
+    }
+
+    SerializedInputSplit requestNextInputSplit(
+            JobVertexID vertexID, ExecutionAttemptID executionAttempt) throws IOException {
+        return executionGraphHandler.requestNextInputSplit(vertexID, executionAttempt);
+    }
+
+    ExecutionState requestPartitionState(
+            IntermediateDataSetID intermediateResultId, ResultPartitionID resultPartitionId)
+            throws PartitionProducerDisposedException {
+        return executionGraphHandler.requestPartitionState(intermediateResultId, resultPartitionId);
+    }
+
+    void acknowledgeCheckpoint(
+            JobID jobID,
+            ExecutionAttemptID executionAttemptID,
+            long checkpointId,
+            CheckpointMetrics checkpointMetrics,
+            TaskStateSnapshot checkpointState) {
+
+        executionGraphHandler.acknowledgeCheckpoint(
+                jobID, executionAttemptID, checkpointId, checkpointMetrics, checkpointState);
+    }
+
+    void declineCheckpoint(DeclineCheckpoint decline) {
+        executionGraphHandler.declineCheckpoint(decline);
+    }
+
+    void updateAccumulators(AccumulatorSnapshot accumulatorSnapshot) {
+        executionGraph.updateAccumulators(accumulatorSnapshot);
+    }
+
+    KvStateLocation requestKvStateLocation(JobID jobId, String registrationName)
+            throws FlinkJobNotFoundException, UnknownKvStateLocation {
+        return kvStateHandler.requestKvStateLocation(jobId, registrationName);
+    }
+
+    void notifyKvStateRegistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName,
+            KvStateID kvStateId,
+            InetSocketAddress kvStateServerAddress)
+            throws FlinkJobNotFoundException {
+        kvStateHandler.notifyKvStateRegistered(
+                jobId,
+                jobVertexId,
+                keyGroupRange,
+                registrationName,
+                kvStateId,
+                kvStateServerAddress);
+    }
+
+    void notifyKvStateUnregistered(
+            JobID jobId,
+            JobVertexID jobVertexId,
+            KeyGroupRange keyGroupRange,
+            String registrationName)
+            throws FlinkJobNotFoundException {
+        kvStateHandler.notifyKvStateUnregistered(
+                jobId, jobVertexId, keyGroupRange, registrationName);
+    }
+
+    CompletableFuture<String> triggerSavepoint(String targetDirectory, boolean cancelJob) {
+        final CheckpointCoordinator checkpointCoordinator =
+                executionGraph.getCheckpointCoordinator();
+        if (checkpointCoordinator == null) {
+            throw new IllegalStateException(
+                    String.format("Job %s is not a streaming job.", executionGraph.getJobID()));
+        } else if (targetDirectory == null
+                && !checkpointCoordinator.getCheckpointStorage().hasDefaultSavepointLocation()) {
+            logger.info(
+                    "Trying to cancel job {} with savepoint, but no savepoint directory configured.",
+                    executionGraph.getJobID());
+
+            throw new IllegalStateException(
+                    "No savepoint directory configured. You can either specify a directory "
+                            + "while cancelling via -s :targetDirectory or configure a cluster-wide "
+                            + "default via key '"
+                            + CheckpointingOptions.SAVEPOINT_DIRECTORY.key()
+                            + "'.");
+        }
+
+        logger.info(
+                "Triggering {}savepoint for job {}.",
+                cancelJob ? "cancel-with-" : "",
+                executionGraph.getJobID());
+
+        if (cancelJob) {
+            checkpointCoordinator.stopCheckpointScheduler();
+        }
+
+        return checkpointCoordinator
+                .triggerSavepoint(targetDirectory)
+                .thenApply(CompletedCheckpoint::getExternalPointer)
+                .handleAsync(
+                        (path, throwable) -> {
+                            if (throwable != null) {
+                                if (cancelJob && context.isState(this)) {
+                                    startCheckpointScheduler(checkpointCoordinator);
+                                }
+                                throw new CompletionException(throwable);
+                            } else if (cancelJob && context.isState(this)) {
+                                logger.info(
+                                        "Savepoint stored in {}. Now cancelling {}.",
+                                        path,
+                                        executionGraph.getJobID());
+                                cancel();
+                            }
+                            return path;
+                        },
+                        context.getMainThreadExecutor());
+    }
+
+    CompletableFuture<String> stopWithSavepoint(
+            String targetDirectory, boolean advanceToEndOfEventTime) {
+        final CheckpointCoordinator checkpointCoordinator =
+                executionGraph.getCheckpointCoordinator();
+
+        if (checkpointCoordinator == null) {
+            return FutureUtils.completedExceptionally(
+                    new IllegalStateException(
+                            String.format(
+                                    "Job %s is not a streaming job.", executionGraph.getJobID())));
+        }
+
+        if (targetDirectory == null
+                && !checkpointCoordinator.getCheckpointStorage().hasDefaultSavepointLocation()) {
+            logger.info(
+                    "Trying to cancel job {} with savepoint, but no savepoint directory configured.",
+                    executionGraph.getJobID());
+
+            return FutureUtils.completedExceptionally(
+                    new IllegalStateException(
+                            "No savepoint directory configured. You can either specify a directory "
+                                    + "while cancelling via -s :targetDirectory or configure a cluster-wide "
+                                    + "default via key '"
+                                    + CheckpointingOptions.SAVEPOINT_DIRECTORY.key()
+                                    + "'."));
+        }
+
+        logger.info("Triggering stop-with-savepoint for job {}.", executionGraph.getJobID());
+
+        // we stop the checkpoint coordinator so that we are guaranteed
+        // to have only the data of the synchronous savepoint committed.
+        // in case of failure, and if the job restarts, the coordinator
+        // will be restarted by the CheckpointCoordinatorDeActivator.
+        checkpointCoordinator.stopCheckpointScheduler();
+
+        final CompletableFuture<String> savepointFuture =
+                checkpointCoordinator
+                        .triggerSynchronousSavepoint(advanceToEndOfEventTime, targetDirectory)
+                        .thenApply(CompletedCheckpoint::getExternalPointer);
+
+        final CompletableFuture<JobStatus> terminationFuture =
+                executionGraph
+                        .getTerminationFuture()
+                        .handle(
+                                (jobstatus, throwable) -> {
+                                    if (throwable != null) {
+                                        logger.info(
+                                                "Failed during stopping job {} with a savepoint. Reason: {}",
+                                                executionGraph.getJobID(),
+                                                throwable.getMessage());
+                                        throw new CompletionException(throwable);
+                                    } else if (jobstatus != JobStatus.FINISHED) {
+                                        logger.info(
+                                                "Failed during stopping job {} with a savepoint. Reason: Reached state {} instead of FINISHED.",
+                                                executionGraph.getJobID(),
+                                                jobstatus);
+                                        throw new CompletionException(
+                                                new FlinkException(
+                                                        "Reached state "
+                                                                + jobstatus
+                                                                + " instead of FINISHED."));
+                                    }
+                                    return jobstatus;
+                                });
+
+        return savepointFuture
+                .thenCompose((path) -> terminationFuture.thenApply((jobStatus -> path)))
+                .handleAsync(
+                        (path, throwable) -> {
+                            if (throwable != null) {
+                                if (context.isState(this)) {
+                                    // restart the checkpoint coordinator if stopWithSavepoint
+                                    // failed.
+                                    startCheckpointScheduler(checkpointCoordinator);
+                                }
+                                throw new CompletionException(throwable);
+                            }
+
+                            return path;
+                        },
+                        context.getMainThreadExecutor());
+    }
+
+    private void startCheckpointScheduler(final CheckpointCoordinator checkpointCoordinator) {
+        if (checkpointCoordinator.isPeriodicCheckpointingConfigured()) {
+            try {
+                checkpointCoordinator.startCheckpointScheduler();
+            } catch (IllegalStateException ignored) {
+                // Concurrent shut down of the coordinator
+            }
+        }
+    }
+
+    void deliverOperatorEventToCoordinator(
+            ExecutionAttemptID taskExecutionId, OperatorID operatorId, OperatorEvent evt)
+            throws FlinkException {
+        operatorCoordinatorHandler.deliverOperatorEventToCoordinator(
+                taskExecutionId, operatorId, evt);
+    }
+
+    CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+            OperatorID operatorId, CoordinationRequest request) throws FlinkException {
+        return operatorCoordinatorHandler.deliverCoordinationRequestToCoordinator(
+                operatorId, request);
+    }
+
+    /**
+     * Updates the execution graph with the given task execution state transition.
+     *
+     * @param taskExecutionStateTransition taskExecutionStateTransition to update the ExecutionGraph
+     *     with
+     * @return {@code true} if the update was successful; otherwise {@code false}
+     */
+    abstract boolean updateTaskExecutionState(
+            TaskExecutionStateTransition taskExecutionStateTransition);
+
+    /**
+     * Callback which is called once the execution graph reaches a terminal state.
+     *
+     * @param terminalState terminalState which the execution graph reached
+     */
+    abstract void onTerminalState(JobStatus terminalState);
+
+    /** Context of the {@link StateWithExecutionGraph} state. */
+    interface Context {
+
+        /**
+         * Run the given action if the current state equals the expected state.
+         *
+         * @param expectedState expectedState is the expected state
+         * @param action action to run if the current state equals the expected state
+         */
+        void runIfState(State expectedState, Runnable action);
+
+        /**
+         * Checks whether the current state is the expected state.
+         *
+         * @param expectedState expectedState is the expected state
+         * @return {@code true} if the current state equals the expected state; otherwise {@code
+         *     false}
+         */
+        boolean isState(State expectedState);
+
+        /**
+         * Gets the main thread executor.
+         *
+         * @return the main thread executor
+         */
+        Executor getMainThreadExecutor();
+
+        /**
+         * Transitions into the {@link Finished} state.
+         *
+         * @param archivedExecutionGraph archivedExecutionGraph which is passed to the {@link
+         *     Finished} state
+         */
+        void goToFinished(ArchivedExecutionGraph archivedExecutionGraph);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -305,11 +305,11 @@ abstract class StateWithExecutionGraph implements State {
             TaskExecutionStateTransition taskExecutionStateTransition);
 
     /**
-     * Callback which is called once the execution graph reaches a terminal state.
+     * Callback which is called once the execution graph reaches a globally terminal state.
      *
-     * @param terminalState terminalState which the execution graph reached
+     * @param globallyTerminalState globally terminal state which the execution graph reached
      */
-    abstract void onGloballyTerminalState(JobStatus terminalState);
+    abstract void onGloballyTerminalState(JobStatus globallyTerminalState);
 
     /** Context of the {@link StateWithExecutionGraph} state. */
     interface Context {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -118,8 +118,8 @@ abstract class StateWithExecutionGraph implements State {
     }
 
     @Override
-    public void onLeave(State newState) {
-        if (!StateWithExecutionGraph.class.isAssignableFrom(newState.getClass())) {
+    public void onLeave(Class<? extends State> newState) {
+        if (!StateWithExecutionGraph.class.isAssignableFrom(newState)) {
             // we are leaving the StateWithExecutionGraph --> we need to dispose temporary services
             operatorCoordinatorHandler.disposeAllOperatorCoordinators();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -1,0 +1,25 @@
+package org.apache.flink.runtime.concurrent;
+
+/** Testing ComponentMainThreadExecutor which can be manually triggered. */
+public class ManuallyTriggeredComponentMainThreadExecutor
+        extends ManuallyTriggeredScheduledExecutorService implements ComponentMainThreadExecutor {
+
+    private Thread executorThread = null;
+
+    @Override
+    public void assertRunningInMainThread() {
+        // always true
+    }
+
+    @Override
+    public void trigger() {
+        Thread actual = Thread.currentThread();
+        if (executorThread == null) {
+            executorThread = actual;
+        } else if (executorThread != actual) {
+            throw new IllegalStateException(
+                    "Expecting the use of the same thread for all trigger invocations.");
+        }
+        super.trigger();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -26,18 +26,16 @@ public class ManuallyTriggeredComponentMainThreadExecutor
 
     @Override
     public void assertRunningInMainThread() {
-        assert executorThread != null && Thread.currentThread() == executorThread;
+        Thread actual = Thread.currentThread();
+        if (executorThread == null) {
+            executorThread = actual;
+        }
+        assert actual == executorThread;
     }
 
     @Override
     public void trigger() {
-        Thread actual = Thread.currentThread();
-        if (executorThread == null) {
-            executorThread = actual;
-        } else if (executorThread != actual) {
-            throw new IllegalStateException(
-                    "Expecting the use of the same thread for all trigger invocations.");
-        }
+        assertRunningInMainThread();
         super.trigger();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.concurrent;
 
 /** Testing ComponentMainThreadExecutor which can be manually triggered. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -26,7 +26,7 @@ public class ManuallyTriggeredComponentMainThreadExecutor
 
     @Override
     public void assertRunningInMainThread() {
-        // always true
+        assert executorThread != null && Thread.currentThread() == executorThread;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -22,15 +22,11 @@ package org.apache.flink.runtime.concurrent;
 public class ManuallyTriggeredComponentMainThreadExecutor
         extends ManuallyTriggeredScheduledExecutorService implements ComponentMainThreadExecutor {
 
-    private Thread executorThread = null;
+    private final Thread executorThread = Thread.currentThread();
 
     @Override
     public void assertRunningInMainThread() {
-        Thread actual = Thread.currentThread();
-        if (executorThread == null) {
-            executorThread = actual;
-        }
-        assert actual == executorThread;
+        assert Thread.currentThread() == executorThread;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -22,7 +22,11 @@ package org.apache.flink.runtime.concurrent;
 public class ManuallyTriggeredComponentMainThreadExecutor
         extends ManuallyTriggeredScheduledExecutorService implements ComponentMainThreadExecutor {
 
-    private final Thread executorThread = Thread.currentThread();
+    private final Thread executorThread;
+
+    public ManuallyTriggeredComponentMainThreadExecutor(Thread executor) {
+        executorThread = executor;
+    }
 
     @Override
     public void assertRunningInMainThread() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -252,7 +252,7 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
         }
     }
 
-    private static class SubmitFailingSimpleAckingTaskManagerGateway
+    public static class SubmitFailingSimpleAckingTaskManagerGateway
             extends SimpleAckingTaskManagerGateway {
         @Override
         public CompletableFuture<Acknowledge> submitTask(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertexDeploymentTest;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.NoOpExecutionDeploymentListener;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategyFactoryLoader;
+import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.apache.flink.runtime.scheduler.declarative.WaitingForResourcesTest.assertNonNull;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/** Tests for declarative scheduler's {@link Executing} state. */
+public class ExecutingTest extends TestLogger {
+    @Test
+    public void testTransitionToFailing() throws Exception {
+        final String failureMsg = "test exception";
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            exec.onEnter();
+            ctx.setExpectFailing(
+                    (failingArguments -> {
+                        assertThat(failingArguments.getExecutionGraph(), notNullValue());
+                        assertThat(failingArguments.getFailureCause().getMessage(), is(failureMsg));
+                    }));
+            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            exec.handleGlobalFailure(new RuntimeException(failureMsg));
+        }
+    }
+
+    @Test
+    public void testTransitionToRestarting() throws Exception {
+        final Duration duration = Duration.ZERO;
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            exec.onEnter();
+            ctx.setExpectRestarting(
+                    (restartingArguments ->
+                            assertThat(restartingArguments.getBackoffTime(), is(duration))));
+            ctx.setHowToHandleFailure((t) -> Executing.FailureResult.canRestart(duration));
+            exec.handleGlobalFailure(new RuntimeException("Recoverable error"));
+        }
+    }
+
+    @Test
+    public void testTransitionToCancelling() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            exec.onEnter();
+            ctx.setExpectCancelling(assertNonNull());
+            exec.cancel();
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedOnTerminalState() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            exec.onEnter();
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
+
+            ctx.setExpectedStateChecker((state) -> state == exec);
+            // transition EG into terminal state, which will notify the Executing state about the
+            // failure (async via the supplied executor)
+            exec.getExecutionGraph().failJob(new RuntimeException("test failure"));
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedOnSuspend() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            ctx.setExpectedStateChecker((state) -> state == exec);
+
+            ctx.setExpectFinished(
+                    archivedExecutionGraph -> {
+                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
+                    });
+            exec.onEnter();
+            exec.suspend(new RuntimeException("suspend"));
+        }
+    }
+
+    @Test
+    public void testScaleUp() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            exec.onEnter();
+
+            ctx.setExpectRestarting(
+                    restartingArguments -> {
+                        // expect immediate restart on scale up
+                        assertThat(restartingArguments.getBackoffTime(), is(Duration.ZERO));
+                    });
+            ctx.setCanScaleUp(() -> true);
+            exec.notifyNewResourcesAvailable();
+        }
+    }
+
+    @Test
+    public void testNoScaleUp() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            ctx.setCanScaleUp(() -> false);
+            exec.onEnter();
+            exec.notifyNewResourcesAvailable();
+        }
+    }
+
+    @Test
+    public void testFailingOnDeploymentFailure() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            ctx.setCanScaleUp(() -> false);
+            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setExpectFailing(assertNonNull());
+
+            // create ExecutionGraph with one ExecutionVertex, which fails during deployment.
+            JobGraph jobGraph = new JobGraph(new JobVertex("test"));
+            Executing exec = getExecutingState(ctx, null, jobGraph);
+            TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+            TaskManagerGateway taskManagerGateway =
+                    new ExecutionVertexDeploymentTest.SubmitFailingSimpleAckingTaskManagerGateway();
+            slotBuilder.setTaskManagerGateway(taskManagerGateway);
+            LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+            exec.getExecutionGraph()
+                    .getAllExecutionVertices()
+                    .forEach(executionVertex -> executionVertex.tryAssignResource(slot));
+
+            // trigger deployment
+            exec.onEnter();
+        }
+    }
+
+    @Test
+    public void testFailureReportedViaUpdateTaskExecutionState() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            ExecutionGraph returnsFailedStateExecutionGraph =
+                    new ReturnsTrueOnUpdateExecutionGraph();
+            Executing exec = getExecutingState(ctx, returnsFailedStateExecutionGraph, null);
+            exec.onEnter();
+            ctx.setCanScaleUp(() -> false);
+            ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
+            ctx.setExpectFailing(assertNonNull());
+
+            TaskExecutionStateTransition stateTransition =
+                    new TaskExecutionStateTransition(
+                            new TaskExecutionState(
+                                    exec.getExecutionGraph().getJobID(),
+                                    new ExecutionAttemptID(),
+                                    ExecutionState.FAILED,
+                                    new RuntimeException()));
+
+            exec.updateTaskExecutionState(stateTransition);
+        }
+    }
+
+    @Test
+    public void testJobInformationMethods() throws Exception {
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            Executing exec = getExecutingState(ctx);
+            final JobID jobId = exec.getExecutionGraph().getJobID();
+            exec.onEnter();
+            assertThat(exec.getJob(), instanceOf(ArchivedExecutionGraph.class));
+            assertThat(exec.getJob().getJobID(), is(jobId));
+            assertThat(exec.getJobStatus(), is(JobStatus.CREATED));
+        }
+    }
+
+    public Executing getExecutingState(MockExecutingContext ctx)
+            throws JobException, JobExecutionException {
+        return getExecutingState(ctx, null, null);
+    }
+
+    public Executing getExecutingState(
+            MockExecutingContext ctx,
+            @Nullable ExecutionGraph alternativeEG,
+            @Nullable JobGraph jobGraph)
+            throws JobException, JobExecutionException {
+        ExecutionGraph executionGraph = alternativeEG;
+        if (alternativeEG == null) {
+            executionGraph = TestingExecutionGraphBuilder.newBuilder().build();
+        }
+        if (jobGraph != null) {
+            executionGraph.attachJobGraph(jobGraph.getVerticesSortedTopologicallyFromSources());
+        }
+        final ExecutionGraphHandler executionGraphHandler =
+                new ExecutionGraphHandler(
+                        executionGraph,
+                        log,
+                        ctx.getMainThreadExecutor(),
+                        ctx.getMainThreadExecutor());
+        final OperatorCoordinatorHandler operatorCoordinatorHandler =
+                new OperatorCoordinatorHandler(
+                        executionGraph,
+                        (throwable) -> {
+                            throw new RuntimeException("Error in test", throwable);
+                        });
+        return new Executing(
+                executionGraph,
+                executionGraphHandler,
+                operatorCoordinatorHandler,
+                log,
+                ctx,
+                ClassLoader.getSystemClassLoader());
+    }
+
+    private static class MockExecutingContext extends MockStateWithExecutionGraphContext
+            implements Executing.Context {
+
+        private final StateValidator<FailingArguments> failingStateValidator =
+                new StateValidator<>("failing");
+        private final StateValidator<RestartingArguments> restartingStateValidator =
+                new StateValidator<>("restarting");
+        private final StateValidator<CancellingArguments> cancellingStateValidator =
+                new StateValidator<>("cancelling");
+
+        private Function<Throwable, Executing.FailureResult> howToHandleFailure;
+        private Supplier<Boolean> canScaleUp;
+
+        public void setExpectFailing(Consumer<FailingArguments> asserter) {
+            failingStateValidator.expectInput(asserter);
+        }
+
+        public void setExpectRestarting(Consumer<RestartingArguments> asserter) {
+            restartingStateValidator.expectInput(asserter);
+        }
+
+        public void setExpectCancelling(Consumer<CancellingArguments> asserter) {
+            cancellingStateValidator.expectInput(asserter);
+        }
+
+        public void setHowToHandleFailure(Function<Throwable, Executing.FailureResult> function) {
+            this.howToHandleFailure = function;
+        }
+
+        public void setCanScaleUp(Supplier<Boolean> supplier) {
+            this.canScaleUp = supplier;
+        }
+
+        // --------- Interface Implementations ------- //
+
+        @Override
+        public void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+            cancellingStateValidator.validateInput(
+                    new CancellingArguments(
+                            executionGraph, executionGraphHandler, operatorCoordinatorHandler));
+        }
+
+        @Override
+        public Executing.FailureResult howToHandleFailure(Throwable failure) {
+            return howToHandleFailure.apply(failure);
+        }
+
+        @Override
+        public boolean canScaleUp(ExecutionGraph executionGraph) {
+            return canScaleUp.get();
+        }
+
+        @Override
+        public void goToRestarting(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Duration backoffTime) {
+            restartingStateValidator.validateInput(
+                    new RestartingArguments(
+                            executionGraph,
+                            executionGraphHandler,
+                            operatorCoordinatorHandler,
+                            backoffTime));
+        }
+
+        @Override
+        public void goToFailing(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Throwable failureCause) {
+            failingStateValidator.validateInput(
+                    new FailingArguments(
+                            executionGraph,
+                            executionGraphHandler,
+                            operatorCoordinatorHandler,
+                            failureCause));
+        }
+
+        @Override
+        public void close() throws Exception {
+            super.close();
+            failingStateValidator.close();
+            restartingStateValidator.close();
+            cancellingStateValidator.close();
+        }
+    }
+
+    static class CancellingArguments {
+        private final ExecutionGraph executionGraph;
+        private final ExecutionGraphHandler executionGraphHandler;
+        private final OperatorCoordinatorHandler operatorCoordinatorHandle;
+
+        public CancellingArguments(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandle) {
+            this.executionGraph = executionGraph;
+            this.executionGraphHandler = executionGraphHandler;
+            this.operatorCoordinatorHandle = operatorCoordinatorHandle;
+        }
+
+        public ExecutionGraph getExecutionGraph() {
+            return executionGraph;
+        }
+
+        public ExecutionGraphHandler getExecutionGraphHandler() {
+            return executionGraphHandler;
+        }
+
+        public OperatorCoordinatorHandler getOperatorCoordinatorHandle() {
+            return operatorCoordinatorHandle;
+        }
+    }
+
+    static class RestartingArguments extends CancellingArguments {
+        private final Duration backoffTime;
+
+        public RestartingArguments(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Duration backoffTime) {
+            super(executionGraph, executionGraphHandler, operatorCoordinatorHandler);
+            this.backoffTime = backoffTime;
+        }
+
+        public Duration getBackoffTime() {
+            return backoffTime;
+        }
+    }
+
+    static class FailingArguments extends CancellingArguments {
+        private final Throwable failureCause;
+
+        public FailingArguments(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Throwable failureCause) {
+            super(executionGraph, executionGraphHandler, operatorCoordinatorHandler);
+            this.failureCause = failureCause;
+        }
+
+        public Throwable getFailureCause() {
+            return failureCause;
+        }
+    }
+
+    private static class ReturnsTrueOnUpdateExecutionGraph extends ExecutionGraph {
+        ReturnsTrueOnUpdateExecutionGraph() throws IOException {
+            super(
+                    new JobInformation(
+                            new JobID(),
+                            "Test Job",
+                            new SerializedValue<>(new ExecutionConfig()),
+                            new Configuration(),
+                            Collections.emptyList(),
+                            Collections.emptyList()),
+                    TestingUtils.defaultExecutor(),
+                    TestingUtils.defaultExecutor(),
+                    AkkaUtils.getDefaultTimeout(),
+                    1,
+                    ExecutionGraph.class.getClassLoader(),
+                    VoidBlobWriter.getInstance(),
+                    PartitionReleaseStrategyFactoryLoader.loadPartitionReleaseStrategyFactory(
+                            new Configuration()),
+                    NettyShuffleMaster.INSTANCE,
+                    NoOpJobMasterPartitionTracker.INSTANCE,
+                    ScheduleMode.EAGER,
+                    NoOpExecutionDeploymentListener.get(),
+                    (execution, newState) -> {},
+                    0L);
+        }
+
+        @Override
+        public boolean updateState(TaskExecutionStateTransition state) {
+            return true;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
@@ -156,49 +156,6 @@ public class ExecutingTest extends TestLogger {
     }
 
     @Test
-    public void testEnsureOnlyGlobalTerminalStateCallbacksNoCall() throws Exception {
-        // modify MockExecutingContext to disable the "runIfState()" check
-        MockExecutingContext ctx =
-                new MockExecutingContext() {
-                    @Override
-                    public void runIfState(State expectedState, Runnable action) {
-                        action.run();
-                    }
-                };
-        MockedExecuting exec = new ExecutingStateBuilder().build(ctx);
-
-        ctx.setExpectFinished(
-                archivedExecutionGraph ->
-                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
-        exec.onEnter();
-        exec.suspend(
-                new RuntimeException("suspend")); // trigger transition to non-global terminal state
-        ctx.close(); // manually close context to trigger callbacks
-
-        assertThat(exec.isOnGloballyTerminalStateCalled(), is(false));
-    }
-
-    @Test
-    public void testEnsureOnlyGlobalTerminalStateCallbacksWithCall() throws Exception {
-        // modify MockExecutingContext to disable the "runIfState()" check
-        MockExecutingContext ctx =
-                new MockExecutingContext() {
-                    @Override
-                    public void runIfState(State expectedState, Runnable action) {
-                        action.run();
-                    }
-                };
-        MockedExecuting exec = new ExecutingStateBuilder().build(ctx);
-        ctx.setExpectFinished(
-                archivedExecutionGraph ->
-                        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
-        exec.getExecutionGraph()
-                .failJob(new RuntimeException()); // trigger transition to global terminal state
-        ctx.close(); // manually close context to trigger callbacks
-        assertThat(exec.isOnGloballyTerminalStateCalled(), is(true));
-    }
-
-    @Test
     public void testTransitionToFinishedOnSuspend() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
@@ -334,7 +291,7 @@ public class ExecutingTest extends TestLogger {
             return this;
         }
 
-        private MockedExecuting build(MockExecutingContext ctx) {
+        private Executing build(MockExecutingContext ctx) {
             executionGraph.transitionToRunning();
             final ExecutionGraphHandler executionGraphHandler =
                     new ExecutionGraphHandler(
@@ -343,43 +300,13 @@ public class ExecutingTest extends TestLogger {
                             ctx.getMainThreadExecutor(),
                             ctx.getMainThreadExecutor());
 
-            return new MockedExecuting(
+            return new Executing(
                     executionGraph,
                     executionGraphHandler,
                     operatorCoordinatorHandler,
                     log,
                     ctx,
                     ClassLoader.getSystemClassLoader());
-        }
-    }
-
-    private static class MockedExecuting extends Executing {
-        private boolean onGloballyTerminalStateCalled = false;
-
-        MockedExecuting(
-                ExecutionGraph executionGraph,
-                ExecutionGraphHandler executionGraphHandler,
-                OperatorCoordinatorHandler operatorCoordinatorHandler,
-                Logger logger,
-                Context context,
-                ClassLoader userCodeClassLoader) {
-            super(
-                    executionGraph,
-                    executionGraphHandler,
-                    operatorCoordinatorHandler,
-                    logger,
-                    context,
-                    userCodeClassLoader);
-        }
-
-        @Override
-        void onGloballyTerminalState(JobStatus terminalState) {
-            super.onGloballyTerminalState(terminalState);
-            onGloballyTerminalStateCalled = true;
-        }
-
-        public boolean isOnGloballyTerminalStateCalled() {
-            return onGloballyTerminalStateCalled;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
@@ -94,7 +94,7 @@ public class ExecutingTest extends TestLogger {
                     new ExecutingStateBuilder()
                             .setOperatorCoordinatorHandler(operatorCoordinator)
                             .build(ctx);
-            exec.onLeave(new MockState());
+            exec.onLeave(MockState.class);
 
             assertThat(operatorCoordinator.isDisposed(), is(true));
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Context, AutoCloseable {
+
+    private final StateValidator<ArchivedExecutionGraph> finishedStateValidator =
+            new StateValidator<>("finished");
+
+    Function<State, Boolean> expectedStateChecker =
+            (ign) -> {
+                throw new UnsupportedOperationException("Remember to set me");
+            };
+
+    private final ManuallyTriggeredComponentMainThreadExecutor executor =
+            new ManuallyTriggeredComponentMainThreadExecutor();
+
+    public void setExpectedStateChecker(Function<State, Boolean> function) {
+        this.expectedStateChecker = function;
+    }
+
+    public void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
+        finishedStateValidator.expectInput(asserter);
+    }
+
+    @Override
+    public void runIfState(State expectedState, Runnable action) {
+        if (expectedStateChecker.apply(expectedState)) {
+            action.run();
+        }
+    }
+
+    @Override
+    public boolean isState(State expectedState) {
+        throw new UnsupportedOperationException("Not covered by this test at the moment");
+    }
+
+    @Override
+    public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
+        finishedStateValidator.validateInput(archivedExecutionGraph);
+    }
+
+    @Override
+    public ComponentMainThreadExecutor getMainThreadExecutor() {
+        return executor;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // trigger executor to make sure there are no outstanding state transitions
+        executor.triggerAll();
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.MINUTES);
+        finishedStateValidator.close();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
@@ -34,7 +34,7 @@ class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Cont
             new StateValidator<>("Finished");
 
     private final ManuallyTriggeredComponentMainThreadExecutor executor =
-            new ManuallyTriggeredComponentMainThreadExecutor();
+            new ManuallyTriggeredComponentMainThreadExecutor(Thread.currentThread());
 
     protected boolean hadStateTransition = false;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
@@ -74,7 +74,7 @@ class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Cont
         finishedStateValidator.close();
     }
 
-    protected void assertNoStateTransition() {
+    protected final void assertNoStateTransition() {
         assertThat(hadStateTransition, is(false));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockStateWithExecutionGraphContext.java
@@ -25,10 +25,13 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Context, AutoCloseable {
 
     private final StateValidator<ArchivedExecutionGraph> finishedStateValidator =
-            new StateValidator<>("finished");
+            new StateValidator<>("Finished");
 
     private final ManuallyTriggeredComponentMainThreadExecutor executor =
             new ManuallyTriggeredComponentMainThreadExecutor();
@@ -68,10 +71,10 @@ class MockStateWithExecutionGraphContext implements StateWithExecutionGraph.Cont
         executor.triggerAll();
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.MINUTES);
-        assertNotStateTransition();
+        finishedStateValidator.close();
     }
 
-    protected void assertNotStateTransition() {
-        finishedStateValidator.close();
+    protected void assertNoStateTransition() {
+        assertThat(hadStateTransition, is(false));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
@@ -96,11 +96,11 @@ public class RestartingTest extends TestLogger {
     }
 
     @Test
-    public void testGlobalFailure() throws Exception {
+    public void testGlobalFailuresAreIgnored() throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             Restarting restarting = createRestartingState(ctx);
             restarting.handleGlobalFailure(new RuntimeException());
-            ctx.assertNotStateTransition();
+            ctx.assertNoStateTransition();
         }
     }
 
@@ -118,6 +118,7 @@ public class RestartingTest extends TestLogger {
                         (throwable) -> {
                             throw new RuntimeException("Error in test", throwable);
                         });
+        executionGraph.transitionToRunning();
         return new Restarting(
                 ctx,
                 executionGraph,
@@ -177,11 +178,6 @@ public class RestartingTest extends TestLogger {
         @Override
         public void close() throws Exception {
             super.close();
-            assertNotStateTransition();
-        }
-
-        public void assertNotStateTransition() {
-            super.assertNotStateTransition();
             cancellingStateValidator.close();
             waitingForResourcesStateValidator.close();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
@@ -70,7 +70,7 @@ public class RestartingTest extends TestLogger {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             Restarting restarting = createRestartingState(ctx);
             ctx.setExpectWaitingForResources();
-            restarting.onTerminalState(JobStatus.CANCELED);
+            restarting.onGloballyTerminalState(JobStatus.CANCELED);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+import static org.apache.flink.runtime.scheduler.declarative.WaitingForResourcesTest.assertNonNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link Restarting} state of the declarative scheduler. */
+public class RestartingTest extends TestLogger {
+
+    @Test
+    public void testOnEnter() throws Exception {
+        try (MockRestartingContext ctx = new MockRestartingContext()) {
+            Restarting restarting = getRestartingState(ctx);
+            ctx.setExpectedStateChecker((state) -> state == restarting);
+            ctx.setExpectWaitingForResources();
+            restarting.onEnter();
+        }
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        try (MockRestartingContext ctx = new MockRestartingContext()) {
+            Restarting restarting = getRestartingState(ctx);
+            ctx.setExpectCancelling(assertNonNull());
+            restarting.cancel();
+        }
+    }
+
+    @Test
+    public void testSuspend() throws Exception {
+        try (MockRestartingContext ctx = new MockRestartingContext()) {
+            Restarting restarting = getRestartingState(ctx);
+            ctx.setExpectedStateChecker((state) -> state == restarting);
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
+            restarting.suspend(new RuntimeException("suspend"));
+        }
+    }
+
+    @Test
+    public void testGlobalFailure() throws Exception {
+        try (MockRestartingContext ctx = new MockRestartingContext()) {
+            Restarting restarting = getRestartingState(ctx);
+            restarting.handleGlobalFailure(new RuntimeException());
+            // no state transition expected
+        }
+    }
+
+    public Restarting getRestartingState(MockRestartingContext ctx)
+            throws JobException, JobExecutionException {
+        ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder().build();
+        final ExecutionGraphHandler executionGraphHandler =
+                new ExecutionGraphHandler(
+                        executionGraph,
+                        log,
+                        ctx.getMainThreadExecutor(),
+                        ctx.getMainThreadExecutor());
+        final OperatorCoordinatorHandler operatorCoordinatorHandler =
+                new OperatorCoordinatorHandler(
+                        executionGraph,
+                        (throwable) -> {
+                            throw new RuntimeException("Error in test", throwable);
+                        });
+        return new Restarting(
+                ctx,
+                executionGraph,
+                executionGraphHandler,
+                operatorCoordinatorHandler,
+                log,
+                Duration.ZERO);
+    }
+
+    private static class MockRestartingContext extends MockStateWithExecutionGraphContext
+            implements Restarting.Context {
+
+        private final StateValidator<ExecutingTest.CancellingArguments> cancellingStateValidator =
+                new StateValidator<>("Cancelling");
+
+        private final StateValidator<Void> waitingForResourcesStateValidator =
+                new StateValidator<>("WaitingForResources");
+
+        public void setExpectCancelling(Consumer<ExecutingTest.CancellingArguments> asserter) {
+            cancellingStateValidator.expectInput(asserter);
+        }
+
+        public void setExpectWaitingForResources() {
+            waitingForResourcesStateValidator.expectInput((none) -> {});
+        }
+
+        @Override
+        public void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+            cancellingStateValidator.validateInput(
+                    new ExecutingTest.CancellingArguments(
+                            executionGraph, executionGraphHandler, operatorCoordinatorHandler));
+        }
+
+        @Override
+        public void goToWaitingForResources() {
+            waitingForResourcesStateValidator.validateInput(null);
+        }
+
+        @Override
+        public void runIfState(State expectedState, Runnable action, Duration delay) {
+            if (expectedStateChecker.apply(expectedState)) {
+                action.run();
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            super.close();
+            cancellingStateValidator.close();
+            waitingForResourcesStateValidator.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateValidator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/StateValidator.java
@@ -78,6 +78,11 @@ public class StateValidator<T> {
     }
 
     public final void expectNoStateTransition() {
-        consumer = (T) -> fail("No consumer has been set. Unexpected state transition");
+        consumer =
+                (T) ->
+                        fail(
+                                "No consumer has been set for "
+                                        + stateName
+                                        + ". Unexpected state transition");
     }
 }

--- a/flink-runtime/src/test/resources/log4j2-test.properties
+++ b/flink-runtime/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = INFO
+rootLogger.level = OFF
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-runtime/src/test/resources/log4j2-test.properties
+++ b/flink-runtime/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. 

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.