### PR TITLE
[hotfix] Javadoc should end the first sentence with a period

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/EnvironmentInformation.java
@@ -492,7 +492,7 @@ public class EnvironmentInformation {
 
     // --------------------------------------------------------------------------------------------
 
-    /** Don't instantiate this class */
+    /** Don't instantiate this class. */
     private EnvironmentInformation() {}
 
     // --------------------------------------------------------------------------------------------
@@ -503,10 +503,10 @@ public class EnvironmentInformation {
      */
     public static class RevisionInformation {
 
-        /** The git commit id (hash) */
+        /** The git commit id (hash). */
         public final String commitId;
 
-        /** The git commit date */
+        /** The git commit date. */
         public final String commitDate;
 
         public RevisionInformation(String commitId, String commitDate) {


### PR DESCRIPTION
This is a simple JavaDoc fix, some of the problems found when checkstyle