### PR TITLE
[FLINK-21339][tests] Enable and fix ExceptionUtilsITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -57,7 +57,11 @@ public class ExceptionUtilsITCase extends TestLogger {
     public void testIsDirectOutOfMemoryError() throws IOException, InterruptedException {
         String className = DummyDirectAllocatingProgram.class.getName();
         String out = run(className, Collections.emptyList(), DIRECT_MEMORY_SIZE, -1);
-        assertThat(out, is(""));
+        // JAVA_TOOL_OPTIONS is configured on CI which affects the process output
+        assertThat(
+                out,
+                either(is(""))
+                        .or(is("Picked up JAVA_TOOL_OPTIONS: -XX:+HeapDumpOnOutOfMemoryError")));
     }
 
     @Test

--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -39,11 +39,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /** Tests for {@link ExceptionUtils} which require to spawn JVM process and set JVM memory args. */
-public class ExceptionUtilsITCases extends TestLogger {
+public class ExceptionUtilsITCase extends TestLogger {
     private static final int DIRECT_MEMORY_SIZE = 10 * 1024; // 10Kb
     private static final int DIRECT_MEMORY_ALLOCATION_PAGE_SIZE = 1024; // 1Kb
     private static final int DIRECT_MEMORY_PAGE_NUMBER =
@@ -68,7 +69,11 @@ public class ExceptionUtilsITCases extends TestLogger {
         long okMetaspace = Long.parseLong(normalOut);
         // load more classes to cause 'OutOfMemoryError: Metaspace'
         String oomOut = run(className, getDummyClassLoadingProgramArgs(1000), -1, okMetaspace);
-        assertThat(oomOut, is(""));
+        // JAVA_TOOL_OPTIONS is configured on CI which affects the process output
+        assertThat(
+                oomOut,
+                either(is(""))
+                        .or(is("Picked up JAVA_TOOL_OPTIONS: -XX:+HeapDumpOnOutOfMemoryError")));
     }
 
     private static String run(

--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -57,11 +57,7 @@ public class ExceptionUtilsITCase extends TestLogger {
     public void testIsDirectOutOfMemoryError() throws IOException, InterruptedException {
         String className = DummyDirectAllocatingProgram.class.getName();
         String out = run(className, Collections.emptyList(), DIRECT_MEMORY_SIZE, -1);
-        // JAVA_TOOL_OPTIONS is configured on CI which affects the process output
-        assertThat(
-                out,
-                either(is(""))
-                        .or(is("Picked up JAVA_TOOL_OPTIONS: -XX:+HeapDumpOnOutOfMemoryError")));
+        assertThat(out, is(""));
     }
 
     @Test
@@ -73,11 +69,7 @@ public class ExceptionUtilsITCase extends TestLogger {
         long okMetaspace = Long.parseLong(normalOut);
         // load more classes to cause 'OutOfMemoryError: Metaspace'
         String oomOut = run(className, getDummyClassLoadingProgramArgs(1000), -1, okMetaspace);
-        // JAVA_TOOL_OPTIONS is configured on CI which affects the process output
-        assertThat(
-                oomOut,
-                either(is(""))
-                        .or(is("Picked up JAVA_TOOL_OPTIONS: -XX:+HeapDumpOnOutOfMemoryError")));
+        assertThat(oomOut, is(""));
     }
 
     private static String run(
@@ -98,8 +90,16 @@ public class ExceptionUtilsITCase extends TestLogger {
         }
         TestProcess p = taskManagerProcessBuilder.start();
         p.getProcess().waitFor();
-        assertThat(p.getErrorOutput().toString().trim(), is(""));
+        assertErrorOutputEmpty(p.getErrorOutput().toString());
         return p.getProcessOutput().toString().trim();
+    }
+
+    private static void assertErrorOutputEmpty(String output) {
+        // JAVA_TOOL_OPTIONS is configured on CI which affects the process output
+        assertThat(
+                output.trim(),
+                either(is(""))
+                        .or(is("Picked up JAVA_TOOL_OPTIONS: -XX:+HeapDumpOnOutOfMemoryError")));
     }
 
     private static Collection<String> getDummyClassLoadingProgramArgs(int numberOfLoadedClasses) {


### PR DESCRIPTION
Renames the test so that it is picked up by surefire, and allows the test to pass on CI by accounting for the possibility of JAVA_TOOL_OPTIONS being set.