### PR TITLE
[hotfix][tests] Disable incremental checkpoints in CEPOperatorTest

### DIFF
--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -202,7 +203,8 @@ public class CEPOperatorTest extends TestLogger {
     public void testKeyedCEPOperatorCheckpointingWithRocksDB() throws Exception {
 
         String rocksDbPath = tempFolder.newFolder().getAbsolutePath();
-        RocksDBStateBackend rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
+        RocksDBStateBackend rocksDBStateBackend =
+                new RocksDBStateBackend(new MemoryStateBackend(), TernaryBoolean.FALSE);
         rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
         OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
@@ -414,7 +416,8 @@ public class CEPOperatorTest extends TestLogger {
     public void testKeyedCEPOperatorNFAUpdateWithRocksDB() throws Exception {
 
         String rocksDbPath = tempFolder.newFolder().getAbsolutePath();
-        RocksDBStateBackend rocksDBStateBackend = new RocksDBStateBackend(new MemoryStateBackend());
+        RocksDBStateBackend rocksDBStateBackend =
+                new RocksDBStateBackend(new MemoryStateBackend(), TernaryBoolean.FALSE);
         rocksDBStateBackend.setDbStoragePath(rocksDbPath);
 
         CepOperator<Event, Integer, Map<String, List<Event>>> operator =


### PR DESCRIPTION
## What is the purpose of the change

The test doesn't support incremental checkpoints and currently works
only because `state.backend.incremental` is set to false by default.

The change allows to enable `state.backend.incremental` by default.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
