### PR TITLE
[FLINK-21259] Add Failing state for DeclarativeScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Failing.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+
+/** State which describes a failing job which is currently being canceled. */
+class Failing extends StateWithExecutionGraph {
+    private final Context context;
+
+    private final Throwable failureCause;
+
+    Failing(
+            Context context,
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            Logger logger,
+            Throwable failureCause) {
+        super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
+        this.context = context;
+        this.failureCause = failureCause;
+    }
+
+    @Override
+    public void onEnter() {
+        getExecutionGraph().failJob(failureCause);
+    }
+
+    @Override
+    public void cancel() {
+        context.goToCanceling(
+                getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {
+        // nothing to do since we are already failing
+    }
+
+    @Override
+    boolean updateTaskExecutionState(TaskExecutionStateTransition taskExecutionStateTransition) {
+        return getExecutionGraph().updateState(taskExecutionStateTransition);
+    }
+
+    @Override
+    void onGloballyTerminalState(JobStatus globallyTerminalState) {
+        Preconditions.checkState(globallyTerminalState == JobStatus.FAILED);
+        context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
+    }
+
+    /** Context of the {@link Failing} state. */
+    interface Context extends StateWithExecutionGraph.Context {
+
+        /**
+         * Transitions into the {@link Canceling} state.
+         *
+         * @param executionGraph executionGraph to pass to the {@link Canceling} state
+         * @param executionGraphHandler executionGraphHandler to pass to the {@link Canceling} state
+         * @param operatorCoordinatorHandler operatorCoordinatorHandler to pass to the {@link
+         *     Canceling} state
+         */
+        void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -139,7 +139,9 @@ abstract class StateWithExecutionGraph implements State {
     @Override
     public void suspend(Throwable cause) {
         executionGraph.suspend(cause);
-        Preconditions.checkState(executionGraph.getState() == JobStatus.SUSPENDED);
+        Preconditions.checkState(
+                executionGraph.getState() == JobStatus.SUSPENDED
+                        || executionGraph.getState().isTerminalState());
         context.goToFinished(ArchivedExecutionGraph.createFrom(executionGraph));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -139,9 +139,7 @@ abstract class StateWithExecutionGraph implements State {
     @Override
     public void suspend(Throwable cause) {
         executionGraph.suspend(cause);
-        Preconditions.checkState(
-                executionGraph.getState() == JobStatus.SUSPENDED
-                        || executionGraph.getState().isTerminalState());
+        Preconditions.checkState(executionGraph.getState() == JobStatus.SUSPENDED);
         context.goToFinished(ArchivedExecutionGraph.createFrom(executionGraph));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
@@ -113,7 +113,6 @@ public class CancelingTest extends TestLogger {
                                     new RuntimeException()));
             canceling.updateTaskExecutionState(update);
             ctx.assertNoStateTransition();
-            assertThat(meg.isFailGlobalCalled(), is(true));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/CancelingTest.java
@@ -18,34 +18,16 @@
 
 package org.apache.flink.runtime.scheduler.declarative;
 
-import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.blob.VoidBlobWriter;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.JobInformation;
-import org.apache.flink.runtime.executiongraph.NoOpExecutionDeploymentListener;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
-import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategyFactoryLoader;
-import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
-import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -158,71 +140,5 @@ public class CancelingTest extends TestLogger {
                         operatorCoordinatorHandler,
                         log);
         return canceling;
-    }
-
-    /**
-     * Mocked ExecutionGraph, which stays in CANCELLING, when cancel() gets called, until the
-     * "completeCancellationFuture" is completed.
-     */
-    private static class MockExecutionGraph extends ExecutionGraph {
-
-        private final CompletableFuture<?> completeCancellationFuture = new CompletableFuture<>();
-        private boolean isCancelling = false;
-        private boolean isFailGlobalCalled = false;
-
-        public MockExecutionGraph() throws IOException {
-            super(
-                    new JobInformation(
-                            new JobID(),
-                            "Test Job",
-                            new SerializedValue<>(new ExecutionConfig()),
-                            new Configuration(),
-                            Collections.emptyList(),
-                            Collections.emptyList()),
-                    TestingUtils.defaultExecutor(),
-                    TestingUtils.defaultExecutor(),
-                    AkkaUtils.getDefaultTimeout(),
-                    1,
-                    ExecutionGraph.class.getClassLoader(),
-                    VoidBlobWriter.getInstance(),
-                    PartitionReleaseStrategyFactoryLoader.loadPartitionReleaseStrategyFactory(
-                            new Configuration()),
-                    NettyShuffleMaster.INSTANCE,
-                    NoOpJobMasterPartitionTracker.INSTANCE,
-                    ScheduleMode.EAGER,
-                    NoOpExecutionDeploymentListener.get(),
-                    (execution, newState) -> {},
-                    0L);
-            this.setJsonPlan(""); // field must not be null for ArchivedExecutionGraph creation
-        }
-
-        void completeCancellation() {
-            completeCancellationFuture.complete(null);
-        }
-
-        public boolean isCancelling() {
-            return isCancelling;
-        }
-
-        public boolean isFailGlobalCalled() {
-            return isFailGlobalCalled;
-        }
-
-        // overwrites for the tests
-        @Override
-        public void cancel() {
-            super.cancel();
-            this.isCancelling = true;
-        }
-
-        @Override
-        public void failGlobal(Throwable t) {
-            isFailGlobalCalled = true;
-        }
-
-        @Override
-        protected FutureUtils.ConjunctFuture<Void> cancelVerticesAsync() {
-            return FutureUtils.completeAll(Collections.singleton(completeCancellationFuture));
-        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FailingTest.java
@@ -57,7 +57,6 @@ public class FailingTest extends TestLogger {
             MockExecutionGraph meg = new MockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
             failing.onEnter(); // transition from RUNNING to FAILING
-            assertThat(meg.isFailing(), is(true));
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
@@ -121,7 +120,6 @@ public class FailingTest extends TestLogger {
                                     new RuntimeException()));
             failing.updateTaskExecutionState(update);
             ctx.assertNoStateTransition();
-            assertThat(meg.isFailGlobalCalled(), is(true));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FailingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import static org.apache.flink.runtime.scheduler.declarative.WaitingForResourcesTest.assertNonNull;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link Failing} state of the declarative scheduler. */
+public class FailingTest extends TestLogger {
+
+    private final Throwable testFailureCause = new RuntimeException();
+
+    @Test
+    public void testFailingStateOnEnter() throws Exception {
+        try (MockFailingContext ctx = new MockFailingContext()) {
+            MockExecutionGraph meg = new MockExecutionGraph();
+            Failing failing = createFailingState(ctx, meg);
+            failing.onEnter();
+            assertThat(meg.isFailing(), is(true));
+            ctx.assertNoStateTransition();
+        }
+    }
+
+    @Test
+    public void testTransitionToFailedWhenFailingCompletes() throws Exception {
+        try (MockFailingContext ctx = new MockFailingContext()) {
+            MockExecutionGraph meg = new MockExecutionGraph();
+            Failing failing = createFailingState(ctx, meg);
+            failing.onEnter(); // transition from RUNNING to FAILING
+            assertThat(meg.isFailing(), is(true));
+            meg.cancelVerticesAsync(); // transition to FAILED
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
+        }
+    }
+
+    @Test
+    public void testIgnoreGlobalFailure() throws Exception {
+        try (MockFailingContext ctx = new MockFailingContext()) {
+            MockExecutionGraph meg = new MockExecutionGraph();
+            Failing failing = createFailingState(ctx, meg);
+            failing.onEnter();
+            failing.handleGlobalFailure(new RuntimeException());
+            ctx.assertNoStateTransition();
+        }
+    }
+
+    @Test
+    public void testTransitionToCancelingOnCancel() throws Exception {
+        try (MockFailingContext ctx = new MockFailingContext()) {
+            MockExecutionGraph meg = new MockExecutionGraph();
+            Failing failing = createFailingState(ctx, meg);
+            ctx.setExpectCanceling(assertNonNull());
+            failing.onEnter();
+            failing.cancel();
+        }
+    }
+
+    @Test
+    public void testTransitionToFinishedOnSuspend() throws Exception {
+        try (MockFailingContext ctx = new MockFailingContext()) {
+            MockExecutionGraph meg = new MockExecutionGraph();
+            Failing failing = createFailingState(ctx, meg);
+            ctx.setExpectFinished(
+                    archivedExecutionGraph ->
+                            assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
+
+            failing.onEnter();
+            failing.suspend(new RuntimeException("suspend"));
+        }
+    }
+
+    private Failing createFailingState(MockFailingContext ctx, ExecutionGraph executionGraph) {
+        final ExecutionGraphHandler executionGraphHandler =
+                new ExecutionGraphHandler(
+                        executionGraph,
+                        log,
+                        ctx.getMainThreadExecutor(),
+                        ctx.getMainThreadExecutor());
+        final OperatorCoordinatorHandler operatorCoordinatorHandler =
+                new OperatorCoordinatorHandler(
+                        executionGraph,
+                        (throwable) -> {
+                            throw new RuntimeException("Error in test", throwable);
+                        });
+        executionGraph.transitionToRunning();
+        return new Failing(
+                ctx,
+                executionGraph,
+                executionGraphHandler,
+                operatorCoordinatorHandler,
+                log,
+                testFailureCause);
+    }
+
+    private static class MockFailingContext extends MockStateWithExecutionGraphContext
+            implements Failing.Context {
+
+        private final StateValidator<ExecutingTest.CancellingArguments> cancellingStateValidator =
+                new StateValidator<>("cancelling");
+
+        public void setExpectCanceling(Consumer<ExecutingTest.CancellingArguments> asserter) {
+            cancellingStateValidator.expectInput(asserter);
+        }
+
+        @Override
+        public void goToCanceling(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler) {
+            cancellingStateValidator.validateInput(
+                    new ExecutingTest.CancellingArguments(
+                            executionGraph, executionGraphHandler, operatorCoordinatorHandler));
+            hadStateTransition = true;
+        }
+
+        @Override
+        public void close() throws Exception {
+            super.close();
+            cancellingStateValidator.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/MockExecutionGraph.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.JobInformation;
+import org.apache.flink.runtime.executiongraph.NoOpExecutionDeploymentListener;
+import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionReleaseStrategyFactoryLoader;
+import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.ScheduleMode;
+import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.SerializedValue;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Mocked ExecutionGraph with the following properties:
+ *
+ * <ul>
+ *   <li>it stays in CANCELLING, when cancel() gets called
+ *   <li>it stays in FAILING then failJob() gets called
+ *   <li>it leaves above states when completeCancellation() gets called.
+ * </ul>
+ */
+class MockExecutionGraph extends ExecutionGraph {
+
+    private final CompletableFuture<?> completeCancellationFuture = new CompletableFuture<>();
+    private boolean isCancelling = false;
+    private boolean isFailGlobalCalled = false;
+    private boolean isFailing = false;
+
+    public MockExecutionGraph() throws IOException {
+        super(
+                new JobInformation(
+                        new JobID(),
+                        "Test Job",
+                        new SerializedValue<>(new ExecutionConfig()),
+                        new Configuration(),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
+                TestingUtils.defaultExecutor(),
+                TestingUtils.defaultExecutor(),
+                AkkaUtils.getDefaultTimeout(),
+                1,
+                ExecutionGraph.class.getClassLoader(),
+                VoidBlobWriter.getInstance(),
+                PartitionReleaseStrategyFactoryLoader.loadPartitionReleaseStrategyFactory(
+                        new Configuration()),
+                NettyShuffleMaster.INSTANCE,
+                NoOpJobMasterPartitionTracker.INSTANCE,
+                ScheduleMode.EAGER,
+                NoOpExecutionDeploymentListener.get(),
+                (execution, newState) -> {},
+                0L);
+        this.setJsonPlan(""); // field must not be null for ArchivedExecutionGraph creation
+    }
+
+    void completeCancellation() {
+        completeCancellationFuture.complete(null);
+    }
+
+    public boolean isCancelling() {
+        return isCancelling;
+    }
+
+    public boolean isFailGlobalCalled() {
+        return isFailGlobalCalled;
+    }
+
+    public boolean isFailing() {
+        return isFailing;
+    }
+
+    // overwrites for the tests
+    @Override
+    public void cancel() {
+        super.cancel();
+        this.isCancelling = true;
+    }
+
+    @Override
+    public void failJob(Throwable cause) {
+        super.failJob(cause);
+        this.isFailing = true;
+    }
+
+    @Override
+    public void failGlobal(Throwable t) {
+        isFailGlobalCalled = true;
+    }
+
+    @Override
+    protected FutureUtils.ConjunctFuture<Void> cancelVerticesAsync() {
+        return FutureUtils.completeAll(Collections.singleton(completeCancellationFuture));
+    }
+}


### PR DESCRIPTION
This PR is based on https://github.com/apache/flink/pull/14879

## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. 

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.