### PR TITLE
[BP-1.12][FLINK-21274][runtime] Change the ClusterEntrypoint.runClusterEntrypoint to wait on the result of clusterEntrypoint.getTerminationFuture().get() and do the System.exit outside of the future callback

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
@@ -36,6 +36,6 @@ public class KubernetesTaskExecutorRunner {
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-        TaskManagerRunner.runTaskManagerSecurely(args);
+        TaskManagerRunner.runTaskManagerProcessSecurely(args);
     }
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -68,6 +68,6 @@ public class MesosTaskExecutorRunner {
             return;
         }
 
-        TaskManagerRunner.runTaskManagerSecurely(configuration);
+        TaskManagerRunner.runTaskManagerProcessSecurely(configuration);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -574,25 +574,22 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        clusterEntrypoint
-                .getTerminationFuture()
-                .whenComplete(
-                        (applicationStatus, throwable) -> {
-                            final int returnCode;
+        int returnCode;
+        Throwable throwable = null;
 
-                            if (throwable != null) {
-                                returnCode = RUNTIME_FAILURE_RETURN_CODE;
-                            } else {
-                                returnCode = applicationStatus.processExitCode();
-                            }
+        try {
+            returnCode = clusterEntrypoint.getTerminationFuture().get().processExitCode();
+        } catch (Throwable e) {
+            throwable = ExceptionUtils.stripExecutionException(e);
+            returnCode = RUNTIME_FAILURE_RETURN_CODE;
+        }
 
-                            LOG.info(
-                                    "Terminating cluster entrypoint process {} with exit code {}.",
-                                    clusterEntrypointName,
-                                    returnCode,
-                                    throwable);
-                            System.exit(returnCode);
-                        });
+        LOG.info(
+                "Terminating cluster entrypoint process {} with exit code {}.",
+                clusterEntrypointName,
+                returnCode,
+                throwable);
+        System.exit(returnCode);
     }
 
     /** Execution mode of the {@link MiniDispatcher}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -80,6 +80,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -92,15 +93,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * constructs the related components (network, I/O manager, memory manager, RPC service, HA service)
  * and starts them.
  */
-public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync {
+public class TaskManagerRunner implements FatalErrorHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(TaskManagerRunner.class);
 
     private static final long FATAL_ERROR_SHUTDOWN_TIMEOUT_MS = 10000L;
 
-    private static final int STARTUP_FAILURE_RETURN_CODE = 1;
-
-    @VisibleForTesting static final int RUNTIME_FAILURE_RETURN_CODE = 2;
+    private static final int SUCCESS_EXIT_CODE = 0;
+    @VisibleForTesting static final int FAILURE_EXIT_CODE = 1;
 
     private final Object lock = new Object();
 
@@ -123,7 +123,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
     private final TaskExecutorService taskExecutorService;
 
-    private final CompletableFuture<Void> terminationFuture;
+    private final CompletableFuture<Result> terminationFuture;
 
     private boolean shutdown;
 
@@ -193,7 +193,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
         this.shutdown = false;
         handleUnexpectedTaskExecutorServiceTermination();
 
-        MemoryLogger.startIfConfigured(LOG, configuration, terminationFuture);
+        MemoryLogger.startIfConfigured(
+                LOG, configuration, terminationFuture.thenAccept(ignored -> {}));
     }
 
     private void handleUnexpectedTaskExecutorServiceTermination() {
@@ -220,8 +221,19 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
         taskExecutorService.start();
     }
 
-    @Override
-    public CompletableFuture<Void> closeAsync() {
+    public void close() throws Exception {
+        try {
+            closeAsync().get();
+        } catch (ExecutionException e) {
+            ExceptionUtils.rethrowException(ExceptionUtils.stripExecutionException(e));
+        }
+    }
+
+    public CompletableFuture<Result> closeAsync() {
+        return closeAsync(Result.SUCCESS);
+    }
+
+    private CompletableFuture<Result> closeAsync(Result terminationResult) {
         synchronized (lock) {
             if (!shutdown) {
                 shutdown = true;
@@ -238,7 +250,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
                             if (throwable != null) {
                                 terminationFuture.completeExceptionally(throwable);
                             } else {
-                                terminationFuture.complete(null);
+                                terminationFuture.complete(terminationResult);
                             }
                         });
             }
@@ -291,7 +303,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
     }
 
     // export the termination future for caller to know it is terminated
