### PR TITLE
[FLINK-21338][test] Relax ITCase naming constraints 

### DIFF
--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -261,8 +261,11 @@ under the License.
 						</goals>
 						<configuration>
 							<includes>
-								<include>**/*ITCase.*</include>
+								<include>**/*.*</include>
 							</includes>
+							<excludes>
+								<exclude>${test.unit.pattern}</exclude>
+							</excludes>
 							<!-- Disable all tests by default.
                                 Uses a separate property to make it configurable from the command-line. -->
 							<groups>${includeE2E}</groups>

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -44,6 +44,7 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -76,6 +77,7 @@ import static org.junit.Assert.fail;
  * ITCases testing the stop with savepoint functionality. This includes checking both SUSPEND and
  * TERMINATE.
  */
+@Ignore("broken test; see FLINK-21031")
 public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/CheckForbiddenMethodsUsage.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/CheckForbiddenMethodsUsage.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.manual;
 import org.apache.flink.types.parser.FieldParserTest;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.reflections.Reflections;
 import org.reflections.scanners.MemberUsageScanner;
@@ -44,6 +45,7 @@ import static org.junit.Assert.assertEquals;
  * <p>Forbidden calls include: - Byte / String conversions that do not specify an explicit charset
  * because they produce different results in different locales
  */
+@Ignore("broken test; see FLINK-21340")
 public class CheckForbiddenMethodsUsage {
 
     private static class ForbiddenCall {

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@ under the License.
 
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed>${git.commit.id}</test.randomization.seed>
+		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 	</properties>
 
 	<dependencies>
@@ -1607,7 +1608,7 @@ under the License.
 						</goals>
 						<configuration>
 							<includes>
-								<include>**/*Test.*</include>
+								<include>${test.unit.pattern}</include>
 							</includes>
 						</configuration>
 					</execution>
@@ -1620,8 +1621,11 @@ under the License.
 						</goals>
 						<configuration>
 							<includes>
-								<include>**/*ITCase.*</include>
+								<include>**/*.*</include>
 							</includes>
+							<excludes>
+								<exclude>${test.unit.pattern}</exclude>
+							</excludes>
 							<reuseForks>false</reuseForks>
 						</configuration>
 					</execution>


### PR DESCRIPTION
~~Based on #14911 and #14918.~~
Based on #14930.

Relaxes naming constraints for ITCases, such that any test not ending in `*Test.java` is considered an IT case.