### PR TITLE
[FLINK-20847][checkpointing] Remove unused argument from shutdown() in CompletedCheckpointStore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -93,8 +93,7 @@ public interface CompletedCheckpointStore {
      *
      * @param jobStatus Job state on shut down
      */
-    void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
-            throws Exception;
+    void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) throws Exception;
 
     /**
      * Returns all {@link CompletedCheckpoint} instances.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -92,6 +92,7 @@ public interface CompletedCheckpointStore {
      * or kept.
      *
      * @param jobStatus Job state on shut down
+     * @param checkpointsCleaner that will cleanup copmpleted checkpoints if needed
      */
     void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -24,7 +24,8 @@ import java.util.List;
 
 /**
  * This class represents a {@link CompletedCheckpointStore} if checkpointing has been enabled.
- * Consequently, no component should use methods other than {@link #shutdown}.
+ * Consequently, no component should use methods other than {@link
+ * CompletedCheckpointStore#shutdown}.
  */
 public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCheckpointStore {
     INSTANCE;
@@ -44,8 +45,7 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
     }
 
     @Override
-    public void shutdown(
-            JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
+    public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
             throws Exception {}
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -259,8 +259,7 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
     }
 
     @Override
-    public void shutdown(
-            JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
+    public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
             throws Exception {
         if (jobStatus.isGloballyTerminalState()) {
             LOG.info("Shutting down");
@@ -270,7 +269,7 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
                         checkpoint,
                         checkpoint.shouldBeDiscardedOnShutdown(jobStatus),
                         checkpointsCleaner,
-                        postCleanup);
+                        () -> {});
             }
 
             completedCheckpoints.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -74,8 +74,7 @@ public class EmbeddedCompletedCheckpointStore implements CompletedCheckpointStor
     }
 
     @Override
