### PR TITLE
[FLINK-21258] Add Canceling state for DeclarativeScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -895,7 +895,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
         }
     }
 
-    private ConjunctFuture<Void> cancelVerticesAsync() {
+    @VisibleForTesting
+    protected ConjunctFuture<Void> cancelVerticesAsync() {
         final ArrayList<CompletableFuture<?>> futures =
                 new ArrayList<>(verticesInCreationOrder.size());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Canceling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Canceling.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+
+import org.slf4j.Logger;
+
+/** State which describes a job which is currently being canceled. */
+class Canceling extends StateWithExecutionGraph {
+
+    private final Context context;
+
+    Canceling(
+            Context context,
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            Logger logger) {
+        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+        this.context = context;
+    }
+
+    @Override
+    public void onEnter() {
+        getExecutionGraph().cancel();
+    }
+
+    @Override
+    public void cancel() {
+        // we are already in the state canceling
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        // ignore global failures
+    }
+
+    @Override
+    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
+        return getExecutionGraph().updateState(taskExecutionStateTransition);
+    }
+
+    @Override
+    void onGloballyTerminalState(JobStatus globallyTerminalState) {
+        context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.InternalFailuresListener;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link Canceling} state of the declarative scheduler. */
+public class CancelingTest extends TestLogger {
+
+    @Test
+    public void testExecutionGraphCancelationOnEnter() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            RestartingTest.CancellableExecutionGraph cancellableExecutionGraph =
+                    new RestartingTest.CancellableExecutionGraph();
+            Canceling canceling = createCancelingState(ctx, cancellableExecutionGraph);
+
+            canceling.onEnter();
+            assertThat(cancellableExecutionGraph.isCancelled(), is(true));
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedWhenCancellationCompletes() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            Canceling canceling = createCancelingState(ctx);
+
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.CANCELED)));
+            canceling
+                    .getExecutionGraph()
+                    .cancel(); // this calls onTerminalState.onGloballyTerminal()
+        }
+    }
+
+    @Test
+    public void testTransitionToSuspend() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            Canceling canceling = createCancelingState(ctx);
+            canceling.onEnter();
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
+            canceling.suspend(new RuntimeException("suspend"));
+        }
+    }
+
+    @Test
+    public void testCancelIsIgnored() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            Canceling canceling = createCancelingState(ctx);
+            canceling.cancel();
+            ctx.assertNoStateTransition();
+        }
+    }
+
+    @Test
+    public void testGlobalFailuresAreIgnored() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            Canceling canceling = createCancelingState(ctx);
+            canceling.handleGlobalFailure(new RuntimeException("test"));
+            ctx.assertNoStateTransition();
+        }
+    }
+
+    @Test
+    public void testTaskFailuresAreIgnored() throws Exception {
+        try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
+            Canceling canceling = createCancelingState(ctx);
+            // register execution at EG
+            ExecutingTest.MockExecutionJobVertex ejv =
+                    new ExecutingTest.MockExecutionJobVertex(canceling.getExecutionGraph());
+            TaskExecutionStateTransition update =
+                    new TaskExecutionStateTransition(
+                            new TaskExecutionState(
+                                    canceling.getJob().getJobID(),
+                                    ejv.getMockExecutionVertex()
+                                            .getCurrentExecutionAttempt()
+                                            .getAttemptId(),
+                                    ExecutionState.FAILED,
+                                    new RuntimeException()));
+            canceling.updateTaskExecutionState(update);
+            ctx.assertNoStateTransition();
+        }
+    }
+
+    private Canceling createCancelingState(MockStateWithExecutionGraphContext ctx)
+            throws JobException, JobExecutionException {
+        return createCancelingState(ctx, TestingExecutionGraphBuilder.newBuilder().build());
+    }
+
+    private Canceling createCancelingState(
+            MockStateWithExecutionGraphContext ctx, ExecutionGraph executionGraph) {
+        final ExecutionGraphHandler executionGraphHandler =
+                new ExecutionGraphHandler(
+                        executionGraph,
+                        log,
+                        ctx.getMainThreadExecutor(),
+                        ctx.getMainThreadExecutor());
+        final OperatorCoordinatorHandler operatorCoordinatorHandler =
+                new OperatorCoordinatorHandler(
+                        executionGraph,
+                        (throwable) -> {
+                            throw new RuntimeException("Error in test", throwable);
+                        });
+        executionGraph.transitionToRunning();
+        Canceling canceling =
+                new Canceling(
+                        ctx,
+                        executionGraph,
+                        executionGraphHandler,
+                        operatorCoordinatorHandler,
+                        log);
+        executionGraph.setInternalTaskFailuresListener(new TestInternalFailuresListener(canceling));
+        return canceling;
+    }
+
+    private static class TestInternalFailuresListener implements InternalFailuresListener {
+
+        private final Canceling canceling;
+
+        public TestInternalFailuresListener(Canceling canceling) {
+            this.canceling = canceling;
+        }
+
+        @Override
+        public void notifyTaskFailure(
+                ExecutionAttemptID attemptId,
+                Throwable t,
+                boolean cancelTask,
+                boolean releasePartitions) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void notifyGlobalFailure(Throwable t) {
+            canceling.handleGlobalFailure(t);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/ExecutingTest.java
@@ -246,7 +246,7 @@ public class ExecutingTest extends TestLogger {
         }
     }
 
-    private TaskExecutionStateTransition createFailingStateTransition(JobID jobId) {
+    private static TaskExecutionStateTransition createFailingStateTransition(JobID jobId) {
         return new TaskExecutionStateTransition(
                 new TaskExecutionState(
                         jobId,
@@ -568,17 +568,15 @@ public class ExecutingTest extends TestLogger {
         }
     }
 
-    private static class MockExecutionJobVertex extends ExecutionJobVertex {
+    static class MockExecutionJobVertex extends ExecutionJobVertex {
         private final MockExecutionVertex mockExecutionVertex;
 
         MockExecutionJobVertex() throws JobException, JobExecutionException {
-            super(
-                    TestingExecutionGraphBuilder.newBuilder().build(),
-                    new JobVertex("test"),
-                    1,
-                    1,
-                    Time.milliseconds(1L),
-                    1L);
+            this(TestingExecutionGraphBuilder.newBuilder().build());
+        }
+
+        MockExecutionJobVertex(ExecutionGraph executionGraph) throws JobException {
+            super(executionGraph, new JobVertex("test"), 1, 1, Time.milliseconds(1L), 1L);
             mockExecutionVertex = new MockExecutionVertex(this);
         }
 
@@ -587,12 +585,16 @@ public class ExecutingTest extends TestLogger {
             return new ExecutionVertex[] {mockExecutionVertex};
         }
 
+        public MockExecutionVertex getMockExecutionVertex() {
+            return mockExecutionVertex;
+        }
+
         public boolean isExecutionDeployed() {
             return mockExecutionVertex.isDeployed();
         }
     }
 
-    private static class MockExecutionVertex extends ExecutionVertex {
+    static class MockExecutionVertex extends ExecutionVertex {
         private boolean deployed = false;
 
         MockExecutionVertex(ExecutionJobVertex jobVertex) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/RestartingTest.java
@@ -183,7 +183,7 @@ public class RestartingTest extends TestLogger {
         }
     }
 
-    private static class CancellableExecutionGraph extends ExecutionGraph {
+    static class CancellableExecutionGraph extends ExecutionGraph {
         private boolean cancelled = false;
 
         CancellableExecutionGraph() throws IOException {


### PR DESCRIPTION

This PR is based on https://github.com/apache/flink/pull/14879

## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. 

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.