### PR TITLE
[FLINK-21260] Add Finished state for DeclarativeScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Finished.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Finished.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+
+import org.slf4j.Logger;
+
+/** State which describes a finished job execution. */
+class Finished implements State {
+
+    private final Context context;
+
+    private final ArchivedExecutionGraph archivedExecutionGraph;
+
+    private final Logger logger;
+
+    Finished(Context context, ArchivedExecutionGraph archivedExecutionGraph, Logger logger) {
+        this.context = context;
+        this.archivedExecutionGraph = archivedExecutionGraph;
+        this.logger = logger;
+    }
+
+    @Override
+    public void onEnter() {
+        context.onFinished(archivedExecutionGraph);
+    }
+
+    @Override
+    public void cancel() {}
+
+    @Override
+    public void suspend(Throwable cause) {}
+
+    @Override
+    public JobStatus getJobStatus() {
+        return archivedExecutionGraph.getState();
+    }
+
+    @Override
+    public ArchivedExecutionGraph getJob() {
+        return archivedExecutionGraph;
+    }
+
+    @Override
+    public void handleGlobalFailure(Throwable cause) {}
+
+    @Override
+    public Logger getLogger() {
+        return logger;
+    }
+
+    /** Context of the {@link Finished} state. */
+    interface Context {
+
+        /**
+         * Callback which is called when the execution reaches the {@link Finished} state.
+         *
+         * @param archivedExecutionGraph archivedExecutionGraph represents the final state of the
+         *     job execution
+         */
+        void onFinished(ArchivedExecutionGraph archivedExecutionGraph);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FinishedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/declarative/FinishedTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/** Tests for declarative scheduler's {@link Finished} state. */
+public class FinishedTest extends TestLogger {
+
+    @Test
+    public void testOnFinishedCallOnEnter() throws Exception {
+        MockFinishedContext ctx = new MockFinishedContext();
+        Finished finished = createFinishedState(ctx);
+        finished.onEnter();
+
+        assertThat(ctx.getArchivedExecutionGraph().getState(), is(JobStatus.FAILED));
+    }
+
+    @Test
+    public void testCancelIgnored() throws Exception {
+        MockFinishedContext ctx = new MockFinishedContext();
+        createFinishedState(ctx).cancel();
+        ctx.assertNoStateTransition();
+    }
+
+    @Test
+    public void testSuspendIgnored() throws Exception {
+        MockFinishedContext ctx = new MockFinishedContext();
+        createFinishedState(ctx).suspend(new RuntimeException());
+        ctx.assertNoStateTransition();
+    }
+
+    @Test
+    public void testGlobalFailureIgnored() throws Exception {
+        MockFinishedContext ctx = new MockFinishedContext();
+        createFinishedState(ctx).handleGlobalFailure(new RuntimeException());
+        ctx.assertNoStateTransition();
+    }
+
+    @Test
+    public void testGetJobStatus() throws Exception {
+        MockFinishedContext ctx = new MockFinishedContext();
+        assertThat(createFinishedState(ctx).getJobStatus(), is(JobStatus.FAILED));
+    }
+
+    private Finished createFinishedState(MockFinishedContext ctx)
+            throws JobException, JobExecutionException {
+        // put in FAILED state to test against
+        final ExecutionGraph executionGraph = TestingExecutionGraphBuilder.newBuilder().build();
+        executionGraph.failJob(new RuntimeException());
+        final ArchivedExecutionGraph archivedExecutionGraph =
+                ArchivedExecutionGraph.createFrom(executionGraph);
+        return new Finished(ctx, archivedExecutionGraph, log);
+    }
+
+    private static class MockFinishedContext implements Finished.Context {
+
+        private ArchivedExecutionGraph archivedExecutionGraph = null;
+
+        @Override
+        public void onFinished(ArchivedExecutionGraph archivedExecutionGraph) {
+            if (archivedExecutionGraph != null) {
+                this.archivedExecutionGraph = archivedExecutionGraph;
+            } else {
+                throw new AssertionError("Transitioned to onFinished twice");
+            }
+        }
+
+        private void assertNoStateTransition() {
+            assertThat(archivedExecutionGraph, nullValue());
+        }
+
+        private ArchivedExecutionGraph getArchivedExecutionGraph() {
+            return archivedExecutionGraph;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[Declarative Scheduler](https://cwiki.apache.org/confluence/display/FLINK/FLIP-160%3A+Declarative+Scheduler) consists of a number of internal states. 

Note that this change is currently not usable as-is, as the other parts of declarative scheduler are not merged yet (See for the prototype this PR is based on: https://github.com/tillrohrmann/flink/tree/declarative-scheduler) 


## Verifying this change

- The change is adding unit tests.
- Note that integration tests for the declarative scheduler will cover additional functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

Will be handled in a separate PR.