### PR TITLE
[BP-1.11][FLINK-21274][runtime] Change the ClusterEntrypoint.runClusterEntrypoint to wait on the result of clusterEntrypoint.getTerminationFuture().get() and do the System.exit outside of the future callback

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
@@ -43,6 +43,6 @@ public class KubernetesTaskExecutorRunner {
         Preconditions.checkArgument(
                 resourceID != null, "Pod name variable %s not set", Constants.ENV_FLINK_POD_NAME);
 
-        TaskManagerRunner.runTaskManagerSecurely(args, new ResourceID(resourceID));
+        TaskManagerRunner.runTaskManagerProcessSecurely(args, new ResourceID(resourceID));
     }
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -81,6 +81,6 @@ public class MesosTaskExecutorRunner {
         final ResourceID resourceId = new ResourceID(containerID);
         LOG.info("ResourceID assigned for this container: {}", resourceId);
 
-        TaskManagerRunner.runTaskManagerSecurely(configuration, resourceId);
+        TaskManagerRunner.runTaskManagerProcessSecurely(configuration, resourceId);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -566,25 +566,22 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             System.exit(STARTUP_FAILURE_RETURN_CODE);
         }
 
-        clusterEntrypoint
-                .getTerminationFuture()
-                .whenComplete(
-                        (applicationStatus, throwable) -> {
-                            final int returnCode;
+        int returnCode;
+        Throwable throwable = null;
 
-                            if (throwable != null) {
-                                returnCode = RUNTIME_FAILURE_RETURN_CODE;
-                            } else {
-                                returnCode = applicationStatus.processExitCode();
-                            }
+        try {
+            returnCode = clusterEntrypoint.getTerminationFuture().get().processExitCode();
+        } catch (Throwable e) {
+            throwable = ExceptionUtils.stripExecutionException(e);
+            returnCode = RUNTIME_FAILURE_RETURN_CODE;
+        }
 
-                            LOG.info(
-                                    "Terminating cluster entrypoint process {} with exit code {}.",
-                                    clusterEntrypointName,
-                                    returnCode,
-                                    throwable);
-                            System.exit(returnCode);
-                        });
+        LOG.info(
+                "Terminating cluster entrypoint process {} with exit code {}.",
+                clusterEntrypointName,
+                returnCode,
+                throwable);
+        System.exit(returnCode);
     }
 
     /** Execution mode of the {@link MiniDispatcher}. */

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -337,7 +337,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 
                 TaskManagerRunner.runTaskManager(cfg, ResourceID.generate(), pluginManager);
             } catch (Throwable t) {
-                LOG.error("Failed to start TaskManager process", t);
+                LOG.error("Failed to run the TaskManager process", t);
                 System.exit(1);
             }
         }


### PR DESCRIPTION
Backport of #14906 to `release-1.11`.