### PR TITLE
[FLINK-20952][json]  Changelog json formats should support inherit options from JSON format

### DIFF
--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.formats.json;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
@@ -79,6 +80,125 @@ public class JsonOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Optional flag to specify whether to encode all decimals as plain numbers instead of possible scientific notations, false by default.");
+
+    // ------------------------------------------------------------------------------------------
+    // Json attributes
+    // ------------------------------------------------------------------------------------------
+
+    private final boolean failOnMissingField;
+    private final boolean ignoreParseErrors;
+    private final MapNullKeyMode mapNullKeyMode;
+    private final String mapNullKeyLiteral;
+    private final TimestampFormat timestampFormat;
+    private final boolean encodeDecimalAsPlainNumber;
+
+    protected JsonOptions(
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            MapNullKeyMode mapNullKeyMode,
+            String mapNullKeyLiteral,
+            TimestampFormat timestampFormat,
+            boolean encodeDecimalAsPlainNumber) {
+        this.failOnMissingField = failOnMissingField;
+        this.ignoreParseErrors = ignoreParseErrors;
+        this.mapNullKeyMode = mapNullKeyMode;
+        this.mapNullKeyLiteral = mapNullKeyLiteral;
+        this.timestampFormat = timestampFormat;
+        this.encodeDecimalAsPlainNumber = encodeDecimalAsPlainNumber;
+    }
+
+    public boolean isFailOnMissingField() {
+        return failOnMissingField;
+    }
+
+    public boolean isIgnoreParseErrors() {
+        return ignoreParseErrors;
+    }
+
+    public MapNullKeyMode getMapNullKeyMode() {
+        return mapNullKeyMode;
+    }
+
+    public String getMapNullKeyLiteral() {
+        return mapNullKeyLiteral;
+    }
+
+    public TimestampFormat getTimestampFormat() {
+        return timestampFormat;
+    }
+
+    public boolean isEncodeDecimalAsPlainNumber() {
+        return encodeDecimalAsPlainNumber;
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Builder
+    // ------------------------------------------------------------------------------------------
+
+    /** Creates A builder for building a {@link JsonOptions}. */
+    public static Builder builder(ReadableConfig conf) {
+        return new Builder(conf);
+    }
+
+    /** A builder for creating a {@link JsonOptions}. */
+    @Internal
+    public static class Builder {
+        protected boolean failOnMissingField;
+        protected boolean ignoreParseErrors;
+        protected MapNullKeyMode mapNullKeyMode;
+        protected String mapNullKeyLiteral;
+        protected TimestampFormat timestampFormat;
+        protected boolean encodeDecimalAsPlainNumber;
+
+        public Builder(ReadableConfig conf) {
+            this.failOnMissingField = conf.get(FAIL_ON_MISSING_FIELD);
+            this.ignoreParseErrors = conf.get(IGNORE_PARSE_ERRORS);
+            this.mapNullKeyMode = getMapNullKeyMode(conf);
+            this.mapNullKeyLiteral = conf.get(MAP_NULL_KEY_LITERAL);
+            this.timestampFormat = getTimestampFormat(conf);
+            this.encodeDecimalAsPlainNumber = conf.get(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        }
+
+        public Builder setFailOnMissingField(boolean failOnMissingField) {
+            this.failOnMissingField = failOnMissingField;
+            return this;
+        }
+
+        public Builder setIgnoreParseErrors(boolean ignoreParseErrors) {
+            this.ignoreParseErrors = ignoreParseErrors;
+            return this;
+        }
+
+        public Builder setMapNullKeyMode(MapNullKeyMode mapNullKeyMode) {
+            this.mapNullKeyMode = mapNullKeyMode;
+            return this;
+        }
+
+        public Builder setMapNullKeyLiteral(String mapNullKeyLiteral) {
+            this.mapNullKeyLiteral = mapNullKeyLiteral;
+            return this;
+        }
+
+        public Builder setTimestampFormat(TimestampFormat timestampFormat) {
+            this.timestampFormat = timestampFormat;
+            return this;
+        }
+
+        public Builder setEncodeDecimalAsPlainNumber(boolean encodeDecimalAsPlainNumber) {
+            this.encodeDecimalAsPlainNumber = encodeDecimalAsPlainNumber;
+            return this;
+        }
+
+        public JsonOptions build() {
+            return new JsonOptions(
+                    failOnMissingField,
+                    ignoreParseErrors,
+                    mapNullKeyMode,
+                    mapNullKeyLiteral,
+                    timestampFormat,
+                    encodeDecimalAsPlainNumber);
+        }
+    }
 
     // --------------------------------------------------------------------------------------------
     // Option enumerations
@@ -193,5 +313,16 @@ public class JsonOptions {
                             "Unsupported value '%s' for %s. Supported values are [SQL, ISO-8601].",
                             timestampFormat, TIMESTAMP_FORMAT.key()));
         }
