### PR TITLE
[FLINK-20580][core] Don't support nullable value for SerializedValue

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
@@ -20,8 +20,6 @@ package org.apache.flink.util;
 
 import org.apache.flink.annotation.Internal;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -43,35 +41,50 @@ public class SerializedValue<T> implements java.io.Serializable {
     private static final long serialVersionUID = -3564011643393683761L;
 
     /** The serialized data. */
-    @Nullable private final byte[] serializedData;
+    private final byte[] serializedData;
 
     private SerializedValue(byte[] serializedData) {
-        Preconditions.checkNotNull(serializedData, "Serialized data");
+        Preconditions.checkNotNull(serializedData, "Serialized data must not be null");
+        Preconditions.checkArgument(
+                serializedData.length != 0, "Serialized data must not be empty");
         this.serializedData = serializedData;
     }
 
+    /**
+     * Constructs a serialized value.
+     *
+     * @param value value to serialize
+     * @throws NullPointerException if value is null
+     * @throws IOException exception during serialization
+     */
     public SerializedValue(T value) throws IOException {
-        this.serializedData = value == null ? null : InstantiationUtil.serializeObject(value);
+        Preconditions.checkNotNull(value, "Value must not be null");
+        this.serializedData = InstantiationUtil.serializeObject(value);
     }
 
-    @SuppressWarnings("unchecked")
     public T deserializeValue(ClassLoader loader) throws IOException, ClassNotFoundException {
         Preconditions.checkNotNull(loader, "No classloader has been passed");
-        return serializedData == null
-                ? null
-                : (T) InstantiationUtil.deserializeObject(serializedData, loader);
+        return InstantiationUtil.deserializeObject(serializedData, loader);
     }
 
     /**
-     * Returns the serialized value or <code>null</code> if no value is set.
+     * Returns byte array for serialized data.
      *
      * @return Serialized data.
      */
-    @Nullable
     public byte[] getByteArray() {
         return serializedData;
     }
 
+    /**
+     * Constructs serialized value from serialized data.
+     *
+     * @param serializedData serialized data
+     * @param <T> type
+     * @return serialized value
+     * @throws NullPointerException if serialized data is null
+     * @throws IllegalArgumentException if serialized data is empty
+     */
     public static <T> SerializedValue<T> fromBytes(byte[] serializedData) {
         return new SerializedValue<>(serializedData);
     }
@@ -80,17 +93,14 @@ public class SerializedValue<T> implements java.io.Serializable {
 
     @Override
     public int hashCode() {
-        return serializedData == null ? 0 : Arrays.hashCode(serializedData);
+        return Arrays.hashCode(serializedData);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof SerializedValue) {
             SerializedValue<?> other = (SerializedValue<?>) obj;
-            return this.serializedData == null
-                    ? other.serializedData == null
-                    : (other.serializedData != null
-                            && Arrays.equals(this.serializedData, other.serializedData));
+            return Arrays.equals(this.serializedData, other.serializedData);
         } else {
             return false;
         }

--- a/flink-core/src/test/java/org/apache/flink/util/SerializedValueTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/SerializedValueTest.java
@@ -22,9 +22,12 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /** Tests for the {@link SerializedValue}. */
@@ -47,6 +50,14 @@ public class SerializedValueTest {
             assertNotNull(v.toString());
             assertNotNull(copy.toString());
 
+            assertNotEquals(0, v.getByteArray().length);
+            assertArrayEquals(v.getByteArray(), copy.getByteArray());
+
+            byte[] bytes = v.getByteArray();
+            SerializedValue<String> saved =
+                    SerializedValue.fromBytes(Arrays.copyOf(bytes, bytes.length));
+            assertEquals(v, saved);
+            assertArrayEquals(v.getByteArray(), saved.getByteArray());
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -54,19 +65,32 @@ public class SerializedValueTest {
     }
 
     @Test
-    public void testNullValue() {
+    public void testNullValue() throws Exception {
         try {
-            SerializedValue<Object> v = new SerializedValue<>(null);
-            SerializedValue<Object> copy = CommonTestUtils.createCopySerializable(v);
+            new SerializedValue<>(null);
+            fail("expect NullPointerException");
+        } catch (NullPointerException e) {
+            // ignore
+        }
+    }
 
-            assertNull(copy.deserializeValue(getClass().getClassLoader()));
+    @Test
+    public void testFromNullBytes() {
+        try {
+            SerializedValue.fromBytes(null);
+            fail("expect NullPointerException");
+        } catch (NullPointerException e) {
+            // ignore
+        }
+    }
 
-            assertEquals(v, copy);
-            assertEquals(v.hashCode(), copy.hashCode());
-            assertEquals(v.toString(), copy.toString());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+    @Test
+    public void testFromEmptyBytes() {
+        try {
+            SerializedValue.fromBytes(new byte[0]);
+            fail("expect IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // ignore
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriter.java
@@ -85,7 +85,7 @@ public interface BlobWriter {
         final SerializedValue<T> serializedValue = new SerializedValue<>(value);
 
         if (serializedValue.getByteArray().length < blobWriter.getMinOffloadingSize()) {
-            return Either.Left(new SerializedValue<>(value));
+            return Either.Left(serializedValue);
         } else {
             try {
                 final PermanentBlobKey permanentBlobKey =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.rpc.messages.RpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RunAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.SerializedValue;
 
 import akka.actor.ActorRef;
 import akka.pattern.Patterns;
@@ -389,9 +388,9 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
     }
 
     static Object deserializeValueIfNeeded(Object o, Method method) {
-        if (o instanceof SerializedValue) {
+        if (o instanceof AkkaRpcSerializedValue) {
             try {
-                return ((SerializedValue<?>) o)
+                return ((AkkaRpcSerializedValue) o)
                         .deserializeValue(AkkaInvocationHandler.class.getClassLoader());
             } catch (IOException | ClassNotFoundException e) {
                 throw new CompletionException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSerializedValue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSerializedValue.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/** A self-contained serialized value to decouple from user values and transfer on wire. */
+class AkkaRpcSerializedValue implements Serializable {
+    @Nullable private final byte[] serializedData;
+
+    private AkkaRpcSerializedValue(@Nullable byte[] serializedData) {
+        this.serializedData = serializedData;
+    }
+
+    @Nullable
+    public byte[] getSerializedData() {
+        return serializedData;
+    }
+
+    /** Return length of serialized data, zero if no serialized data. */
+    public int getSerializedDataLength() {
+        return serializedData == null ? 0 : serializedData.length;
+    }
+
+    @Nullable
+    public <T> T deserializeValue(ClassLoader loader) throws IOException, ClassNotFoundException {
+        Preconditions.checkNotNull(loader, "No classloader has been passed");
+        return serializedData == null
+                ? null
+                : InstantiationUtil.deserializeObject(serializedData, loader);
+    }
+
+    /**
+     * Construct a serialized value to transfer on wire.
+     *
+     * @param value nullable value
+     * @return serialized value to transfer on wire
+     * @throws IOException exception during value serialization
+     */
+    public static AkkaRpcSerializedValue valueOf(@Nullable Object value) throws IOException {
+        byte[] serializedData = value == null ? null : InstantiationUtil.serializeObject(value);
+        return new AkkaRpcSerializedValue(serializedData);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof AkkaRpcSerializedValue) {
+            AkkaRpcSerializedValue other = (AkkaRpcSerializedValue) o;
+            return Arrays.equals(serializedData, other.serializedData);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(serializedData);
+    }
+
+    @Override
+    public String toString() {
+        return serializedData == null ? "AkkaRpcSerializedValue(null)" : "AkkaRpcSerializedValue";
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSerializedValueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSerializedValueTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.util.InstantiationUtil;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class AkkaRpcSerializedValueTest {
+
+    @Test
+    public void testNullValue() throws Exception {
+        AkkaRpcSerializedValue serializedValue = AkkaRpcSerializedValue.valueOf(null);
+        assertThat(serializedValue.getSerializedData(), nullValue());
+        assertThat(serializedValue.getSerializedDataLength(), equalTo(0));
+        assertThat(serializedValue.deserializeValue(getClass().getClassLoader()), nullValue());
+
+        AkkaRpcSerializedValue otherSerializedValue = AkkaRpcSerializedValue.valueOf(null);
+        assertThat(otherSerializedValue, equalTo(serializedValue));
+        assertThat(otherSerializedValue.hashCode(), equalTo(serializedValue.hashCode()));
+
+        AkkaRpcSerializedValue clonedSerializedValue = InstantiationUtil.clone(serializedValue);
+        assertThat(clonedSerializedValue.getSerializedData(), nullValue());
+        assertThat(clonedSerializedValue.getSerializedDataLength(), equalTo(0));
+        assertThat(
+                clonedSerializedValue.deserializeValue(getClass().getClassLoader()), nullValue());
+        assertThat(clonedSerializedValue, equalTo(serializedValue));
+        assertThat(clonedSerializedValue.hashCode(), equalTo(serializedValue.hashCode()));
+    }
+
+    @Test
+    public void testNotNullValues() throws Exception {
+        Set<Object> values =
+                Stream.of(
+                                true,
+                                (byte) 5,
+                                (short) 6,
+                                5,
+                                5L,
+                                5.5F,
+                                6.5,
+                                'c',
+                                "string",
+                                Instant.now(),
+                                BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.TEN),
+                                BigDecimal.valueOf(Math.PI))
+                        .collect(Collectors.toSet());
+
+        Object previousValue = null;
+        AkkaRpcSerializedValue previousSerializedValue = null;
+        for (Object value : values) {
+            AkkaRpcSerializedValue serializedValue = AkkaRpcSerializedValue.valueOf(value);
+            assertThat(value.toString(), serializedValue.getSerializedData(), notNullValue());
+            assertThat(value.toString(), serializedValue.getSerializedDataLength(), greaterThan(0));
+            assertThat(
+                    value.toString(),
+                    serializedValue.deserializeValue(getClass().getClassLoader()),
+                    equalTo(value));
+
+            AkkaRpcSerializedValue otherSerializedValue = AkkaRpcSerializedValue.valueOf(value);
+            assertThat(value.toString(), otherSerializedValue, equalTo(serializedValue));
+            assertThat(
+                    value.toString(),
+                    otherSerializedValue.hashCode(),
+                    equalTo(serializedValue.hashCode()));
+
+            AkkaRpcSerializedValue clonedSerializedValue = InstantiationUtil.clone(serializedValue);
+            assertThat(
+                    value.toString(),
+                    clonedSerializedValue.getSerializedData(),
+                    equalTo(serializedValue.getSerializedData()));
+            assertThat(
+                    value.toString(),
+                    clonedSerializedValue.deserializeValue(getClass().getClassLoader()),
+                    equalTo(value));
+            assertThat(value.toString(), clonedSerializedValue, equalTo(serializedValue));
+            assertThat(
+                    value.toString(),
+                    clonedSerializedValue.hashCode(),
+                    equalTo(serializedValue.hashCode()));
+
+            if (previousValue != null && !previousValue.equals(value)) {
+                assertThat(
+                        value.toString() + " " + previousValue.toString(),
+                        serializedValue,
+                        not(equalTo(previousSerializedValue)));
+            }
+
+            previousValue = value;
+            previousSerializedValue = serializedValue;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
@@ -93,7 +93,7 @@ public class TaskExecutorOperatorEventHandlingTest extends TestLogger {
             final TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
             final CompletableFuture<?> resultFuture =
                     tmGateway.sendOperatorEventToTask(
-                            eid, new OperatorID(), new SerializedValue<>(null));
+                            eid, new OperatorID(), new SerializedValue<>(new TestOperatorEvent()));
 
             assertThat(
                     resultFuture,


### PR DESCRIPTION
## What is the purpose of the change
Dropping nullable-value support from `SerializedValue` to simplify its usages. Callers should resort to nullabe/optional variable of `SerializedValue` if them want such behavior but just can't treat `SerializedValue` as another optional container anymore.

## Brief change log

  - Migrate usage of `SerializedValue` in rpc module to its own wire value class. This make this module self-contained and resistant to rpc usages of `SerializedValue`.
  - Dropping nullable-value support from `SerializedValue`.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
* `SerializedValueTest.testSimpleValue`.

This change added tests and can be verified as follows:
- `SerializedValueTest.testNullValue`, `SerializedValueTest.testFromNullBytes`, `SerializedValueTest.testFromEmptyBytes`
- `AkkaRpcSerializedValueTest`
- `AkkaRpcActorTest.canRespondWithSerializedValueLocally`, `RemoteAkkaRpcActorTest.canRespondWithSerializedValueRemotely`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## WARNING
**This change will breaking tm/jm rolling update if we ever support it.** I got nothing of such supporting from docs and assume no such guarantee.
