### PR TITLE
[FLINK-21337] ComparableInputTypeStrategyTests is not running

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTest.java
@@ -19,7 +19,8 @@
 package org.apache.flink.table.types.inference;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.PojoSerializer;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -35,6 +36,7 @@ import org.junit.runners.Parameterized;
 
 import javax.annotation.Nonnull;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -43,7 +45,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 /** Tests for {@link ComparableTypeStrategy}. */
-public class ComparableInputTypeStrategyTests extends InputTypeStrategiesTestBase {
+public class ComparableInputTypeStrategyTest extends InputTypeStrategiesTestBase {
 
     @Parameterized.Parameters(name = "{index}: {0}")
     public static List<TestSpec> testData() {
@@ -256,11 +258,17 @@ public class ComparableInputTypeStrategyTests extends InputTypeStrategiesTestBas
                                 InputTypeStrategies.TWO_EQUALS_COMPARABLE)
                         .calledWithArgumentTypes(
                                 rawType(NotComparableClass.class),
-                                DataTypes.RAW(TypeInformation.of(NotComparableClass.class)))
+                                DataTypes.RAW(
+                                        NotComparableClass.class,
+                                        new PojoSerializer<>(
+                                                NotComparableClass.class,
+                                                new TypeSerializer[0],
+                                                new Field[0],
+                                                new ExecutionConfig())))
                         .expectErrorMessage(
                                 String.format(
                                         "All types in a comparison should support 'EQUALS' comparison with"
-                                                + " each other. Can not compare RAW('%s', '...') with RAW('%s', ?)",
+                                                + " each other. Can not compare RAW('%s', '...') with RAW('%s', '...')",
                                         NotComparableClass.class.getName(),
                                         NotComparableClass.class.getName())),
                 TestSpec.forStrategy(


### PR DESCRIPTION
## What is the purpose of the change

Rename test to fit the filter for running tests

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
