### PR TITLE
[hotfix][state] Improve error messages in SharedStateRegistry and HeapRestoreOperation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -147,7 +147,9 @@ public class SharedStateRegistry implements AutoCloseable {
             entry = registeredStates.get(registrationKey);
 
             Preconditions.checkState(
-                    entry != null, "Cannot unregister a state that is not registered.");
+                    entry != null,
+                    "Cannot unregister a state that is not registered: %s",
+                    registrationKey);
 
             entry.decreaseReferenceCount();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -271,7 +271,9 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
             // Check that restored key groups all belong to the backend.
             Preconditions.checkState(
                     keyGroupRange.contains(keyGroupIndex),
-                    "The key group must belong to the backend.");
+                    "Key group %s doesn't belong to this backend with key group range: %s",
+                    keyGroupIndex,
+                    keyGroupRange);
 
             fsDataInputStream.seek(offset);
 


### PR DESCRIPTION
## What is the purpose of the change

A trivial change that slightly improves logging in `SharedStateRegistry` and `HeapRestoreOperation`.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
