### PR TITLE
[FLINK-20957][task][tests] Make sure we enter the measured sleep after the Task thread started measuring backPressure/idle time

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
@@ -79,4 +79,9 @@ public class TimerGauge implements Gauge<Long>, View {
     public synchronized long getCount() {
         return currentCount;
     }
+
+    @VisibleForTesting
+    public synchronized boolean isMeasuring() {
+        return currentMeasurementStart != 0;
+    }
 }


### PR DESCRIPTION
Make sure that the Task thread actually starts measuring the backpressure before
we start the measured sleep. The WaitingThread is started from within the mailbox
so we should first wait until mailbox loop starts idling before we enter the
measured sleep

## Verifying this change

Bug was easy to reproduce/verify after modifying `WaitingThread` starting sequence from:
```
            executor.submit(
                    waitingThread::start,
                    "This task will submit another task to execute after processing input once.");
```
to:
```
            executor.submit(() -> {
                            waitingThread.start();
                            Thread.sleep(10);
                     },
                    "This task will submit another task to execute after processing input once.");
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
