### PR TITLE
[FLINK-21289][deployment] FIX missing load pipeline.classpaths in app…

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
@@ -49,6 +49,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -416,6 +417,27 @@ public class DefaultPackagedProgramRetrieverTest extends TestLogger {
         assertThat(
                 actualClasspath,
                 IsIterableContainingInAnyOrder.containsInAnyOrder(expectedClasspath.toArray()));
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClasspathsWithPipelineClasspaths() throws Exception {
+        final Configuration configuration = new Configuration();
+        final List<String> pipelineJars = new ArrayList<>();
+        final Collection<URL> expectedMergedURLs = new ArrayList<>();
+        for (URL jarFile : singleEntryClassClasspathProvider.getURLUserClasspath()) {
+            pipelineJars.add(jarFile.toString());
+            expectedMergedURLs.add(jarFile);
+        }
+        configuration.set(PipelineOptions.CLASSPATHS, pipelineJars);
+
+        final PackagedProgramRetriever retrieverUnderTest =
+                DefaultPackagedProgramRetriever.create(
+                        null,
+                        singleEntryClassClasspathProvider.getJobClassName(),
+                        ClasspathProvider.parametersForTestJob("suffix"),
+                        configuration);
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, new Configuration());
+        assertThat(jobGraph.getClasspaths(), containsInAnyOrder(expectedMergedURLs.toArray()));
     }
 
     @Test


### PR DESCRIPTION
…lication mode, for both k8s and yarn


## What is the purpose of the change

Makes application mode support `-C` option correctly

## Brief change log

ClassPathPackagedProgramRetriever support merge *pipeline.classpaths* and userClassPath, that let pipeline.classpaths visible by the "user program" ClassLoader
kubernetes and yarn ClusterEntry for application mode fetch configuration of *pipeline.classpaths* and pass the URL collection to ClassPathPackagedProgramRetriever

## Verifying this change

Reproduce: 

Submitting an application that dependencies need pass through `-C` should throw *ClassNotFoundException*. This usage works when old mode(user program execute in client), but failed in application mode(user program execute in jobmanager)

Fix:

After patched, that will be ok!

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no