### PR TITLE
 [FLINK-21369][docs] Document Checkpoint Storage 

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/plugins.md
+++ b/docs/content.zh/docs/deployment/filesystems/plugins.md
@@ -73,7 +73,7 @@ possible across Flink core, plugins, and user code.
 
 ## File Systems
 
-All [file systems]({%link deployment/filesystems/index.md %}) **except MapR** are pluggable. That means they can and should
+All [file systems]({{< ref "docs/deployment/filesystems/overview" >}}) **except MapR** are pluggable. That means they can and should
 be used as plugins. To use a pluggable file system, copy the corresponding JAR file from the `opt`
 directory to a directory under `plugins` directory of your Flink distribution before starting Flink,
 e.g.

--- a/docs/content/docs/concepts/glossary.md
+++ b/docs/content/docs/concepts/glossary.md
@@ -25,6 +25,10 @@ under the License.
 
 # Glossary
 
+#### Checkpoint Storage
+
+The location where the [State Backend](#state-backend) will store its snapshot during a checkpoint (Java Heap of [JobManager](#flink-jobmanager) or Filesystem).
+
 #### Flink Application Cluster
 
 A Flink Application Cluster is a dedicated [Flink Cluster](#flink-cluster) that
@@ -160,8 +164,7 @@ Formerly, a Flink Session Cluster was also known as a Flink Cluster in *session 
 
 For stream processing programs, the State Backend of a [Flink Job](#flink-job) determines how its
 [state](#managed-state) is stored on each TaskManager (Java Heap of TaskManager or (embedded)
-RocksDB) as well as where it is written upon a checkpoint (Java Heap of
-[JobManager](#flink-jobmanager) or Filesystem).
+RocksDB).
 
 #### Sub-Task
 

--- a/docs/content/docs/deployment/filesystems/azure.md
+++ b/docs/content/docs/deployment/filesystems/azure.md
@@ -30,8 +30,6 @@ under the License.
 [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/) is a Microsoft-managed service providing cloud storage for a variety of use cases.
 You can use Azure Blob Storage with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{< ref "docs/ops/state/state_backends" >}})  
 
-
-
 You can use Azure Blob Storage objects like regular files by specifying paths in the following format:
 
 ```plain
@@ -50,8 +48,8 @@ env.readTextFile("wasb://<your-container>@$<your-azure-account>.blob.core.window
 // Write to Azure Blob storage
 stream.writeAsText("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>")
 
-// Use Azure Blob Storage as FsStatebackend
-env.setStateBackend(new FsStateBackend("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>"));
+// Use Azure Blob Storage as checkpoint storage
+env.getCheckpointConfig().setCheckpointStorage("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>");
 ```
 
 ### Shaded Hadoop Azure Blob Storage file system

--- a/docs/content/docs/deployment/filesystems/oss.md
+++ b/docs/content/docs/deployment/filesystems/oss.md
@@ -49,8 +49,8 @@ env.readTextFile("oss://<your-bucket>/<object-name>");
 // Write to OSS bucket
 stream.writeAsText("oss://<your-bucket>/<object-name>")
 
-// Use OSS as FsStatebackend
-env.setStateBackend(new FsStateBackend("oss://<your-bucket>/<object-name>"));
+// Use OSS as checkpoint storage
+env.getCheckpointConfig().setCheckpointStorage("oss://<your-bucket>/<object-name>");
 ```
 
 ### Shaded Hadoop OSS file system

--- a/docs/content/docs/deployment/filesystems/plugins.md
+++ b/docs/content/docs/deployment/filesystems/plugins.md
@@ -73,7 +73,7 @@ possible across Flink core, plugins, and user code.
 
 ## File Systems
 
-All [file systems]({%link deployment/filesystems/index.md %}) **except MapR** are pluggable. That means they can and should
+All [file systems]({{< ref "docs/deployment/filesystems/overview" >}}) **except MapR** are pluggable. That means they can and should
 be used as plugins. To use a pluggable file system, copy the corresponding JAR file from the `opt`
 directory to a directory under `plugins` directory of your Flink distribution before starting Flink,
 e.g.

--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -29,8 +29,6 @@ under the License.
 
 [Amazon Simple Storage Service](http://aws.amazon.com/s3/) (Amazon S3) provides cloud object storage for a variety of use cases. You can use S3 with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{< ref "docs/ops/state/state_backends" >}}).
 
-
-
 You can use S3 objects like regular files by specifying paths in the following format:
 
 ```plain
@@ -46,11 +44,11 @@ env.readTextFile("s3://<bucket>/<endpoint>");
 // Write to S3 bucket
 stream.writeAsText("s3://<bucket>/<endpoint>");
 
-// Use S3 as FsStatebackend
-env.setStateBackend(new FsStateBackend("s3://<your-bucket>/<endpoint>"));
+// Use S3 as checkpoint storage
+env.getCheckpointConfig().setCheckpointStorage("s3://<your-bucket>/<endpoint>");
 ```
 
-Note that these examples are *not* exhaustive and you can use S3 in other places as well, including your [high availability setup]({{< ref "docs/deployment/ha/overview" >}}) or the [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend); everywhere that Flink expects a FileSystem URI.
+Note that these examples are *not* exhaustive and you can use S3 in other places as well, including your [high availability setup]({{< ref "docs/deployment/ha/overview" >}}) or the [EmbeddedRocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend); everywhere that Flink expects a FileSystem URI.
 
 For most use cases, you may use one of our `flink-s3-fs-hadoop` and `flink-s3-fs-presto` S3 filesystem plugins which are self-contained and easy to set up.
 For some cases, however, e.g., for using S3 as YARN's resource storage dir, it may be necessary to set up a specific Hadoop S3 filesystem implementation.

--- a/docs/content/docs/deployment/memory/mem_tuning.md
+++ b/docs/content/docs/deployment/memory/mem_tuning.md
@@ -63,15 +63,14 @@ This is only relevant for TaskManagers.
 When deploying a Flink streaming application, the type of [state backend]({{< ref "docs/ops/state/state_backends" >}}) used
 will dictate the optimal memory configurations of your cluster.
 
-### Heap state backend
+### HashMap state backend
 
-When running a stateless job or using a heap state backend ([MemoryStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-memorystatebackend)
-or [FsStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-fsstatebackend)), set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
+When running a stateless job or using the [HashMapStateBackend]({{< ref "docs/ops/state/state_backends#the-hashmapstatebackend" >}})), set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
 This will ensure that the maximum amount of heap memory is allocated for user code on the JVM.
 
 ### RocksDB state backend
 
-The [RocksDBStateBackend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend) uses native memory. By default,
+The [EmbeddedRocksDBStateBackend]({{< ref "docs/ops/state/state_backends#the-embeddedrocksdbstatebackend" >}}) uses native memory. By default,
 RocksDB is set up to limit native memory allocation to the size of the [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory).
 Therefore, it is important to reserve enough *managed memory* for your state. If you disable the default RocksDB memory control,
 TaskManagers can be killed in containerized deployments if RocksDB allocates memory above the limit of the requested container size

--- a/docs/content/docs/dev/datastream/fault-tolerance/custom_serialization.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/custom_serialization.md
@@ -151,7 +151,7 @@ To wrap up, this section concludes how Flink, or more specifically the state bac
 abstractions. The interaction is slightly different depending on the state backend, but this is orthogonal
 to the implementation of state serializers and their serializer snapshots.
 
-#### Off-heap state backends (e.g. `RocksDBStateBackend`)
+#### Off-heap state backends (e.g. `EmbeddedRocksDBStateBackend`)
 
  1. **Register new state with a state serializer that has schema _A_**
   - the registered `TypeSerializer` for the state is used to read / write state on every state access.
@@ -172,7 +172,7 @@ to the implementation of state serializers and their serializer snapshots.
    of the accessed state is migrated all-together before processing continues.
   - If the resolution signals incompatibility, then the state access fails with an exception.
  
-#### Heap state backends (e.g. `MemoryStateBackend`, `FsStateBackend`)
+#### Heap state backends (e.g. `HashMapStateBackend`)
 
  1. **Register new state with a state serializer that has schema _A_**
   - the registered `TypeSerializer` is maintained by the state backend.
@@ -215,7 +215,7 @@ as your serializer's snapshot class:
  - `TypeSerializerSchemaCompatibility.incompatible()`, if the new serializer class is different then the previous one.
  
 Below is an example of how the `SimpleTypeSerializerSnapshot` is used, using Flink's `IntSerializer` as an example:
-<div data-lang="java" markdown="1">
+
 ```java
 public class IntSerializerSnapshot extends SimpleTypeSerializerSnapshot<Integer> {
     public IntSerializerSnapshot() {
@@ -223,7 +223,6 @@ public class IntSerializerSnapshot extends SimpleTypeSerializerSnapshot<Integer>
     }
 }
 ```
-</div>
 
 The `IntSerializer` has no state or configurations. Serialization format is solely defined by the serializer
 class itself, and can only be read by another `IntSerializer`. Therefore, it suits the use case of the
@@ -252,7 +251,7 @@ composite serializers. It deals with reading and writing the nested serializer s
 the final compatibility result taking into account the compatibility of all nested serializers.
 
 Below is an example of how the `CompositeTypeSerializerSnapshot` is used, using Flink's `MapSerializer` as an example:
-<div data-lang="java" markdown="1">
+
 ```java
 public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot<Map<K, V>, MapSerializer> {
 
@@ -284,7 +283,7 @@ public class MapSerializerSnapshot<K, V> extends CompositeTypeSerializerSnapshot
     }
 }
 ```
-</div>
+
 
 When implementing a new serializer snapshot as a subclass of `CompositeTypeSerializerSnapshot`,
 the following three methods must be implemented:
@@ -313,7 +312,7 @@ has outer snapshot information, then all three methods must be implemented.
 Below is an example of how the `CompositeTypeSerializerSnapshot` is used for composite serializer snapshots
 that do have outer snapshot information, using Flink's `GenericArraySerializer` as an example:
 
-<div data-lang="java" markdown="1">
+
 ```java
 public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerializerSnapshot<C[], GenericArraySerializer> {
 
@@ -364,7 +363,7 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
     }
 }
 ```
-</div>
+
 
 There are two important things to notice in the above code snippet. First of all, since this
 `CompositeTypeSerializerSnapshot` implementation has outer snapshot information that is written as part of the snapshot,

--- a/docs/content/docs/dev/datastream/fault-tolerance/custom_serialization.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/custom_serialization.md
@@ -37,7 +37,7 @@ If you're simply using Flink's own serializers, this page is irrelevant and can 
 
 When registering a managed operator or keyed state, a `StateDescriptor` is required
 to specify the state's name, as well as information about the type of the state. The type information is used by Flink's
-[type serialization framework](../../types_serialization.html) to create appropriate serializers for the state.
+[type serialization framework]({{< ref "docs/dev/serialization/types_serialization" >}}) to create appropriate serializers for the state.
 
 It is also possible to completely bypass this and let Flink use your own custom serializer to serialize managed states,
 simply by directly instantiating the `StateDescriptor` with your own `TypeSerializer` implementation:

--- a/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/queryable_state.md
@@ -43,10 +43,10 @@ useful for debugging purposes.
   When querying a state object, that object is accessed from a concurrent 
   thread without any synchronization or copying. This is a design choice, as any of the above would lead
   to increased job latency, which we wanted to avoid. Since any state backend using Java heap space, 
-  <i>e.g.</i> <code>MemoryStateBackend</code> or <code>FsStateBackend</code>, does not work 
+  <i>e.g.</i> <code>HashMapStateBackend</code>, does not work 
   with copies when retrieving values but instead directly references the stored values, read-modify-write 
   patterns are unsafe and may cause the queryable state server to fail due to concurrent modifications.
-  The <code>RocksDBStateBackend</code> is safe from these issues.
+  The <code>EmbeddedRocksDBStateBackend</code> is safe from these issues.
 {{< /hint >}}
 
 ## Architecture

--- a/docs/content/docs/dev/datastream/fault-tolerance/schema_evolution.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/schema_evolution.md
@@ -105,15 +105,22 @@ Flink fully supports evolving schema of Avro type state, as long as the schema c
 One limitation is that Avro generated classes used as the state type cannot be relocated or have different
 namespaces when the job is restored.
 
-{{< hint warning >}}
-Schema evolution of keys is not supported.
-{{< /hint >}}
+## Schema Migration Limiations
 
-Example: RocksDB state backend relies on binary objects identity, rather than `hashCode` method implementation. Any changes to the keys object structure could lead to non deterministic behaviour.  
+Flink's schema migration has some limitations that are required to ensure correctness. For users that need to work
+around these limitations, and understand them to be safe in their specific use-case, consider using
+a [custom serializer]({{< ref "docs/dev/datastream/fault-tolerance/custom_serialization" >}}) or the
+[state processor api]({{< ref "docs/libs/state_processor_api" >}}).
 
-{{< hint warning >}}
-**Kryo** cannot be used for schema evolution.  
-{{< /hint >}}
+### Schema evolution of keys is not supported.
+
+The structure of a key cannot be migrated as this may lead to non-deterministic behavior. 
+For example, if a POJO is used as a key and one field is dropped then there may suddenly be 
+multiple separate keys that are now identical. Flink has no way to merge the corresponding values. 
+
+Additionally, the RocksDB state backend relies on binary object identity, rather than the `hashCode` method. Any change to the keys' object structure can lead to non-deterministic behavior.  
+
+### **Kryo** cannot be used for schema evolution.  
 
 When Kryo is used, there is no possibility for the framework to verify if any incompatible changes have been made.
 

--- a/docs/content/docs/ops/state/large_state_tuning.md
+++ b/docs/content/docs/ops/state/large_state_tuning.md
@@ -292,10 +292,10 @@ also cover operator state and timers.*
 
 The following state backends can support task-local recovery.
 
-- FsStateBackend: task-local recovery is supported for keyed state. The implementation will duplicate the state to a local file. This can introduce additional write costs
+- **HashMapStateBackend**: task-local recovery is supported for keyed state. The implementation will duplicate the state to a local file. This can introduce additional write costs
 and occupy local disk space. In the future, we might also offer an implementation that keeps task-local state in memory.
 
-- RocksDBStateBackend: task-local recovery is supported for keyed state. For *full checkpoints*, state is duplicated to a local file. This can introduce additional write costs
+- **EmbeddedRocksDBStateBackend**: task-local recovery is supported for keyed state. For *full checkpoints*, state is duplicated to a local file. This can introduce additional write costs
 and occupy local disk space. For *incremental snapshots*, the local state is based on RocksDB's native checkpointing mechanism. This mechanism is also used as the first step
 to create the primary copy, which means that in this case no additional cost is introduced for creating the secondary copy. We simply keep the native checkpoint directory around
 instead of deleting it after uploading to the distributed store. This local copy can share active files with the working directory of RocksDB (via hard links), so for active

--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -128,7 +128,7 @@ because the injected path entropy spreads the files over many directories. Lacki
 
 Unlike savepoints, checkpoints cannot generally be moved to a different location, because checkpoints may include some absolute path references.
 
-If you use the `MemoryStateBackend`, metadata *and* savepoint state will be stored in the `_metadata` file, so don't be confused by the absence of additional data files.
+If you use `JobManagerCheckpointStorage`, metadata *and* savepoint state will be stored in the `_metadata` file, so don't be confused by the absence of additional data files.
 
 {{< hint warning  >}}
 It is discouraged to move or delete the last savepoint of a running job, because this might interfere with failure-recovery. Savepoints have side-effects on exactly-once sinks, therefore 
@@ -187,18 +187,32 @@ Note that it is possible to also manually delete a savepoint via regular file sy
 
 ### Configuration
 
-You can configure a default savepoint target directory via the `state.savepoints.dir` key. When triggering savepoints, this directory will be used to store the savepoint. You can overwrite the default by specifying a custom target directory with the trigger commands (see the [`:targetDirectory` argument](#trigger-a-savepoint)).
+You can configure a default savepoint target directory via the `state.savepoints.dir` key or `StreamExecutionEnvironment`. When triggering savepoints, this directory will be used to store the savepoint. You can overwrite the default by specifying a custom target directory with the trigger commands (see the [`:targetDirectory` argument](#trigger-a-savepoint)).
 
+{{< tabs "config" >}}
+{{< tab "flink-conf.yaml" >}}
 ```yaml
 # Default savepoint target directory
 state.savepoints.dir: hdfs:///flink/savepoints
 ```
+{{< /tab >}}
+{{< tab "Java" >}}
+```java
+env.setDefaultSavepointDir("hdfs:///flink/savepoints");
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+env.setDefaultSavepointDir("hdfs:///flink/savepoints")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 If you neither configure a default nor specify a custom target directory, triggering the savepoint will fail.
 
