### PR TITLE
[FLINK-21296][sql-client] Use module name to perform module factory discovery

### DIFF
--- a/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/conf/sql-client-defaults.yaml
@@ -86,7 +86,6 @@ catalogs: [] # empty list
 
 #modules: # note the following modules will be of the order they are specified
 #  - name: core
-#    type: core
 
 #==============================================================================
 # Execution properties

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ModuleEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ModuleEntry.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.client.config.entries;
 
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.client.config.ConfigUtil;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 
@@ -61,6 +62,15 @@ public class ModuleEntry extends ConfigEntry {
         final DescriptorProperties cleanedProperties =
                 properties.withoutKeys(Collections.singletonList(MODULE_NAME));
 
+        // mapping modules purely by name
+        if (cleanedProperties.containsKey(MODULE_TYPE)) {
+            throw new ValidationException(
+                    String.format(
+                            "Property 'type' is deprecated, please remove it and rename "
+                                    + "module name '%s' to type name '%s' and try again",
+                            name, cleanedProperties.getString(MODULE_TYPE)));
+        }
+        cleanedProperties.putString(MODULE_TYPE, name);
         return new ModuleEntry(name, cleanedProperties);
     }
 }

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
@@ -43,15 +43,4 @@ execution:
 deployment:
   response-timeout: 5000
 
-modules:
-  - name: core
-    type: core
-  - name: mymodule
-    type: ModuleDependencyTest
-    test: test
-  - name: myhive
-    type: hive
-  - name: myhive2
-    type: hive
-    hive-version: 2.3.4
-
+modules: $VAR_MODULE_LIST


### PR DESCRIPTION
## What is the purpose of the change

Simplify the module factory discovery and mapping modules purely by module's name. This implies  

1. Deprecate and remove the redundant 'type' from the `sql-client-defaults.yaml` configuration.
- Before
 ```yaml
modules:
  - name: core
    type: core
  - name: hive
    type: hive
 ```
- After
 ```yaml
modules:
  - name: core
  - name: hive
 ```
2. The module's name is case-sensitive and needs to be equal to the module's type, which is defined in the `ModuleFactory` impl or `ModuleDescriptor` impl.
- Before
 ```yaml
modules:
  - name: mymodule
    type: ModuleDependencyTest
    test: test
 ```
- After    
```yaml
modules:
  - name: ModuleDependencyTest
    test: test 
 ```
3. The framework will now explicitly prevent loading parameterized modules with different parameters at the same time.
    
- Before
 ```yaml
modules:
  - name: myhive
    type: hive
  - name: myhive2
    type: hive
    hive-version: 2.3.4
 ```
- After   
```yaml
modules:
  - name: hive
 ```
or
```yaml
modules:
  - name: hive
    hive-version: 2.3.4 
 ```
These two cannot present at the same time. 

## Brief change log

  - Add module name as the type to `DescriptorProperties` in `ModuleEntry` implicitly

## Verifying this change

This change added tests and can be verified as follows:

  - Add tests in `EnvironmentTest` to verify loading modules without type and module name's case sensitivity.
  - Add tests in `ExecutionContextTest` to verify the YAML configuration before and after this PR behaves correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
    - Docs will be updated after FLINK-21300 finish.
