### PR TITLE
[FLINK-21370][Connectors-JDBC] flink-1.12.1 - JDBCExecutionOptions defaults config JDBCDynamicTableFactory default config is not consistent

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExecutionOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExecutionOptions.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 @PublicEvolving
 public class JdbcExecutionOptions implements Serializable {
     public static final int DEFAULT_MAX_RETRY_TIMES = 3;
-    private static final int DEFAULT_INTERVAL_MILLIS = 0;
-    public static final int DEFAULT_SIZE = 5000;
+    public static final int DEFAULT_INTERVAL_MILLIS = 1000;
+    public static final int DEFAULT_SIZE = 100;
 
     private final long batchIntervalMs;
     private final int batchSize;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableFactory.java
@@ -148,21 +148,21 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
     private static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS =
             ConfigOptions.key("sink.buffer-flush.max-rows")
                     .intType()
-                    .defaultValue(100)
+                    .defaultValue(JdbcExecutionOptions.DEFAULT_SIZE)
                     .withDescription(
                             "the flush max size (includes all append, upsert and delete records), over this number"
                                     + " of records, will flush data. The default value is 100.");
     private static final ConfigOption<Duration> SINK_BUFFER_FLUSH_INTERVAL =
             ConfigOptions.key("sink.buffer-flush.interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(1))
+                    .defaultValue(Duration.ofMillis(JdbcExecutionOptions.DEFAULT_INTERVAL_MILLIS))
                     .withDescription(
                             "the flush interval mills, over this time, asynchronous threads will flush data. The "
                                     + "default value is 1s.");
     private static final ConfigOption<Integer> SINK_MAX_RETRIES =
             ConfigOptions.key("sink.max-retries")
                     .intType()
-                    .defaultValue(3)
+                    .defaultValue(JdbcExecutionOptions.DEFAULT_MAX_RETRY_TIMES)
                     .withDescription("the max retry times if writing records to database failed.");
 
     @Override


### PR DESCRIPTION
fix https://issues.apache.org/jira/projects/FLINK/issues/FLINK-21370


## What is the purpose of the change

This change makes JDBCExecutionOptions defaults config JDBCDynamicTableFactory default config is consistent

## Brief change log

- org.apache.flink.connector.jdbc.JdbcExecutionOptions#DEFAULT_INTERVAL_MILLIS now is pulibc and values is 1000 
- org.apache.flink.connector.jdbc.JdbcExecutionOptions#DEFAULT_SIZE values is 100 


## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:yes 
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
