### PR TITLE
[FLINK-21364][connector] piggyback finishedSplitIds in RequestSplitEv…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/RequestSplitEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/event/RequestSplitEvent.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /**
@@ -35,15 +36,23 @@ public final class RequestSplitEvent implements OperatorEvent {
     private static final long serialVersionUID = 1L;
 
     @Nullable private final String hostName;
+    @Nullable private final Collection<String> finishedSplitIds;
 
     /** Creates a new {@code RequestSplitEvent} with no host information. */
     public RequestSplitEvent() {
-        this(null);
+        this(null, null);
     }
 
     /** Creates a new {@code RequestSplitEvent} with a hostname. */
     public RequestSplitEvent(@Nullable String hostName) {
+        this(hostName, null);
+    }
+
+    /** Creates a new {@code RequestSplitEvent} with a hostname and finishedSplitIds. */
+    public RequestSplitEvent(
+            @Nullable String hostName, @Nullable Collection<String> finishedSplitIds) {
         this.hostName = hostName;
+        this.finishedSplitIds = finishedSplitIds;
     }
 
     // ------------------------------------------------------------------------
@@ -51,6 +60,11 @@ public final class RequestSplitEvent implements OperatorEvent {
     @Nullable
     public String hostName() {
         return hostName;
+    }
+
+    @Nullable
+    public Collection<String> finishedSplitIds() {
+        return finishedSplitIds;
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
…ent for FLIP-27 source

## What is the purpose of the change

For some split assignment strategy, the enumerator/assigner needs to track the completed splits to advance watermark for event time alignment or rough ordering. Right now, `RequestSplitEvent` for FLIP-27 source doesn't support pass-along of the `finishedSplitIds` info and hence we have to create our own custom source event type for Iceberg source.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
