### PR TITLE
Upgrade the os-maven-plugin depency, to version 1.7.0

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -209,7 +209,7 @@ under the License.
 			<extension>
 				<groupId>kr.motd.maven</groupId>
 				<artifactId>os-maven-plugin</artifactId>
-				<version>1.5.0.Final</version>
+				<version>1.7.0</version>
 			</extension>
 		</extensions>
 


### PR DESCRIPTION
That would ensure that RISC-V arch. is supported.
I tested it on a U54-MC based board - it worked.

Hence https://github.com/trustin/os-maven-plugin/commit/43df41a94dab780d03f47f17c5cbc8e2ef400c3b 

CC @trustin 