### PR TITLE
[FLINK-21377][coordination][tests] Make JobMaster QS tests pass with declarative scheduler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
@@ -21,109 +21,74 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.queryablestate.KvStateID;
-import org.apache.flink.runtime.checkpoint.OperatorState;
-import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
-import org.apache.flink.runtime.heartbeat.HeartbeatServices;
-import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
-import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.KeyGroupRange;
-import org.apache.flink.runtime.state.OperatorStreamStateHandle;
-import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
-import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-import javax.annotation.Nonnull;
-
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
 
-import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
-import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
-import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
+import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests for the queryable-state logic of the {@link JobMaster}. */
 public class JobMasterQueryableStateTest extends TestLogger {
 
-    @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
-
     private static final Time testingTimeout = Time.seconds(10L);
-
-    private static final long heartbeatInterval = 1000L;
-    private static final long heartbeatTimeout = 5_000_000L;
 
     private static TestingRpcService rpcService;
 
-    private static HeartbeatServices heartbeatServices;
+    private static final int PARALLELISM = 4;
+    private static final JobVertex JOB_VERTEX_1;
+    private static final JobVertex JOB_VERTEX_2;
+    private static final JobGraph JOB_GRAPH;
 
-    private Configuration configuration;
+    static {
+        JOB_VERTEX_1 = new JobVertex("v1");
+        JOB_VERTEX_1.setParallelism(PARALLELISM);
+        JOB_VERTEX_1.setInvokableClass(AbstractInvokable.class);
 
-    private TestingHighAvailabilityServices haServices;
+        JOB_VERTEX_2 = new JobVertex("v2");
+        JOB_VERTEX_2.setParallelism(PARALLELISM);
+        JOB_VERTEX_2.setInvokableClass(AbstractInvokable.class);
 
-    private TestingFatalErrorHandler testingFatalErrorHandler;
+        // explicit configuration required for #testRegisterAndUnregisterKvState
+        JOB_VERTEX_1.setMaxParallelism(16);
+        JOB_VERTEX_2.setMaxParallelism(16);
+
+        JOB_GRAPH = new JobGraph(JOB_VERTEX_1, JOB_VERTEX_2);
+        JOB_GRAPH.setJobType(JobType.STREAMING);
+    }
 
     @BeforeClass
     public static void setupClass() {
         rpcService = new TestingRpcService();
-
-        heartbeatServices = new HeartbeatServices(heartbeatInterval, heartbeatTimeout);
-    }
-
-    @Before
-    public void setup() throws IOException {
-        configuration = new Configuration();
-        haServices = new TestingHighAvailabilityServices();
-
-        testingFatalErrorHandler = new TestingFatalErrorHandler();
-
-        haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
-
-        SettableLeaderRetrievalService rmLeaderRetrievalService =
-                new SettableLeaderRetrievalService(null, null);
-        haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
-
-        configuration.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
     }
 
     @After
     public void teardown() throws Exception {
-        if (testingFatalErrorHandler != null) {
-            testingFatalErrorHandler.rethrowError();
-        }
-
         rpcService.clearGateways();
     }
 
@@ -137,14 +102,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
     @Test
     public void testRequestKvStateWithoutRegistration() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
 
         jobMaster.start();
 
@@ -153,7 +111,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
         try {
             // lookup location
             try {
-                jobMasterGateway.requestKvStateLocation(graph.getJobID(), "unknown").get();
+                jobMasterGateway.requestKvStateLocation(JOB_GRAPH.getJobID(), "unknown").get();
                 fail("Expected to fail with UnknownKvStateLocation");
             } catch (Exception e) {
                 assertTrue(
@@ -166,14 +124,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
     @Test
     public void testRequestKvStateOfWrongJob() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
 
         jobMaster.start();
 
@@ -185,40 +136,16 @@ public class JobMasterQueryableStateTest extends TestLogger {
                 jobMasterGateway.requestKvStateLocation(new JobID(), "unknown").get();
                 fail("Expected to fail with FlinkJobNotFoundException");
             } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
-                                .isPresent());
+                assertThat(e, containsCause(FlinkJobNotFoundException.class));
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
         }
     }
 
-    @Nonnull
-    public JobGraph createKvJobGraph() {
-        final JobVertex vertex1 = new JobVertex("v1");
-        vertex1.setParallelism(4);
-        vertex1.setMaxParallelism(16);
-        vertex1.setInvokableClass(BlockingNoOpInvokable.class);
-
-        final JobVertex vertex2 = new JobVertex("v2");
-        vertex2.setParallelism(4);
-        vertex2.setMaxParallelism(16);
-        vertex2.setInvokableClass(BlockingNoOpInvokable.class);
-
-        return new JobGraph(vertex1, vertex2);
-    }
-
     @Test
     public void testRequestKvStateWithIrrelevantRegistration() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
 
         jobMaster.start();
 
@@ -227,20 +154,10 @@ public class JobMasterQueryableStateTest extends TestLogger {
         try {
             // register an irrelevant KvState
             try {
-                jobMasterGateway
-                        .notifyKvStateRegistered(
-                                new JobID(),
-                                new JobVertexID(),
-                                new KeyGroupRange(0, 0),
-                                "any-name",
-                                new KvStateID(),
-                                new InetSocketAddress(InetAddress.getLocalHost(), 1233))
-                        .get();
+                registerKvState(jobMasterGateway, new JobID(), new JobVertexID(), "any-name");
                 fail("Expected to fail with FlinkJobNotFoundException.");
             } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
-                                .isPresent());
+                assertThat(e, containsCause(FlinkJobNotFoundException.class));
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
@@ -248,24 +165,14 @@ public class JobMasterQueryableStateTest extends TestLogger {
     }
 
     @Test
-    public void testRegisterAndUnregisterKvState() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
-        final JobVertex vertex1 = jobVertices.get(0);
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
+    public void testRegisterKvState() throws Exception {
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
 
         jobMaster.start();
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
         try {
-            // register a KvState
             final String registrationName = "register-me";
             final KvStateID kvStateID = new KvStateID();
             final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
@@ -274,8 +181,8 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
             jobMasterGateway
                     .notifyKvStateRegistered(
-                            graph.getJobID(),
-                            vertex1.getID(),
+                            JOB_GRAPH.getJobID(),
+                            JOB_VERTEX_1.getID(),
                             keyGroupRange,
                             registrationName,
                             kvStateID,
@@ -284,30 +191,64 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
             final KvStateLocation location =
                     jobMasterGateway
-                            .requestKvStateLocation(graph.getJobID(), registrationName)
+                            .requestKvStateLocation(JOB_GRAPH.getJobID(), registrationName)
                             .get();
 
-            assertEquals(graph.getJobID(), location.getJobId());
-            assertEquals(vertex1.getID(), location.getJobVertexId());
-            assertEquals(vertex1.getMaxParallelism(), location.getNumKeyGroups());
+            assertEquals(JOB_GRAPH.getJobID(), location.getJobId());
+            assertEquals(JOB_VERTEX_1.getID(), location.getJobVertexId());
+            assertEquals(JOB_VERTEX_1.getMaxParallelism(), location.getNumKeyGroups());
             assertEquals(1, location.getNumRegisteredKeyGroups());
             assertEquals(1, keyGroupRange.getNumberOfKeyGroups());
             assertEquals(kvStateID, location.getKvStateID(keyGroupRange.getStartKeyGroup()));
             assertEquals(
                     address, location.getKvStateServerAddress(keyGroupRange.getStartKeyGroup()));
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
 
-            // unregister the KvState
+    @Test
+    public void testUnregisterKvState() throws Exception {
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        registerSlotsRequiredForJobExecution(jobMasterGateway);
+
+        try {
+            final String registrationName = "register-me";
+            final KvStateID kvStateID = new KvStateID();
+            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
+            final InetSocketAddress address =
+                    new InetSocketAddress(InetAddress.getLocalHost(), 1029);
+
+            jobMasterGateway
+                    .notifyKvStateRegistered(
+                            JOB_GRAPH.getJobID(),
+                            JOB_VERTEX_1.getID(),
+                            keyGroupRange,
+                            registrationName,
+                            kvStateID,
+                            address)
+                    .get();
+
             jobMasterGateway
                     .notifyKvStateUnregistered(
-                            graph.getJobID(), vertex1.getID(), keyGroupRange, registrationName)
+                            JOB_GRAPH.getJobID(),
+                            JOB_VERTEX_1.getID(),
+                            keyGroupRange,
+                            registrationName)
                     .get();
 
             try {
-                jobMasterGateway.requestKvStateLocation(graph.getJobID(), registrationName).get();
+                jobMasterGateway
+                        .requestKvStateLocation(JOB_GRAPH.getJobID(), registrationName)
+                        .get();
                 fail("Expected to fail with an UnknownKvStateLocation.");
             } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, UnknownKvStateLocation.class).isPresent());
+                assertThat(e, containsCause(UnknownKvStateLocation.class));
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
@@ -316,17 +257,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
     @Test
     public void testDuplicatedKvStateRegistrationsFailTask() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
-        final JobVertex vertex1 = jobVertices.get(0);
-        final JobVertex vertex2 = jobVertices.get(1);
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
+        final JobMaster jobMaster = new JobMasterBuilder(JOB_GRAPH, rpcService).createJobMaster();
 
         jobMaster.start();
 
@@ -335,38 +266,22 @@ public class JobMasterQueryableStateTest extends TestLogger {
         try {
             // duplicate registration fails task
 
-            // register a KvState
             final String registrationName = "duplicate-me";
-            final KvStateID kvStateID = new KvStateID();
-            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
-            final InetSocketAddress address =
-                    new InetSocketAddress(InetAddress.getLocalHost(), 4396);
 
-            jobMasterGateway
-                    .notifyKvStateRegistered(
-                            graph.getJobID(),
-                            vertex1.getID(),
-                            keyGroupRange,
-                            registrationName,
-                            kvStateID,
-                            address)
-                    .get();
-
+            registerKvState(
+                    jobMasterGateway, JOB_GRAPH.getJobID(), JOB_VERTEX_1.getID(), registrationName);
             try {
-                jobMasterGateway
-                        .notifyKvStateRegistered(
-                                graph.getJobID(),
-                                vertex2.getID(), // <--- different operator, but...
-                                keyGroupRange,
-                                registrationName, // ...same name
-                                kvStateID,
-                                address)
-                        .get();
+                registerKvState(
+                        jobMasterGateway,
+                        JOB_GRAPH.getJobID(),
+                        JOB_VERTEX_2.getID(),
+                        registrationName);
                 fail("Expected to fail because of clashing registration message.");
             } catch (Exception e) {
                 assertTrue(
                         ExceptionUtils.findThrowableWithMessage(e, "Registration name clash")
                                 .isPresent());
+
                 assertEquals(
                         JobStatus.FAILED, jobMasterGateway.requestJobStatus(testingTimeout).get());
             }
@@ -375,27 +290,20 @@ public class JobMasterQueryableStateTest extends TestLogger {
         }
     }
 
-    private Collection<OperatorState> createOperatorState(OperatorID... operatorIds) {
-        Random random = new Random();
-        Collection<OperatorState> operatorStates = new ArrayList<>(operatorIds.length);
-
-        for (OperatorID operatorId : operatorIds) {
-            final OperatorState operatorState = new OperatorState(operatorId, 1, 42);
-            final OperatorSubtaskState subtaskState =
-                    OperatorSubtaskState.builder()
-                            .setManagedOperatorState(
-                                    new OperatorStreamStateHandle(
-                                            Collections.emptyMap(),
-                                            new ByteStreamStateHandle("foobar", new byte[0])))
-                            .setInputChannelState(
-                                    singleton(createNewInputChannelStateHandle(10, random)))
-                            .setResultSubpartitionState(
-                                    singleton(createNewResultSubpartitionStateHandle(10, random)))
-                            .build();
-            operatorState.putState(0, subtaskState);
-            operatorStates.add(operatorState);
-        }
-
-        return operatorStates;
+    private static void registerKvState(
+            KvStateRegistryGateway stateRegistryGateway,
+            JobID jobId,
+            JobVertexID jobVertexId,
+            String registrationName)
+            throws UnknownHostException, ExecutionException, InterruptedException {
+        stateRegistryGateway
+                .notifyKvStateRegistered(
+                        jobId,
+                        jobVertexId,
+                        new KeyGroupRange(0, 0),
+                        registrationName,
+                        new KvStateID(),
+                        new InetSocketAddress(InetAddress.getLocalHost(), 1233))
+                .get();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.queryablestate.KvStateID;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.query.KvStateLocation;
+import org.apache.flink.runtime.query.UnknownKvStateLocation;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Tests for the queryable-state logic of the {@link JobMaster}. */
+public class JobMasterQueryableStateTest extends TestLogger {
+
+    @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final Time testingTimeout = Time.seconds(10L);
+
+    private static final long heartbeatInterval = 1000L;
+    private static final long heartbeatTimeout = 5_000_000L;
+
+    private static TestingRpcService rpcService;
+
+    private static HeartbeatServices heartbeatServices;
+
+    private Configuration configuration;
+
+    private TestingHighAvailabilityServices haServices;
+
+    private TestingFatalErrorHandler testingFatalErrorHandler;
+
+    @BeforeClass
+    public static void setupClass() {
+        rpcService = new TestingRpcService();
+
+        heartbeatServices = new HeartbeatServices(heartbeatInterval, heartbeatTimeout);
+    }
+
+    @Before
+    public void setup() throws IOException {
+        configuration = new Configuration();
+        haServices = new TestingHighAvailabilityServices();
+
+        testingFatalErrorHandler = new TestingFatalErrorHandler();
+
+        haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
+
+        SettableLeaderRetrievalService rmLeaderRetrievalService =
+                new SettableLeaderRetrievalService(null, null);
+        haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
+
+        configuration.setString(
+                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+    }
+
+    @After
+    public void teardown() throws Exception {
+        if (testingFatalErrorHandler != null) {
+            testingFatalErrorHandler.rethrowError();
+        }
+
+        rpcService.clearGateways();
+    }
+
+    @AfterClass
+    public static void teardownClass() {
+        if (rpcService != null) {
+            rpcService.stopService();
+            rpcService = null;
+        }
+    }
+
+    @Test
+    public void testRequestKvStateWithoutRegistration() throws Exception {
+        final JobGraph graph = createKvJobGraph();
+
+        final JobMaster jobMaster =
+                new JobMasterBuilder(graph, rpcService)
+                        .withConfiguration(configuration)
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        try {
+            // lookup location
+            try {
+                jobMasterGateway.requestKvStateLocation(graph.getJobID(), "unknown").get();
+                fail("Expected to fail with UnknownKvStateLocation");
+            } catch (Exception e) {
+                assertTrue(
+                        ExceptionUtils.findThrowable(e, UnknownKvStateLocation.class).isPresent());
+            }
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    @Test
+    public void testRequestKvStateOfWrongJob() throws Exception {
+        final JobGraph graph = createKvJobGraph();
+
+        final JobMaster jobMaster =
+                new JobMasterBuilder(graph, rpcService)
+                        .withConfiguration(configuration)
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        try {
+            // lookup location
+            try {
+                jobMasterGateway.requestKvStateLocation(new JobID(), "unknown").get();
+                fail("Expected to fail with FlinkJobNotFoundException");
+            } catch (Exception e) {
+                assertTrue(
+                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
+                                .isPresent());
+            }
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    @Nonnull
+    public JobGraph createKvJobGraph() {
+        final JobVertex vertex1 = new JobVertex("v1");
+        vertex1.setParallelism(4);
+        vertex1.setMaxParallelism(16);
+        vertex1.setInvokableClass(BlockingNoOpInvokable.class);
+
+        final JobVertex vertex2 = new JobVertex("v2");
+        vertex2.setParallelism(4);
+        vertex2.setMaxParallelism(16);
+        vertex2.setInvokableClass(BlockingNoOpInvokable.class);
+
+        return new JobGraph(vertex1, vertex2);
+    }
+
+    @Test
+    public void testRequestKvStateWithIrrelevantRegistration() throws Exception {
+        final JobGraph graph = createKvJobGraph();
+
+        final JobMaster jobMaster =
+                new JobMasterBuilder(graph, rpcService)
+                        .withConfiguration(configuration)
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        try {
+            // register an irrelevant KvState
+            try {
+                jobMasterGateway
+                        .notifyKvStateRegistered(
+                                new JobID(),
+                                new JobVertexID(),
+                                new KeyGroupRange(0, 0),
+                                "any-name",
+                                new KvStateID(),
+                                new InetSocketAddress(InetAddress.getLocalHost(), 1233))
+                        .get();
+                fail("Expected to fail with FlinkJobNotFoundException.");
+            } catch (Exception e) {
+                assertTrue(
+                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
+                                .isPresent());
+            }
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    @Test
+    public void testRegisterAndUnregisterKvState() throws Exception {
+        final JobGraph graph = createKvJobGraph();
+        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
+        final JobVertex vertex1 = jobVertices.get(0);
+
+        final JobMaster jobMaster =
+                new JobMasterBuilder(graph, rpcService)
+                        .withConfiguration(configuration)
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        try {
+            // register a KvState
+            final String registrationName = "register-me";
+            final KvStateID kvStateID = new KvStateID();
+            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
+            final InetSocketAddress address =
+                    new InetSocketAddress(InetAddress.getLocalHost(), 1029);
+
+            jobMasterGateway
+                    .notifyKvStateRegistered(
+                            graph.getJobID(),
+                            vertex1.getID(),
+                            keyGroupRange,
+                            registrationName,
+                            kvStateID,
+                            address)
+                    .get();
+
+            final KvStateLocation location =
+                    jobMasterGateway
+                            .requestKvStateLocation(graph.getJobID(), registrationName)
+                            .get();
+
+            assertEquals(graph.getJobID(), location.getJobId());
+            assertEquals(vertex1.getID(), location.getJobVertexId());
+            assertEquals(vertex1.getMaxParallelism(), location.getNumKeyGroups());
+            assertEquals(1, location.getNumRegisteredKeyGroups());
+            assertEquals(1, keyGroupRange.getNumberOfKeyGroups());
+            assertEquals(kvStateID, location.getKvStateID(keyGroupRange.getStartKeyGroup()));
+            assertEquals(
+                    address, location.getKvStateServerAddress(keyGroupRange.getStartKeyGroup()));
+
+            // unregister the KvState
+            jobMasterGateway
+                    .notifyKvStateUnregistered(
+                            graph.getJobID(), vertex1.getID(), keyGroupRange, registrationName)
+                    .get();
+
+            try {
+                jobMasterGateway.requestKvStateLocation(graph.getJobID(), registrationName).get();
+                fail("Expected to fail with an UnknownKvStateLocation.");
+            } catch (Exception e) {
+                assertTrue(
+                        ExceptionUtils.findThrowable(e, UnknownKvStateLocation.class).isPresent());
+            }
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    @Test
+    public void testDuplicatedKvStateRegistrationsFailTask() throws Exception {
+        final JobGraph graph = createKvJobGraph();
+        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
+        final JobVertex vertex1 = jobVertices.get(0);
+        final JobVertex vertex2 = jobVertices.get(1);
+
+        final JobMaster jobMaster =
+                new JobMasterBuilder(graph, rpcService)
+                        .withConfiguration(configuration)
+                        .withHighAvailabilityServices(haServices)
+                        .withHeartbeatServices(heartbeatServices)
+                        .createJobMaster();
+
+        jobMaster.start();
+
+        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
+
+        try {
+            // duplicate registration fails task
+
+            // register a KvState
+            final String registrationName = "duplicate-me";
+            final KvStateID kvStateID = new KvStateID();
+            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
+            final InetSocketAddress address =
+                    new InetSocketAddress(InetAddress.getLocalHost(), 4396);
+
+            jobMasterGateway
+                    .notifyKvStateRegistered(
+                            graph.getJobID(),
+                            vertex1.getID(),
+                            keyGroupRange,
+                            registrationName,
+                            kvStateID,
+                            address)
+                    .get();
+
+            try {
+                jobMasterGateway
+                        .notifyKvStateRegistered(
+                                graph.getJobID(),
+                                vertex2.getID(), // <--- different operator, but...
+                                keyGroupRange,
+                                registrationName, // ...same name
+                                kvStateID,
+                                address)
+                        .get();
+                fail("Expected to fail because of clashing registration message.");
+            } catch (Exception e) {
+                assertTrue(
+                        ExceptionUtils.findThrowableWithMessage(e, "Registration name clash")
+                                .isPresent());
+                assertEquals(
+                        JobStatus.FAILED, jobMasterGateway.requestJobStatus(testingTimeout).get());
+            }
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    private Collection<OperatorState> createOperatorState(OperatorID... operatorIds) {
+        Random random = new Random();
+        Collection<OperatorState> operatorStates = new ArrayList<>(operatorIds.length);
+
+        for (OperatorID operatorId : operatorIds) {
+            final OperatorState operatorState = new OperatorState(operatorId, 1, 42);
+            final OperatorSubtaskState subtaskState =
+                    OperatorSubtaskState.builder()
+                            .setManagedOperatorState(
+                                    new OperatorStreamStateHandle(
+                                            Collections.emptyMap(),
+                                            new ByteStreamStateHandle("foobar", new byte[0])))
+                            .setInputChannelState(
+                                    singleton(createNewInputChannelStateHandle(10, random)))
+                            .setResultSubpartitionState(
+                                    singleton(createNewResultSubpartitionStateHandle(10, random)))
+                            .build();
+            operatorState.putState(0, subtaskState);
+            operatorStates.add(operatorState);
+        }
+
+        return operatorStates;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.hamcrest.CoreMatchers.either;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -307,8 +309,9 @@ public class JobMasterQueryableStateTest extends TestLogger {
                         ExceptionUtils.findThrowableWithMessage(e, "Registration name clash")
                                 .isPresent());
 
-                assertEquals(
-                        JobStatus.FAILED, jobMasterGateway.requestJobStatus(testingTimeout).get());
+                assertThat(
+                        jobMasterGateway.requestJobStatus(testingTimeout).get(),
+                        either(is(JobStatus.FAILED)).or(is(JobStatus.FAILING)));
             }
         } finally {
             RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -36,7 +36,6 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.core.io.InputSplitSource;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
@@ -95,10 +94,7 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolServiceFactory;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
-import org.apache.flink.runtime.query.KvStateLocation;
-import org.apache.flink.runtime.query.UnknownKvStateLocation;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -113,7 +109,6 @@ import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
 import org.apache.flink.runtime.scheduler.TestingSchedulerNGFactory;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
-import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -127,7 +122,6 @@ import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
-import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -154,8 +148,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.URLClassLoader;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -197,7 +189,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1348,246 +1339,6 @@ public class JobMasterTest extends TestLogger {
         @Override
         public int hashCode() {
             return Objects.hash(splitNumber);
-        }
-    }
-
-    @Test
-    public void testRequestKvStateWithoutRegistration() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
-
-        jobMaster.start();
-
-        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-
-        try {
-            // lookup location
-            try {
-                jobMasterGateway.requestKvStateLocation(graph.getJobID(), "unknown").get();
-                fail("Expected to fail with UnknownKvStateLocation");
-            } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, UnknownKvStateLocation.class).isPresent());
-            }
-        } finally {
-            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
-        }
-    }
-
-    @Test
-    public void testRequestKvStateOfWrongJob() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
-
-        jobMaster.start();
-
-        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-
-        try {
-            // lookup location
-            try {
-                jobMasterGateway.requestKvStateLocation(new JobID(), "unknown").get();
-                fail("Expected to fail with FlinkJobNotFoundException");
-            } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
-                                .isPresent());
-            }
-        } finally {
-            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
-        }
-    }
-
-    @Nonnull
-    public JobGraph createKvJobGraph() {
-        final JobVertex vertex1 = new JobVertex("v1");
-        vertex1.setParallelism(4);
-        vertex1.setMaxParallelism(16);
-        vertex1.setInvokableClass(BlockingNoOpInvokable.class);
-
-        final JobVertex vertex2 = new JobVertex("v2");
-        vertex2.setParallelism(4);
-        vertex2.setMaxParallelism(16);
-        vertex2.setInvokableClass(BlockingNoOpInvokable.class);
-
-        return new JobGraph(vertex1, vertex2);
-    }
-
-    @Test
-    public void testRequestKvStateWithIrrelevantRegistration() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
-
-        jobMaster.start();
-
-        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-
-        try {
-            // register an irrelevant KvState
-            try {
-                jobMasterGateway
-                        .notifyKvStateRegistered(
-                                new JobID(),
-                                new JobVertexID(),
-                                new KeyGroupRange(0, 0),
-                                "any-name",
-                                new KvStateID(),
-                                new InetSocketAddress(InetAddress.getLocalHost(), 1233))
-                        .get();
-                fail("Expected to fail with FlinkJobNotFoundException.");
-            } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, FlinkJobNotFoundException.class)
-                                .isPresent());
-            }
-        } finally {
-            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
-        }
-    }
-
-    @Test
-    public void testRegisterAndUnregisterKvState() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
-        final JobVertex vertex1 = jobVertices.get(0);
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
-
-        jobMaster.start();
-
-        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-
-        try {
-            // register a KvState
-            final String registrationName = "register-me";
-            final KvStateID kvStateID = new KvStateID();
-            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
-            final InetSocketAddress address =
-                    new InetSocketAddress(InetAddress.getLocalHost(), 1029);
-
-            jobMasterGateway
-                    .notifyKvStateRegistered(
-                            graph.getJobID(),
-                            vertex1.getID(),
-                            keyGroupRange,
-                            registrationName,
-                            kvStateID,
-                            address)
-                    .get();
-
-            final KvStateLocation location =
-                    jobMasterGateway
-                            .requestKvStateLocation(graph.getJobID(), registrationName)
-                            .get();
-
-            assertEquals(graph.getJobID(), location.getJobId());
-            assertEquals(vertex1.getID(), location.getJobVertexId());
-            assertEquals(vertex1.getMaxParallelism(), location.getNumKeyGroups());
-            assertEquals(1, location.getNumRegisteredKeyGroups());
-            assertEquals(1, keyGroupRange.getNumberOfKeyGroups());
-            assertEquals(kvStateID, location.getKvStateID(keyGroupRange.getStartKeyGroup()));
-            assertEquals(
-                    address, location.getKvStateServerAddress(keyGroupRange.getStartKeyGroup()));
-
-            // unregister the KvState
-            jobMasterGateway
-                    .notifyKvStateUnregistered(
-                            graph.getJobID(), vertex1.getID(), keyGroupRange, registrationName)
-                    .get();
-
-            try {
-                jobMasterGateway.requestKvStateLocation(graph.getJobID(), registrationName).get();
-                fail("Expected to fail with an UnknownKvStateLocation.");
-            } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowable(e, UnknownKvStateLocation.class).isPresent());
-            }
-        } finally {
-            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
-        }
-    }
-
-    @Test
-    public void testDuplicatedKvStateRegistrationsFailTask() throws Exception {
-        final JobGraph graph = createKvJobGraph();
-        final List<JobVertex> jobVertices = graph.getVerticesSortedTopologicallyFromSources();
-        final JobVertex vertex1 = jobVertices.get(0);
-        final JobVertex vertex2 = jobVertices.get(1);
-
-        final JobMaster jobMaster =
-                new JobMasterBuilder(graph, rpcService)
-                        .withConfiguration(configuration)
-                        .withHighAvailabilityServices(haServices)
-                        .withHeartbeatServices(heartbeatServices)
-                        .createJobMaster();
-
-        jobMaster.start();
-
-        final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
-
-        try {
-            // duplicate registration fails task
-
-            // register a KvState
-            final String registrationName = "duplicate-me";
-            final KvStateID kvStateID = new KvStateID();
-            final KeyGroupRange keyGroupRange = new KeyGroupRange(0, 0);
-            final InetSocketAddress address =
-                    new InetSocketAddress(InetAddress.getLocalHost(), 4396);
-
-            jobMasterGateway
-                    .notifyKvStateRegistered(
-                            graph.getJobID(),
-                            vertex1.getID(),
-                            keyGroupRange,
-                            registrationName,
-                            kvStateID,
-                            address)
-                    .get();
-
-            try {
-                jobMasterGateway
-                        .notifyKvStateRegistered(
-                                graph.getJobID(),
-                                vertex2.getID(), // <--- different operator, but...
-                                keyGroupRange,
-                                registrationName, // ...same name
-                                kvStateID,
-                                address)
-                        .get();
-                fail("Expected to fail because of clashing registration message.");
-            } catch (Exception e) {
-                assertTrue(
-                        ExceptionUtils.findThrowableWithMessage(e, "Registration name clash")
-                                .isPresent());
-                assertEquals(
-                        JobStatus.FAILED, jobMasterGateway.requestJobStatus(testingTimeout).get());
-            }
-        } finally {
-            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
         }
     }
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkMatchers.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkMatchers.java
@@ -83,7 +83,7 @@ public class FlinkMatchers {
 
     /** Checks for a {@link Throwable} that matches by class and message. */
     public static Matcher<Throwable> containsCause(Throwable failureCause) {
-        return new ContainsCauseMatcher(failureCause);
+        return new ContainsCauseAndMessageMatcher(failureCause);
     }
 
     /** Checks for a {@link Throwable} that contains the expected error message. */
@@ -229,11 +229,12 @@ public class FlinkMatchers {
         }
     }
 
-    private static final class ContainsCauseMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+    private static final class ContainsCauseAndMessageMatcher
+            extends TypeSafeDiagnosingMatcher<Throwable> {
 
         private final Throwable failureCause;
 
-        private ContainsCauseMatcher(Throwable failureCause) {
+        private ContainsCauseAndMessageMatcher(Throwable failureCause) {
             this.failureCause = failureCause;
         }
 


### PR DESCRIPTION
- moves JobMaster QS tests to separate file, because the existing JobMasterTest file is big enough as is
- apply various refactorings/cleanup to these tests
  - remove many unnecessary components (HA services, Heartbeat services, fatal error handler, add utility methods)
- provide enough slots for the job to start being deployed
  - this is important for the declarative scheduler so that it moves into an `Executing` state and creates the `ExecutionGraph`
  - related: relax job status check, because we can't really be sure that we haven't started deployment, where some tasks will be stuck in a CANCELING state