### PR TITLE
[FLINK-21274][runtime] Change the ClusterEntrypoint.runClusterEntrypoint to wait on the result of clusterEntrypoint.getTerminationFuture().get() and do the System.exit outside of the future callback

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
@@ -36,6 +36,6 @@ public class KubernetesTaskExecutorRunner {
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-        TaskManagerRunner.runTaskManagerSecurely(args);
+        TaskManagerRunner.runTaskManagerProcessSecurely(args);
     }
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -68,6 +68,6 @@ public class MesosTaskExecutorRunner {
             return;
         }
 
-        TaskManagerRunner.runTaskManagerSecurely(configuration);
+        TaskManagerRunner.runTaskManagerProcessSecurely(configuration);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -589,25 +589,22 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        clusterEntrypoint
-                .getTerminationFuture()
-                .whenComplete(
-                        (applicationStatus, throwable) -> {
-                            final int returnCode;
+        int returnCode;
+        Throwable throwable = null;
 
-                            if (throwable != null) {
-                                returnCode = RUNTIME_FAILURE_RETURN_CODE;
-                            } else {
-                                returnCode = applicationStatus.processExitCode();
-                            }
+        try {
+            returnCode = clusterEntrypoint.getTerminationFuture().get().processExitCode();
+        } catch (Throwable e) {
+            throwable = ExceptionUtils.stripExecutionException(e);
+            returnCode = RUNTIME_FAILURE_RETURN_CODE;
+        }
 
-                            LOG.info(
-                                    "Terminating cluster entrypoint process {} with exit code {}.",
-                                    clusterEntrypointName,
-                                    returnCode,
-                                    throwable);
-                            System.exit(returnCode);
-                        });
+        LOG.info(
+                "Terminating cluster entrypoint process {} with exit code {}.",
+                clusterEntrypointName,
+                returnCode,
+                throwable);
+        System.exit(returnCode);
     }
 
     /** Execution mode of the {@link MiniDispatcher}. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -25,13 +25,10 @@ import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -39,10 +36,8 @@ import org.junit.rules.Timeout;
 import javax.annotation.Nonnull;
 
 import java.net.InetAddress;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -54,14 +49,7 @@ public class TaskManagerRunnerTest extends TestLogger {
 
     @Rule public final Timeout timeout = Timeout.seconds(30);
 
-    private SystemExitTrackingSecurityManager systemExitTrackingSecurityManager;
     private TaskManagerRunner taskManagerRunner;
-
-    @Before
-    public void before() {
-        systemExitTrackingSecurityManager = new SystemExitTrackingSecurityManager();
-        System.setSecurityManager(systemExitTrackingSecurityManager);
-    }
 
     @After
     public void after() throws Exception {
@@ -80,8 +68,9 @@ public class TaskManagerRunnerTest extends TestLogger {
 
         taskManagerRunner.onFatalError(new RuntimeException());
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -91,8 +80,9 @@ public class TaskManagerRunnerTest extends TestLogger {
                 TaskManagerOptions.REGISTRATION_TIMEOUT, TimeUtils.parseDuration("10 ms"));
         taskManagerRunner = createTaskManagerRunner(configuration);
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -169,10 +159,11 @@ public class TaskManagerRunnerTest extends TestLogger {
                         createConfiguration(),
                         createTaskExecutorServiceFactory(taskExecutorService));
 
-        terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+        terminationFuture.complete(null);
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -191,11 +182,11 @@ public class TaskManagerRunnerTest extends TestLogger {
 
         taskManagerRunner.closeAsync();
 
-        terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+        terminationFuture.complete(null);
 
         assertThat(
-                systemExitTrackingSecurityManager.getSystemExitFuture(),
-                willNotComplete(Duration.ofMillis(10L)));
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.SUCCESS)));
     }
 
     @Nonnull

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -336,7 +336,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
                 TaskManagerRunner.runTaskManager(cfg, pluginManager);
             } catch (Throwable t) {
-                LOG.error("Failed to start TaskManager process", t);
+                LOG.error("Failed to run the TaskManager process", t);
                 System.exit(1);
             }
         }


### PR DESCRIPTION

## What is the purpose of the change

In some cases we don't have non-daemon thread remaining which causes the JVM to terminate before all tasks have been completed. 

To solve this problem, my fix is to block the main thread so that it exits after all tasks in the JVM are completed.

## Brief change log

  - Change the ClusterEntrypoint.runClusterEntrypoint to wait on the result of clusterEntrypoint.getTerminationFuture().get() and do the System.exit outside of the future callback


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)