-    public CompletableFuture<Void> getTerminationFuture() {
+    public CompletableFuture<Result> getTerminationFuture() {
         return terminationFuture;
     }
 
@@ -314,17 +326,15 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
                 && !ExceptionUtils.isMetaspaceOutOfMemoryError(exception)) {
             terminateJVM();
         } else {
-            closeAsync();
+            closeAsync(Result.FAILURE);
 
             FutureUtils.orTimeout(
                     terminationFuture, FATAL_ERROR_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-
-            terminationFuture.whenComplete((Void ignored, Throwable throwable) -> terminateJVM());
         }
     }
 
     private void terminateJVM() {
-        System.exit(RUNTIME_FAILURE_RETURN_CODE);
+        System.exit(FAILURE_EXIT_CODE);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -345,7 +355,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
             LOG.info("Cannot determine the maximum number of open file descriptors");
         }
 
-        runTaskManagerSecurely(args);
+        runTaskManagerProcessSecurely(args);
     }
 
     public static Configuration loadConfiguration(String[] args) throws FlinkParseException {
@@ -353,41 +363,70 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
                 args, TaskManagerRunner.class.getSimpleName());
     }
 
-    public static void runTaskManager(Configuration configuration, PluginManager pluginManager)
+    public static int runTaskManager(Configuration configuration, PluginManager pluginManager)
             throws Exception {
-        final TaskManagerRunner taskManagerRunner =
-                new TaskManagerRunner(
-                        configuration, pluginManager, TaskManagerRunner::createTaskExecutorService);
+        final TaskManagerRunner taskManagerRunner;
 
-        taskManagerRunner.start();
-    }
-
-    public static void runTaskManagerSecurely(String[] args) {
         try {
-            Configuration configuration = loadConfiguration(args);
-            runTaskManagerSecurely(configuration);
+            taskManagerRunner =
+                    new TaskManagerRunner(
+                            configuration,
+                            pluginManager,
+                            TaskManagerRunner::createTaskExecutorService);
+            taskManagerRunner.start();
+        } catch (Exception exception) {
+            throw new FlinkException("Failed to start the TaskManagerRunner.", exception);
+        }
+
+        try {
+            return taskManagerRunner.getTerminationFuture().get().getExitCode();
         } catch (Throwable t) {
-            final Throwable strippedThrowable =
-                    ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
-            LOG.error("TaskManager initialization failed.", strippedThrowable);
-            System.exit(STARTUP_FAILURE_RETURN_CODE);
+            throw new FlinkException(
+                    "Unexpected failure during runtime of TaskManagerRunner.",
+                    ExceptionUtils.stripExecutionException(t));
         }
     }
 
