### PR TITLE
[FLINK-21302][table-planner-blink] Fix NPE when use row_number() in over agg

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -380,7 +380,7 @@ object AggregateUtil extends Enumeration {
       .zipWithIndex
       .map { case (call, index) =>
         val argIndexes = call.getAggregation match {
-          case _: SqlRankFunction => orderKeyIndexes
+          case _: SqlRankFunction => if (orderKeyIndexes != null) orderKeyIndexes else Array[Int]()
           case _ => call.getArgList.map(_.intValue()).toArray
         }
         transformToAggregateInfo(


### PR DESCRIPTION
## What is the purpose of the change
Fix NPE when use row_number() in over agg.

## Brief change log
Minor update in `DeclarativeAggCodeGen` to take aggregate without parameters into consideration.

## Verifying this change
ITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
