### PR TITLE
[FLINK-20895][flink-table-planner-blink] support local aggregate push down in blink planner

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -95,6 +95,16 @@ public class OptimizerConfigOptions {
                                     + TABLE_OPTIMIZER_REUSE_SUB_PLAN_ENABLED.key()
                                     + " is true.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+    public static final ConfigOption<Boolean> TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED =
+            key("table.optimizer.source.aggregate-pushdown-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When it is true, the optimizer will push down the local aggregates into "
+                                    + "the TableSource which implements SupportsAggregatePushDown. "
+                                    + "Default value is false.");
+
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED =
             key("table.optimizer.source.predicate-pushdown-enabled")

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/AggregatePushDownSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/AggregatePushDownSpec.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.source;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
+import org.apache.flink.table.expressions.AggregateExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A sub-class of {@link SourceAbilitySpec} that can not only serialize/deserialize the aggregation
+ * to/from JSON, but also can push the filter into a {@link SupportsAggregatePushDown}.
+ */
+@JsonTypeName("AggregatePushDown")
+public class AggregatePushDownSpec extends SourceAbilitySpecBase {
+
+    public static final String FIELD_NAME_GROUPING_SETS = "groupingSets";
+
+    public static final String FIELD_NAME_AGGREGATE_EXPRESSIONS = "aggregateExpressions";
+
+    @JsonProperty(FIELD_NAME_GROUPING_SETS)
+    private final List<int[]> groupingSets;
+
+    @JsonProperty(FIELD_NAME_AGGREGATE_EXPRESSIONS)
+    private final List<AggregateExpression> aggregateExpressions;
+
+    @JsonCreator
+    public AggregatePushDownSpec(
+            @JsonProperty(FIELD_NAME_GROUPING_SETS) List<int[]> groupingSets,
+            @JsonProperty(FIELD_NAME_AGGREGATE_EXPRESSIONS)
+                    List<AggregateExpression> aggregateExpressions,
+            @JsonProperty(FIELD_NAME_PRODUCED_TYPE) RowType producedType) {
+        super(producedType);
+        this.groupingSets = new ArrayList<>(checkNotNull(groupingSets));
+        this.aggregateExpressions = new ArrayList<>(checkNotNull(aggregateExpressions));
+    }
+
+    @Override
+    public void apply(DynamicTableSource tableSource, SourceAbilityContext context) {
+        checkArgument(getProducedType().isPresent());
+        apply(groupingSets, aggregateExpressions, getProducedType().get(), tableSource);
+    }
+
+    public static boolean apply(
+            List<int[]> groupingSets,
+            List<AggregateExpression> aggregateExpressions,
+            RowType producedType,
+            DynamicTableSource tableSource) {
+        if (tableSource instanceof SupportsAggregatePushDown) {
+            DataType producedDataType = TypeConversions.fromLogicalToDataType(producedType);
+            return ((SupportsAggregatePushDown) tableSource)
+                    .applyAggregates(groupingSets, aggregateExpressions, producedDataType);
+        } else {
+            throw new TableException(
+                    String.format(
+                            "%s does not support SupportsAggregatePushDown.",
+                            tableSource.getClass().getName()));
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilityContext.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rel.core.TableScan;
  *   <li>project push down (SupportsProjectionPushDown)
  *   <li>partition push down (SupportsPartitionPushDown)
  *   <li>watermark push down (SupportsWatermarkPushDown)
+ *   <li>aggregate push down (SupportsAggregatePushDown)
  *   <li>reading metadata (SupportsReadingMetadata)
  * </ul>
  */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
@@ -40,7 +40,8 @@ import java.util.Optional;
     @JsonSubTypes.Type(value = ProjectPushDownSpec.class),
     @JsonSubTypes.Type(value = ReadingMetadataSpec.class),
     @JsonSubTypes.Type(value = WatermarkPushDownSpec.class),
-    @JsonSubTypes.Type(value = SourceWatermarkSpec.class)
+    @JsonSubTypes.Type(value = SourceWatermarkSpec.class),
+    @JsonSubTypes.Type(value = AggregatePushDownSpec.class)
 })
 @Internal
 public interface SourceAbilitySpec {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleBase.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
+import org.apache.flink.table.expressions.AggregateExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.aggfunctions.AvgAggFunction;
+import org.apache.flink.table.planner.functions.aggfunctions.CountAggFunction;
+import org.apache.flink.table.planner.functions.aggfunctions.Sum0AggFunction;
+import org.apache.flink.table.planner.plan.abilities.source.AggregatePushDownSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalGroupAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.plan.utils.AggregateInfo;
+import org.apache.flink.table.planner.plan.utils.AggregateInfoList;
+import org.apache.flink.table.planner.plan.utils.AggregateUtil;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+
+/**
+ * Planner rule that tries to push a local aggregator into an {@link BatchPhysicalTableSourceScan}
+ * which table is a {@link TableSourceTable}. And the table source in the table is a {@link
+ * SupportsAggregatePushDown}.
+ *
+ * <p>The aggregate push down does not support a number of more complex statements at present:
+ *
+ * <ul>
+ *   <li>complex grouping operations such as ROLLUP, CUBE, or GROUPING SETS.
+ *   <li>expressions inside the aggregation function call: such as sum(a * b).
+ *   <li>aggregations with ordering.
+ *   <li>aggregations with filter.
+ * </ul>
+ */
+public abstract class PushLocalAggIntoTableSourceScanRuleBase extends RelOptRule {
+
+    public PushLocalAggIntoTableSourceScanRuleBase(RelOptRuleOperand operand, String description) {
+        super(operand, description);
+    }
+
+    protected boolean isMatch(
+            RelOptRuleCall call,
+            BatchPhysicalGroupAggregateBase aggregate,
+            BatchPhysicalTableSourceScan tableSourceScan) {
+        TableConfig tableConfig = ShortcutUtils.unwrapContext(call.getPlanner()).getTableConfig();
+        if (!tableConfig
+                .getConfiguration()
+                .getBoolean(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED)) {
+            return false;
+        }
+
+        if (aggregate.isFinal() || aggregate.getAggCallList().size() < 1) {
+            return false;
+        }
+        List<AggregateCall> aggCallList =
+                JavaConverters.seqAsJavaListConverter(aggregate.getAggCallList()).asJava();
+        for (AggregateCall aggCall : aggCallList) {
+            if (aggCall.isDistinct()
+                    || aggCall.isApproximate()
+                    || aggCall.getArgList().size() > 1
+                    || aggCall.hasFilter()
+                    || !aggCall.getCollation().getFieldCollations().isEmpty()) {
+                return false;
+            }
+        }
+        TableSourceTable tableSourceTable = tableSourceScan.tableSourceTable();
+        // we can not push aggregates twice
+        return tableSourceTable != null
+                && tableSourceTable.tableSource() instanceof SupportsAggregatePushDown
+                && Arrays.stream(tableSourceTable.abilitySpecs())
+                        .noneMatch(spec -> spec instanceof AggregatePushDownSpec);
+    }
+
+    protected void pushLocalAggregateIntoScan(
+            RelOptRuleCall call,
+            BatchPhysicalGroupAggregateBase localAgg,
+            BatchPhysicalTableSourceScan oldScan) {
+        RelDataType originalInputRowType = oldScan.deriveRowType();
+        AggregateInfoList aggInfoList =
+                AggregateUtil.transformToBatchAggregateInfoList(
+                        FlinkTypeFactory.toLogicalRowType(localAgg.getInput().getRowType()),
+                        localAgg.getAggCallList(),
+                        null,
+                        null);
+        if (aggInfoList.aggInfos().length == 0) {
+            // no agg function need to be pushed down
+            return;
+        }
+
+        List<int[]> groupingSets = Collections.singletonList(localAgg.grouping());
+        List<AggregateExpression> aggExpressions =
+                buildAggregateExpressions(originalInputRowType, aggInfoList);
+        RelDataType relDataType = localAgg.deriveRowType();
+
+        TableSourceTable oldTableSourceTable = oldScan.tableSourceTable();
+        DynamicTableSource newTableSource = oldScan.tableSource().copy();
+
+        boolean isPushDownSuccess =
+                AggregatePushDownSpec.apply(
+                        groupingSets,
+                        aggExpressions,
+                        (RowType) FlinkTypeFactory.toLogicalType(relDataType),
+                        newTableSource);
+
+        if (!isPushDownSuccess) {
+            // aggregate push down failed, just return without changing any nodes.
+            return;
+        }
+
+        FlinkStatistic newFlinkStatistic = getNewFlinkStatistic(oldTableSourceTable);
+        String[] newExtraDigests =
+                getNewExtraDigests(originalInputRowType, localAgg.grouping(), aggExpressions);
+        AggregatePushDownSpec aggregatePushDownSpec =
+                new AggregatePushDownSpec(
+                        groupingSets,
+                        aggExpressions,
+                        (RowType) FlinkTypeFactory.toLogicalType(relDataType));
+        TableSourceTable newTableSourceTable =
+                oldTableSourceTable
+                        .copy(
+                                newTableSource,
+                                newFlinkStatistic,
+                                newExtraDigests,
+                                new SourceAbilitySpec[] {aggregatePushDownSpec})
+                        .copy(relDataType);
+        BatchPhysicalTableSourceScan newScan =
+                oldScan.copy(oldScan.getTraitSet(), newTableSourceTable);
+        BatchPhysicalExchange oldExchange = call.rel(0);
+        BatchPhysicalExchange newExchange =
+                oldExchange.copy(oldExchange.getTraitSet(), newScan, oldExchange.getDistribution());
+        call.transformTo(newExchange);
+    }
+
+    private List<AggregateExpression> buildAggregateExpressions(
+            RelDataType originalInputRowType, AggregateInfoList aggInfoList) {
+        List<AggregateExpression> aggExpressions = new ArrayList<>();
+        for (AggregateInfo aggInfo : aggInfoList.aggInfos()) {
+            List<FieldReferenceExpression> arguments = new ArrayList<>(1);
+            for (int argIndex : aggInfo.argIndexes()) {
+                DataType argType =
+                        TypeConversions.fromLogicalToDataType(
+                                FlinkTypeFactory.toLogicalType(
+                                        originalInputRowType
+                                                .getFieldList()
+                                                .get(argIndex)
+                                                .getType()));
+                FieldReferenceExpression field =
+                        new FieldReferenceExpression(
+                                originalInputRowType.getFieldNames().get(argIndex),
+                                argType,
+                                argIndex,
+                                argIndex);
+                arguments.add(field);
+            }
+            if (aggInfo.function() instanceof AvgAggFunction) {
+                Tuple2<Sum0AggFunction, CountAggFunction> sum0AndCountFunction =
+                        AggregateUtil.deriveSumAndCountFromAvg(aggInfo.function());
+                AggregateExpression sum0Expression =
+                        new AggregateExpression(
+                                sum0AndCountFunction._1(),
+                                arguments,
+                                null,
+                                aggInfo.externalResultType(),
+                                aggInfo.agg().isDistinct(),
+                                aggInfo.agg().isApproximate(),
+                                aggInfo.agg().ignoreNulls());
+                aggExpressions.add(sum0Expression);
+                AggregateExpression countExpression =
+                        new AggregateExpression(
+                                sum0AndCountFunction._2(),
+                                arguments,
+                                null,
+                                aggInfo.externalResultType(),
+                                aggInfo.agg().isDistinct(),
+                                aggInfo.agg().isApproximate(),
+                                aggInfo.agg().ignoreNulls());
+                aggExpressions.add(countExpression);
+            } else {
+                AggregateExpression aggregateExpression =
+                        new AggregateExpression(
+                                aggInfo.function(),
+                                arguments,
+                                null,
+                                aggInfo.externalResultType(),
+                                aggInfo.agg().isDistinct(),
+                                aggInfo.agg().isApproximate(),
+                                aggInfo.agg().ignoreNulls());
+                aggExpressions.add(aggregateExpression);
+            }
+        }
+        return aggExpressions;
+    }
+
+    private FlinkStatistic getNewFlinkStatistic(TableSourceTable tableSourceTable) {
+        FlinkStatistic oldStatistic = tableSourceTable.getStatistic();
+        FlinkStatistic newStatistic;
+        if (oldStatistic == FlinkStatistic.UNKNOWN()) {
+            newStatistic = oldStatistic;
+        } else {
+            // Remove tableStats after all of aggregate have been pushed down
+            newStatistic =
+                    FlinkStatistic.builder().statistic(oldStatistic).tableStats(null).build();
+        }
+        return newStatistic;
+    }
+
+    private String[] getNewExtraDigests(
+            RelDataType originalInputRowType,
+            int[] grouping,
+            List<AggregateExpression> aggregateExpressions) {
+        String extraDigest;
+        String groupingStr = "null";
+        if (grouping.length > 0) {
+            groupingStr =
+                    Arrays.stream(grouping)
+                            .mapToObj(index -> originalInputRowType.getFieldNames().get(index))
+                            .collect(Collectors.joining(","));
+        }
+        String aggFunctionsStr = "null";
+        if (aggregateExpressions.size() > 0) {
+            aggFunctionsStr =
+                    aggregateExpressions.stream()
+                            .map(AggregateExpression::asSummaryString)
+                            .collect(Collectors.joining(","));
+        }
+        extraDigest =
+                "aggregates=[grouping=["
+                        + groupingStr
+                        + "], aggFunctions=["
+                        + aggFunctionsStr
+                        + "]]";
+        return new String[] {extraDigest};
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggWithSortIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggWithSortIntoTableSourceScanRule.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalGroupAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalLocalSortAggregate;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSort;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+
+/**
+ * Planner rule that tries to push a local sort aggregate which with sort into a {@link
+ * BatchPhysicalTableSourceScan} which table is a {@link TableSourceTable}. And the table source in
+ * the table is a {@link SupportsAggregatePushDown}.
+ *
+ * <p>When the {@code OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED} is
+ * true, we have the original physical plan:
+ *
+ * <pre>{@code
+ * BatchPhysicalSortAggregate (global)
+ * +- Sort (exists if group keys are not empty)
+ *    +- BatchPhysicalExchange (hash by group keys if group keys is not empty, else singleton)
+ *       +- BatchPhysicalLocalSortAggregate (local)
+ *          +- Sort (exists if group keys are not empty)
+ *             +- BatchPhysicalTableSourceScan
+ * }</pre>
+ *
+ * <p>This physical plan will be rewritten to:
+ *
+ * <pre>{@code
+ * BatchPhysicalSortAggregate (global)
+ * +- Sort (exists if group keys are not empty)
+ *    +- BatchPhysicalExchange (hash by group keys if group keys is not empty, else singleton)
+ *       +- BatchPhysicalTableSourceScan (with local aggregate pushed down)
+ * }</pre>
+ */
+public class PushLocalAggWithSortIntoTableSourceScanRule
+        extends PushLocalAggIntoTableSourceScanRuleBase {
+    public static final PushLocalAggWithSortIntoTableSourceScanRule INSTANCE =
+            new PushLocalAggWithSortIntoTableSourceScanRule();
+
+    public PushLocalAggWithSortIntoTableSourceScanRule() {
+        super(
+                operand(
+                        BatchPhysicalExchange.class,
+                        operand(
+                                BatchPhysicalLocalSortAggregate.class,
+                                operand(
+                                        BatchPhysicalSort.class,
+                                        operand(BatchPhysicalTableSourceScan.class, none())))),
+                "PushLocalAggWithSortIntoTableSourceScanRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        BatchPhysicalGroupAggregateBase localAggregate = call.rel(1);
+        BatchPhysicalTableSourceScan tableSourceScan = call.rel(3);
+        return isMatch(call, localAggregate, tableSourceScan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        BatchPhysicalGroupAggregateBase localSortAgg = call.rel(1);
+        BatchPhysicalTableSourceScan oldScan = call.rel(3);
+        pushLocalAggregateIntoScan(call, localSortAgg, oldScan);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggWithoutSortIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggWithoutSortIntoTableSourceScanRule.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalGroupAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+
+/**
+ * Planner rule that tries to push a local hash or sort aggregate which without sort into a {@link
+ * BatchPhysicalTableSourceScan} which table is a {@link TableSourceTable}. And the table source in
+ * the table is a {@link SupportsAggregatePushDown}.
+ *
+ * <p>When the {@code OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED} is
+ * true, we have the original physical plan:
+ *
+ * <pre>{@code
+ * BatchPhysicalHashAggregate (global)
+ * +- BatchPhysicalExchange (hash by group keys if group keys is not empty, else singleton)
+ *    +- BatchPhysicalGroupAggregateBase (local)
+ *       +- BatchPhysicalTableSourceScan
+ * }</pre>
+ *
+ * <p>This physical plan will be rewritten to:
+ *
+ * <pre>{@code
+ * BatchPhysicalHashAggregate (global)
+ * +- BatchPhysicalExchange (hash by group keys if group keys is not empty, else singleton)
+ *    +- BatchPhysicalTableSourceScan (with local aggregate pushed down)
+ * }</pre>
+ */
+public class PushLocalAggWithoutSortIntoTableSourceScanRule
+        extends PushLocalAggIntoTableSourceScanRuleBase {
+    public static final PushLocalAggWithoutSortIntoTableSourceScanRule INSTANCE =
+            new PushLocalAggWithoutSortIntoTableSourceScanRule();
+
+    public PushLocalAggWithoutSortIntoTableSourceScanRule() {
+        super(
+                operand(
+                        BatchPhysicalExchange.class,
+                        operand(
+                                BatchPhysicalGroupAggregateBase.class,
+                                operand(BatchPhysicalTableSourceScan.class, none()))),
+                "PushLocalAggWithoutSortIntoTableSourceScanRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        BatchPhysicalGroupAggregateBase localAggregate = call.rel(1);
+        BatchPhysicalTableSourceScan tableSourceScan = call.rel(2);
+        return isMatch(call, localAggregate, tableSourceScan);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        BatchPhysicalGroupAggregateBase localHashAgg = call.rel(1);
+        BatchPhysicalTableSourceScan oldScan = call.rel(2);
+        pushLocalAggregateIntoScan(call, localHashAgg, oldScan);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalTableSourceScan.scala
@@ -49,6 +49,12 @@ class BatchPhysicalTableSourceScan(
     new BatchPhysicalTableSourceScan(cluster, traitSet, getHints, tableSourceTable)
   }
 
+  def copy(
+      traitSet: RelTraitSet,
+      tableSourceTable: TableSourceTable): BatchPhysicalTableSourceScan = {
+    new BatchPhysicalTableSourceScan(cluster, traitSet, getHints, tableSourceTable)
+  }
+
   override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
     val rowCnt = mq.getRowCount(this)
     if (rowCnt == null) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -446,6 +446,8 @@ object FlinkBatchRuleSets {
     */
   val PHYSICAL_REWRITE: RuleSet = RuleSets.ofList(
     EnforceLocalHashAggRule.INSTANCE,
-    EnforceLocalSortAggRule.INSTANCE
+    EnforceLocalSortAggRule.INSTANCE,
+    PushLocalAggWithoutSortIntoTableSourceScanRule.INSTANCE,
+    PushLocalAggWithSortIntoTableSourceScanRule.INSTANCE
   )
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -118,4 +118,22 @@ class TableSourceTable(
       extraDigests ++ newExtraDigests,
       abilitySpecs ++ newAbilitySpecs)
   }
+
+  /**
+   * Creates a copy of this table, changing the rowType
+   *
+   * @param newRowType new row type
+   * @return New TableSourceTable instance with new row type
+   */
+  def copy(newRowType: RelDataType): TableSourceTable = {
+    new TableSourceTable(
+      relOptSchema,
+      tableIdentifier,
+      newRowType,
+      statistic,
+      tableSource,
+      isStreamingMode,
+      catalogTable,
+      extraDigests)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for {@link PushLocalAggWithoutSortIntoTableSourceScanRule} and {@link
+ * PushLocalAggWithSortIntoTableSourceScanRule}.
+ */
+public class PushLocalAggIntoTableSourceScanRuleTest extends TableTestBase {
+    protected BatchTableTestUtil util = batchTestUtil(new TableConfig());
+
+    @Before
+    public void setup() {
+        TableConfig tableConfig = util.tableEnv().getConfig();
+        tableConfig
+                .getConfiguration()
+                .setBoolean(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED,
+                        true);
+        String ddl =
+                "CREATE TABLE inventory (\n"
+                        + "  id INT,\n"
+                        + "  name STRING,\n"
+                        + "  amount INT,\n"
+                        + "  price DOUBLE,\n"
+                        + "  type STRING\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'filterable-fields' = 'id',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")";
+        util.tableEnv().executeSql(ddl);
+    }
+
+    @Test
+    public void testCanPushDownWithGroup() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  sum(amount),\n"
+                        + "  name,\n"
+                        + "  type\n"
+                        + "FROM inventory\n"
+                        + "  group by name, type");
+    }
+
+    @Test
+    public void testCanPushDownWithoutGroup() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  min(id),\n"
+                        + "  max(amount),\n"
+                        + "  max(name),\n"
+                        + "  sum(price),\n"
+                        + "  avg(price),\n"
+                        + "  count(id)\n"
+                        + "FROM inventory");
+    }
+
+    @Test
+    public void testCannotPushDownWithColumnExpression() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  min(amount + price),\n"
+                        + "  max(amount),\n"
+                        + "  sum(price),\n"
+                        + "  count(id),\n"
+                        + "  name\n"
+                        + "FROM inventory\n"
+                        + "  group by name");
+    }
+
+    @Test
+    public void testCannotPushDownWithUnsupportedAggFunction() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  min(id),\n"
+                        + "  max(amount),\n"
+                        + "  sum(price),\n"
+                        + "  count(distinct id),\n"
+                        + "  name\n"
+                        + "FROM inventory\n"
+                        + "  group by name");
+    }
+
+    @Test
+    public void testCannotPushDownWithWindowAggFunction() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  id,\n"
+                        + "  amount,\n"
+                        + "  sum(price) over (partition by name),\n"
+                        + "  name\n"
+                        + "FROM inventory");
+    }
+
+    @Test
+    public void testCannotPushDownWithFilter() {
+        util.verifyRelPlan(
+                "SELECT\n"
+                        + "  min(id),\n"
+                        + "  max(amount),\n"
+                        + "  sum(price),\n"
+                        + "  count(id) FILTER(WHERE id > 100),\n"
+                        + "  name\n"
+                        + "FROM inventory\n"
+                        + "  group by name");
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/PushLocalAggIntoTableSourceScanRuleTest.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testCanPushDownWithGroup">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  sum(amount),
+  name,
+  type
+FROM inventory
+  group by name, type]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2], name=[$0], type=[$1])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(name=[$1], type=[$4], amount=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[EXPR$0, name, type])
++- HashAggregate(isMerge=[true], groupBy=[name, type], select=[name, type, Final_SUM(sum$0) AS EXPR$0])
+   +- Exchange(distribution=[hash[name, type]])
+      +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[name, type, amount], aggregates=[grouping=[name,type], aggFunctions=[IntSumAggFunction(amount)]]]], fields=[name, type, sum$0])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCanPushDownWithoutGroup">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  min(id),
+  max(amount),
+  max(name),
+  sum(price),
+  avg(price),
+  count(id)
+FROM inventory]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)], EXPR$1=[MAX($1)], EXPR$2=[MAX($2)], EXPR$3=[SUM($3)], EXPR$4=[AVG($3)], EXPR$5=[COUNT($0)])
++- LogicalProject(id=[$0], amount=[$2], name=[$1], price=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_MIN(min$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_MAX(max$2) AS EXPR$2, Final_SUM(sum$3) AS EXPR$3, Final_AVG(sum$4, count$5) AS EXPR$4, Final_COUNT(count$6) AS EXPR$5])
++- Exchange(distribution=[single])
+   +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[id, amount, name, price], aggregates=[grouping=[null], aggFunctions=[IntMinAggFunction(id),IntMaxAggFunction(amount),StringMaxAggFunction(name),DoubleSumAggFunction(price),DoubleSum0AggFunction(price),CountAggFunction(price),CountAggFunction(id)]]]], fields=[min$0, max$1, max$2, sum$3, sum$4, count$5, count$6])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDownWithColumnExpression">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  min(amount + price),
+  max(amount),
+  sum(price),
+  count(id),
+  name
+FROM inventory
+  group by name]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4], name=[$0])
++- LogicalAggregate(group=[{0}], EXPR$0=[MIN($1)], EXPR$1=[MAX($2)], EXPR$2=[SUM($3)], EXPR$3=[COUNT($4)])
+   +- LogicalProject(name=[$1], $f1=[+($2, $3)], amount=[$2], price=[$3], id=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2, EXPR$3, name])
++- HashAggregate(isMerge=[true], groupBy=[name], select=[name, Final_MIN(min$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3])
+   +- Exchange(distribution=[hash[name]])
+      +- LocalHashAggregate(groupBy=[name], select=[name, Partial_MIN($f1) AS min$0, Partial_MAX(amount) AS max$1, Partial_SUM(price) AS sum$2, Partial_COUNT(id) AS count$3])
+         +- Calc(select=[name, +(amount, price) AS $f1, amount, price, id])
+            +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[name, amount, price, id]]], fields=[name, amount, price, id])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDownWithUnsupportedAggFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  min(id),
+  max(amount),
+  sum(price),
+  count(distinct id),
+  name
+FROM inventory
+  group by name]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4], name=[$0])
++- LogicalAggregate(group=[{0}], EXPR$0=[MIN($1)], EXPR$1=[MAX($2)], EXPR$2=[SUM($3)], EXPR$3=[COUNT(DISTINCT $1)])
+   +- LogicalProject(name=[$1], id=[$0], amount=[$2], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2, EXPR$3, name])
++- HashAggregate(isMerge=[true], groupBy=[name], select=[name, Final_MIN(min$0) AS EXPR$0, Final_MIN(min$1) AS EXPR$1, Final_MIN(min$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3])
+   +- Exchange(distribution=[hash[name]])
+      +- LocalHashAggregate(groupBy=[name], select=[name, Partial_MIN(EXPR$0) FILTER $g_1 AS min$0, Partial_MIN(EXPR$1) FILTER $g_1 AS min$1, Partial_MIN(EXPR$2) FILTER $g_1 AS min$2, Partial_COUNT(id) FILTER $g_0 AS count$3])
+         +- Calc(select=[name, id, EXPR$0, EXPR$1, EXPR$2, =(CASE(=($e, 0:BIGINT), 0:BIGINT, 1:BIGINT), 0) AS $g_0, =(CASE(=($e, 0:BIGINT), 0:BIGINT, 1:BIGINT), 1) AS $g_1])
+            +- HashAggregate(isMerge=[true], groupBy=[name, id, $e], select=[name, id, $e, Final_MIN(min$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2])
+               +- Exchange(distribution=[hash[name, id, $e]])
+                  +- LocalHashAggregate(groupBy=[name, id, $e], select=[name, id, $e, Partial_MIN(id_0) AS min$0, Partial_MAX(amount) AS max$1, Partial_SUM(price) AS sum$2])
+                     +- Expand(projects=[{name, id, amount, price, 0 AS $e, id AS id_0}, {name, null AS id, amount, price, 1 AS $e, id AS id_0}])
+                        +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[name, id, amount, price]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDownWithWindowAggFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  id,
+  amount,
+  sum(price) over (partition by name),
+  name
+FROM inventory]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], amount=[$2], EXPR$2=[CASE(>(COUNT($3) OVER (PARTITION BY $1), 0), $SUM0($3) OVER (PARTITION BY $1), null:DOUBLE)], name=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[id, amount, CASE(>(w0$o0, 0:BIGINT), w0$o1, null:DOUBLE) AS EXPR$2, name])
++- OverAggregate(partitionBy=[name], window#0=[COUNT(price) AS w0$o0, $SUM0(price) AS w0$o1 RANG BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING], select=[id, name, amount, price, w0$o0, w0$o1])
+   +- Sort(orderBy=[name ASC])
+      +- Exchange(distribution=[hash[name]])
+         +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[id, name, amount, price]]], fields=[id, name, amount, price])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDownWithFilter">
+    <Resource name="sql">
+      <![CDATA[SELECT
+  min(id),
+  max(amount),
+  sum(price),
+  count(id) FILTER(WHERE id > 100),
+  name
+FROM inventory
+  group by name]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1], EXPR$1=[$2], EXPR$2=[$3], EXPR$3=[$4], name=[$0])
++- LogicalAggregate(group=[{0}], EXPR$0=[MIN($1)], EXPR$1=[MAX($2)], EXPR$2=[SUM($3)], EXPR$3=[COUNT($1) FILTER $4])
+   +- LogicalProject(name=[$1], id=[$0], amount=[$2], price=[$3], $f4=[IS TRUE(>($0, 100))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, inventory]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[EXPR$0, EXPR$1, EXPR$2, EXPR$3, name])
++- HashAggregate(isMerge=[true], groupBy=[name], select=[name, Final_MIN(min$0) AS EXPR$0, Final_MAX(max$1) AS EXPR$1, Final_SUM(sum$2) AS EXPR$2, Final_COUNT(count$3) AS EXPR$3])
+   +- Exchange(distribution=[hash[name]])
+      +- LocalHashAggregate(groupBy=[name], select=[name, Partial_MIN(id) AS min$0, Partial_MAX(amount) AS max$1, Partial_SUM(price) AS sum$2, Partial_COUNT(id) FILTER $f4 AS count$3])
+         +- Calc(select=[name, id, amount, price, IS TRUE(>(id, 100)) AS $f4])
+            +- TableSourceScan(table=[[default_catalog, default_database, inventory, project=[name, id, amount, price]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/LocalAggregatePushDownITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/LocalAggregatePushDownITCase.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql.agg
+
+import org.apache.flink.table.api.config.OptimizerConfigOptions
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
+import org.junit.{Before, Test}
+
+class LocalAggregatePushDownITCase extends BatchTestBase {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    env.setParallelism(1) // set sink parallelism to 1
+    conf.getConfiguration.setBoolean(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_AGGREGATE_PUSHDOWN_ENABLED, true)
+    val testDataId = TestValuesTableFactory.registerData(TestData.personData)
+    val ddl =
+      s"""
+         |CREATE TABLE AggregatableTable (
+         |  id int,
+         |  age int,
+         |  name string,
+         |  height int,
+         |  gender string,
+         |  deposit bigint
+         |) WITH (
+         |  'connector' = 'values',
+         |  'data-id' = '$testDataId',
+         |  'bounded' = 'true'
+         |)
+       """.stripMargin
+    tEnv.executeSql(ddl)
+
+  }
+
+  @Test
+  def testAggregateWithGroupBy(): Unit = {
+    checkResult(
+      """
+        |SELECT
+        |  min(age) as min_age,
+        |  max(height),
+        |  avg(deposit),
+        |  sum(deposit),
+        |  count(1),
+        |  gender
+        |FROM
+        |  AggregatableTable
+        |GROUP BY gender
+        |ORDER BY min_age
+        |""".stripMargin,
+      Seq(
+        row(19, 180, 126, 630, 5, "f"),
+        row(23, 182, 220, 1320, 6, "m"))
+    )
+  }
+
+  @Test
+  def testAggregateWithMultiGroupBy(): Unit = {
+    checkResult(
+      """
+        |SELECT
+        |  min(age),
+        |  max(height),
+        |  avg(deposit),
+        |  sum(deposit),
+        |  count(1),
+        |  gender,
+        |  age
+        |FROM
+        |  AggregatableTable
+        |GROUP BY gender, age
+        |""".stripMargin,
+      Seq(
+        row(19, 172, 50, 50, 1, "f", 19),
+        row(20, 180, 200, 200, 1, "f", 20),
+        row(23, 182, 250, 750, 3, "m", 23),
+        row(25, 171, 126, 380, 3, "f", 25),
+        row(27, 175, 300, 300, 1, "m", 27),
+        row(28, 165, 170, 170, 1, "m", 28),
+        row(34, 170, 100, 100, 1, "m", 34))
+    )
+  }
+
+  @Test
+  def testAggregateWithoutGroupBy(): Unit = {
+    checkResult(
+      """
+        |SELECT
+        |  min(age),
+        |  max(height),
+        |  avg(deposit),
+        |  sum(deposit),
+        |  count(*)
+        |FROM
+        |  AggregatableTable
+        |""".stripMargin,
+      Seq(
+        row(19, 182, 177, 1950, 11))
+    )
+  }
+
+  @Test
+  def testAggregateCanNotPushDown(): Unit = {
+    checkResult(
+      """
+        |SELECT
+        |  min(age),
+        |  max(height),
+        |  avg(deposit),
+        |  sum(deposit),
+        |  count(distinct age),
+        |  gender
+        |FROM
+        |  AggregatableTable
+        |GROUP BY gender
+        |""".stripMargin,
+      Seq(
+        row(19, 180, 126, 630, 3, "f"),
+        row(23, 182, 220, 1320, 4, "m"))
+    )
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -414,17 +414,17 @@ object TestData {
 
   // person test data
   lazy val personData: Seq[Row] = Seq(
-    row(1, 23, "tom", 172, "m"),
-    row(2, 21, "mary", 161, "f"),
-    row(3, 18, "jack", 182, "m"),
-    row(4, 25, "rose", 165, "f"),
-    row(5, 27, "danny", 175, "m"),
-    row(6, 31, "tommas", 172, "m"),
-    row(7, 19, "olivia", 172, "f"),
-    row(8, 34, "stef", 170, "m"),
-    row(9, 32, "emma", 171, "f"),
-    row(10, 28, "benji", 165, "m"),
-    row(11, 20, "eva", 180, "f")
+    row(1, 23, "tom", 172, "m", 200L),
+    row(2, 25, "mary", 161, "f", 100L),
+    row(3, 23, "jack", 182, "m", 150L),
+    row(4, 25, "rose", 165, "f", 100L),
+    row(5, 27, "danny", 175, "m", 300L),
+    row(6, 23, "tommas", 172, "m", 400L),
+    row(7, 19, "olivia", 172, "f", 50L),
+    row(8, 34, "stef", 170, "m", 100L),
+    row(9, 25, "emma", 171, "f", 180L),
+    row(10, 28, "benji", 165, "m", 170L),
+    row(11, 20, "eva", 180, "f", 200L)
   )
 
   val nullablesOfPersonData = Array(true, true, true, true, true)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request add some new planner rules for local aggregation pushing down in Blink planner. With this rule, the connector developer can decide whether to push down some of the aggregation computing logic to the storage layer for better computing & IO performance.*


## Brief change log

  - *Add an abstract class of `PushLocalAggIntoTableSourceScanRuleBase` for supporting both with and without sort operator.*
  - *Add a new rule of `PushLocalAggWithoutSortIntoTableSourceScanRule` for aggregation without sort case.*
  - *Add a new rule of `PushLocalAggWithSortIntoTableSourceScanRule` for aggregation with sort case.*
  - *Implement the `SupportsAggregatePushDown` interface for `TestValuesScanTableSource `*
  - *Add a new configuration of `table.optimizer.source.aggregate-pushdown-enabled` to control the aggregation push down, and default value is false which is up to the user to decide enable or not.*
  - *Some other unit tests and integration tests.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests of `LocalAggregatePushDownITCase` for end-to-end functional test*
  - *Added unit tests that validates that the optimized plan is expected including the aggregation which can and cannot be pushed down.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