-<div class="alert alert-warning">
-<strong>Attention:</strong> The target directory has to be a location accessible by both the JobManager(s) and TaskManager(s) e.g. a location on a distributed file-system.
-</div>
+{{< hint warning >}}
+The target directory has to be a location accessible by both the JobManager(s) and TaskManager(s) e.g. a location on a distributed file-system.
+{{< /hint >}}
 
 ## F.A.Q
 

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -39,59 +39,27 @@ When checkpointing is activated, such state is persisted upon checkpoints to gua
 How the state is represented internally, and how and where it is persisted upon checkpoints depends on the
 chosen **State Backend**.
 
-# Available State Backends
+## Available State Backends
 
 Out of the box, Flink bundles these state backends:
 
- - *MemoryStateBackend*
- - *FsStateBackend*
- - *RocksDBStateBackend*
+ - *HashMapStateBackend*
+ - *EmbeddedRocksDBStateBackend*
 
-If nothing else is configured, the system will use the MemoryStateBackend.
+If nothing else is configured, the system will use the HashMapStateBackend.
 
+### The HashMapStateBackend
 
-### The MemoryStateBackend
-
-The *MemoryStateBackend* holds data internally as objects on the Java heap. Key/value state and window operators hold hash tables
+The *HashMapStateBackend* holds data internally as objects on the Java heap. Key/value state and window operators hold hash tables
 that store the values, triggers, etc.
 
