### PR TITLE
[FLINK-21295][table] Support 'useModules' and 'listFullModules' in ModuleManager and TableEnvironment

### DIFF
--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -43,6 +43,8 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTest
             'create',
             'loadModule',
             'unloadModule',
+            'useModules',
+            'listFullModules',
             'createTemporarySystemFunction',
             'dropTemporarySystemFunction',
             'createFunction',

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.module.Module;
+import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.AbstractDataType;
@@ -384,6 +385,14 @@ public interface TableEnvironment {
     void loadModule(String moduleName, Module module);
 
     /**
+     * Enable modules in use with declared name order. Modules that have been loaded but not exist
+     * in names varargs will become unused. There is no guarantee on unused module's order.
+     *
+     * @param moduleNames module names to be used
+     */
+    void useModules(String... moduleNames);
+
+    /**
      * Unloads a {@link Module} with given name. ValidationException is thrown when there is no
      * module with the given name.
      *
@@ -718,11 +727,19 @@ public interface TableEnvironment {
     String[] listCatalogs();
 
     /**
-     * Gets an array of names of all modules in this environment in the loaded order.
+     * Gets an array of names of all used modules in this environment in the most-recent use order.
      *
-     * @return A list of the names of all modules in the loaded order.
+     * @return A list of the names of used modules in the most-recent use order.
      */
     String[] listModules();
+
+    /**
+     * Gets an array of all loaded modules with use status in this environment. Used modules are
+     * kept in most-recent use order.
+     *
+     * @return A list of name and use status entries of all loaded modules.
+     */
+    ModuleEntry[] listFullModules();
 
     /**
      * Gets the names of all databases registered in the current catalog.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -386,7 +386,7 @@ public interface TableEnvironment {
 
     /**
      * Enable modules in use with declared name order. Modules that have been loaded but not exist
-     * in names varargs will become unused. There is no guarantee on unused module's order.
+     * in names varargs will become unused.
      *
      * @param moduleNames module names to be used
      */
@@ -727,15 +727,15 @@ public interface TableEnvironment {
     String[] listCatalogs();
 
     /**
-     * Gets an array of names of all used modules in this environment in the most-recent use order.
+     * Gets an array of names of all used modules in this environment in resolution order.
      *
-     * @return A list of the names of used modules in the most-recent use order.
+     * @return A list of the names of used modules in resolution order.
      */
     String[] listModules();
 
     /**
      * Gets an array of all loaded modules with use status in this environment. Used modules are
-     * kept in most-recent use order.
+     * kept in resolution order.
      *
      * @return A list of name and use status entries of all loaded modules.
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -79,6 +79,7 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.module.Module;
+import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogQueryOperation;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
@@ -371,6 +372,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     }
 
     @Override
+    public void useModules(String... moduleNames) {
+        moduleManager.useModules(moduleNames);
+    }
+
+    @Override
     public void unloadModule(String moduleName) {
         moduleManager.unloadModule(moduleName);
     }
@@ -537,6 +543,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     @Override
     public String[] listModules() {
         return moduleManager.listModules().toArray(new String[0]);
+    }
+
+    @Override
+    public ModuleEntry[] listFullModules() {
+        return moduleManager.listFullModules().toArray(new ModuleEntry[0]);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleEntry.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleEntry.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/** A POJO to represent a module's name and use status. */
+public class ModuleEntry {
+    private final String name;
+    private final boolean used;
+
+    public ModuleEntry(String name, boolean used) {
+        this.name = name;
+        this.used = used;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public boolean used() {
+        return used;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ModuleEntry entry = (ModuleEntry) o;
+
+        return new EqualsBuilder().append(used, entry.used).append(name, entry.name).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(name).append(used).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ModuleEntry{" + "name='" + name + '\'' + ", used=" + used + '}';
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleEntry.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleEntry.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.module;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /** A POJO to represent a module's name and use status. */
+@PublicEvolving
 public class ModuleEntry {
     private final String name;
     private final boolean used;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.module;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.util.StringUtils;
@@ -26,7 +27,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,99 +49,149 @@ public class ModuleManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ModuleManager.class);
 
-    private LinkedHashMap<String, Module> modules;
+    private Map<String, Module> loadedModules;
+    private List<String> usedModules;
 
     public ModuleManager() {
-        this.modules = new LinkedHashMap<>();
-
-        modules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+        this.loadedModules = new HashMap<>();
+        this.usedModules = new ArrayList<>();
+        loadedModules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+        usedModules.add(MODULE_TYPE_CORE);
     }
 
     /**
      * Load a module under a unique name. Modules will be kept in the loaded order, and new module
-     * will be added to the end. ValidationException is thrown when there is already a module with
-     * the same name.
+     * will be added to the left before the unused module and turn on use by default.
      *
      * @param name name of the module
      * @param module the module instance
+     * @throws ValidationException when there already exists a module with the same name
      */
     public void loadModule(String name, Module module) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(name), "name cannot be null or empty string");
         checkNotNull(module, "module cannot be null");
 
-        if (!modules.containsKey(name)) {
-            modules.put(name, module);
-
-            LOG.info("Loaded module {} from class {}", name, module.getClass().getName());
-        } else {
+        if (loadedModules.containsKey(name)) {
             throw new ValidationException(
                     String.format("A module with name %s already exists", name));
+        } else {
+            usedModules.add(name);
+            loadedModules.put(name, module);
+            LOG.info("Loaded module {} from class {}", name, module.getClass().getName());
         }
     }
 
     /**
-     * Unload a module with given name. ValidationException is thrown when there is no module with
-     * the given name.
+     * Unload a module with given name.
      *
      * @param name name of the module
+     * @throws ValidationException when there is no module with the given name
      */
     public void unloadModule(String name) {
-        if (modules.containsKey(name)) {
-            modules.remove(name);
-
-            LOG.info("Unloaded module {}", name);
+        if (loadedModules.containsKey(name)) {
+            loadedModules.remove(name);
+            boolean used = usedModules.remove(name);
+            LOG.info("Unloaded an {} module {}", used ? "used" : "unused", name);
         } else {
             throw new ValidationException(String.format("No module with name %s exists", name));
         }
     }
 
     /**
-     * Get names of all modules loaded.
+     * Enable modules in use with declared name order. Modules that have been loaded but not exist
+     * in names varargs will become unused. There is no guarantee on unused module's order.
      *
-     * @return a list of names of modules loaded
+     * @param names module names to be used
+     * @throws ValidationException when module names contain an unloaded name
      */
-    public List<String> listModules() {
-        return new ArrayList<>(modules.keySet());
+    public void useModules(String... names) {
+        checkNotNull(names, "names cannot be null");
+        Set<String> deduplicateNames = new HashSet<>();
+        for (String name : names) {
+            if (!loadedModules.containsKey(name)) {
+                throw new ValidationException(String.format("No module with name %s exists", name));
+            }
+            if (!deduplicateNames.add(name)) {
+                throw new ValidationException(
+                        String.format("Module %s appears more than once", name));
+            }
+        }
+        usedModules.clear();
+        usedModules.addAll(Arrays.asList(names));
     }
 
     /**
-     * Get names of all functions from all modules.
+     * Get names of all used modules in most-recent use order.
      *
-     * @return a set of names of registered modules.
+     * @return a list of names of used modules
+     */
+    public List<String> listModules() {
+        return usedModules;
+    }
+
+    /**
+     * Get all loaded modules with use status. Modules in use status are returned in the most-recent
+     * use order.
+     *
+     * @return a list of module entries with module name and use status
+     */
+    public List<ModuleEntry> listFullModules() {
+        // keep the order for used modules
+        List<ModuleEntry> moduleEntries =
+                usedModules.stream()
+                        .map(name -> new ModuleEntry(name, true))
+                        .collect(Collectors.toList());
+        loadedModules.keySet().stream()
+                .filter(name -> !usedModules.contains(name))
+                .forEach(name -> moduleEntries.add(new ModuleEntry(name, false)));
+        return moduleEntries;
+    }
+
+    /**
+     * Get names of all functions from used modules.
+     *
+     * @return a set of function names of used modules
      */
     public Set<String> listFunctions() {
-        return modules.values().stream()
-                .map(m -> m.listFunctions())
-                .flatMap(n -> n.stream())
+        return usedModules.stream()
+                .map(name -> loadedModules.get(name).listFunctions())
+                .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
     }
 
     /**
      * Get an optional of {@link FunctionDefinition} by a given name. Function will be resolved to
-     * modules in the loaded order, and the first match will be returned. If no match is found in
-     * all modules, return an optional.
+     * modules in the used order, and the first match will be returned. If no match is found in all
+     * modules, return an optional.
      *
      * @param name name of the function
      * @return an optional of {@link FunctionDefinition}
      */
     public Optional<FunctionDefinition> getFunctionDefinition(String name) {
-        Optional<Map.Entry<String, Module>> result =
-                modules.entrySet().stream()
+        Optional<String> module =
+                usedModules.stream()
                         .filter(
-                                p ->
-                                        p.getValue().listFunctions().stream()
+                                n ->
+                                        loadedModules.get(n).listFunctions().stream()
                                                 .anyMatch(e -> e.equalsIgnoreCase(name)))
                         .findFirst();
-
-        if (result.isPresent()) {
-            LOG.debug("Got FunctionDefinition '{}' from '{}' module.", name, result.get().getKey());
-
-            return result.get().getValue().getFunctionDefinition(name);
-        } else {
-            LOG.debug("Cannot find FunctionDefinition '{}' from any loaded modules.", name);
-
-            return Optional.empty();
+        if (module.isPresent()) {
+            LOG.debug("Got FunctionDefinition '{}' from '{}' module.", name, module.get());
+            return loadedModules.get(module.get()).getFunctionDefinition(name);
         }
+        LOG.debug("Cannot find FunctionDefinition '{}' from any loaded modules.", name);
+
+        return Optional.empty();
+    }
+
+    @VisibleForTesting
+    List<String> getUsedModules() {
+        return usedModules;
+    }
+
+    @VisibleForTesting
+    Map<String, Module> getLoadedModules() {
+        return loadedModules;
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/module/ModuleManagerTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/module/ModuleManagerTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.module;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.utils.ModuleMock;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.descriptors.CoreModuleDescriptorValidator.MODULE_TYPE_CORE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ModuleManager}. */
+public class ModuleManagerTest extends TestLogger {
+    private static final Comparator<ModuleEntry> COMPARATOR =
+            Comparator.comparing(ModuleEntry::name);
+    private ModuleManager manager;
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void before() {
+        manager = new ModuleManager();
+    }
+
+    @Test
+    public void testLoadModuleTwice() {
+        // CoreModule is loaded by default
+        assertEquals(Collections.singletonList(MODULE_TYPE_CORE), manager.getUsedModules());
+        assertEquals(CoreModule.INSTANCE, manager.getLoadedModules().get(MODULE_TYPE_CORE));
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("A module with name core already exists");
+        manager.loadModule(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+    }
+
+    @Test
+    public void testLoadModuleWithoutUnusedModulesExist() {
+        ModuleMock.ModuleX x = new ModuleMock.ModuleX("x");
+        ModuleMock.ModuleY y = new ModuleMock.ModuleY("y");
+        ModuleMock.ModuleZ z = new ModuleMock.ModuleZ("z");
+        manager.loadModule(x.getType(), x);
+        manager.loadModule(y.getType(), y);
+        manager.loadModule(z.getType(), z);
+
+        Map<String, Module> expectedLoadedModules = new HashMap<>();
+        expectedLoadedModules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+        expectedLoadedModules.put("x", x);
+        expectedLoadedModules.put("y", y);
+        expectedLoadedModules.put("z", z);
+
+        assertEquals(Arrays.asList(MODULE_TYPE_CORE, "x", "y", "z"), manager.getUsedModules());
+        assertEquals(expectedLoadedModules, manager.getLoadedModules());
+    }
+
+    @Test
+    public void testLoadModuleWithUnusedModulesExist() {
+        ModuleMock.ModuleY y = new ModuleMock.ModuleY("y");
+        ModuleMock.ModuleZ z = new ModuleMock.ModuleZ("z");
+        manager.loadModule(y.getType(), y);
+        manager.loadModule(z.getType(), z);
+
+        Map<String, Module> expectedLoadedModules = new HashMap<>();
+        expectedLoadedModules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+        expectedLoadedModules.put("y", y);
+        expectedLoadedModules.put("z", z);
+
+        assertEquals(Arrays.asList(MODULE_TYPE_CORE, "y", "z"), manager.getUsedModules());
+        assertEquals(expectedLoadedModules, manager.getLoadedModules());
+
+        // reset usedModules to mock module y and z are disabled
+        manager.getUsedModules().remove("z");
+        manager.getUsedModules().remove("y");
+
+        // load module x to test the order
+        ModuleMock.ModuleX x = new ModuleMock.ModuleX("x");
+        manager.loadModule(x.getType(), x);
+        expectedLoadedModules.put("x", x);
+
+        assertEquals(Arrays.asList(MODULE_TYPE_CORE, "x"), manager.getUsedModules());
+        assertEquals(expectedLoadedModules, manager.getLoadedModules());
+    }
+
+    @Test
+    public void testUnloadModuleTwice() {
+        assertEquals(Collections.singletonList(MODULE_TYPE_CORE), manager.getUsedModules());
+
+        manager.unloadModule(MODULE_TYPE_CORE);
+        assertEquals(Collections.emptyList(), manager.getUsedModules());
+        assertEquals(Collections.emptyMap(), manager.getLoadedModules());
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("No module with name core exists");
+        manager.unloadModule(MODULE_TYPE_CORE);
+    }
+
+    @Test
+    public void testUseUnloadedModules() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("No module with name x exists");
+        manager.useModules(MODULE_TYPE_CORE, "x");
+    }
+
+    @Test
+    public void testUseModulesWithDuplicateModuleName() {
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("Module core appears more than once");
+        manager.useModules(MODULE_TYPE_CORE, MODULE_TYPE_CORE);
+    }
+
+    @Test
+    public void testUseModules() {
+        ModuleMock.ModuleX x = new ModuleMock.ModuleX("x");
+        ModuleMock.ModuleY y = new ModuleMock.ModuleY("y");
+        ModuleMock.ModuleZ z = new ModuleMock.ModuleZ("z");
+        manager.loadModule(x.getType(), x);
+        manager.loadModule(y.getType(), y);
+        manager.loadModule(z.getType(), z);
+
+        assertEquals(Arrays.asList(MODULE_TYPE_CORE, "x", "y", "z"), manager.getUsedModules());
+
+        // test order for used modules
+        manager.useModules("z", MODULE_TYPE_CORE);
+        assertEquals(Arrays.asList("z", MODULE_TYPE_CORE), manager.getUsedModules());
+
+        // test unmentioned modules are still loaded
+        Map<String, Module> expectedLoadedModules = new HashMap<>();
+        expectedLoadedModules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
+        expectedLoadedModules.put("x", x);
+        expectedLoadedModules.put("y", y);
+        expectedLoadedModules.put("z", z);
+        assertEquals(expectedLoadedModules, manager.getLoadedModules());
+    }
+
+    @Test
+    public void testListModules() {
+        ModuleMock.ModuleY y = new ModuleMock.ModuleY("y");
+        ModuleMock.ModuleZ z = new ModuleMock.ModuleZ("z");
+        manager.loadModule("y", y);
+        manager.loadModule("z", z);
+        manager.useModules("z", "y");
+
+        assertEquals(Arrays.asList("z", "y"), manager.listModules());
+    }
+
+    @Test
+    public void testListFullModules() {
+        ModuleMock.ModuleZ x = new ModuleMock.ModuleZ("x");
+        ModuleMock.ModuleY y = new ModuleMock.ModuleY("y");
+        ModuleMock.ModuleZ z = new ModuleMock.ModuleZ("z");
+
+        manager.loadModule("y", y);
+        manager.loadModule("x", x);
+        manager.loadModule("z", z);
+        manager.useModules("z", "y");
+
+        assertEquals(
+                getExpectedModuleEntries(2, "z", "y", MODULE_TYPE_CORE, "x"),
+                getActualModuleEntries());
+    }
+
+    @Test
+    public void testListFunctions() {
+        ModuleMock.ModuleX x = new ModuleMock.ModuleX("x");
+        manager.loadModule(x.getType(), x);
+
+        assertTrue(manager.listFunctions().contains("dummy"));
+
+        // should not return function name of an unused module
+        manager.useModules(MODULE_TYPE_CORE);
+        assertFalse(manager.listFunctions().contains("dummy"));
+    }
+
+    @Test
+    public void testGetFunctionDefinition() {
+        ModuleMock.ModuleX x = new ModuleMock.ModuleX("x");
+        manager.loadModule(x.getType(), x);
+
+        assertTrue(manager.getFunctionDefinition("dummy").isPresent());
+
+        // should not return function definition of an unused module
+        manager.useModules(MODULE_TYPE_CORE);
+        assertFalse(manager.getFunctionDefinition("dummy").isPresent());
+    }
+
+    private static List<ModuleEntry> getExpectedModuleEntries(int index, String... names) {
+        List<ModuleEntry> expected = new ArrayList<>();
+        // keep order for used modules
+        IntStream.range(0, index).forEach(i -> expected.add(new ModuleEntry(names[i], true)));
+        // sort unused modules for comparing
+        expected.addAll(
+                IntStream.range(index, names.length)
+                        .mapToObj(i -> new ModuleEntry(names[i], false))
+                        .sorted(COMPARATOR)
+                        .collect(Collectors.toList()));
+        return expected;
+    }
+
+    private List<ModuleEntry> getActualModuleEntries() {
+        List<ModuleEntry> actual = manager.listFullModules();
+        List<ModuleEntry> sortedActual = actual.subList(0, manager.listModules().size());
+        sortedActual.addAll(
+                actual.subList(manager.listModules().size(), actual.size()).stream()
+                        .sorted(COMPARATOR)
+                        .collect(Collectors.toList()));
+        return sortedActual;
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ModuleMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ModuleMock.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 
 /** Mocking {@link Module} for tests. */
-public abstract class ModuleMock implements Module {
+public class ModuleMock implements Module {
     private static final Set<String> BUILT_IN_FUNCTIONS =
             Collections.unmodifiableSet(new HashSet<>(Collections.singletonList("dummy")));
     private final String type;
@@ -56,26 +56,5 @@ public abstract class ModuleMock implements Module {
             return Optional.of(functionDef);
         }
         return Optional.empty();
-    }
-
-    /** A simple mock module with type "x". */
-    public static class ModuleX extends ModuleMock {
-        public ModuleX(String type) {
-            super(type);
-        }
-    }
-
-    /** A simple mock module with type "y". */
-    public static class ModuleY extends ModuleMock {
-        public ModuleY(String type) {
-            super(type);
-        }
-    }
-
-    /** A simple mock module with type "z". */
-    public static class ModuleZ extends ModuleMock {
-        public ModuleZ(String type) {
-            super(type);
-        }
     }
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ModuleMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ModuleMock.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionKind;
+import org.apache.flink.table.module.Module;
+import org.apache.flink.table.types.inference.utils.FunctionDefinitionMock;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/** Mocking {@link Module} for tests. */
+public abstract class ModuleMock implements Module {
+    private static final Set<String> BUILT_IN_FUNCTIONS =
+            Collections.unmodifiableSet(new HashSet<>(Collections.singletonList("dummy")));
+    private final String type;
+    private final FunctionDefinitionMock functionDef;
+
+    public ModuleMock(String type) {
+        this.type = type;
+        functionDef = new FunctionDefinitionMock();
+        functionDef.functionKind = FunctionKind.OTHER;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public Set<String> listFunctions() {
+        return BUILT_IN_FUNCTIONS;
+    }
+
+    @Override
+    public Optional<FunctionDefinition> getFunctionDefinition(String name) {
+        if (BUILT_IN_FUNCTIONS.contains(name)) {
+            return Optional.of(functionDef);
+        }
+        return Optional.empty();
+    }
+
+    /** A simple mock module with type "x". */
+    public static class ModuleX extends ModuleMock {
+        public ModuleX(String type) {
+            super(type);
+        }
+    }
+
+    /** A simple mock module with type "y". */
+    public static class ModuleY extends ModuleMock {
+        public ModuleY(String type) {
+            super(type);
+        }
+    }
+
+    /** A simple mock module with type "z". */
+    public static class ModuleZ extends ModuleMock {
+        public ModuleZ(String type) {
+            super(type);
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/resources/log4j2-test.properties
+++ b/flink-table/flink-table-api-java/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -34,7 +34,7 @@ import org.apache.flink.table.expressions.resolver.SqlExpressionResolver
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSinkFactoryContextImpl}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction, _}
-import org.apache.flink.table.module.{Module, ModuleManager}
+import org.apache.flink.table.module.{Module, ModuleEntry, ModuleManager}
 import org.apache.flink.table.operations.ddl._
 import org.apache.flink.table.operations.utils.OperationTreeBuilder
 import org.apache.flink.table.operations.{CatalogQueryOperation, TableSourceQueryOperation, _}
@@ -45,7 +45,6 @@ import org.apache.flink.table.types.{AbstractDataType, DataType}
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.utils.PrintUtils
 import org.apache.flink.types.Row
-
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.tools.FrameworkConfig
@@ -53,7 +52,6 @@ import org.apache.calcite.tools.FrameworkConfig
 import _root_.java.lang.{Iterable => JIterable, Long => JLong}
 import _root_.java.util.function.{Function => JFunction, Supplier => JSupplier}
 import _root_.java.util.{Optional, Collections => JCollections, HashMap => JHashMap, List => JList, Map => JMap}
-
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.util.Try
@@ -283,6 +281,10 @@ abstract class TableEnvImpl(
     moduleManager.loadModule(moduleName, module)
   }
 
+  override def useModules(moduleNames: String*): Unit = {
+    moduleManager.useModules(moduleNames: _*)
+  }
+
   override def unloadModule(moduleName: String): Unit = {
     moduleManager.unloadModule(moduleName)
   }
@@ -459,6 +461,10 @@ abstract class TableEnvImpl(
 
   override def listModules(): Array[String] = {
     moduleManager.listModules().asScala.toArray
+  }
+
+  override def listFullModules(): Array[ModuleEntry] = {
+    moduleManager.listFullModules().asScala.toArray
   }
 
   override def listCatalogs(): Array[String] = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -20,14 +20,13 @@ package org.apache.flink.table.utils
 
 import java.lang.{Iterable => JIterable}
 import java.util.Optional
-
 import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.table.api.{ExplainDetail, StatementSet, Table, TableConfig, TableEnvironment, TableResult}
 import org.apache.flink.table.catalog.Catalog
 import org.apache.flink.table.descriptors.{ConnectTableDescriptor, ConnectorDescriptor}
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.functions.{ScalarFunction, UserDefinedFunction}
-import org.apache.flink.table.module.Module
+import org.apache.flink.table.module.{Module, ModuleEntry}
 import org.apache.flink.table.sources.TableSource
 import org.apache.flink.table.types.AbstractDataType
 
@@ -46,6 +45,8 @@ class MockTableEnvironment extends TableEnvironment {
   override def listCatalogs(): Array[String] = ???
 
   override def listModules(): Array[String] = ???
+
+  override def listFullModules(): Array[ModuleEntry] = ???
 
   override def listDatabases(): Array[String] = ???
 
@@ -101,6 +102,8 @@ class MockTableEnvironment extends TableEnvironment {
   override def execute(jobName: String): JobExecutionResult = ???
 
   override def loadModule(moduleName: String, module: Module): Unit = ???
+
+  override def useModules(moduleNames: String*): Unit = ???
 
   override def unloadModule(moduleName: String): Unit = ???
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request aims to support changing the resolution order of modules more flexibly by introducing two methods `void useModules(String... moduleNames)` and `List<ModuleEntry> listFullModules()` in both `ModuleManager` and `TableEnvironment`.*


## Brief change log

  - *The `ModuleEntry` is a POJO representing the current loaded module name and whether the module is currently in use*.
  - *The `usedModules` in `ModuleManager` is an `ArrayList<String>` maintaining the current module names of used modules.*. 
  - *Since `usedModules` keeps the resolution order, `loadedModules` can be persisted using a `HashMap<String, Module>`*.
 
## Verifying this change

This change added tests and can be verified as follows:

  - *Added `ModuleManagerTest` to verify all public methods in `ModuleManager` behave correctly*.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
    - Docs will be updated after [FLINK-21300](https://issues.apache.org/jira/browse/FLINK-21300) finish.
  