### PR TITLE
[FLINK-21303][coordination] Maybe remove LogicalSlot#getPhysicalSlotNumber

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -128,9 +128,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
     /** The list of consumed intermediate result partitions. */
     private final List<InputGateDeploymentDescriptor> inputGates;
 
-    /** Slot number to run the sub task in on the target machine. */
-    private final int targetSlotNumber;
-
     /** Information to restore the task. This can be null if there is no state to restore. */
     @Nullable private final JobManagerTaskRestore taskRestore;
 
@@ -142,7 +139,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
             AllocationID allocationId,
             int subtaskIndex,
             int attemptNumber,
-            int targetSlotNumber,
             @Nullable JobManagerTaskRestore taskRestore,
             List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
             List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
@@ -160,10 +156,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
         Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
         this.attemptNumber = attemptNumber;
-
-        Preconditions.checkArgument(
-                0 <= targetSlotNumber, "The target slot number must be positive.");
-        this.targetSlotNumber = targetSlotNumber;
 
         this.taskRestore = taskRestore;
 
@@ -232,15 +224,6 @@ public final class TaskDeploymentDescriptor implements Serializable {
     /** Returns the attempt number of the subtask. */
     public int getAttemptNumber() {
         return attemptNumber;
-    }
-
-    /**
-     * Gets the number of the slot into which the task is to be deployed.
-     *
-     * @return The number of the target slot.
-     */
-    public int getTargetSlotNumber() {
-        return targetSlotNumber;
     }
 
     public List<ResultPartitionDeploymentDescriptor> getProducedPartitions() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -85,7 +85,6 @@ public class TaskDeploymentDescriptorFactory {
 
     public TaskDeploymentDescriptor createDeploymentDescriptor(
             AllocationID allocationID,
-            int targetSlotNumber,
             @Nullable JobManagerTaskRestore taskRestore,
             Collection<ResultPartitionDeploymentDescriptor> producedPartitions) {
         return new TaskDeploymentDescriptor(
@@ -96,7 +95,6 @@ public class TaskDeploymentDescriptorFactory {
                 allocationID,
                 subtaskIndex,
                 attemptNumber,
-                targetSlotNumber,
                 taskRestore,
                 new ArrayList<>(producedPartitions),
                 createInputGateDeploymentDescriptors());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -570,7 +570,6 @@ public class Execution
                     TaskDeploymentDescriptorFactory.fromExecutionVertex(vertex, attemptNumber)
                             .createDeploymentDescriptor(
                                     slot.getAllocationId(),
-                                    slot.getPhysicalSlotNumber(),
                                     taskRestore,
                                     producedPartitions.values());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/LogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/LogicalSlot.java
@@ -113,14 +113,6 @@ public interface LogicalSlot {
     CompletableFuture<?> releaseSlot(@Nullable Throwable cause);
 
     /**
-     * Gets the slot number on the TaskManager. Multiple logical slots can share the same slot
-     * number.
-     *
-     * @return slot number
-     */
-    int getPhysicalSlotNumber();
-
-    /**
      * Gets the allocation id of this slot. Multiple logical slots can share the same allocation id.
      *
      * @return allocation id of this slot

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
@@ -135,11 +135,6 @@ public class SingleLogicalSlot implements LogicalSlot, PhysicalSlot.Payload {
     }
 
     @Override
-    public int getPhysicalSlotNumber() {
-        return slotContext.getPhysicalSlotNumber();
-    }
-
-    @Override
     public AllocationID getAllocationId() {
         return slotContext.getAllocationId();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -646,7 +646,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             tdd.getAttemptNumber(),
                             tdd.getProducedPartitions(),
                             tdd.getInputGates(),
-                            tdd.getTargetSlotNumber(),
                             memoryManager,
                             taskExecutorServices.getIOManager(),
                             taskExecutorServices.getShuffleEnvironment(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -304,7 +304,6 @@ public class Task
             int attemptNumber,
             List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
             List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
-            int targetSlotNumber,
             MemoryManager memManager,
             IOManager ioManager,
             ShuffleEnvironment<?, ?> shuffleEnvironment,
@@ -331,8 +330,6 @@ public class Task
 
         Preconditions.checkArgument(0 <= subtaskIndex, "The subtask index must be positive.");
         Preconditions.checkArgument(0 <= attemptNumber, "The attempt number must be positive.");
-        Preconditions.checkArgument(
-                0 <= targetSlotNumber, "The target slot number must be positive.");
 
         this.taskInfo =
                 new TaskInfo(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
@@ -48,7 +48,6 @@ public class TaskDeploymentDescriptorBuilder {
     private int attemptNumber;
     private List<ResultPartitionDeploymentDescriptor> producedPartitions;
     private List<InputGateDeploymentDescriptor> inputGates;
-    private int targetSlotNumber;
 
     @Nullable private JobManagerTaskRestore taskRestore;
 
@@ -74,7 +73,6 @@ public class TaskDeploymentDescriptorBuilder {
         this.attemptNumber = 0;
         this.producedPartitions = Collections.emptyList();
         this.inputGates = Collections.emptyList();
-        this.targetSlotNumber = 0;
         this.taskRestore = null;
     }
 
@@ -127,11 +125,6 @@ public class TaskDeploymentDescriptorBuilder {
         return this;
     }
 
-    public TaskDeploymentDescriptorBuilder setTargetSlotNumber(int targetSlotNumber) {
-        this.targetSlotNumber = targetSlotNumber;
-        return this;
-    }
-
     public TaskDeploymentDescriptorBuilder setTaskRestore(
             @Nullable JobManagerTaskRestore taskRestore) {
         this.taskRestore = taskRestore;
@@ -147,7 +140,6 @@ public class TaskDeploymentDescriptorBuilder {
                 allocationId,
                 subtaskIndex,
                 attemptNumber,
-                targetSlotNumber,
                 taskRestore,
                 producedPartitions,
                 inputGates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -72,7 +72,6 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
             new ArrayList<InputGateDeploymentDescriptor>(0);
     private static final List<PermanentBlobKey> requiredJars = new ArrayList<>(0);
     private static final List<URL> requiredClasspaths = new ArrayList<>(0);
-    private static final int targetSlotNumber = 47;
     private static final TaskStateSnapshot taskStateHandles = new TaskStateSnapshot();
     private static final JobManagerTaskRestore taskRestore =
             new JobManagerTaskRestore(1L, taskStateHandles);
@@ -123,7 +122,6 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
         assertEquals(orig.getAllocationId(), copy.getAllocationId());
         assertEquals(orig.getSubtaskIndex(), copy.getSubtaskIndex());
         assertEquals(orig.getAttemptNumber(), copy.getAttemptNumber());
-        assertEquals(orig.getTargetSlotNumber(), copy.getTargetSlotNumber());
         assertEquals(
                 orig.getTaskRestore().getRestoreCheckpointId(),
                 copy.getTaskRestore().getRestoreCheckpointId());
@@ -165,7 +163,6 @@ public class TaskDeploymentDescriptorTest extends TestLogger {
                 allocationId,
                 indexInSubtaskGroup,
                 attemptNumber,
-                targetSlotNumber,
                 taskRestore,
                 producedResults,
                 inputGates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexDeploymentTest.java
@@ -305,7 +305,6 @@ public class ExecutionVertexDeploymentTest extends TestLogger {
             TaskDeploymentDescriptor tdd =
                     tddFactory.createDeploymentDescriptor(
                             new AllocationID(),
-                            0,
                             null,
                             Execution.registerProducedPartitions(
                                             vertex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlot.java
@@ -38,8 +38,6 @@ public class TestingLogicalSlot implements LogicalSlot {
 
     private final AtomicReference<Payload> payloadReference;
 
-    private final int slotNumber;
-
     private final CompletableFuture<?> releaseFuture;
 
     private final boolean automaticallyCompleteReleaseFuture;
@@ -55,7 +53,6 @@ public class TestingLogicalSlot implements LogicalSlot {
     TestingLogicalSlot(
             TaskManagerLocation taskManagerLocation,
             TaskManagerGateway taskManagerGateway,
-            int slotNumber,
             AllocationID allocationId,
             SlotRequestId slotRequestId,
             boolean automaticallyCompleteReleaseFuture,
@@ -64,7 +61,6 @@ public class TestingLogicalSlot implements LogicalSlot {
         this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
         this.taskManagerGateway = Preconditions.checkNotNull(taskManagerGateway);
         this.payloadReference = new AtomicReference<>();
-        this.slotNumber = slotNumber;
         this.allocationId = Preconditions.checkNotNull(allocationId);
         this.slotRequestId = Preconditions.checkNotNull(slotRequestId);
         this.releaseFuture = new CompletableFuture<>();
@@ -119,11 +115,6 @@ public class TestingLogicalSlot implements LogicalSlot {
         }
 
         return releaseFuture;
-    }
-
-    @Override
-    public int getPhysicalSlotNumber() {
-        return slotNumber;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlotBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingLogicalSlotBuilder.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 public class TestingLogicalSlotBuilder {
     private TaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
     private TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
-    private int slotNumber = 0;
     private AllocationID allocationId = new AllocationID();
     private SlotRequestId slotRequestId = new SlotRequestId();
     private SlotOwner slotOwner = new DummySlotOwner();
@@ -43,11 +42,6 @@ public class TestingLogicalSlotBuilder {
     public TestingLogicalSlotBuilder setTaskManagerLocation(
             TaskManagerLocation taskManagerLocation) {
         this.taskManagerLocation = taskManagerLocation;
-        return this;
-    }
-
-    public TestingLogicalSlotBuilder setSlotNumber(int slotNumber) {
-        this.slotNumber = slotNumber;
         return this;
     }
 
@@ -76,7 +70,6 @@ public class TestingLogicalSlotBuilder {
         return new TestingLogicalSlot(
                 taskManagerLocation,
                 taskManagerGateway,
-                slotNumber,
                 allocationId,
                 slotRequestId,
                 automaticallyCompleteReleaseFuture,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SharedSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SharedSlotTest.java
@@ -88,14 +88,9 @@ public class SharedSlotTest extends TestLogger {
         AllocationID allocationId = new AllocationID();
         LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
         SimpleAckingTaskManagerGateway taskManagerGateway = new SimpleAckingTaskManagerGateway();
-        int physicalSlotNumber = 3;
         slotContextFuture.complete(
                 new TestingPhysicalSlot(
-                        allocationId,
-                        taskManagerLocation,
-                        physicalSlotNumber,
-                        taskManagerGateway,
-                        RP));
+                        allocationId, taskManagerLocation, 3, taskManagerGateway, RP));
 
         assertThat(sharedSlot.isEmpty(), is(false));
         assertThat(released.isDone(), is(false));
@@ -104,7 +99,6 @@ public class SharedSlotTest extends TestLogger {
         assertThat(logicalSlot.getAllocationId(), is(allocationId));
         assertThat(logicalSlot.getTaskManagerLocation(), is(taskManagerLocation));
         assertThat(logicalSlot.getTaskManagerGateway(), is(taskManagerGateway));
-        assertThat(logicalSlot.getPhysicalSlotNumber(), is(physicalSlotNumber));
         assertThat(logicalSlot.getLocality(), is(Locality.UNKNOWN));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/allocator/SharedSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/allocator/SharedSlotTest.java
@@ -66,7 +66,6 @@ public class SharedSlotTest extends TestLogger {
         assertThat(logicalSlot.getAllocationId(), equalTo(physicalSlot.getAllocationId()));
         assertThat(logicalSlot.getLocality(), is(Locality.UNKNOWN));
         assertThat(logicalSlot.getPayload(), nullValue());
-        assertThat(logicalSlot.getPhysicalSlotNumber(), is(physicalSlot.getPhysicalSlotNumber()));
         assertThat(
                 logicalSlot.getTaskManagerLocation(),
                 equalTo(physicalSlot.getTaskManagerLocation()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
@@ -182,8 +182,7 @@ public class TaskExecutorOperatorEventHandlingTest extends TestLogger {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Collections.emptyList(),
-                0);
+                Collections.emptyList());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -428,8 +428,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
                         Collections.singletonList(taskResultPartitionDescriptor),
                         Collections.emptyList(),
                         Collections.emptyList(),
-                        Collections.emptyList(),
-                        0);
+                        Collections.emptyList());
 
         final TaskSlotTable<Task> taskSlotTable = createTaskSlotTable();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -691,8 +691,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                 producedPartitions,
                 inputGates,
                 Collections.emptyList(),
-                Collections.emptyList(),
-                0);
+                Collections.emptyList());
     }
 
     static TaskDeploymentDescriptor createTaskDeploymentDescriptor(
@@ -711,8 +710,7 @@ public class TaskExecutorSubmissionTest extends TestLogger {
             List<ResultPartitionDeploymentDescriptor> producedPartitions,
             List<InputGateDeploymentDescriptor> inputGates,
             Collection<PermanentBlobKey> requiredJarFiles,
-            Collection<URL> requiredClasspaths,
-            int targetSlotNumber)
+            Collection<URL> requiredClasspaths)
             throws IOException {
 
         JobInformation jobInformation =
@@ -746,7 +744,6 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                 new AllocationID(),
                 subtaskIndex,
                 attemptNumber,
-                targetSlotNumber,
                 null,
                 producedPartitions,
                 inputGates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -210,7 +210,6 @@ public class TaskAsyncCallTest extends TestLogger {
                 0,
                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                0,
                 mock(MemoryManager.class),
                 mock(IOManager.class),
                 shuffleEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -216,7 +216,6 @@ public final class TestTaskBuilder {
                 0,
                 resultPartitions,
                 inputGates,
-                0,
                 MemoryManagerBuilder.newBuilder().setMemorySize(1024 * 1024).build(),
                 mock(IOManager.class),
                 shuffleEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -216,7 +216,6 @@ public class JvmExitOnFatalErrorTest {
                                 0, // attemptNumber
                                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                                0, // targetSlotNumber
                                 memoryManager,
                                 ioManager,
                                 shuffleEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -269,7 +269,6 @@ public class InterruptSensitiveRestoreTest {
                 0,
                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                0,
                 mock(MemoryManager.class),
                 mock(IOManager.class),
                 shuffleEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSystemExitTest.java
@@ -187,7 +187,6 @@ public class StreamTaskSystemExitTest extends TestLogger {
                 0,
                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                0,
                 MemoryManagerBuilder.newBuilder().setMemorySize(32L * 1024L).build(),
                 new IOManagerAsync(),
                 shuffleEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -168,7 +168,6 @@ public class StreamTaskTerminationTest extends TestLogger {
                         0,
                         Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                         Collections.<InputGateDeploymentDescriptor>emptyList(),
-                        0,
                         MemoryManagerBuilder.newBuilder().setMemorySize(32L * 1024L).build(),
                         new IOManagerAsync(),
                         shuffleEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -262,7 +262,6 @@ public class SynchronousCheckpointITCase {
                 0,
                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                0,
                 mock(MemoryManager.class),
                 mock(IOManager.class),
                 shuffleEnvironment,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -222,7 +222,6 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                 0,
                 Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
                 Collections.<InputGateDeploymentDescriptor>emptyList(),
-                0,
                 mock(MemoryManager.class),
                 mock(IOManager.class),
                 shuffleEnvironment,


### PR DESCRIPTION
## What is the purpose of the change

*The `PhysicalSlotNumber` is the index of a slot on a task manager. This is currently not used in any meaningful by the `LogicalSlot` or it's consumers. Therefore, the `getPhysicalSlotNumber` of `LogicalSlot` could possibly be removed.*

## Brief change log

  - *`LogicalSlot` removes the `getPhysicalSlotNumber` method and the associated invokers remove the `targetSlotNumber`.*

## Verifying this change

  - *The associated test cases for the `getPhysicalSlotNumber` of `LogicalSlot` remove the `targetSlotNumber`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)