-Upon checkpoints, this state backend will snapshot the state and send it as part of the checkpoint acknowledgement messages to the
-JobManager, which stores it on its heap as well.
-
-The MemoryStateBackend can be configured to use asynchronous snapshots. While we strongly encourage the use of asynchronous snapshots to avoid blocking pipelines, please note that this is currently enabled 
-by default. To disable this feature, users can instantiate a `MemoryStateBackend` with the corresponding boolean flag in the constructor set to `false`(this should only used for debug), e.g.:
+The HashMapStateBackend uses *asynchronous snapshots by default* to avoid blocking the processing pipeline while writing state checkpoints. To disable this feature, users can instantiate a HashMapStateBackend with the corresponding boolean flag in the constructor set to `false`, e.g.:
 
 ```java
-new MemoryStateBackend(MAX_MEM_STATE_SIZE, false);
+new HashMapStateBackend(false);
 ```
 
-Limitations of the MemoryStateBackend:
-
-  - The size of each individual state is by default limited to 5 MB. This value can be increased in the constructor of the MemoryStateBackend.
-  - Irrespective of the configured maximal state size, the state cannot be larger than the akka frame size (see [Configuration]({{< ref "docs/deployment/config" >}})).
-  - The aggregate state must fit into the JobManager memory.
-
-The MemoryStateBackend is encouraged for:
-
-  - Local development and debugging
-  - Jobs that do hold little state, such as jobs that consist only of record-at-a-time functions (Map, FlatMap, Filter, ...). The Kafka Consumer requires very little state.
-
-It is also recommended to set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
-This will ensure that the maximum amount of memory is allocated for user code on the JVM.
-
-### The FsStateBackend
-
-The *FsStateBackend* is configured with a file system URL (type, address, path), such as "hdfs://namenode:40010/flink/checkpoints" or "file:///data/flink/checkpoints".
-
-The FsStateBackend holds in-flight data in the TaskManager's memory. Upon checkpointing, it writes state snapshots into files in the configured file system and directory. Minimal metadata is stored in the JobManager's memory (or, in high-availability mode, in the metadata checkpoint).
-
-The FsStateBackend uses *asynchronous snapshots by default* to avoid blocking the processing pipeline while writing state checkpoints. To disable this feature, users can instantiate a `FsStateBackend` with the corresponding boolean flag in the constructor set to `false`, e.g.:
-
-```java
-new FsStateBackend(path, false);
-```
-
-The FsStateBackend is encouraged for:
+The HashMapStateBackend is encouraged for:
 
   - Jobs with large state, long windows, large key/value states.
   - All high-availability setups.
