### PR TITLE
[FLINK-21363][docs] Fix baseurl in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ From this directory:
 	hugo serve
 	```
 
-The site can be viewed at http://localhost:1313
+The site can be viewed at http://localhost:1313/projects/flink/flink-docs-master/
 
 ## Generate configuration tables
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseURL = '/'
+baseURL = '//ci.apache.org/projects/flink/flink-docs-master'
 languageCode = "en-us"
 title = "Apache Flink"
 enableGitInfo = false

--- a/docs/layouts/partials/docs/inject/head.html
+++ b/docs/layouts/partials/docs/inject/head.html
@@ -19,8 +19,8 @@ under the License.
 <!--
     Misc other content that should run in the header
 -->
-<link rel="stylesheet" type="text/css" href="/css/github.css">
-<link rel="stylesheet" type="text/css" href="/font-awesome/css/font-awesome.min.css">
-<script src="/js/anchor.min.js"></script>
-<script src="/js/flink.js"></script>
+<link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}/css/github.css">
+<link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}/font-awesome/css/font-awesome.min.css">
+<script src="{{.Site.BaseURL}}/js/anchor.min.js"></script>
+<script src="{{.Site.BaseURL}}/js/flink.js"></script>
 

--- a/docs/layouts/partials/docs/inject/menu-before.html
+++ b/docs/layouts/partials/docs/inject/menu-before.html
@@ -20,6 +20,6 @@ under the License.
     Partial that renders at the top of the menu.
 -->
 <a id="logo" href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}">
-    <img width="70%" src="/flink-header-logo.svg">
+    <img width="70%" src="{{.Site.BaseURL}}/flink-header-logo.svg">
 </a>
 <p style="text-align:right">v{{ $.Site.Params.Version }}</p>

--- a/docs/layouts/shortcodes/img.html
+++ b/docs/layouts/shortcodes/img.html
@@ -27,7 +27,7 @@ under the License.
       - width: Image width (optional)
 */}}
 <img 
-  src="{{ .Get "src" }}"
+  src="{{.Site.BaseURL}}{{ .Get "src" }}"
   alt="{{ .Get "alt" }}"
   width="{{ .Get "width" }}"
   style="display:block;margin-left:auto;margin-right:auto"


### PR DESCRIPTION
Adds the proper `baseurl` to our documentation so everything renders properly on the build bot. 