### PR TITLE
[FLINK-21342][tests] Add '@Ignore' to *TestInstance classes

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -262,6 +263,7 @@ public class CompositeSerializerTest {
         }
     }
 
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
     private static class CompositeSerializerTestInstance
             extends SerializerTestInstance<List<Object>> {
         @SuppressWarnings("unchecked")

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeComparatorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/AbstractGenericTypeComparatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeComparator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -108,6 +109,7 @@ public abstract class AbstractGenericTypeComparatorTest {
     // test instance
     // ------------------------------------------------------------------------
 
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
     private class ComparatorTestInstance<T> extends ComparatorTestBase<T> {
 
         private final T[] testData;

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.types.Either;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.StringValue;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -226,6 +227,7 @@ public class EitherSerializerTest {
      * that the type of the created instance is the same as the type class parameter. Since we
      * arbitrarily create always create a Left instance we override this test.
      */
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
     private class EitherSerializerTestInstance<T> extends SerializerTestInstance<T> {
 
         public EitherSerializerTestInstance(

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/LegacyRowSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/LegacyRowSerializerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.types.Row;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -144,6 +145,7 @@ public class LegacyRowSerializerTest {
         return row;
     }
 
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
     private class RowSerializerTestInstance extends SerializerTestInstance<Row> {
 
         RowSerializerTestInstance(TypeSerializer<Row> serializer, Row... testData) {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/RowSerializerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.RowUtils;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -222,6 +223,7 @@ public class RowSerializerTest {
         return row;
     }
 
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
     private class RowSerializerTestInstance extends SerializerTestInstance<Row> {
 
         RowSerializerTestInstance(TypeSerializer<Row> serializer, Row... testData) {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/ScalaSpecialTypesSerializerTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.testutils.DeeplyEqualsChecker
 import org.apache.flink.testutils.DeeplyEqualsChecker.CustomEqualityChecker
 import org.junit.Assert._
-import org.junit.{Assert, Test}
+import org.junit.{Assert, Ignore, Test}
 
 import scala.collection.{SortedMap, SortedSet}
 import scala.util.{Failure, Success}
@@ -194,6 +194,7 @@ object ScalaSpecialTypesSerializerTestInstance {
     }
 }
 
+@Ignore("Prevents this class from being considered a test class by JUnit.")
 class ScalaSpecialTypesSerializerTestInstance[T](
     serializer: TypeSerializer[T],
     typeClass: Class[T],

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.typeutils.TraversableSerializer
 import org.junit.Assert._
-import org.junit.{Assert, Test}
+import org.junit.{Assert, Ignore, Test}
 
 import scala.collection.immutable.{BitSet, LinearSeq}
 import scala.collection.mutable
@@ -175,6 +175,7 @@ class Pojo(var name: String, var count: Int) {
   }
 }
 
+@Ignore("Prevents this class from being considered a test class by JUnit.")
 class TraversableSerializerTestInstance[T](
     serializer: TypeSerializer[T],
     typeClass: Class[T],

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TupleSerializerTestInstance.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeutils.{SerializerTestInstance, TypeSerial
 import org.apache.flink.testutils.DeeplyEqualsChecker
 import org.apache.flink.testutils.DeeplyEqualsChecker.CustomEqualityChecker
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Ignore, Test}
 
 
 object TupleSerializerTestInstance {
@@ -55,6 +55,7 @@ object TupleSerializerTestInstance {
     }
 }
 
+@Ignore("Prevents this class from being considered a test class by JUnit.")
 class TupleSerializerTestInstance[T <: Product] (
     serializer: TypeSerializer[T],
     typeClass: Class[T],

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -47,8 +48,6 @@ import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingIT
 @RunWith(Parameterized.class)
 public class LocalRecoveryITCase extends TestLogger {
 
-    private final boolean localRecoveryEnabled = true;
-
     @Rule public TestName testName = new TestName();
 
     @Parameterized.Parameter public StateBackendEnum backendEnum;
@@ -62,23 +61,7 @@ public class LocalRecoveryITCase extends TestLogger {
     public final void executeTest() throws Exception {
         EventTimeWindowCheckpointingITCase.tempFolder.create();
         EventTimeWindowCheckpointingITCase windowChkITCase =
-                new EventTimeWindowCheckpointingITCase() {
-
-                    @Override
-                    protected StateBackendEnum getStateBackend() {
-                        return backendEnum;
-                    }
-
-                    @Override
-                    protected Configuration createClusterConfig() throws IOException {
-                        Configuration config = super.createClusterConfig();
-
-                        config.setBoolean(
-                                CheckpointingOptions.LOCAL_RECOVERY, localRecoveryEnabled);
-
-                        return config;
-                    }
-                };
+                new EventTimeWindowCheckpointingITCaseInstance(backendEnum, true);
 
         executeTest(windowChkITCase);
     }
@@ -106,6 +89,34 @@ public class LocalRecoveryITCase extends TestLogger {
             }
         } finally {
             EventTimeWindowCheckpointingITCase.tempFolder.delete();
+        }
+    }
+
+    @Ignore("Prevents this class from being considered a test class by JUnit.")
+    private static class EventTimeWindowCheckpointingITCaseInstance
+            extends EventTimeWindowCheckpointingITCase {
+
+        private final StateBackendEnum backendEnum;
+        private final boolean localRecoveryEnabled;
+
+        public EventTimeWindowCheckpointingITCaseInstance(
+                StateBackendEnum backendEnum, boolean localRecoveryEnabled) {
+            this.backendEnum = backendEnum;
+            this.localRecoveryEnabled = localRecoveryEnabled;
+        }
+
+        @Override
+        protected StateBackendEnum getStateBackend() {
+            return backendEnum;
+        }
+
+        @Override
+        protected Configuration createClusterConfig() throws IOException {
+            Configuration config = super.createClusterConfig();
+
+            config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, localRecoveryEnabled);
+
+            return config;
         }
     }
 }


### PR DESCRIPTION
Various tests (mostly serializer tests) use a pattern where they have an inner class extending a test base. When the naming conventions are relaxed these are picked up as test classes, but they lack a public constructor.

Explicitly setting `@Ignore` solves the issue.