-    public static void runTaskManagerSecurely(Configuration configuration) throws Exception {
+    public static void runTaskManagerProcessSecurely(String[] args) {
+        Configuration configuration = null;
+
+        try {
+            configuration = loadConfiguration(args);
+        } catch (FlinkParseException fpe) {
+            LOG.error("Could not load the configuration.", fpe);
+            System.exit(FAILURE_EXIT_CODE);
+        }
+
+        runTaskManagerProcessSecurely(checkNotNull(configuration));
+    }
+
+    public static void runTaskManagerProcessSecurely(Configuration configuration) {
         replaceGracefulExitWithHaltIfConfigured(configuration);
         final PluginManager pluginManager =
                 PluginUtils.createPluginManagerFromRootFolder(configuration);
         FileSystem.initialize(configuration, pluginManager);
 
-        SecurityUtils.install(new SecurityConfiguration(configuration));
+        int exitCode;
+        Throwable throwable = null;
 
-        SecurityUtils.getInstalledContext()
-                .runSecured(
-                        () -> {
-                            runTaskManager(configuration, pluginManager);
-                            return null;
-                        });
+        try {
+            SecurityUtils.install(new SecurityConfiguration(configuration));
+
+            exitCode =
+                    SecurityUtils.getInstalledContext()
+                            .runSecured(() -> runTaskManager(configuration, pluginManager));
+        } catch (Throwable t) {
+            throwable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
+            exitCode = FAILURE_EXIT_CODE;
+        }
+
+        if (throwable != null) {
+            LOG.error("Terminating TaskManagerRunner with exit code {}.", exitCode, throwable);
+        } else {
+            LOG.info("Terminating TaskManagerRunner with exit code {}.", exitCode);
+        }
+
+        System.exit(exitCode);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -611,5 +650,20 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
         void start();
 
         CompletableFuture<Void> getTerminationFuture();
+    }
+
+    public enum Result {
+        SUCCESS(SUCCESS_EXIT_CODE),
+        FAILURE(FAILURE_EXIT_CODE);
+
+        private final int exitCode;
+
+        Result(int exitCode) {
+            this.exitCode = exitCode;
+        }
+
+        public int getExitCode() {
+            return exitCode;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -25,13 +25,10 @@ import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -39,10 +36,8 @@ import org.junit.rules.Timeout;
 import javax.annotation.Nonnull;
 
 import java.net.InetAddress;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -54,14 +49,7 @@ public class TaskManagerRunnerTest extends TestLogger {
 
     @Rule public final Timeout timeout = Timeout.seconds(30);
 
-    private SystemExitTrackingSecurityManager systemExitTrackingSecurityManager;
     private TaskManagerRunner taskManagerRunner;
-
-    @Before
-    public void before() {
-        systemExitTrackingSecurityManager = new SystemExitTrackingSecurityManager();
-        System.setSecurityManager(systemExitTrackingSecurityManager);
-    }
 
     @After
     public void after() throws Exception {
@@ -80,8 +68,9 @@ public class TaskManagerRunnerTest extends TestLogger {
 
         taskManagerRunner.onFatalError(new RuntimeException());
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -91,8 +80,9 @@ public class TaskManagerRunnerTest extends TestLogger {
                 TaskManagerOptions.REGISTRATION_TIMEOUT, TimeUtils.parseDuration("10 ms"));
         taskManagerRunner = createTaskManagerRunner(configuration);
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -169,10 +159,11 @@ public class TaskManagerRunnerTest extends TestLogger {
                         createConfiguration(),
                         createTaskExecutorServiceFactory(taskExecutorService));
 
-        terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+        terminationFuture.complete(null);
 
-        Integer statusCode = systemExitTrackingSecurityManager.getSystemExitFuture().get();
-        assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
+        assertThat(
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.FAILURE)));
     }
 
     @Test
@@ -191,11 +182,11 @@ public class TaskManagerRunnerTest extends TestLogger {
 
         taskManagerRunner.closeAsync();
 
-        terminationFuture.completeExceptionally(new FlinkException("Test exception."));
+        terminationFuture.complete(null);
 
         assertThat(
-                systemExitTrackingSecurityManager.getSystemExitFuture(),
-                willNotComplete(Duration.ofMillis(10L)));
+                taskManagerRunner.getTerminationFuture().join(),
+                is(equalTo(TaskManagerRunner.Result.SUCCESS)));
     }
 
     @Nonnull

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -336,7 +336,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
                 TaskManagerRunner.runTaskManager(cfg, pluginManager);
             } catch (Throwable t) {
-                LOG.error("Failed to start TaskManager process", t);
+                LOG.error("Failed to run the TaskManager process", t);
                 System.exit(1);
             }
         }


### PR DESCRIPTION
Backport of #14906 to `release-1.12`.