@@ -99,36 +67,32 @@ The FsStateBackend is encouraged for:
 It is also recommended to set [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) to zero.
 This will ensure that the maximum amount of memory is allocated for user code on the JVM.
 
-### The RocksDBStateBackend
+### The EmbeddedRocksDBStateBackend
 
-The *RocksDBStateBackend* is configured with a file system URL (type, address, path), such as "hdfs://namenode:40010/flink/checkpoints" or "file:///data/flink/checkpoints".
+The EmbeddedRocksDBStateBackend holds in-flight data in a [RocksDB](http://rocksdb.org) database
+that is (per default) stored in the TaskManager local data directories.
 
-The RocksDBStateBackend holds in-flight data in a [RocksDB](http://rocksdb.org) database
-that is (per default) stored in the TaskManager data directories. Upon checkpointing, the whole
-RocksDB database will be checkpointed into the configured file system and directory. Minimal
-metadata is stored in the JobManager's memory (or, in high-availability mode, in the metadata checkpoint).
+The EmbeddedRocksDBStateBackend always performs asynchronous snapshots.
 
-The RocksDBStateBackend always performs asynchronous snapshots.
-
-Limitations of the RocksDBStateBackend:
+Limitations of the EmbeddedRocksDBStateBackend:
 
   - As RocksDB's JNI bridge API is based on byte[], the maximum supported size per key and per value is 2^31 bytes each. 
-  IMPORTANT: states that use merge operations in RocksDB (e.g. ListState) can silently accumulate value sizes > 2^31 bytes and will then fail on their next retrieval. This is currently a limitation of RocksDB JNI.
+  States that use merge operations in RocksDB (e.g. ListState) can silently accumulate value sizes > 2^31 bytes and will then fail on their next retrieval. This is currently a limitation of RocksDB JNI.
 
-The RocksDBStateBackend is encouraged for:
+The EmbeddedRocksDBStateBackend is encouraged for:
 
   - Jobs with very large state, long windows, large key/value states.
   - All high-availability setups.
 
 Note that the amount of state that you can keep is only limited by the amount of disk space available.
-This allows keeping very large state, compared to the FsStateBackend that keeps state in memory.
+This allows keeping very large state, compared to the HashMapStateBackend that keeps state in memory.
 This also means, however, that the maximum throughput that can be achieved will be lower with
 this state backend. All reads/writes from/to this backend have to go through de-/serialization to retrieve/store the state objects, which is also more expensive than always working with the
 on-heap representation as the heap-based backends are doing.
 
-Check also recommendations about the [task executor memory configuration]({{< ref "docs/deployment/memory/mem_tuning" >}}#rocksdb-state-backend) for the RocksDBStateBackend.
+Check also recommendations about the [task executor memory configuration]({{< ref "docs/deployment/memory/mem_tuning" >}}#rocksdb-state-backend) for the EmbeddedRocksDBStateBackend.
 
-RocksDBStateBackend is currently the only backend that offers incremental checkpoints (see [here]({{< ref "docs/ops/state/large_state_tuning" >}})). 
+EmbeddedRocksDBStateBackend is currently the only backend that offers incremental checkpoints (see [here]({{< ref "docs/ops/state/large_state_tuning" >}})). 
 
 Certain RocksDB native metrics are available but disabled by default, you can find full documentation [here]({{< ref "docs/deployment/config" >}}#rocksdb-native-metrics)
 
@@ -136,9 +100,8 @@ The total memory amount of RocksDB instance(s) per slot can also be bounded, ple
 
 # Choose The Right State Backend
 
-In general, we recommend avoiding `MemoryStateBackend` in production because it stores its snapshots inside the JobManager as opposed to persistent disk.
-When deciding between `FsStateBackend` and `RocksDB`, it is a choice between performance and scalability.
-`FsStateBackend` is very fast as each state access and update operates on objects on the Java heap; however, state size is limited by available memory within the cluster.
+When deciding between `HashMapStateBackend` and `RocksDB`, it is a choice between performance and scalability.
+`HashMapStateBackend` is very fast as each state access and update operates on objects on the Java heap; however, state size is limited by available memory within the cluster.
 On the other hand, `RocksDB` can scale based on available disk space and is the only state backend to support incremental snapshots.
 However, each state access and update requires (de-)serialization and potentially reading from disk which leads to average performance that is an order of magnitude slower than the memory state backends.
 
@@ -147,6 +110,7 @@ In Flink 1.13 we unified the binary format of Flink's savepoints. That means you
 All the state backends produce a common format only starting from version 1.13. Therefore, if you want to switch the state backend you should first upgrade your Flink version then
 take a savepoint with the new version, and only after that you can restore it with a different state backend.
 {{< /hint >}}
+
 # Configuring a State Backend
 
 The default state backend, if you specify nothing, is the jobmanager. If you wish to establish a different default for all jobs on your cluster, you can do so by defining a new default state backend in **flink-conf.yaml**. The default state backend can be overridden on a per-job basis, as shown below.
@@ -159,18 +123,18 @@ The per-job state backend is set on the `StreamExecutionEnvironment` of the job,
 {{< tab "Java" >}}
 ```java
 StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-env.setStateBackend(new FsStateBackend("hdfs://namenode:40010/flink/checkpoints"));
+env.setStateBackend(new HashMapStateBackend());
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
 val env = StreamExecutionEnvironment.getExecutionEnvironment()
-env.setStateBackend(new FsStateBackend("hdfs://namenode:40010/flink/checkpoints"))
+env.setStateBackend(new HashMapStateBackend())
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
-If you want to use the `RocksDBStateBackend` in your IDE or configure it programmatically in your Flink job, you will have to add the following dependency to your Flink project.
+If you want to use the `EmbeddedRocksDBStateBackend` in your IDE or configure it programmatically in your Flink job, you will have to add the following dependency to your Flink project.
 
 ```xml
 <dependency>
@@ -181,18 +145,18 @@ If you want to use the `RocksDBStateBackend` in your IDE or configure it program
 </dependency>
 ```
 
-<div class="alert alert-info" markdown="span">
-  <strong>Note:</strong> Since RocksDB is part of the default Flink distribution, you do not need this dependency if you are not using any RocksDB code in your job and configure the state backend via `state.backend` and further [checkpointing]({{< ref "docs/deployment/config" >}}#checkpointing) and [RocksDB-specific]({{< ref "docs/deployment/config" >}}#rocksdb-state-backend) parameters in your `flink-conf.yaml`.
-</div>
+{{< hint info >}}
+Since RocksDB is part of the default Flink distribution, you do not need this dependency if you are not using any RocksDB code in your job and configure the state backend via `state.backend` and further [checkpointing]({{< ref "docs/deployment/config" >}}#checkpointing) and [RocksDB-specific]({{< ref "docs/deployment/config" >}}#rocksdb-state-backend) parameters in your `flink-conf.yaml`.
+{{< /hint >}}
 
 
 ### Setting Default State Backend
 
 A default state backend can be configured in the `flink-conf.yaml`, using the configuration key `state.backend`.
 
-Possible values for the config entry are *jobmanager* (MemoryStateBackend), *filesystem* (FsStateBackend), *rocksdb* (RocksDBStateBackend), or the fully qualified class
+Possible values for the config entry are *hashmap* (HashMapStateBackend), *rocksdb* (EmbeddedRocksDBStateBackend), or the fully qualified class
 name of the class that implements the state backend factory [StateBackendFactory](https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendFactory.java),
-such as `org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory` for RocksDBStateBackend.
+such as `org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendFactory` for EmbeddedRocksDBStateBackend.
 
 The `state.checkpoints.dir` option defines the directory to which all backends write checkpoint data and meta data files.
 You can find more details about the checkpoint directory structure [here]({{< ref "docs/ops/state/checkpoints" >}}#directory-structure).
@@ -201,12 +165,11 @@ A sample section in the configuration file could look as follows:
 
 ```yaml
 # The backend that will be used to store operator state checkpoints
-state.backend: filesystem
+state.backend: hashmap
 
 # Directory for storing checkpoints
 state.checkpoints.dir: hdfs://namenode:40010/flink/checkpoints
 ```
-
 
 # RocksDB State Backend Details
 
@@ -223,7 +186,7 @@ Recovery time of incremental checkpoints may be longer or shorter compared to fu
 
 While we encourage the use of incremental checkpoints for large state, you need to enable this feature manually:
   - Setting a default in your `flink-conf.yaml`: `state.backend.incremental: true` will enable incremental checkpoints, unless the application overrides this setting in the code.
-  - You can alternatively configure this directly in the code (overrides the config default): `RocksDBStateBackend backend = new RocksDBStateBackend(checkpointDirURI, true);`
+  - You can alternatively configure this directly in the code (overrides the config default): `EmbeddedRocksDBStateBackend backend = new EmbeddedRocksDBStateBackend(true);`
 
 Notice that once incremental checkpoont is enabled, the `Checkpointed Data Size` showed in web UI only represents the 
 delta checkpointed data size of that checkpoint instead of full state size.
@@ -255,9 +218,13 @@ For advanced tuning, Flink also provides two parameters to control the division 
   Moreover, the L0 level filter and index are pinned into the cache by default to mitigate performance problems,
   more details please refer to the [RocksDB-documentation](https://github.com/facebook/rocksdb/wiki/Block-Cache#caching-index-filter-and-compression-dictionary-blocks).
 
-<span class="label label-info">Note</span> When the above described mechanism (`cache` and `write buffer manager`) is enabled, it will override any customized settings for block caches and write buffers done via [`PredefinedOptions`](#predefined-per-columnfamily-options) and [`RocksDBOptionsFactory`](#passing-options-factory-to-rocksdb).
+{{< hint info >}}
+When the above described mechanism (`cache` and `write buffer manager`) is enabled, it will override any customized settings for block caches and write buffers done via [`PredefinedOptions`](#predefined-per-columnfamily-options) and [`RocksDBOptionsFactory`](#passing-options-factory-to-rocksdb).
+{{< /hint >}}
 
-<span class="label label-info">Note</span> *Expert Mode*: To control memory manually, you can set `state.backend.rocksdb.memory.managed` to `false` and configure RocksDB via [`ColumnFamilyOptions`](#passing-options-factory-to-rocksdb). Alternatively, you can use the above mentioned cache/buffer-manager mechanism, but set the memory size to a fixed amount independent of Flink's managed memory size (`state.backend.rocksdb.memory.fixed-per-slot` option). Note that in both cases, users need to ensure on their own that enough memory is available outside the JVM for RocksDB.
+{{< details "Expert Mode" >}}
+To control memory manually, you can set `state.backend.rocksdb.memory.managed` to `false` and configure RocksDB via [`ColumnFamilyOptions`](#passing-options-factory-to-rocksdb). Alternatively, you can use the above mentioned cache/buffer-manager mechanism, but set the memory size to a fixed amount independent of Flink's managed memory size (`state.backend.rocksdb.memory.fixed-per-slot` option). Note that in both cases, users need to ensure on their own that enough memory is available outside the JVM for RocksDB.
+{{< /details >}}
 
 ### Timers (Heap vs. RocksDB)
 
@@ -267,9 +234,13 @@ When selecting the RocksDB State Backend, timers are by default also stored in R
 
 Set the configuration option `state.backend.rocksdb.timer-service.factory` to `heap` (rather than the default, `rocksdb`) to store timers on heap.
 
-<span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does **NOT** support asynchronous snapshots for the timers state. Other state like keyed state is still snapshotted asynchronously.*
+{{< hint warning >}}
+*The combination RocksDB state backend with heap-based timers currently does **NOT** support asynchronous snapshots for the timers state. Other state like keyed state is still snapshotted asynchronously.*
+{{< /hint >}}
 
-<span class="label label-info">Note</span> *When using RocksDB state backend with heap-based timers, checkpointing and taking savepoints is expected to fail if there are operators in application that write to raw keyed state.*
+{{< hint warning >}}
+*When using RocksDB state backend with heap-based timers, checkpointing and taking savepoints is expected to fail if there are operators in application that write to raw keyed state.* This is only relevant to advanced users who are writing custom stream operators.
+{{< /hint >}}
 
 ### Enabling RocksDB Native Metrics
 
@@ -280,25 +251,25 @@ See [configuration docs]({{< ref "docs/deployment/config" >}}#rocksdb-native-met
 Enabling RocksDB's native metrics may have a negative performance impact on your application.
 {{< /hint >}}
 
-### Predefined Per-ColumnFamily Options
+### Advanced RocksDB Memory Turning
 
 {{< hint info >}}
-With the introduction of [memory management for RocksDB](#memory-management) this mechanism should be mainly used for *expert tuning* or *trouble shooting*.
+Flink offers sophisticated default [memory management for RocksDB](#memory-management) that should work for most use-cases. The below mechanisms should mainly be used for *expert tuning* or *trouble shooting*.
 {{< /hint >}}
+
+#### Predefined Per-ColumnFamily Options
 
 With *Predefined Options*, users can apply some predefined config profiles on each RocksDB Column Family, configuring for example memory use, thread, compaction settings, etc. There is currently one Column Family per each state in each operator.
 
 There are two ways to select predefined options to be applied:
   - Set the option's name in `flink-conf.yaml` via `state.backend.rocksdb.predefined-options`.
-  - Set the predefined options programmatically: `RocksDBStateBackend.setPredefinedOptions(PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)`.
+  - Set the predefined options programmatically: `EmbeddedRocksDBStateBackend.setPredefinedOptions(PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)`.
 
 The default value for this option is `DEFAULT` which translates to `PredefinedOptions.DEFAULT`.
 
-<span class="label label-info">Note</span> Predefined options set programmatically would override the ones configured via `flink-conf.yaml`.
+Predefined options set programmatically would override the ones configured via `flink-conf.yaml`.
 
-### Passing Options Factory to RocksDB
-
-<span class="label label-info">Note</span> With the introduction of [memory management for RocksDB](#memory-management) this mechanism should be mainly used for *expert tuning* or *trouble shooting*.
+#### Passing Options Factory to RocksDB
 
 To manually control RocksDB's options, you need to configure an `RocksDBOptionsFactory`. This mechanism gives you fine-grained control over the settings of the Column Families, for example memory use, thread, compaction settings, etc. There is currently one Column Family per each state in each operator.
 
@@ -306,12 +277,12 @@ There are two ways to pass a RocksDBOptionsFactory to the RocksDB State Backend:
 
   - Configure options factory class name in the `flink-conf.yaml` via `state.backend.rocksdb.options-factory`.
   
-  - Set the options factory programmatically, e.g. `RocksDBStateBackend.setRocksDBOptions(new MyOptionsFactory());`
+  - Set the options factory programmatically, e.g. `EmbeddedRocksDBStateBackend.setRocksDBOptions(new MyOptionsFactory());`
 
-<span class="label label-info">Note</span> Options factory which set programmatically would override the one configured via `flink-conf.yaml`,
+Options factory which set programmatically would override the one configured via `flink-conf.yaml`,
 and options factory has a higher priority over the predefined options if ever configured or set.
 
-<span class="label label-info">Note</span> RocksDB is a native library that allocates memory directly from the process,
+RocksDB is a native library that allocates memory directly from the process,
 and not from the JVM. Any memory you assign to RocksDB will have to be accounted for, typically by decreasing the JVM heap size
 of the TaskManagers by the same amount. Not doing that may result in YARN/Mesos/etc terminating the JVM processes for
 allocating more memory than configured.


### PR DESCRIPTION
## What is the purpose of the change

Add documentation for the new Checkpoint Storage abstraction and new State Backend apis (HashMap and EmbeddedRocksDB). 

I also cleaned up a few broken links and other misc I found along the way 
