### PR TITLE
[FLINK-21354][statebackend] Introduce ChangelogStateBackend to delegate state access

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -96,6 +96,16 @@ public class CheckpointingOptions {
                                             "Recognized shortcut names are 'jobmanager' and 'filesystem'.")
                                     .build());
 
+    /** Whether to enable state change log. */
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
+    @Documentation.ExcludeFromDocumentation("Hidden for now")
+    public static final ConfigOption<Boolean> ENABLE_STATE_CHANGE_LOG =
+            ConfigOptions.key("state.backend.changelog.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable state backend to write state changes to StateChangelog.");
+
     /** The maximum number of completed checkpoints to retain. */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.util.DynamicCodeLoadingException;
@@ -185,16 +186,21 @@ public class CheckpointStorageLoader {
                     CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDirectory.toString());
         }
 
-        // Legacy state backends always take precedence
-        // for backwards compatibility.
-        if (configuredStateBackend instanceof CheckpointStorage) {
+        // Legacy state backends always take precedence for backwards compatibility.
+        StateBackend rootStateBackend =
+                (configuredStateBackend instanceof DelegatingStateBackend)
+                        ? ((DelegatingStateBackend) configuredStateBackend)
+                                .getDelegatedStateBackend()
+                        : configuredStateBackend;
+
+        if (rootStateBackend instanceof CheckpointStorage) {
             if (logger != null) {
                 logger.info(
                         "Using legacy state backend {} as Job checkpoint storage",
-                        configuredStateBackend);
+                        rootStateBackend);
             }
 
-            return (CheckpointStorage) configuredStateBackend;
+            return (CheckpointStorage) rootStateBackend;
         } else if (fromApplication instanceof ConfigurableCheckpointStorage) {
             if (logger != null) {
                 logger.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.util.Disposable;
 
 import java.util.stream.Stream;
@@ -135,6 +136,10 @@ public interface KeyedStateBackend<K>
      * @return returns true iff listener was registered before.
      */
     boolean deregisterKeySelectionListener(KeySelectionListener<K> listener);
+
+    default boolean isStateImmutableInStateBackend(CheckpointType checkpointOptions) {
+        return false;
+    }
 
     /** Listener is given a callback when {@link #setCurrentKey} is called (key context changes). */
     @FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackendFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
@@ -34,18 +35,29 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** This class contains utility methods to load state backends from configurations. */
 public class StateBackendLoader {
 
     private static final Logger LOG = LoggerFactory.getLogger(StateBackendLoader.class);
+
+    /** Used for Loading ChangelogStateBackend. */
+    private static final String CHANGELOG_STATE_BACKEND =
+            "org.apache.flink.state.changelog.ChangelogStateBackend";
+
+    /** Used for loading RocksDBStateBackend. */
+    private static final String ROCKSDB_STATE_BACKEND_FACTORY =
+            "org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendFactory";
+
     // ------------------------------------------------------------------------
     //  Configuration shortcut names
     // ------------------------------------------------------------------------
-
     /** The shortcut configuration name of the HashMap state backend. */
     public static final String HASHMAP_STATE_BACKEND_NAME = "hashmap";
 
@@ -66,17 +78,18 @@ public class StateBackendLoader {
     // ------------------------------------------------------------------------
 
     /**
-     * Loads the state backend from the configuration, from the parameter 'state.backend', as
-     * defined in {@link CheckpointingOptions#STATE_BACKEND}.
+     * Loads the unwrapped state backend from the configuration, from the parameter 'state.backend',
+     * as defined in {@link CheckpointingOptions#STATE_BACKEND}.
      *
      * <p>The state backends can be specified either via their shortcut name, or via the class name
      * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the
      * factory is instantiated (via its zero-argument constructor) and its {@link
      * StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)} method is called.
      *
-     * <p>Recognized shortcut names are '{@value StateBackendLoader#MEMORY_STATE_BACKEND_NAME}',
-     * '{@value StateBackendLoader#FS_STATE_BACKEND_NAME}', and '{@value
-     * StateBackendLoader#ROCKSDB_STATE_BACKEND_NAME}'.
+     * <p>Recognized shortcut names are '{@value StateBackendLoader#HASHMAP_STATE_BACKEND_NAME}',
+     * '{@value StateBackendLoader#ROCKSDB_STATE_BACKEND_NAME}' '{@value
+     * StateBackendLoader#MEMORY_STATE_BACKEND_NAME}' (Deprecated), and '{@value
+     * StateBackendLoader#FS_STATE_BACKEND_NAME}' (Deprecated).
      *
      * @param config The configuration to load the state backend from
      * @param classLoader The class loader that should be used to load the state backend
@@ -89,7 +102,7 @@ public class StateBackendLoader {
      * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
      *     backend
      */
-    public static StateBackend loadStateBackendFromConfig(
+    private static StateBackend loadUnwrappedStateBackendFromConfig(
             ReadableConfig config, ClassLoader classLoader, @Nullable Logger logger)
             throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
 
@@ -137,8 +150,8 @@ public class StateBackendLoader {
                 return hashMapStateBackend;
 
             case ROCKSDB_STATE_BACKEND_NAME:
-                factoryClassName =
-                        "org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendFactory";
+                factoryClassName = ROCKSDB_STATE_BACKEND_FACTORY;
+
                 // fall through to the 'default' case that uses reflection to load the backend
                 // that way we can keep RocksDB in a separate module
 
@@ -174,6 +187,49 @@ public class StateBackendLoader {
     }
 
     /**
+     * Loads the state backend from the configuration. It returns a {@code ChangelogStateBackend} if
+     * '{@code CheckpointingOptions.ENABLE_STATE_CHANGE_LOG}' is enabled; otherwise returns an
+     * unwrapped state backend created through {@link
+     * StateBackendLoader#loadUnwrappedStateBackendFromConfig}.
+     *
+     * <p>Refer to {@link StateBackendLoader#loadUnwrappedStateBackendFromConfig} for details on how
+     * an unwrapped state backend is loaded from the configuration.
+     *
+     * @param config The configuration to load the state backend from
+     * @param classLoader The class loader that should be used to load the state backend
+     * @param logger Optionally, a logger to log actions to (may be null)
+     * @return The instantiated {@code ChangelogStateBackend} if '{@code
+     *     CheckpointingOptions.ENABLE_STATE_CHANGE_LOG}' is enabled; An unwrapped state backend
+     *     otherwise
+     * @throws DynamicCodeLoadingException Thrown if a state backend factory is configured and the
+     *     factory class was not found or the factory could not be instantiated
+     * @throws IllegalConfigurationException May be thrown by the StateBackendFactory when creating
+     *     / configuring the state backend in the factory
+     * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
+     *     backend
+     */
+    public static StateBackend loadStateBackendFromConfig(
+            ReadableConfig config, ClassLoader classLoader, @Nullable Logger logger)
+            throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+        checkNotNull(config, "config");
+        checkNotNull(classLoader, "classLoader");
+
+        final StateBackend backend =
+                loadUnwrappedStateBackendFromConfig(config, classLoader, logger);
+
+        checkArgument(
+                !(backend instanceof DelegatingStateBackend),
+                "expecting non-delegating state backend");
+
+        if (config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG) && (backend != null)) {
+            return loadChangelogStateBackend(backend, classLoader);
+        } else {
+            return backend;
+        }
+    }
+
+    /**
      * Checks if an application-defined state backend is given, and if not, loads the state backend
      * from the configuration, from the parameter 'state.backend', as defined in {@link
      * CheckpointingOptions#STATE_BACKEND}. If no state backend is configured, this instantiates the
@@ -183,8 +239,8 @@ public class StateBackendLoader {
      * ConfigurableStateBackend}, this methods calls {@link
      * ConfigurableStateBackend#configure(ReadableConfig, ClassLoader)} on the state backend.
      *
-     * <p>Refer to {@link #loadStateBackendFromConfig(ReadableConfig, ClassLoader, Logger)} for
-     * details on how the state backend is loaded from the configuration.
+     * <p>Refer to {@link #loadUnwrappedStateBackendFromConfig(ReadableConfig, ClassLoader, Logger)}
+     * for details on how the state backend is loaded from the configuration.
      *
      * @param config The configuration to load the state backend from
      * @param classLoader The class loader that should be used to load the state backend
@@ -197,7 +253,7 @@ public class StateBackendLoader {
      * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
      *     backend
      */
-    public static StateBackend fromApplicationOrConfigOrDefault(
+    private static StateBackend loadFromApplicationOrConfigOrDefaultInternal(
             @Nullable StateBackend fromApplication,
             Configuration config,
             ClassLoader classLoader,
@@ -232,7 +288,8 @@ public class StateBackendLoader {
             }
         } else {
             // (2) check if the config defines a state backend
-            final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, logger);
+            final StateBackend fromConfig =
+                    loadUnwrappedStateBackendFromConfig(config, classLoader, logger);
             if (fromConfig != null) {
                 backend = fromConfig;
             } else {
@@ -247,6 +304,43 @@ public class StateBackendLoader {
         }
 
         return backend;
+    }
+
+    /**
+     * This is the state backend loader that loads a {@link DelegatingStateBackend} wrapping the
+     * state backend loaded from {@link
+     * StateBackendLoader#loadFromApplicationOrConfigOrDefaultInternal} when delegation is enabled.
+     * If delegation is not enabled, the underlying wrapped state backend is returned instead.
+     *
+     * @param fromApplication StateBackend defined from application
+     * @param config The configuration to load the state backend from
+     * @param classLoader The class loader that should be used to load the state backend
+     * @param logger Optionally, a logger to log actions to (may be null)
+     * @return The instantiated state backend.
+     * @throws DynamicCodeLoadingException Thrown if a state backend (factory) is configured and the
+     *     (factory) class was not found or could not be instantiated
+     * @throws IllegalConfigurationException May be thrown by the StateBackendFactory when creating
+     *     / configuring the state backend in the factory
+     * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
+     *     backend
+     */
+    public static StateBackend fromApplicationOrConfigOrDefault(
+            @Nullable StateBackend fromApplication,
+            Configuration config,
+            ClassLoader classLoader,
+            @Nullable Logger logger)
+            throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+        final StateBackend backend =
+                loadFromApplicationOrConfigOrDefaultInternal(
+                        fromApplication, config, classLoader, logger);
+
+        if (config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG)
+                && !(fromApplication instanceof DelegatingStateBackend)) {
+            return loadChangelogStateBackend(backend, classLoader);
+        } else {
+            return backend;
+        }
     }
 
     /**
@@ -273,7 +367,8 @@ public class StateBackendLoader {
 
         // (2) check if the config defines a state backend
         try {
-            final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, LOG);
+            final StateBackend fromConfig =
+                    loadUnwrappedStateBackendFromConfig(config, classLoader, LOG);
             if (fromConfig != null) {
                 return fromConfig.useManagedMemory();
             }
@@ -286,6 +381,32 @@ public class StateBackendLoader {
 
         // (3) use the default MemoryStateBackend
         return false;
+    }
+
+    private static StateBackend loadChangelogStateBackend(
+            StateBackend backend, ClassLoader classLoader) throws DynamicCodeLoadingException {
+
+        LOG.info(
+                "Delegate State Backend is used, and the root State Backend is {}",
+                backend.getClass().getSimpleName());
+
+        // ChangelogStateBackend resides in a separate module, load it using reflection
+        try {
+            Constructor<? extends DelegatingStateBackend> constructor =
+                    Class.forName(CHANGELOG_STATE_BACKEND, false, classLoader)
+                            .asSubclass(DelegatingStateBackend.class)
+                            .getConstructor(StateBackend.class);
+            return constructor.newInstance(backend);
+        } catch (ClassNotFoundException e) {
+            throw new DynamicCodeLoadingException(
+                    "Cannot find DelegateStateBackend class: " + CHANGELOG_STATE_BACKEND, e);
+        } catch (InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | InvocationTargetException e) {
+            throw new DynamicCodeLoadingException(
+                    "Fail to initialize: " + CHANGELOG_STATE_BACKEND, e);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TestableKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TestableKeyedStateBackend.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+/** A keyed state backend interface for internal testing purpose. */
+@VisibleForTesting
+public interface TestableKeyedStateBackend {
+    /** Returns the total number of state entries across all keys/namespaces. */
+    int numKeyValueStateEntries();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/delegate/DelegatingStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/delegate/DelegatingStateBackend.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.delegate;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.StateBackend;
+
+/**
+ * An interface to delegate state backend.
+ *
+ * <p>As its name, it should include a state backend to delegate.
+ */
+@Internal
+public interface DelegatingStateBackend extends StateBackend {
+    StateBackend getDelegatedStateBackend();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -347,7 +347,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             final N namespace,
             final TypeSerializer<N> namespaceSerializer,
             final StateDescriptor<S, T> stateDescriptor,
-            final KeyedStateFunction<K, S> function)
+            final KeyedStateFunction<K, S> function,
+            final PartitionStateFactory partitionStateFactory)
             throws Exception {
 
         try (Stream<K> keyStream = getKeys(stateDescriptor.getName(), namespace)) {
@@ -356,7 +357,8 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             // when state.clear() is invoked in function.process().
             final List<K> keys = keyStream.collect(Collectors.toList());
 
-            final S state = getPartitionedState(namespace, namespaceSerializer, stateDescriptor);
+            final S state =
+                    partitionStateFactory.get(namespace, namespaceSerializer, stateDescriptor);
 
             for (K key : keys) {
                 setCurrentKey(key);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -193,24 +193,24 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         return checkpointStreamFactory;
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer)
-            throws Exception {
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer) throws Exception {
         return createKeyedBackend(keySerializer, env);
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer, Environment env) throws Exception {
         return createKeyedBackend(keySerializer, 10, new KeyGroupRange(0, 9), env);
     }
 
-    protected <K> AbstractKeyedStateBackend<K> createKeyedBackend(
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,
             KeyGroupRange keyGroupRange,
             Environment env)
             throws Exception {
 
-        AbstractKeyedStateBackend<K> backend =
+        CheckpointableKeyedStateBackend<K> backend =
                 getStateBackend()
                         .createKeyedStateBackend(
                                 env,
@@ -271,7 +271,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final int namespace1ElementsNum = 1000;
         final int namespace2ElementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             ValueState<Integer> keyedState1 =
@@ -336,7 +337,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testGetKeysAndNamespaces() throws Exception {
         final int elementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             ValueState<Integer> keyedState1 =
@@ -384,7 +386,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoDefaultSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         // cast because our test serializer is not typed to TestPojo
@@ -450,7 +452,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoDefaultSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         // cast because our test serializer is not typed to TestPojo
@@ -518,7 +520,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         env.getExecutionConfig()
                 .registerTypeWithKryoSerializer(
@@ -582,7 +584,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testBackendUsesRegisteredKryoSerializerUsingGetOrCreate() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         env.getExecutionConfig()
@@ -655,7 +657,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithRegisteredType() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         TypeInformation<TestPojo> pojoType = new GenericTypeInfo<>(TestPojo.class);
@@ -727,7 +729,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testKryoRegisteringRestoreResilienceWithDefaultSerializer() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
 
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE, env);
@@ -853,7 +855,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
 
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE, env);
@@ -968,7 +970,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         env.getExecutionConfig().registerKryoType(TestNestedPojoClassA.class);
         env.getExecutionConfig().registerKryoType(TestNestedPojoClassB.class);
 
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         try {
@@ -1097,7 +1099,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         env.getExecutionConfig().registerPojoType(TestNestedPojoClassA.class);
         env.getExecutionConfig().registerPojoType(TestNestedPojoClassB.class);
 
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         try {
@@ -1192,7 +1194,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testValueState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -1393,7 +1396,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testValueStateWorkWithTtl() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             ValueStateDescriptor<MutableLong> kvId =
                     new ValueStateDescriptor<>("id", MutableLong.class);
@@ -1419,7 +1423,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testValueStateRace() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
         final Integer namespace = 1;
 
@@ -1549,7 +1553,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMultipleValueStates() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, 1, new KeyGroupRange(0, 0), env);
 
         ValueStateDescriptor<String> desc1 =
@@ -1637,7 +1641,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<Long> kvId =
                 new ValueStateDescriptor<>("id", LongSerializer.INSTANCE, 42L);
@@ -1692,7 +1697,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testListState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -1917,7 +1923,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -1945,7 +1951,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddAllNullEntries() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -1978,7 +1984,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateAddAllNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2006,7 +2012,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateUpdateNullEntries() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2039,7 +2045,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testListStateUpdateNull() throws Exception {
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2064,7 +2070,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testListStateAPIs() throws Exception {
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2130,7 +2136,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // make sure all lists / maps are cleared
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2140,7 +2148,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     public void testListStateMerging() throws Exception {
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         final ListStateDescriptor<Long> stateDescr =
@@ -2248,7 +2256,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             state.clear();
 
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2260,7 +2270,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testReducingState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ReducingStateDescriptor<String> kvId =
                 new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
@@ -2466,7 +2477,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final ReducingStateDescriptor<Long> stateDescr =
                 new ReducingStateDescriptor<>("my-state", (a, b) -> a + b, Long.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2510,7 +2521,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // make sure all lists / maps are cleared
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2529,7 +2542,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2630,7 +2643,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             state.clear();
 
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2644,7 +2659,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new AggregatingStateDescriptor<>(
                         "my-state", new MutableAggregatingAddingFunction(), MutableLong.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2688,7 +2703,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // make sure all lists / maps are cleared
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2708,7 +2725,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2809,7 +2826,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             state.clear();
 
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2823,7 +2842,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new AggregatingStateDescriptor<>(
                         "my-state", new ImmutableAggregatingAddingFunction(), Long.class);
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2867,7 +2886,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // make sure all lists / maps are cleared
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -2887,7 +2908,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         final Long expectedResult = 165L;
 
-        AbstractKeyedStateBackend<String> keyedBackend =
+        CheckpointableKeyedStateBackend<String> keyedBackend =
                 createKeyedBackend(StringSerializer.INSTANCE);
 
         try {
@@ -2988,7 +3009,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             state.clear();
 
             assertThat(
-                    "State backend is not empty.", keyedBackend.numKeyValueStateEntries(), is(0));
+                    "State backend is not empty.",
+                    ((TestableKeyedStateBackend) keyedBackend).numKeyValueStateEntries(),
+                    is(0));
         } finally {
             keyedBackend.close();
             keyedBackend.dispose();
@@ -3000,7 +3023,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMapState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<String> backend = createKeyedBackend(StringSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<String> backend =
+                createKeyedBackend(StringSerializer.INSTANCE);
 
         MapStateDescriptor<Integer, String> kvId =
                 new MapStateDescriptor<>("id", Integer.class, String.class);
@@ -3332,7 +3356,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         MapStateDescriptor<Integer, Long> kvId =
                 new MapStateDescriptor<>("id", Integer.class, Long.class);
 
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapState<Integer, Long> state =
@@ -3367,7 +3392,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         MapStateDescriptor<Integer, Long> kvId =
                 new MapStateDescriptor<>("id", Integer.class, Long.class);
 
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapState<Integer, Long> state =
@@ -3411,7 +3437,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that {@link ValueStateDescriptor} allows {@code null} as default. */
     @Test
     public void testValueStateNullAsDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, null);
 
@@ -3434,7 +3461,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ValueState} will yield the default value. */
     @Test
     public void testValueStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class, "Hello");
 
@@ -3457,7 +3485,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ReduceState} yields {@code null}. */
     @Test
     public void testReducingStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ReducingStateDescriptor<String> kvId =
                 new ReducingStateDescriptor<>("id", new AppendingReduce(), String.class);
@@ -3481,7 +3510,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code ListState} yields {@code null}. */
     @Test
     public void testListStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -3504,7 +3534,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     /** Verify that an empty {@code MapState} yields {@code null}. */
     @Test
     public void testMapStateDefaultValue() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         MapStateDescriptor<String, String> kvId =
                 new MapStateDescriptor<>("id", String.class, String.class);
@@ -3535,7 +3566,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testSnapshotNonAccessedState() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<String> backend = createKeyedBackend(StringSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<String> backend =
+                createKeyedBackend(StringSerializer.INSTANCE);
 
         final String stateName = "test-name";
         try {
@@ -3680,7 +3712,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         List<KeyGroupRange> keyGroupRanges = new ArrayList<>();
-        List<AbstractKeyedStateBackend<Integer>> stateBackends = new ArrayList<>();
+        List<CheckpointableKeyedStateBackend<Integer>> stateBackends = new ArrayList<>();
         for (int i = 0; i < sourceParallelism; ++i) {
             keyGroupRanges.add(
                     KeyGroupRange.of(
@@ -3702,7 +3734,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         List<Integer> keyInKeyGroups = new ArrayList<>(maxParallelism);
         List<String> expectedValue = new ArrayList<>(maxParallelism);
         for (int i = 0; i < sourceParallelism; ++i) {
-            AbstractKeyedStateBackend<Integer> backend = stateBackends.get(i);
+            CheckpointableKeyedStateBackend<Integer> backend = stateBackends.get(i);
             KeyGroupRange range = keyGroupRanges.get(i);
             for (int j = range.getStartKeyGroup(); j <= range.getEndKeyGroup(); ++j) {
                 ValueState<String> state =
@@ -3756,11 +3788,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
 
         // restore and verify
-        List<AbstractKeyedStateBackend<Integer>> targetBackends =
+        List<CheckpointableKeyedStateBackend<Integer>> targetBackends =
                 new ArrayList<>(targetParallelism);
 
         for (int i = 0; i < targetParallelism; ++i) {
-            AbstractKeyedStateBackend<Integer> backend =
+            CheckpointableKeyedStateBackend<Integer> backend =
                     restoreKeyedBackend(
                             IntSerializer.INSTANCE,
                             maxParallelism,
@@ -3794,7 +3826,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
         // use an IntSerializer at first
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
@@ -3837,7 +3870,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testValueStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
@@ -3893,7 +3927,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testListStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
@@ -3948,7 +3983,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testReducingStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ReducingStateDescriptor<String> kvId =
@@ -4007,7 +4043,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testMapStateRestoreWithWrongSerializers() throws Exception {
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             MapStateDescriptor<String, String> kvId =
@@ -4064,7 +4101,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testCopyDefaultValue() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<IntValue> kvId =
@@ -4094,7 +4131,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testRequireNonNullNamespace() throws Exception {
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<IntValue> kvId =
@@ -4128,7 +4165,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @SuppressWarnings("unchecked")
     protected void testConcurrentMapIfQueryable() throws Exception {
         final int numberOfKeyGroups = 1;
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(
                         IntSerializer.INSTANCE,
                         numberOfKeyGroups,
@@ -4260,7 +4297,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
         KeyGroupRange expectedKeyGroupRange = backend.getKeyGroupRange();
 
@@ -4324,7 +4361,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         try {
             CheckpointStreamFactory streamFactory = createStreamFactory();
             SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-            AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+            CheckpointableKeyedStateBackend<Integer> backend =
+                    createKeyedBackend(IntSerializer.INSTANCE);
 
             ListStateDescriptor<String> kvId = new ListStateDescriptor<>("id", String.class);
 
@@ -4351,11 +4389,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testNumStateEntries() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
 
-        assertEquals(0, backend.numKeyValueStateEntries());
+        assertEquals(0, ((TestableKeyedStateBackend) backend).numKeyValueStateEntries());
 
         ValueState<String> state =
                 backend.getPartitionedState(
@@ -4365,22 +4404,22 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         state.update("hello");
         state.update("ciao");
 
-        assertEquals(1, backend.numKeyValueStateEntries());
+        assertEquals(1, ((TestableKeyedStateBackend) backend).numKeyValueStateEntries());
 
         backend.setCurrentKey(42);
         state.update("foo");
 
-        assertEquals(2, backend.numKeyValueStateEntries());
+        assertEquals(2, ((TestableKeyedStateBackend) backend).numKeyValueStateEntries());
 
         backend.setCurrentKey(0);
         state.clear();
 
-        assertEquals(1, backend.numKeyValueStateEntries());
+        assertEquals(1, ((TestableKeyedStateBackend) backend).numKeyValueStateEntries());
 
         backend.setCurrentKey(42);
         state.clear();
 
-        assertEquals(0, backend.numKeyValueStateEntries());
+        assertEquals(0, ((TestableKeyedStateBackend) backend).numKeyValueStateEntries());
 
         backend.dispose();
     }
@@ -4406,7 +4445,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         streamFactory.setBlockerLatch(blocker);
         streamFactory.setAfterNumberInvocations(10);
 
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
@@ -4476,7 +4515,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testNonConcurrentSnapshotTransformerAccess() throws Exception {
         BlockerCheckpointStreamFactory streamFactory =
                 new BlockerCheckpointStreamFactory(1024 * 1024);
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
         try {
             backend = createKeyedBackend(IntSerializer.INSTANCE);
             new StateSnapshotTransformerTest(backend, streamFactory)
@@ -4496,7 +4535,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 new BlockerCheckpointStreamFactory(1024 * 1024);
         streamFactory.setWaiterLatch(waiter);
 
-        AbstractKeyedStateBackend<Integer> backend = null;
+        CheckpointableKeyedStateBackend<Integer> backend = null;
         KeyedStateHandle stateHandle = null;
 
         try {
@@ -4585,7 +4624,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testConcurrentModificationWithApplyToAllKeys() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> listStateDescriptor =
@@ -4673,7 +4713,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testApplyToAllKeysLambdaFunction() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
             ListStateDescriptor<String> listStateDescriptor =
@@ -4713,7 +4754,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         streamFactory.setBlockerLatch(blocker);
         streamFactory.setAfterNumberInvocations(10);
 
-        final AbstractKeyedStateBackend<Integer> backend =
+        final CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
 
         try {
@@ -4772,7 +4813,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         final int namespace1ElementsNum = 1000;
         final int namespace2ElementsNum = 1000;
         String fieldName = "get-keys-test";
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         try {
             final String ns1 = "ns1";
             MapState<String, Integer> keyedState1 =
@@ -4841,7 +4883,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     public void testCheckConcurrencyProblemWhenPerformingCheckpointAsync() throws Exception {
 
         CheckpointStreamFactory streamFactory = createStreamFactory();
-        AbstractKeyedStateBackend<Integer> backend =
+        CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE, env);
 
         ExecutorService executorService = Executors.newScheduledThreadPool(1);
@@ -5264,7 +5306,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     }
 
     @SuppressWarnings("serial")
-    private static class MutableAggregatingAddingFunction
+    public static class MutableAggregatingAddingFunction
             implements AggregateFunction<Long, MutableLong, Long> {
 
         @Override
@@ -5315,7 +5357,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         }
     }
 
-    private static final class MutableLong {
+    public static final class MutableLong {
         long value;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -42,12 +42,12 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 class StateSnapshotTransformerTest {
-    private final AbstractKeyedStateBackend<Integer> backend;
+    private final CheckpointableKeyedStateBackend<Integer> backend;
     private final BlockerCheckpointStreamFactory streamFactory;
     private final StateSnapshotTransformFactory<?> snapshotTransformFactory;
 
     StateSnapshotTransformerTest(
-            AbstractKeyedStateBackend<Integer> backend,
+            CheckpointableKeyedStateBackend<Integer> backend,
             BlockerCheckpointStreamFactory streamFactory) {
 
         this.backend = backend;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -180,11 +179,6 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             }
         }
         return count;
-    }
-
-    @Override
-    public boolean requiresLegacySynchronousTimerSnapshots(CheckpointType checkpointOptions) {
-        return false;
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -16,43 +16,69 @@ software distributed under the License is distributed on an
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-libraries</artifactId>
+		<artifactId>flink-state-backends</artifactId>
 		<version>1.13-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-state-processor-api_${scala.binary.version}</artifactId>
-	<name>Flink : Libraries : State processor API</name>
+	<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+	<name>Flink : State backends : Changelog</name>
 
 	<packaging>jar</packaging>
 
 	<dependencies>
 
-		<!-- core dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+        </dependency>
+
+		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-java</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<scope>test</scope>
 		</dependency>
-		
-		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -61,52 +87,6 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 
 </project>

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+/**
+ * Base class for changelog state wrappers of state objects.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <V> The type of values kept internally in state without changelog wrapper
+ * @param <S> Type of originally wrapped state object
+ */
+abstract class AbstractChangelogState<K, N, V, S extends InternalKvState<K, N, V>>
+        implements InternalKvState<K, N, V> {
+    protected final S delegatedState;
+
+    AbstractChangelogState(S state) {
+        this.delegatedState = state;
+    }
+
+    public S getDelegatedState() {
+        return delegatedState;
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return delegatedState.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return delegatedState.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<V> getValueSerializer() {
+        return delegatedState.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        delegatedState.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<V> safeValueSerializer)
+            throws Exception {
+        return delegatedState.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, V> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return delegatedState.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogAggregatingState.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+import java.util.Collection;
+
+/**
+ * Delegated partitioned {@link AggregatingState} that forwards changes to {@link StateChange} upon
+ * {@link AggregatingState} is updated.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <IN> The type of the value added to the state.
+ * @param <ACC> The type of the value stored in the state (the accumulator type).
+ * @param <OUT> The type of the value returned from the state.
+ */
+class ChangelogAggregatingState<K, N, IN, ACC, OUT>
+        extends AbstractChangelogState<K, N, ACC, InternalAggregatingState<K, N, IN, ACC, OUT>>
+        implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+
+    ChangelogAggregatingState(InternalAggregatingState<K, N, IN, ACC, OUT> delegatedState) {
+        super(delegatedState);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        delegatedState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public ACC getInternal() throws Exception {
+        return delegatedState.getInternal();
+    }
+
+    @Override
+    public void updateInternal(ACC valueToStore) throws Exception {
+        delegatedState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public OUT get() throws Exception {
+        return delegatedState.get();
+    }
+
+    @Override
+    public void add(IN value) throws Exception {
+        delegatedState.add(value);
+    }
+
+    @Override
+    public void clear() {
+        delegatedState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> aggregatingState) {
+        return (IS)
+                new ChangelogAggregatingState<>(
+                        (InternalAggregatingState<K, N, T, SV, ?>) aggregatingState);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateFunction;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.SavepointResources;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.TestableKeyedStateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.ttl.TtlStateFactory;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.RunnableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link KeyedStateBackend} that keeps state on the underlying delegated keyed state backend as
+ * well as on the state change log.
+ *
+ * @param <K> The key by which state is keyed.
+ */
+@Internal
+class ChangelogKeyedStateBackend<K>
+        implements CheckpointableKeyedStateBackend<K>,
+                CheckpointListener,
+                TestableKeyedStateBackend {
+
+    private static final Map<Class<? extends StateDescriptor>, StateFactory> STATE_FACTORIES =
+            Stream.of(
+                            Tuple2.of(
+                                    ValueStateDescriptor.class,
+                                    (StateFactory) ChangelogValueState::create),
+                            Tuple2.of(
+                                    ListStateDescriptor.class,
+                                    (StateFactory) ChangelogListState::create),
+                            Tuple2.of(
+                                    ReducingStateDescriptor.class,
+                                    (StateFactory) ChangelogReducingState::create),
+                            Tuple2.of(
+                                    AggregatingStateDescriptor.class,
+                                    (StateFactory) ChangelogAggregatingState::create),
+                            Tuple2.of(
+                                    MapStateDescriptor.class,
+                                    (StateFactory) ChangelogMapState::create))
+                    .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+
+    /** delegated keyedStateBackend. */
+    private final AbstractKeyedStateBackend<K> keyedStateBackend;
+
+    /**
+     * This is the cache maintained by the DelegateKeyedStateBackend itself. It is not the same as
+     * the underlying delegated keyedStateBackend. InternalKvState is a delegated state.
+     */
+    private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
+
+    private final ExecutionConfig executionConfig;
+
+    private final TtlTimeProvider ttlTimeProvider;
+
+    /** last accessed partitioned state. */
+    @SuppressWarnings("rawtypes")
+    private InternalKvState lastState;
+
+    /** For caching the last accessed partitioned state. */
+    private String lastName;
+
+    public ChangelogKeyedStateBackend(
+            AbstractKeyedStateBackend<K> keyedStateBackend,
+            ExecutionConfig executionConfig,
+            TtlTimeProvider ttlTimeProvider) {
+        this.keyedStateBackend = keyedStateBackend;
+        this.executionConfig = executionConfig;
+        this.ttlTimeProvider = ttlTimeProvider;
+        this.keyValueStatesByName = new HashMap<>();
+    }
+
+    // -------------------- CheckpointableKeyedStateBackend --------------------------------
+    @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return keyedStateBackend.getKeyGroupRange();
+    }
+
+    @Override
+    public void close() throws IOException {
+        keyedStateBackend.close();
+    }
+
+    @Override
+    public void setCurrentKey(K newKey) {
+        keyedStateBackend.setCurrentKey(newKey);
+    }
+
+    @Override
+    public K getCurrentKey() {
+        return keyedStateBackend.getCurrentKey();
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return keyedStateBackend.getKeySerializer();
+    }
+
+    @Override
+    public <N> Stream<K> getKeys(String state, N namespace) {
+        return keyedStateBackend.getKeys(state, namespace);
+    }
+
+    @Override
+    public <N> Stream<Tuple2<K, N>> getKeysAndNamespaces(String state) {
+        return keyedStateBackend.getKeysAndNamespaces(state);
+    }
+
+    @Override
+    public void dispose() {
+        keyedStateBackend.dispose();
+        lastName = null;
+        lastState = null;
+        keyValueStatesByName.clear();
+    }
+
+    @Override
+    public void registerKeySelectionListener(KeySelectionListener<K> listener) {
+        keyedStateBackend.registerKeySelectionListener(listener);
+    }
+
+    @Override
+    public boolean deregisterKeySelectionListener(KeySelectionListener<K> listener) {
+        return keyedStateBackend.deregisterKeySelectionListener(listener);
+    }
+
+    @Override
+    public <N, S extends State, T> void applyToAllKeys(
+            N namespace,
+            TypeSerializer<N> namespaceSerializer,
+            StateDescriptor<S, T> stateDescriptor,
+            KeyedStateFunction<K, S> function)
+            throws Exception {
+
+        keyedStateBackend.applyToAllKeys(
+                namespace,
+                namespaceSerializer,
+                stateDescriptor,
+                function,
+                this::getPartitionedState);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <N, S extends State> S getPartitionedState(
+            N namespace,
+            TypeSerializer<N> namespaceSerializer,
+            StateDescriptor<S, ?> stateDescriptor)
+            throws Exception {
+
+        checkNotNull(namespace, "Namespace");
+
+        if (lastName != null && lastName.equals(stateDescriptor.getName())) {
+            lastState.setCurrentNamespace(namespace);
+            return (S) lastState;
+        }
+
+        final InternalKvState<K, ?, ?> previous =
+                keyValueStatesByName.get(stateDescriptor.getName());
+        if (previous != null) {
+            lastState = previous;
+            lastState.setCurrentNamespace(namespace);
+            lastName = stateDescriptor.getName();
+            return (S) previous;
+        }
+
+        final S state = getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
+        final InternalKvState<K, N, ?> kvState = (InternalKvState<K, N, ?>) state;
+
+        lastName = stateDescriptor.getName();
+        lastState = kvState;
+        kvState.setCurrentNamespace(namespace);
+
+        return state;
+    }
+
+    @Nonnull
+    @Override
+    public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+            long checkpointId,
+            long timestamp,
+            @Nonnull CheckpointStreamFactory streamFactory,
+            @Nonnull CheckpointOptions checkpointOptions)
+            throws Exception {
+        return keyedStateBackend.snapshot(
+                checkpointId, timestamp, streamFactory, checkpointOptions);
+    }
+
+    @Nonnull
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+        return keyedStateBackend.create(stateName, byteOrderedElementSerializer);
+    }
+
+    @VisibleForTesting
+    @Override
+    public int numKeyValueStateEntries() {
+        return keyedStateBackend.numKeyValueStateEntries();
+    }
+
+    @Override
+    public boolean isStateImmutableInStateBackend(CheckpointType checkpointOptions) {
+        return keyedStateBackend.isStateImmutableInStateBackend(checkpointOptions);
+    }
+
+    @Nonnull
+    @Override
+    public SavepointResources<K> savepoint() throws Exception {
+        return keyedStateBackend.savepoint();
+    }
+
+    // -------------------- CheckpointListener --------------------------------
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        keyedStateBackend.notifyCheckpointComplete(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        keyedStateBackend.notifyCheckpointAborted(checkpointId);
+    }
+
+    // -------- Methods not simply delegating to wrapped state backend ---------
+    @Override
+    @SuppressWarnings("unchecked")
+    public <N, S extends State, T> S getOrCreateKeyedState(
+            TypeSerializer<N> namespaceSerializer, StateDescriptor<S, T> stateDescriptor)
+            throws Exception {
+        checkNotNull(namespaceSerializer, "Namespace serializer");
+        checkNotNull(
+                getKeySerializer(),
+                "State key serializer has not been configured in the config. "
+                        + "This operation cannot use partitioned state.");
+
+        InternalKvState<K, ?, ?> kvState = keyValueStatesByName.get(stateDescriptor.getName());
+        if (kvState == null) {
+            if (!stateDescriptor.isSerializerInitialized()) {
+                stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+            }
+            kvState =
+                    TtlStateFactory.createStateAndWrapWithTtlIfEnabled(
+                            namespaceSerializer, stateDescriptor, this, ttlTimeProvider);
+            keyValueStatesByName.put(stateDescriptor.getName(), kvState);
+            keyedStateBackend.publishQueryableStateIfEnabled(stateDescriptor, kvState);
+        }
+        return (S) kvState;
+    }
+
+    @Nonnull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <N, SV, SEV, S extends State, IS extends S> IS createInternalState(
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<S, SV> stateDesc,
+            @Nonnull
+                    StateSnapshotTransformer.StateSnapshotTransformFactory<SEV>
+                            snapshotTransformFactory)
+            throws Exception {
+        StateFactory stateFactory = STATE_FACTORIES.get(stateDesc.getClass());
+        if (stateFactory == null) {
+            String message =
+                    String.format(
+                            "State %s is not supported by %s",
+                            stateDesc.getClass(), this.getClass());
+            throw new FlinkRuntimeException(message);
+        }
+
+        return stateFactory.create(
+                keyedStateBackend.createInternalState(
+                        namespaceSerializer, stateDesc, snapshotTransformFactory));
+    }
+
+    // Factory function interface
+    private interface StateFactory {
+        <K, N, SV, S extends State, IS extends S> IS create(InternalKvState<K, N, SV> kvState)
+                throws Exception;
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogListState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogListState.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Delegated partitioned {@link ListState} that forwards changes to {@link StateChange} upon {@link
+ * ListState} is updated.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the value.
+ */
+class ChangelogListState<K, N, V>
+        extends AbstractChangelogState<K, N, List<V>, InternalListState<K, N, V>>
+        implements InternalListState<K, N, V> {
+
+    ChangelogListState(InternalListState<K, N, V> delegatedState) {
+        super(delegatedState);
+    }
+
+    @Override
+    public void update(List<V> values) throws Exception {
+        delegatedState.update(values);
+    }
+
+    @Override
+    public void addAll(List<V> values) throws Exception {
+        delegatedState.addAll(values);
+    }
+
+    @Override
+    public void updateInternal(List<V> valueToStore) throws Exception {
+        delegatedState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public void add(V value) throws Exception {
+        delegatedState.add(value);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        delegatedState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public List<V> getInternal() throws Exception {
+        return delegatedState.getInternal();
+    }
+
+    @Override
+    public Iterable<V> get() throws Exception {
+        return delegatedState.get();
+    }
+
+    @Override
+    public void clear() {
+        delegatedState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> listState) {
+        return (IS) new ChangelogListState<>((InternalListState<K, N, SV>) listState);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Delegated partitioned {@link MapState} that forwards changes to {@link StateChange} upon {@link
+ * MapState} is updated.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <UK> The type of the keys in the state.
+ * @param <UV> The type of the values in the state.
+ */
+class ChangelogMapState<K, N, UK, UV>
+        extends AbstractChangelogState<K, N, Map<UK, UV>, InternalMapState<K, N, UK, UV>>
+        implements InternalMapState<K, N, UK, UV> {
+
+    ChangelogMapState(InternalMapState<K, N, UK, UV> delegatedState) {
+        super(delegatedState);
+    }
+
+    @Override
+    public UV get(UK key) throws Exception {
+        return delegatedState.get(key);
+    }
+
+    @Override
+    public void put(UK key, UV value) throws Exception {
+        delegatedState.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<UK, UV> map) throws Exception {
+        delegatedState.putAll(map);
+    }
+
+    @Override
+    public void remove(UK key) throws Exception {
+        delegatedState.remove(key);
+    }
+
+    @Override
+    public boolean contains(UK key) throws Exception {
+        return delegatedState.contains(key);
+    }
+
+    @Override
+    public Iterable<Map.Entry<UK, UV>> entries() throws Exception {
+        return delegatedState.entries();
+    }
+
+    @Override
+    public Iterable<UK> keys() throws Exception {
+        return delegatedState.keys();
+    }
+
+    @Override
+    public Iterable<UV> values() throws Exception {
+        return delegatedState.values();
+    }
+
+    @Override
+    public Iterator<Map.Entry<UK, UV>> iterator() throws Exception {
+        return delegatedState.iterator();
+    }
+
+    @Override
+    public boolean isEmpty() throws Exception {
+        return delegatedState.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        delegatedState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <UK, UV, K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> mapState) {
+        return (IS) new ChangelogMapState<>((InternalMapState<K, N, UK, UV>) mapState);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogReducingState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogReducingState.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+import java.util.Collection;
+
+/**
+ * Delegated partitioned {@link ReducingState} that forwards changes to {@link StateChange} upon
+ * {@link ReducingState} is updated.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the value.
+ */
+class ChangelogReducingState<K, N, V>
+        extends AbstractChangelogState<K, N, V, InternalReducingState<K, N, V>>
+        implements InternalReducingState<K, N, V> {
+
+    ChangelogReducingState(InternalReducingState<K, N, V> delegatedState) {
+        super(delegatedState);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        delegatedState.mergeNamespaces(target, sources);
+    }
+
+    @Override
+    public V getInternal() throws Exception {
+        return delegatedState.getInternal();
+    }
+
+    @Override
+    public void updateInternal(V valueToStore) throws Exception {
+        delegatedState.updateInternal(valueToStore);
+    }
+
+    @Override
+    public V get() throws Exception {
+        return delegatedState.get();
+    }
+
+    @Override
+    public void add(V value) throws Exception {
+        delegatedState.add(value);
+    }
+
+    @Override
+    public void clear() {
+        delegatedState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> reducingState) {
+        return (IS) new ChangelogReducingState<>((InternalReducingState<K, N, SV>) reducingState);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+
+/**
+ * This state backend holds the working state in the underlying delegatedStateBackend, and forwards
+ * state changes to State Changelog.
+ */
+public class ChangelogStateBackend implements DelegatingStateBackend, ConfigurableStateBackend {
+
+    private static final long serialVersionUID = 1000L;
+
+    private final StateBackend delegatedStateBackend;
+
+    public ChangelogStateBackend(StateBackend stateBackend) {
+        this.delegatedStateBackend = Preconditions.checkNotNull(stateBackend);
+
+        Preconditions.checkArgument(
+                !(stateBackend instanceof DelegatingStateBackend),
+                "Recursive Delegation is not supported.");
+    }
+
+    @Override
+    public <K> ChangelogKeyedStateBackend<K> createKeyedStateBackend(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws Exception {
+        AbstractKeyedStateBackend<K> keyedStateBackend =
+                (AbstractKeyedStateBackend<K>)
+                        delegatedStateBackend.createKeyedStateBackend(
+                                env,
+                                jobID,
+                                operatorIdentifier,
+                                keySerializer,
+                                numberOfKeyGroups,
+                                keyGroupRange,
+                                kvStateRegistry,
+                                ttlTimeProvider,
+                                metricGroup,
+                                stateHandles,
+                                cancelStreamRegistry);
+        return new ChangelogKeyedStateBackend<>(
+                keyedStateBackend, env.getExecutionConfig(), ttlTimeProvider);
+    }
+
+    @Override
+    public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+            Environment env,
+            JobID jobID,
+            String operatorIdentifier,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            TaskKvStateRegistry kvStateRegistry,
+            TtlTimeProvider ttlTimeProvider,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry,
+            double managedMemoryFraction)
+            throws Exception {
+
+        AbstractKeyedStateBackend<K> keyedStateBackend =
+                (AbstractKeyedStateBackend<K>)
+                        delegatedStateBackend.createKeyedStateBackend(
+                                env,
+                                jobID,
+                                operatorIdentifier,
+                                keySerializer,
+                                numberOfKeyGroups,
+                                keyGroupRange,
+                                kvStateRegistry,
+                                ttlTimeProvider,
+                                metricGroup,
+                                stateHandles,
+                                cancelStreamRegistry,
+                                managedMemoryFraction);
+        return new ChangelogKeyedStateBackend<>(
+                keyedStateBackend, env.getExecutionConfig(), ttlTimeProvider);
+    }
+
+    @Override
+    public OperatorStateBackend createOperatorStateBackend(
+            Environment env,
+            String operatorIdentifier,
+            @Nonnull Collection<OperatorStateHandle> stateHandles,
+            CloseableRegistry cancelStreamRegistry)
+            throws Exception {
+        return delegatedStateBackend.createOperatorStateBackend(
+                env, operatorIdentifier, stateHandles, cancelStreamRegistry);
+    }
+
+    @Override
+    public boolean useManagedMemory() {
+        return delegatedStateBackend.useManagedMemory();
+    }
+
+    @Override
+    public StateBackend getDelegatedStateBackend() {
+        return delegatedStateBackend;
+    }
+
+    @Override
+    public StateBackend configure(ReadableConfig config, ClassLoader classLoader)
+            throws IllegalConfigurationException {
+
+        if (delegatedStateBackend instanceof ConfigurableStateBackend) {
+            return new ChangelogStateBackend(
+                    ((ConfigurableStateBackend) delegatedStateBackend)
+                            .configure(config, classLoader));
+        }
+
+        return this;
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogValueState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogValueState.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+import java.io.IOException;
+
+/**
+ * Delegated partitioned {@link ValueState} that forwards changes to {@link StateChange} upon {@link
+ * ValueState} is updated.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the value.
+ */
+class ChangelogValueState<K, N, V>
+        extends AbstractChangelogState<K, N, V, InternalValueState<K, N, V>>
+        implements InternalValueState<K, N, V> {
+
+    ChangelogValueState(InternalValueState<K, N, V> delegatedState) {
+        super(delegatedState);
+    }
+
+    @Override
+    public V value() throws IOException {
+        return delegatedState.value();
+    }
+
+    @Override
+    public void update(V value) throws IOException {
+        delegatedState.update(value);
+    }
+
+    @Override
+    public void clear() {
+        delegatedState.clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, N, SV, S extends State, IS extends S> IS create(
+            InternalKvState<K, N, SV> valueState) {
+        return (IS) new ChangelogValueState<>((InternalValueState<K, N, SV>) valueState);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendTest;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+/** Tests for {@link ChangelogStateBackend} delegating {@link EmbeddedRocksDBStateBackend}. */
+public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
+        extends EmbeddedRocksDBStateBackendTest {
+
+    @Override
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            Environment env)
+            throws Exception {
+
+        return ChangelogStateBackendTestUtils.createKeyedBackend(
+                new ChangelogStateBackend(getStateBackend()),
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.FileStateBackendTest;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+
+/** Tests for {@link ChangelogStateBackend} delegating {@link FsStateBackend}. */
+public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest {
+
+    @Override
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            Environment env)
+            throws Exception {
+
+        return ChangelogStateBackendTestUtils.createKeyedBackend(
+                new ChangelogStateBackend(getStateBackend()),
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.HashMapStateBackendTest;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+/** Tests for {@link ChangelogStateBackend} delegating {@link HashMapStateBackendTest}. */
+public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
+
+    @Override
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            Environment env)
+            throws Exception {
+
+        return ChangelogStateBackendTestUtils.createKeyedBackend(
+                new ChangelogStateBackend(getStateBackend()),
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.MemoryStateBackendTest;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+
+/** Tests for {@link ChangelogStateBackend} delegating {@link MemoryStateBackend}. */
+public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendTest {
+
+    @Override
+    protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            Environment env)
+            throws Exception {
+
+        return ChangelogStateBackendTestUtils.createKeyedBackend(
+                new ChangelogStateBackend(getStateBackend()),
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateStateTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.StateBackendTestBase;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.util.IOUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.apache.flink.state.changelog.ChangelogStateBackendTestUtils.createKeyedBackend;
+import static org.junit.Assert.assertSame;
+
+/** Tests for {@link ChangelogStateBackend} delegating state accesses. */
+@RunWith(Parameterized.class)
+public class ChangelogDelegateStateTest {
+    private MockEnvironment env;
+
+    @Parameterized.Parameters
+    public static List<Supplier<AbstractStateBackend>> delegatedStateBackend() {
+        return Arrays.asList(HashMapStateBackend::new, EmbeddedRocksDBStateBackend::new);
+    }
+
+    @Parameterized.Parameter public Supplier<AbstractStateBackend> backend;
+
+    @Before
+    public void before() {
+        env = MockEnvironment.builder().build();
+    }
+
+    @After
+    public void after() {
+        IOUtils.closeQuietly(env);
+    }
+
+    @Test
+    public void testDelegatingValueState() throws Exception {
+        testDelegatingState(
+                new ValueStateDescriptor<>("id", String.class), ChangelogValueState.class);
+    }
+
+    @Test
+    public void testDelegatingListState() throws Exception {
+        testDelegatingState(
+                new ListStateDescriptor<>("id", String.class), ChangelogListState.class);
+    }
+
+    @Test
+    public void testDelegatingMapState() throws Exception {
+        testDelegatingState(
+                new MapStateDescriptor<>("id", Integer.class, String.class),
+                ChangelogMapState.class);
+    }
+
+    @Test
+    public void testDelegatingReducingState() throws Exception {
+        testDelegatingState(
+                new ReducingStateDescriptor<>(
+                        "id", (value1, value2) -> value1 + "," + value2, String.class),
+                ChangelogReducingState.class);
+    }
+
+    @Test
+    public void testDelegatingAggregatingState() throws Exception {
+        testDelegatingState(
+                new AggregatingStateDescriptor<>(
+                        "my-state",
+                        new StateBackendTestBase.MutableAggregatingAddingFunction(),
+                        StateBackendTestBase.MutableLong.class),
+                ChangelogAggregatingState.class);
+    }
+
+    private void testDelegatingState(StateDescriptor descriptor, Class<?> stateClass)
+            throws Exception {
+        KeyedStateBackend<Integer> delegatedBackend = null;
+        KeyedStateBackend<Integer> changelogBackend = null;
+
+        try {
+            delegatedBackend = createKeyedBackend(backend.get(), env);
+            changelogBackend = createKeyedBackend(new ChangelogStateBackend(backend.get()), env);
+
+            State state =
+                    changelogBackend.getPartitionedState(
+                            VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+            assertSame(state.getClass(), stateClass);
+            assertSame(
+                    ((AbstractChangelogState<?, ?, ?, ?>) state).getDelegatedState().getClass(),
+                    delegatedBackend
+                            .getPartitionedState(
+                                    VoidNamespace.INSTANCE,
+                                    VoidNamespaceSerializer.INSTANCE,
+                                    descriptor)
+                            .getClass());
+        } finally {
+            if (delegatedBackend != null) {
+                delegatedBackend.dispose();
+            }
+
+            if (changelogBackend != null) {
+                changelogBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
+import org.apache.flink.runtime.state.CheckpointStorageLoader;
+import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/** Verify Changelog StateBackend is properly loaded. */
+public class ChangelogStateBackendLoadingTest {
+    @Rule public final TemporaryFolder tmp = new TemporaryFolder();
+
+    private final ClassLoader cl = getClass().getClassLoader();
+
+    private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+
+    @Test
+    public void testLoadingDefault() throws Exception {
+        final StateBackend backend =
+                StateBackendLoader.fromApplicationOrConfigOrDefault(null, config(), cl, null);
+        final CheckpointStorage storage =
+                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+
+        assertDelegateStateBackend(
+                backend, HashMapStateBackend.class, storage, JobManagerCheckpointStorage.class);
+    }
+
+    @Test
+    public void testApplicationDefinedHasPrecedence() throws Exception {
+        final StateBackend appBackend = new MockStateBackend();
+        // "rocksdb" should not take effect
+        final StateBackend backend =
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        appBackend, config("rocksdb"), cl, null);
+        final CheckpointStorage storage =
+                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+
+        assertDelegateStateBackend(
+                backend, MockStateBackend.class, storage, MockStateBackend.class);
+        assertTrue(
+                ((MockStateBackend) (((ChangelogStateBackend) backend).getDelegatedStateBackend()))
+                        .isConfigUpdated());
+    }
+
+    @Test
+    public void testApplicationDefinedChangelogStateBackend() throws Exception {
+        final StateBackend appBackend = new ChangelogStateBackend(new MockStateBackend());
+        // "rocksdb" should not take effect
+        final StateBackend backend =
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        appBackend, config("rocksdb"), cl, null);
+        final CheckpointStorage storage =
+                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+
+        assertDelegateStateBackend(
+                backend, MockStateBackend.class, storage, MockStateBackend.class);
+        assertTrue(
+                ((MockStateBackend) (((ChangelogStateBackend) backend).getDelegatedStateBackend()))
+                        .isConfigUpdated());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRecursiveDelegation() throws Exception {
+        final StateBackend appBackend =
+                new ChangelogStateBackend(new ChangelogStateBackend(new MockStateBackend()));
+
+        StateBackendLoader.fromApplicationOrConfigOrDefault(
+                appBackend, config("rocksdb"), cl, null);
+    }
+
+    // ----------------------------------------------------------
+    // The following tests are testing different combinations of
+    // state backend and checkpointStorage after FLINK-19463
+    // disentangles Checkpointing from state backends.
+    // After "jobmanager" and "filesystem" state backends are removed,
+    // These tests can be simplified.
+    //
+    @Test
+    public void testLoadingMemoryStateBackendFromConfig() throws Exception {
+        testLoadingStateBackend(
+                "jobmanager", MemoryStateBackend.class, MemoryStateBackend.class, true);
+    }
+
+    @Test
+    public void testLoadingMemoryStateBackend() throws Exception {
+        testLoadingStateBackend(
+                "jobmanager", MemoryStateBackend.class, MemoryStateBackend.class, false);
+    }
+
+    @Test
+    public void testLoadingFsStateBackendFromConfig() throws Exception {
+        testLoadingStateBackend(
+                "filesystem", HashMapStateBackend.class, JobManagerCheckpointStorage.class, true);
+    }
+
+    @Test
+    public void testLoadingFsStateBackend() throws Exception {
+        testLoadingStateBackend(
+                "filesystem", HashMapStateBackend.class, JobManagerCheckpointStorage.class, false);
+    }
+
+    @Test
+    public void testLoadingHashMapStateBackendFromConfig() throws Exception {
+        testLoadingStateBackend(
+                "hashmap", HashMapStateBackend.class, JobManagerCheckpointStorage.class, true);
+    }
+
+    @Test
+    public void testLoadingHashMapStateBackend() throws Exception {
+        testLoadingStateBackend(
+                "hashmap", HashMapStateBackend.class, JobManagerCheckpointStorage.class, false);
+    }
+
+    @Test
+    public void testLoadingRocksDBStateBackendFromConfig() throws Exception {
+        testLoadingStateBackend(
+                "rocksdb",
+                EmbeddedRocksDBStateBackend.class,
+                JobManagerCheckpointStorage.class,
+                true);
+    }
+
+    @Test
+    public void testLoadingRocksDBStateBackend() throws Exception {
+        testLoadingStateBackend(
+                "rocksdb",
+                EmbeddedRocksDBStateBackend.class,
+                JobManagerCheckpointStorage.class,
+                false);
+    }
+
+    private Configuration config(String stateBackend) {
+        final Configuration config = config();
+        config.setString(backendKey, stateBackend);
+
+        return config;
+    }
+
+    private Configuration config() {
+        final Configuration config = new Configuration();
+        config.setBoolean(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG, true);
+
+        return config;
+    }
+
+    private void assertDelegateStateBackend(
+            StateBackend backend,
+            Class<?> delegatedStateBackendClass,
+            CheckpointStorage storage,
+            Class<?> storageClass) {
+        assertTrue(backend instanceof ChangelogStateBackend);
+        assertSame(
+                ((DelegatingStateBackend) backend).getDelegatedStateBackend().getClass(),
+                delegatedStateBackendClass);
+        assertSame(storage.getClass(), storageClass);
+    }
+
+    private void testLoadingStateBackend(
+            String backendName,
+            Class<?> delegatedStateBackendClass,
+            Class<?> storageClass,
+            boolean configOnly)
+            throws Exception {
+        final Configuration config = config(backendName);
+        StateBackend backend;
+
+        if (configOnly) {
+            backend = StateBackendLoader.loadStateBackendFromConfig(config, cl, null);
+        } else {
+            backend = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+        }
+
+        final CheckpointStorage storage =
+                CheckpointStorageLoader.load(null, null, backend, config, cl, null);
+
+        assertDelegateStateBackend(backend, delegatedStateBackendClass, storage, storageClass);
+    }
+
+    private static class MockStateBackend extends AbstractStateBackend
+            implements CheckpointStorage, ConfigurableStateBackend {
+        private boolean configUpdated = false;
+
+        @Override
+        public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
+                Environment env,
+                JobID jobID,
+                String operatorIdentifier,
+                TypeSerializer<K> keySerializer,
+                int numberOfKeyGroups,
+                KeyGroupRange keyGroupRange,
+                TaskKvStateRegistry kvStateRegistry,
+                TtlTimeProvider ttlTimeProvider,
+                MetricGroup metricGroup,
+                @Nonnull Collection<KeyedStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) {
+            return null;
+        }
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                Environment env,
+                String operatorIdentifier,
+                @Nonnull Collection<OperatorStateHandle> stateHandles,
+                CloseableRegistry cancelStreamRegistry) {
+            return null;
+        }
+
+        @Override
+        public CompletedCheckpointStorageLocation resolveCheckpoint(String externalPointer) {
+            return null;
+        }
+
+        @Override
+        public CheckpointStorageAccess createCheckpointStorage(JobID jobId) {
+            return null;
+        }
+
+        @Override
+        public StateBackend configure(ReadableConfig config, ClassLoader classLoader)
+                throws IllegalConfigurationException {
+            configUpdated = true;
+            return this;
+        }
+
+        boolean isConfigUpdated() {
+            return configUpdated;
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+
+import java.util.Collections;
+
+/** Test Utilities for Changelog StateBackend. */
+public class ChangelogStateBackendTestUtils {
+
+    public static <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
+            StateBackend stateBackend,
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
+            Environment env)
+            throws Exception {
+
+        return stateBackend.createKeyedStateBackend(
+                env,
+                new JobID(),
+                "test_op",
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env.getTaskKvStateRegistry(),
+                TtlTimeProvider.DEFAULT,
+                new UnregisteredMetricsGroup(),
+                Collections.emptyList(),
+                new CloseableRegistry());
+    }
+
+    public static CheckpointableKeyedStateBackend<Integer> createKeyedBackend(
+            StateBackend stateBackend, Environment env) throws Exception {
+
+        return createKeyedBackend(
+                stateBackend, IntSerializer.INSTANCE, 10, new KeyGroupRange(0, 9), env);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/resources/log4j2.properties
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/resources/log4j2.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %d %-5p %m [%c{0} %t]%n

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -97,6 +97,7 @@ under the License.
 						<configuration>
 							<includes>
 								<include>**/org/apache/flink/contrib/streaming/state/RocksDBTestUtils*</include>
+								<include>**/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest*</include>
 								<include>**/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils*</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -26,8 +27,8 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
@@ -487,7 +488,8 @@ public class EmbeddedRocksDBStateBackendTest
 
     @Test
     public void testDisposeDeletesAllDirectories() throws Exception {
-        AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+        CheckpointableKeyedStateBackend<Integer> backend =
+                createKeyedBackend(IntSerializer.INSTANCE);
         Collection<File> allFilesInDbDir =
                 FileUtils.listFilesAndDirs(
                         new File(dbPath), new AcceptAllFilter(), new AcceptAllFilter());
@@ -521,7 +523,8 @@ public class EmbeddedRocksDBStateBackendTest
     @Test
     public void testSharedIncrementalStateDeRegistration() throws Exception {
         if (enableIncrementalCheckpointing) {
-            AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(IntSerializer.INSTANCE);
+            CheckpointableKeyedStateBackend<Integer> backend =
+                    createKeyedBackend(IntSerializer.INSTANCE);
             try {
                 ValueStateDescriptor<String> kvId =
                         new ValueStateDescriptor<>("id", String.class, null);
@@ -570,7 +573,7 @@ public class EmbeddedRocksDBStateBackendTest
                     }
 
                     previousStateHandles.add(stateHandle);
-                    backend.notifyCheckpointComplete(checkpointId);
+                    ((CheckpointListener) backend).notifyCheckpointComplete(checkpointId);
 
                     // -----------------------------------------------------------------
 

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -39,5 +39,6 @@ under the License.
 	<modules>
 		<module>flink-statebackend-rocksdb</module>
 		<module>flink-statebackend-heap-spillable</module>
+		<module>flink-statebackend-changelog</module>
 	</modules>
 </project>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -93,17 +93,17 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
      * <p><b>IMPORTANT:</b> Keep in sync with {@link InternalTimeServiceManager.Provider}.
      */
     public static <K> InternalTimeServiceManagerImpl<K> create(
-            CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+            CheckpointableKeyedStateBackend<K> keyedStateBackend,
             ClassLoader userClassloader,
             KeyContext keyContext,
             ProcessingTimeService processingTimeService,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
             throws Exception {
-        final KeyGroupRange keyGroupRange = keyedStatedBackend.getKeyGroupRange();
+        final KeyGroupRange keyGroupRange = keyedStateBackend.getKeyGroupRange();
 
         final InternalTimeServiceManagerImpl<K> timeServiceManager =
                 new InternalTimeServiceManagerImpl<>(
-                        keyGroupRange, keyContext, keyedStatedBackend, processingTimeService);
+                        keyGroupRange, keyContext, keyedStateBackend, processingTimeService);
 
         // and then initialize the timer services
         for (KeyGroupStatePartitionStreamProvider streamProvider : rawKeyedStates) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
@@ -21,15 +21,10 @@ package org.apache.flink.table.runtime.util;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 
 /** Utility to create a {@link StateTtlConfig} object. */
 public class StateConfigUtil {
-
-    private static final String ROCKSDB_KEYED_STATE_BACKEND =
-            "org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend";
-
     /**
      * Creates a {@link StateTtlConfig} depends on retentionTime parameter.
      *
@@ -46,10 +41,8 @@ public class StateConfigUtil {
         }
     }
 
-    public static boolean isStateImmutableInStateBackend(KeyedStateBackend<?> stateBackend) {
+    public static boolean isStateImmutableInStateBackend(KeyedStateBackend<?> keyedStateBackend) {
         // TODO: remove the hard code check once FLINK-21027 is supported
-        return (stateBackend instanceof AbstractKeyedStateBackend)
-                && ((AbstractKeyedStateBackend<?>) stateBackend)
-                        .isStateImmutableInStateBackend(CheckpointType.CHECKPOINT);
+        return keyedStateBackend.isStateImmutableInStateBackend(CheckpointType.CHECKPOINT);
     }
 }

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -241,6 +241,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.github.oshi</groupId>
 			<artifactId>oshi-core</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
## What is the purpose of the change

This change is to wrap the existing prod state backend (Rocksdb, Fs, Mem) to delegate state access for these state backends. In the future, we can forward state changes to StateChangeLog when states are updated.

In this PR, we only support keyed-state access.

## Brief changelog

1. Introduce `DelegatingStateBackend` interface for state backend delegation (in the flink-runtime module)
2. Introduce `ChangelogStateBackend` and related delegating states for state delegation (in flink-state-backends module)
3. Implement `ChangelogStateBackend`'s Loader in `StateBackendLoader`.

## Couple of things to highlight in a bit more detail
1. `ChangelogStateBackend` can be enabled through configuration key "state.backend.enable-statechangelog" or through application API directly.
2. `ChangelogStateBackend` Loader encapsulates wrapping logic to `loadStateBackendFromConfig` and `fromApplicationOrConfigOrDefault`. The original loading methods are renamed to `loadUnwrappedStateBackendFromConfig` and `loadFromApplicationOrConfigOrDefaultInternal` respectively, and kept unchanged.
3. Recursive wrapping is not supported:   
        `evn.setStateBackend(new new ChangelogStateBackend(new ChangelogStateBackend(...)))` NOT SUPPORT
4. In the current state backend, state access from applications is interfaced by `InternalKvState`, and `InternalKvState` is where state access is delegated.
5. How a state is physically represented/stored depends on the type of underlying state backend, and we do not need to worry about this part in delegation. Hence they are untouched in this PR.
6. TTL States wrap on top of `InternalKvState` as well. If TTL is enabled, Changelog States wrap on top of TTL States.

## Verifying this change
1. Unit tests
2. We have enabled State Backend Delegation by default to run-through all tests (including end-2-end nightly builds). In the current PR, StateChangeLog is not enabled by default.
3. We will have a follow-up ticket to randomize the tests.  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (not yet)
