### PR TITLE
[FLINK-21384][docs] Automatically copy maven dependencies to clipboard on click

### DIFF
--- a/docs/layouts/shortcodes/artifact.html
+++ b/docs/layouts/shortcodes/artifact.html
@@ -55,3 +55,6 @@ under the License.
     <span class="nt">&ltscope&gt</span>test<span class="nt">&lt/scope&gt</span>{{ end }}{{ if ne $testClassifier "" }}    
     <span class="nt">&ltclassifer&gt</span>tests<span class="nt">&lt/classifier&gt</span>{{ end }}
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
+<div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+Copied to clipboard!
+</div>

--- a/docs/layouts/shortcodes/sql_download_table.html
+++ b/docs/layouts/shortcodes/sql_download_table.html
@@ -94,5 +94,8 @@ and SQL Client with SQL JAR bundles.</p>
   <span class="nt">&ltartifactId&gt</span>{{- partial "docs/interpolate" .ArtifactId -}}<span class="nt">&lt/artifactId&gt</span>
   <span class="nt">&ltversion&gt</span>{{- site.Params.Version -}}<span class="nt">&lt/version&gt</span>
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
+<div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ .ArtifactId }}">
+Copied to clipboard!
+</div>
 {{ end }}
 

--- a/docs/static/js/flink.js
+++ b/docs/static/js/flink.js
@@ -61,13 +61,23 @@ function selectText(containerId) {
     if (document.selection) {
         var range = document.body.createTextRange();
         range.moveToElementText(document.getElementById(containerId));
-        range.select();
+        range.select().createTextRange();
+        document.execCommand("copy");
     } else if (window.getSelection) {
         var range = document.createRange();
         range.selectNode(document.getElementById(containerId));
         window.getSelection().removeAllRanges();
         window.getSelection().addRange(range);
+        document.execCommand("copy");
     }
+
+    document.querySelectorAll("[copyable='flink-module']").forEach(function(alert) {
+        alert.setAttribute("style", "text-align:center;display:none");
+    });
+
+    document.querySelectorAll("[copyable='flink-module'][copyattribute='" + containerId +"'").forEach(function(alert) {
+        alert.setAttribute("style", "text-align:center;display:block");
+    });
 }
 
 document.addEventListener("DOMContentLoaded", function(event) { 


### PR DESCRIPTION
Flink has a number of optional dependencies users may need to copy into their pom files to use, such as connectors and formats. The docs should automatically copy the maven dependency to the users' clipboard when clicked.

For example the kafka connector before click: 

<img width="870" alt="Screen Shot 2021-02-16 at 1 52 24 PM" src="https://user-images.githubusercontent.com/1891970/108114261-34ccb600-705e-11eb-981e-c81118efe10d.png">

After click: 

<img width="887" alt="Screen Shot 2021-02-16 at 1 52 46 PM" src="https://user-images.githubusercontent.com/1891970/108114312-41e9a500-705e-11eb-88e3-645b8861aab9.png">

The module is highlighted, an alert shown, and the pom dependency is on the users' clipboard. 

If a page has multiple dependencies listed, such as elastic, only one is copied at a time and when a new dep is copied the old alert goes away. 

