### PR TITLE
[hotfix][checkpointing] Log detailed statistic (TRACE)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -335,6 +335,13 @@ public class PendingCheckpoint implements Checkpoint {
                 // to prevent null-pointers from concurrent modification, copy reference onto stack
                 PendingCheckpointStats statsCallback = this.statsCallback;
                 if (statsCallback != null) {
+                    LOG.trace(
+                            "Checkpoint {} size: {}Kb, duration: {}ms",
+                            checkpointId,
+                            statsCallback.getStateSize() == 0
+                                    ? 0
+                                    : statsCallback.getStateSize() / 1024,
+                            statsCallback.getEndToEndDuration());
                     // Finalize the statsCallback and give the completed checkpoint a
                     // callback for discards.
                     CompletedCheckpointStats.DiscardCallback discardCallback =
@@ -442,6 +449,16 @@ public class PendingCheckpoint implements Checkpoint {
                                 metrics.getUnalignedCheckpoint(),
                                 true);
 
+                LOG.trace(
+                        "Checkpoint {} stats for {}: size={}Kb, duration={}ms, sync part={}ms, async part={}ms",
+                        checkpointId,
+                        vertex.getTaskNameWithSubtaskIndex(),
+                        subtaskStateStats.getStateSize() == 0
+                                ? 0
+                                : subtaskStateStats.getStateSize() / 1024,
+                        subtaskStateStats.getEndToEndDuration(statsCallback.getTriggerTimestamp()),
+                        subtaskStateStats.getSyncCheckpointDuration(),
+                        subtaskStateStats.getAsyncCheckpointDuration());
                 statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
             }
 


### PR DESCRIPTION
## What is the purpose of the change

Log checkpointing times (TRACE) to ease debugging.
Motivated by FLIP-151 and FLIP-158 but is also helpful without them.

```
Log detailed statistic (TRACE)
Can be enabled with:
logger.checkpoint.name = org.apache.flink.runtime.checkpoint
logger.checkpoint.level = TRACE
``` 

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