-    public void shutdown(
-            JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
+    public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
             throws Exception {
         if (jobStatus.isGloballyTerminalState()) {
             checkpoints.clear();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -96,8 +96,7 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
     }
 
     @Override
-    public void shutdown(
-            JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
+    public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
             throws Exception {
         try {
             LOG.info("Shutting down");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -246,12 +246,7 @@ public abstract class SchedulerBase implements SchedulerNG {
         Exception exception = null;
 
         try {
-            completedCheckpointStore.shutdown(
-                    jobStatus,
-                    checkpointsCleaner,
-                    () -> {
-                        // don't schedule anything on shutdown
-                    });
+            completedCheckpointStore.shutdown(jobStatus, checkpointsCleaner);
         } catch (Exception e) {
             exception = e;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -181,8 +181,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         }
 
         @Override
-        public void shutdown(
-                JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup)
+        public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
                 throws Exception {
             throw new UnsupportedOperationException("Not implemented.");
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -200,7 +200,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
         assertEquals(1, completedCheckpoints.size());
 
         // shutdown the store
-        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner());
 
         // restore the store
         Set<ExecutionJobVertex> tasks = new HashSet<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1345,8 +1345,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             verify(subtaskState13, times(1)).discardState();
 
             checkpointCoordinator.shutdown();
-            completedCheckpointStore.shutdown(
-                    JobStatus.FINISHED, new CheckpointsCleaner(), () -> {});
+            completedCheckpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
 
             // validate that the states in the second checkpoint have been discarded
             verify(subtaskState21, times(1)).discardState();
@@ -2689,7 +2688,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         }
 
         // shutdown the store
-        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner());
 
         // restore the store
         Set<ExecutionJobVertex> tasks = new HashSet<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -183,7 +183,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
             checkpoints.addCheckpoint(checkpoint, new CheckpointsCleaner(), () -> {});
         }
 
-        checkpoints.shutdown(JobStatus.FINISHED, new CheckpointsCleaner(), () -> {});
+        checkpoints.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
 
         // Empty state
         assertNull(checkpoints.getLatestCheckpoint(false));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -241,7 +241,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
         completedCheckpointStore.recover();
         assertThat(completedCheckpointStore.getAllCheckpoints().size(), is(num));
 
-        completedCheckpointStore.shutdown(JobStatus.CANCELED, new CheckpointsCleaner(), () -> {});
+        completedCheckpointStore.shutdown(JobStatus.CANCELED, new CheckpointsCleaner());
         assertThat(removeCalledNum.get(), is(num));
         assertThat(clearEntriesAllFuture.isDone(), is(true));
         assertThat(completedCheckpointStore.getAllCheckpoints().size(), is(0));
@@ -269,7 +269,7 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
         completedCheckpointStore.recover();
         assertThat(completedCheckpointStore.getAllCheckpoints().size(), is(3));
 
-        completedCheckpointStore.shutdown(JobStatus.CANCELLING, new CheckpointsCleaner(), () -> {});
+        completedCheckpointStore.shutdown(JobStatus.CANCELLING, new CheckpointsCleaner());
         try {
             removeAllFuture.get(timeout, TimeUnit.MILLISECONDS);
             fail("We should get an expected timeout because the job is not globally terminated.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -246,8 +246,7 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
         }
 
         @Override
-        public void shutdown(
-                JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner, Runnable postCleanup) {
+        public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) {
             shutdownStatus.complete(jobStatus);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStoreTest.java
@@ -62,7 +62,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
         assertEquals(1, store.getNumberOfRetainedCheckpoints());
         verifyCheckpointRegistered(operatorStates, sharedStateRegistry);
 
-        store.shutdown(JobStatus.FINISHED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
         assertEquals(0, store.getNumberOfRetainedCheckpoints());
         assertTrue(checkpoint.isDiscarded());
         verifyCheckpointDiscarded(operatorStates);
@@ -83,7 +83,7 @@ public class StandaloneCompletedCheckpointStoreTest extends CompletedCheckpointS
         assertEquals(1, store.getNumberOfRetainedCheckpoints());
         verifyCheckpointRegistered(taskStates, sharedStateRegistry);
 
-        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner());
         assertEquals(0, store.getNumberOfRetainedCheckpoints());
         assertTrue(checkpoint.isDiscarded());
         verifyCheckpointDiscarded(taskStates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -169,7 +169,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
                                         + checkpointStoreUtil.checkpointIDToName(
                                                 checkpoint.getCheckpointID())));
 
-        store.shutdown(JobStatus.FINISHED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
         assertEquals(0, store.getNumberOfRetainedCheckpoints());
         assertNull(
                 client.checkExists()
@@ -205,7 +205,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
                                         + checkpointStoreUtil.checkpointIDToName(
                                                 checkpoint.getCheckpointID())));
 
-        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner(), () -> {});
+        store.shutdown(JobStatus.SUSPENDED, new CheckpointsCleaner());
 
         assertEquals(0, store.getNumberOfRetainedCheckpoints());
 
@@ -391,7 +391,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
                 checkpointRequestDecider
                         .chooseRequestToExecute(regularCheckpoint(), false, 0)
                         .isPresent());
-        checkpointStore.shutdown(JobStatus.FINISHED, checkpointsCleaner, () -> {});
+        checkpointStore.shutdown(JobStatus.FINISHED, checkpointsCleaner);
     }
 
     static class HeapRetrievableStateHandle<T extends Serializable>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -184,12 +184,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         try {
             test.accept(store, checkpointsInZk, sharedStateRegistry);
         } finally {
-            store.shutdown(
-                    JobStatus.FINISHED,
-                    new CheckpointsCleaner(),
-                    () -> {
-                        /* no op */
-                    });
+            store.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
             sharedStateRegistry.close();
         }
     }
@@ -254,7 +249,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
             checkpointStore.addCheckpoint(checkpoint1, new CheckpointsCleaner(), () -> {});
             assertThat(checkpointStore.getAllCheckpoints(), Matchers.contains(checkpoint1));
 
-            checkpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner(), () -> {});
+            checkpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
 
             // verify that the checkpoint is discarded
             CompletedCheckpointStoreTest.verifyCheckpointDiscarded(checkpoint1);


### PR DESCRIPTION
## What is the purpose of the change

A trivial change to remove unused method argument.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
