### PR TITLE
[FLINK-21315][state-processor-api]allow users to set DataSource operator names

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/ExistingSavepoint.java
@@ -24,9 +24,9 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.Utils;
+import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -102,7 +102,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} representing the elements in state.
      * @throws IOException If the savepoint path is invalid or the uid does not exist.
      */
-    public <T> DataSet<T> readListState(String uid, String name, TypeInformation<T> typeInfo)
+    public <T> DataSource<T> readListState(String uid, String name, TypeInformation<T> typeInfo)
             throws IOException {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
@@ -123,7 +123,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} representing the elements in state.
      * @throws IOException If the savepoint path is invalid or the uid does not exist.
      */
-    public <T> DataSet<T> readListState(
+    public <T> DataSource<T> readListState(
             String uid, String name, TypeInformation<T> typeInfo, TypeSerializer<T> serializer)
             throws IOException {
 
@@ -143,7 +143,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} representing the elements in state.
      * @throws IOException If the savepoint path is invalid or the uid does not exist.
      */
-    public <T> DataSet<T> readUnionState(String uid, String name, TypeInformation<T> typeInfo)
+    public <T> DataSource<T> readUnionState(String uid, String name, TypeInformation<T> typeInfo)
             throws IOException {
         OperatorState operatorState = metadata.getOperatorState(uid);
         ListStateDescriptor<T> descriptor = new ListStateDescriptor<>(name, typeInfo);
@@ -165,7 +165,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} representing the elements in state.
      * @throws IOException If the savepoint path is invalid or the uid does not exist.
      */
-    public <T> DataSet<T> readUnionState(
+    public <T> DataSource<T> readUnionState(
             String uid, String name, TypeInformation<T> typeInfo, TypeSerializer<T> serializer)
             throws IOException {
 
@@ -188,7 +188,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} of key-value pairs from state.
      * @throws IOException If the savepoint does not contain the specified uid.
      */
-    public <K, V> DataSet<Tuple2<K, V>> readBroadcastState(
+    public <K, V> DataSource<Tuple2<K, V>> readBroadcastState(
             String uid,
             String name,
             TypeInformation<K> keyTypeInfo,
@@ -219,7 +219,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} of key-value pairs from state.
      * @throws IOException If the savepoint path is invalid or the uid does not exist.
      */
-    public <K, V> DataSet<Tuple2<K, V>> readBroadcastState(
+    public <K, V> DataSource<Tuple2<K, V>> readBroadcastState(
             String uid,
             String name,
             TypeInformation<K> keyTypeInfo,
@@ -246,7 +246,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If the savepoint does not contain operator state with the given uid.
      */
-    public <K, OUT> DataSet<OUT> readKeyedState(
+    public <K, OUT> DataSource<OUT> readKeyedState(
             String uid, KeyedStateReaderFunction<K, OUT> function) throws IOException {
 
         TypeInformation<K> keyTypeInfo;
@@ -296,7 +296,7 @@ public class ExistingSavepoint extends WritableSavepoint<ExistingSavepoint> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If the savepoint does not contain operator state with the given uid.
      */
-    public <K, OUT> DataSet<OUT> readKeyedState(
+    public <K, OUT> DataSource<OUT> readKeyedState(
             String uid,
             KeyedStateReaderFunction<K, OUT> function,
             TypeInformation<K> keyTypeInfo,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WindowReader.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSource;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.state.api.functions.WindowReaderFunction;
 import org.apache.flink.state.api.input.KeyedStateInputFormat;
@@ -97,7 +97,7 @@ public class WindowReader<W extends Window> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If savepoint does not contain the specified uid.
      */
-    public <T, K> DataSet<T> reduce(
+    public <T, K> DataSource<T> reduce(
             String uid,
             ReduceFunction<T> function,
             TypeInformation<K> keyType,
@@ -122,7 +122,7 @@ public class WindowReader<W extends Window> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If savepoint does not contain the specified uid.
      */
-    public <K, T, OUT> DataSet<OUT> reduce(
+    public <K, T, OUT> DataSource<OUT> reduce(
             String uid,
             ReduceFunction<T> function,
             WindowReaderFunction<T, OUT, K, W> readerFunction,
@@ -153,7 +153,7 @@ public class WindowReader<W extends Window> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If savepoint does not contain the specified uid.
      */
-    public <K, T, ACC, R> DataSet<R> aggregate(
+    public <K, T, ACC, R> DataSource<R> aggregate(
             String uid,
             AggregateFunction<T, ACC, R> aggregateFunction,
             TypeInformation<K> keyType,
@@ -182,7 +182,7 @@ public class WindowReader<W extends Window> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If savepoint does not contain the specified uid.
      */
-    public <K, T, ACC, R, OUT> DataSet<OUT> aggregate(
+    public <K, T, ACC, R, OUT> DataSource<OUT> aggregate(
             String uid,
             AggregateFunction<T, ACC, R> aggregateFunction,
             WindowReaderFunction<R, OUT, K, W> readerFunction,
@@ -213,7 +213,7 @@ public class WindowReader<W extends Window> {
      * @return A {@code DataSet} of objects read from keyed state.
      * @throws IOException If the savepoint does not contain the specified uid.
      */
-    public <K, T, OUT> DataSet<OUT> process(
+    public <K, T, OUT> DataSource<OUT> process(
             String uid,
             WindowReaderFunction<T, OUT, K, W> readerFunction,
             TypeInformation<K> keyType,
@@ -227,7 +227,7 @@ public class WindowReader<W extends Window> {
         return readWindowOperator(uid, outputType, operator);
     }
 
-    private <K, T, OUT> DataSet<OUT> readWindowOperator(
+    private <K, T, OUT> DataSource<OUT> readWindowOperator(
             String uid,
             TypeInformation<OUT> outputType,
             WindowReaderOperator<?, K, T, W, OUT> operator)

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/WritableSavepoint.java
@@ -105,7 +105,10 @@ public abstract class WritableSavepoint<F extends WritableSavepoint> {
             finalOperatorStates = newOperatorStates;
         } else {
             DataSet<OperatorState> existingOperatorStates =
-                    newOperatorStates.getExecutionEnvironment().fromCollection(existingOperators);
+                    newOperatorStates
+                            .getExecutionEnvironment()
+                            .fromCollection(existingOperators)
+                            .name("existingOperatorStates");
 
             existingOperatorStates
                     .flatMap(new StatePathExtractor())


### PR DESCRIPTION
## What is the purpose of the change

This change is to allow users to set DataSource operator names when using state processor API. Otherwise, the default DataSource operator name is too long, like: 
`DataSource (at write(WritableSavepoint.java:108)(org.apache.flink.api.java.io.CollectionInputFormat))`

## Brief change log

  - change the return type of readKeyedState/readListState/readUnionState/readBroadcastState/readWindowOperator to DataSource<T> instead of DataSet<T>. This is a compatible change as DataSource is a subclass of DataSet.
  - add an operator name when collecting existing operator states

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, but compatible
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? Kind of.
  - If yes, how is the feature documented? It allows users to set operator names when using state processor API, just like they do in a normal Flink job. No additional documentation is needed, I think.