+    }
+
+    public static Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FAIL_ON_MISSING_FIELD);
+        options.add(IGNORE_PARSE_ERRORS);
+        options.add(TIMESTAMP_FORMAT);
+        options.add(MAP_NULL_KEY_MODE);
+        options.add(MAP_NULL_KEY_LITERAL);
+        options.add(ENCODE_DECIMAL_AS_PLAIN_NUMBER);
+        return options;
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -72,22 +72,18 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
     private final TimestampFormat timestampFormat;
 
     public JsonRowDataDeserializationSchema(
-            RowType rowType,
-            TypeInformation<RowData> resultTypeInfo,
-            boolean failOnMissingField,
-            boolean ignoreParseErrors,
-            TimestampFormat timestampFormat) {
+            RowType rowType, TypeInformation<RowData> resultTypeInfo, JsonOptions jsonOptions) {
+        this.failOnMissingField = jsonOptions.isFailOnMissingField();
+        this.ignoreParseErrors = jsonOptions.isIgnoreParseErrors();
+        this.timestampFormat = jsonOptions.getTimestampFormat();
         if (ignoreParseErrors && failOnMissingField) {
             throw new IllegalArgumentException(
                     "JSON format doesn't support failOnMissingField and ignoreParseErrors are both enabled.");
         }
         this.resultTypeInfo = checkNotNull(resultTypeInfo);
-        this.failOnMissingField = failOnMissingField;
-        this.ignoreParseErrors = ignoreParseErrors;
         this.runtimeConverter =
                 new JsonToRowDataConverters(failOnMissingField, ignoreParseErrors, timestampFormat)
                         .createConverter(checkNotNull(rowType));
-        this.timestampFormat = timestampFormat;
         boolean hasDecimalType =
                 LogicalTypeChecks.hasNested(rowType, t -> t instanceof DecimalType);
         if (hasDecimalType) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
@@ -66,17 +66,12 @@ public class JsonRowDataSerializationSchema implements SerializationSchema<RowDa
     /** Flag indicating whether to serialize all decimals as plain numbers. */
     private final boolean encodeDecimalAsPlainNumber;
 
-    public JsonRowDataSerializationSchema(
-            RowType rowType,
-            TimestampFormat timestampFormat,
-            JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral,
-            boolean encodeDecimalAsPlainNumber) {
+    public JsonRowDataSerializationSchema(RowType rowType, JsonOptions jsonOptions) {
         this.rowType = rowType;
-        this.timestampFormat = timestampFormat;
-        this.mapNullKeyMode = mapNullKeyMode;
-        this.mapNullKeyLiteral = mapNullKeyLiteral;
-        this.encodeDecimalAsPlainNumber = encodeDecimalAsPlainNumber;
+        this.timestampFormat = jsonOptions.getTimestampFormat();
+        this.mapNullKeyMode = jsonOptions.getMapNullKeyMode();
+        this.mapNullKeyLiteral = jsonOptions.getMapNullKeyLiteral();
+        this.encodeDecimalAsPlainNumber = jsonOptions.isEncodeDecimalAsPlainNumber();
         this.runtimeConverter =
                 new RowDataToJsonConverters(timestampFormat, mapNullKeyMode, mapNullKeyLiteral)
                         .createConverter(rowType);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonSerializationSchema.java
@@ -21,7 +21,6 @@ package org.apache.flink.formats.json.canal;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
-import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -54,19 +53,10 @@ public class CanalJsonSerializationSchema implements SerializationSchema<RowData
     /** The serializer to serialize Canal JSON data. */
     private final JsonRowDataSerializationSchema jsonSerializer;
 
-    public CanalJsonSerializationSchema(
-            RowType rowType,
-            TimestampFormat timestampFormat,
-            JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral,
-            boolean encodeDecimalAsPlainNumber) {
+    public CanalJsonSerializationSchema(RowType rowType, JsonOptions canalJsonOptions) {
         jsonSerializer =
                 new JsonRowDataSerializationSchema(
-                        createJsonRowType(fromLogicalToDataType(rowType)),
-                        timestampFormat,
-                        mapNullKeyMode,
-                        mapNullKeyLiteral,
-                        encodeDecimalAsPlainNumber);
+                        createJsonRowType(fromLogicalToDataType(rowType)), canalJsonOptions);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDecodingFormat.java
@@ -20,7 +20,7 @@ package org.apache.flink.formats.json.debezium;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.formats.json.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.debezium.DebeziumJsonDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -52,20 +52,13 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
     private List<String> metadataKeys;
 
     // --------------------------------------------------------------------------------------------
-    // Debezium-specific attributes
+    // Debezium attributes
     // --------------------------------------------------------------------------------------------
 
-    private final boolean schemaInclude;
+    private JsonOptions debeziumJsonOptions;
 
-    private final boolean ignoreParseErrors;
-
-    private final TimestampFormat timestampFormat;
-
-    public DebeziumJsonDecodingFormat(
-            boolean schemaInclude, boolean ignoreParseErrors, TimestampFormat timestampFormat) {
-        this.schemaInclude = schemaInclude;
-        this.ignoreParseErrors = ignoreParseErrors;
-        this.timestampFormat = timestampFormat;
+    public DebeziumJsonDecodingFormat(JsonOptions debeziumJsonOptions) {
+        this.debeziumJsonOptions = debeziumJsonOptions;
         this.metadataKeys = Collections.emptyList();
     }
 
@@ -95,12 +88,7 @@ public class DebeziumJsonDecodingFormat implements DecodingFormat<Deserializatio
                 context.createTypeInformation(producedDataType);
 
         return new DebeziumJsonDeserializationSchema(
-                physicalDataType,
-                readableMetadata,
-                producedTypeInfo,
-                schemaInclude,
-                ignoreParseErrors,
-                timestampFormat);
+                physicalDataType, readableMetadata, producedTypeInfo, debeziumJsonOptions);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonSerializationSchema.java
@@ -21,7 +21,6 @@ package org.apache.flink.formats.json.debezium;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
-import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -51,19 +50,10 @@ public class DebeziumJsonSerializationSchema implements SerializationSchema<RowD
 
     private transient GenericRowData genericRowData;
 
-    public DebeziumJsonSerializationSchema(
-            RowType rowType,
-            TimestampFormat timestampFormat,
-            JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral,
-            boolean encodeDecimalAsPlainNumber) {
+    public DebeziumJsonSerializationSchema(RowType rowType, JsonOptions debeziumJsonOptions) {
         jsonSerializer =
                 new JsonRowDataSerializationSchema(
-                        createJsonRowType(fromLogicalToDataType(rowType)),
-                        timestampFormat,
-                        mapNullKeyMode,
-                        mapNullKeyLiteral,
-                        encodeDecimalAsPlainNumber);
+                        createJsonRowType(fromLogicalToDataType(rowType)), debeziumJsonOptions);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
@@ -20,8 +20,8 @@ package org.apache.flink.formats.json.maxwell;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.JsonRowDataDeserializationSchema;
-import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -69,10 +69,9 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
     public MaxwellJsonDeserializationSchema(
             RowType rowType,
             TypeInformation<RowData> resultTypeInfo,
-            boolean ignoreParseErrors,
-            TimestampFormat timestampFormatOption) {
+            JsonOptions maxwellJsonOptions) {
         this.resultTypeInfo = resultTypeInfo;
-        this.ignoreParseErrors = ignoreParseErrors;
+        this.ignoreParseErrors = maxwellJsonOptions.isIgnoreParseErrors();
         this.fieldCount = rowType.getFieldCount();
         this.jsonDeserializer =
                 new JsonRowDataDeserializationSchema(
@@ -80,10 +79,7 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
                         // the result type is never used, so it's fine to pass in Canal's result
                         // type
                         resultTypeInfo,
-                        false, // ignoreParseErrors already contains the functionality of
-                        // failOnMissingField
-                        ignoreParseErrors,
-                        timestampFormatOption);
+                        maxwellJsonOptions);
     }
 
     @Override

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonOptions.java
@@ -18,21 +18,64 @@
 
 package org.apache.flink.formats.json.maxwell;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.formats.json.JsonOptions;
+import org.apache.flink.formats.json.TimestampFormat;
+
+import java.util.Set;
 
 /** Option utils for maxwell-json format. */
-public class MaxwellJsonOptions {
+public class MaxwellJsonOptions extends JsonOptions {
 
-    public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS = JsonOptions.IGNORE_PARSE_ERRORS;
+    // ------------------------------------------------------------------------------------------
+    // Maxwell attributes
+    // ------------------------------------------------------------------------------------------
 
-    public static final ConfigOption<String> TIMESTAMP_FORMAT = JsonOptions.TIMESTAMP_FORMAT;
+    private MaxwellJsonOptions(
+            boolean failOnMissingField,
+            boolean ignoreParseErrors,
+            MapNullKeyMode mapNullKeyMode,
+            String mapNullKeyLiteral,
+            TimestampFormat timestampFormat,
+            boolean encodeDecimalAsPlainNumber) {
+        super(
+                failOnMissingField,
+                ignoreParseErrors,
+                mapNullKeyMode,
+                mapNullKeyLiteral,
+                timestampFormat,
+                encodeDecimalAsPlainNumber);
+    }
 
-    public static final ConfigOption<String> JSON_MAP_NULL_KEY_MODE = JsonOptions.MAP_NULL_KEY_MODE;
+    // ------------------------------------------------------------------------------------------
+    // Builder
+    // ------------------------------------------------------------------------------------------
 
-    public static final ConfigOption<String> JSON_MAP_NULL_KEY_LITERAL =
-            JsonOptions.MAP_NULL_KEY_LITERAL;
+    /** Creates A builder for building a {@link MaxwellJsonOptions}. */
+    public static Builder builder(ReadableConfig conf) {
+        return new Builder(conf);
+    }
+
+    /** A builder for creating a {@link MaxwellJsonOptions}. */
+    @Internal
+    public static class Builder extends JsonOptions.Builder {
+
+        public Builder(ReadableConfig conf) {
+            super(conf);
+        }
+
+        public MaxwellJsonOptions build() {
+            return new MaxwellJsonOptions(
+                    failOnMissingField,
+                    ignoreParseErrors,
+                    mapNullKeyMode,
+                    mapNullKeyLiteral,
+                    timestampFormat,
+                    encodeDecimalAsPlainNumber);
+        }
+    }
 
     // --------------------------------------------------------------------------------------------
     // Validation
@@ -46,5 +89,9 @@ public class MaxwellJsonOptions {
     /** Validator for maxwell encoding format. */
     public static void validateEncodingFormatOptions(ReadableConfig tableOptions) {
         JsonOptions.validateEncodingFormatOptions(tableOptions);
+    }
+
+    public static Set<ConfigOption<?>> optionalOptions() {
+        return JsonOptions.optionalOptions();
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonSerializationSchema.java
@@ -51,20 +51,11 @@ public class MaxwellJsonSerializationSchema implements SerializationSchema<RowDa
 
     private transient GenericRowData reuse;
 
-    public MaxwellJsonSerializationSchema(
-            RowType rowType,
-            TimestampFormat timestampFormat,
-            JsonOptions.MapNullKeyMode mapNullKeyMode,
-            String mapNullKeyLiteral,
-            boolean encodeDecimalAsPlainNumber) {
+    public MaxwellJsonSerializationSchema(RowType rowType, JsonOptions maxwellJsonOptions) {
         this.jsonSerializer =
                 new JsonRowDataSerializationSchema(
-                        createJsonRowType(fromLogicalToDataType(rowType)),
-                        timestampFormat,
-                        mapNullKeyMode,
-                        mapNullKeyLiteral,
-                        encodeDecimalAsPlainNumber);
-        this.timestampFormat = timestampFormat;
+                        createJsonRowType(fromLogicalToDataType(rowType)), maxwellJsonOptions);
+        this.timestampFormat = maxwellJsonOptions.getTimestampFormat();
     }
 
     @Override

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.json;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -148,13 +149,15 @@ public class JsonFormatFactoryTest extends TestLogger {
     // ------------------------------------------------------------------------
 
     private void testSchemaDeserializationSchema(Map<String, String> options) {
+        final JsonOptions jsonOptions =
+                JsonOptions.builder(new DelegatingConfiguration())
+                        .setFailOnMissingField(false)
+                        .setIgnoreParseErrors(true)
+                        .setTimestampFormat(TimestampFormat.ISO_8601)
+                        .build();
         final JsonRowDataDeserializationSchema expectedDeser =
                 new JsonRowDataDeserializationSchema(
-                        ROW_TYPE,
-                        InternalTypeInfo.of(ROW_TYPE),
-                        false,
-                        true,
-                        TimestampFormat.ISO_8601);
+                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), jsonOptions);
 
         final DynamicTableSource actualSource = createTableSource(options);
         assert actualSource instanceof TestDynamicTableFactory.DynamicTableSourceMock;
@@ -169,13 +172,15 @@ public class JsonFormatFactoryTest extends TestLogger {
     }
 
     private void testSchemaSerializationSchema(Map<String, String> options) {
+        final JsonOptions jsonOptions =
+                JsonOptions.builder(new DelegatingConfiguration())
+                        .setTimestampFormat(TimestampFormat.ISO_8601)
+                        .setMapNullKeyMode(JsonOptions.MapNullKeyMode.LITERAL)
+                        .setMapNullKeyLiteral("null")
+                        .setEncodeDecimalAsPlainNumber(true)
+                        .build();
         final JsonRowDataSerializationSchema expectedSer =
-                new JsonRowDataSerializationSchema(
-                        ROW_TYPE,
-                        TimestampFormat.ISO_8601,
-                        JsonOptions.MapNullKeyMode.LITERAL,
-                        "null",
-                        true);
+                new JsonRowDataSerializationSchema(ROW_TYPE, jsonOptions);
 
         final DynamicTableSink actualSink = createTableSink(options);
         assert actualSink instanceof TestDynamicTableFactory.DynamicTableSinkMock;

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/maxwell/MaxwellJsonFormatFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.formats.json.maxwell;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.formats.json.JsonOptions;
 import org.apache.flink.formats.json.TimestampFormat;
 import org.apache.flink.table.api.DataTypes;
@@ -65,17 +66,24 @@ public class MaxwellJsonFormatFactoryTest extends TestLogger {
 
     @Test
     public void testSeDeSchema() {
+        final JsonOptions maxwellJsonOptionsDeser =
+                JsonOptions.builder(new DelegatingConfiguration())
+                        .setIgnoreParseErrors(true)
+                        .setTimestampFormat(TimestampFormat.ISO_8601)
+                        .build();
         final MaxwellJsonDeserializationSchema expectedDeser =
                 new MaxwellJsonDeserializationSchema(
-                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), true, TimestampFormat.ISO_8601);
+                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), maxwellJsonOptionsDeser);
 
+        final JsonOptions maxwellJsonOptionsSer =
+                JsonOptions.builder(new DelegatingConfiguration())
+                        .setTimestampFormat(TimestampFormat.ISO_8601)
+                        .setMapNullKeyMode(JsonOptions.MapNullKeyMode.LITERAL)
+                        .setMapNullKeyLiteral("null")
+                        .setEncodeDecimalAsPlainNumber(true)
+                        .build();
         final MaxwellJsonSerializationSchema expectedSer =
-                new MaxwellJsonSerializationSchema(
-                        ROW_TYPE,
-                        TimestampFormat.ISO_8601,
-                        JsonOptions.MapNullKeyMode.LITERAL,
-                        "null",
-                        true);
+                new MaxwellJsonSerializationSchema(ROW_TYPE, maxwellJsonOptionsSer);
 
         final Map<String, String> options = getAllOptions();
 


### PR DESCRIPTION
## What is the purpose of the change

Implement the canal/maxwell/debezium json options inherit the base class JsonOptions, to aviod adding a small config option into json may need touch debezium-json, canal-json, maxwell-json formats.

## Brief change log

  - Add json option attributions and Builder class in JsonOptions
  - CanalJsonOptions/MaxwellJsonOptions/DebeziumOptions inherit JsonOptions including the builder class
  - Canal/Maxwell/Debezium json deserialization/serialization use jsonOptions parameter instead of exposed json attrbutes

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
