### PR TITLE
[FLINK-21339][tests] Enable and fix ExceptionUtilsITCase

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
@@ -44,6 +44,8 @@ public class TestProcessBuilder {
 
     private MemorySize jvmMemory = MemorySize.parse("80mb");
 
+    private boolean withCleanEnvironment = false;
+
     public TestProcessBuilder(String mainClass) throws IOException {
         File tempLogFile =
                 File.createTempFile(getClass().getSimpleName() + "-", "-log4j.properties");
@@ -70,7 +72,11 @@ public class TestProcessBuilder {
 
         StringWriter processOutput = new StringWriter();
         StringWriter errorOutput = new StringWriter();
-        Process process = new ProcessBuilder(commands).start();
+        final ProcessBuilder processBuilder = new ProcessBuilder(commands);
+        if (withCleanEnvironment) {
+            processBuilder.environment().clear();
+        }
+        Process process = processBuilder.start();
         new PipeForwarder(process.getInputStream(), processOutput);
         new PipeForwarder(process.getErrorStream(), errorOutput);
 
@@ -97,6 +103,11 @@ public class TestProcessBuilder {
             addMainClassArg("--" + keyValue.getKey());
             addMainClassArg(keyValue.getValue());
         }
+        return this;
+    }
+
+    public TestProcessBuilder withCleanEnvironment() {
+        withCleanEnvironment = true;
         return this;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -43,7 +43,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 /** Tests for {@link ExceptionUtils} which require to spawn JVM process and set JVM memory args. */
-public class ExceptionUtilsITCases extends TestLogger {
+public class ExceptionUtilsITCase extends TestLogger {
     private static final int DIRECT_MEMORY_SIZE = 10 * 1024; // 10Kb
     private static final int DIRECT_MEMORY_ALLOCATION_PAGE_SIZE = 1024; // 1Kb
     private static final int DIRECT_MEMORY_PAGE_NUMBER =
@@ -87,6 +87,8 @@ public class ExceptionUtilsITCases extends TestLogger {
         for (String arg : args) {
             taskManagerProcessBuilder.addMainClassArg(arg);
         }
+        // JAVA_TOOL_OPTIONS is configured on CI which would affect the process output
+        taskManagerProcessBuilder.withCleanEnvironment();
         TestProcess p = taskManagerProcessBuilder.start();
         p.getProcess().waitFor();
         assertThat(p.getErrorOutput().toString().trim(), is(""));


### PR DESCRIPTION
- the test was not run due to a trailing 's'
- the test was failing on CI because we set JAVA_TOOL_OPTIONS which affects the output of java processes; we now start the processes with a cleaned environment to prevent this from happening