### PR TITLE
[FLINK-21380][coordination] Hide terminal ExecutionGraph in StateWithExecutionGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -353,9 +353,8 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
         final long[] timestamps = new long[JobStatus.values().length];
 
         // if the state is overridden with a non-globally-terminal state then we need to erase
-        // traces of globally-terminal states
-        final boolean clearGloballyTerminalStateTimestamps =
-                statusOverride != null && !statusOverride.isGloballyTerminalState();
+        // traces of globally-terminal states for consistency
+        final boolean clearGloballyTerminalStateTimestamps = statusOverride != null;
 
         for (JobStatus jobStatus : JobStatus.values()) {
             final int ordinal = jobStatus.ordinal();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -318,6 +318,23 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
      * @return ArchivedExecutionGraph created from the given ExecutionGraph
      */
     public static ArchivedExecutionGraph createFrom(ExecutionGraph executionGraph) {
+        return createFrom(executionGraph, null);
+    }
+
+    /**
+     * Create a {@link ArchivedExecutionGraph} from the given {@link ExecutionGraph}.
+     *
+     * @param executionGraph to create the ArchivedExecutionGraph from
+     * @param statusOverride optionally overrides the JobStatus of the ExecutionGraph with a
+     *     non-globally-terminal state and clears timestamps of globally-terminal states
+     * @return ArchivedExecutionGraph created from the given ExecutionGraph
+     */
+    public static ArchivedExecutionGraph createFrom(
+            ExecutionGraph executionGraph, @Nullable JobStatus statusOverride) {
+        Preconditions.checkArgument(
+                statusOverride == null || !statusOverride.isGloballyTerminalState(),
+                "Status override is only allowed for non-globally-terminal states.");
+
         final int numberVertices = executionGraph.getTotalNumberOfVertices();
 
         Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = new HashMap<>(numberVertices);
@@ -335,9 +352,16 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
 
         final long[] timestamps = new long[JobStatus.values().length];
 
+        // if the state is overridden with a non-globally-terminal state then we need to erase
+        // traces of globally-terminal states
+        final boolean clearGloballyTerminalStateTimestamps =
+                statusOverride != null && !statusOverride.isGloballyTerminalState();
+
         for (JobStatus jobStatus : JobStatus.values()) {
             final int ordinal = jobStatus.ordinal();
-            timestamps[ordinal] = executionGraph.getStatusTimestamp(jobStatus);
+            if (!(clearGloballyTerminalStateTimestamps && jobStatus.isGloballyTerminalState())) {
+                timestamps[ordinal] = executionGraph.getStatusTimestamp(jobStatus);
+            }
         }
 
         return new ArchivedExecutionGraph(
@@ -346,7 +370,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 archivedTasks,
                 archivedVerticesInCreationOrder,
                 timestamps,
-                executionGraph.getState(),
+                statusOverride == null ? executionGraph.getState() : statusOverride,
                 executionGraph.getFailureInfo(),
                 executionGraph.getJsonPlan(),
                 executionGraph.getAccumulatorResultsStringified(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Canceling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Canceling.java
@@ -48,6 +48,11 @@ class Canceling extends StateWithExecutionGraph {
     }
 
     @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.CANCELLING;
+    }
+
+    @Override
     public void cancel() {
         // we are already in the state canceling
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Executing.java
@@ -61,6 +61,11 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
     }
 
     @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.RUNNING;
+    }
+
+    @Override
     public void cancel() {
         context.goToCanceling(
                 getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/Failing.java
@@ -52,6 +52,11 @@ class Failing extends StateWithExecutionGraph {
     }
 
     @Override
+    public JobStatus getJobStatus() {
+        return JobStatus.FAILING;
+    }
+
+    @Override
     public void cancel() {
         context.goToCanceling(
                 getExecutionGraph(), getExecutionGraphHandler(), getOperatorCoordinatorHandler());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateWithExecutionGraph.java
@@ -128,12 +128,7 @@ abstract class StateWithExecutionGraph implements State {
 
     @Override
     public ArchivedExecutionGraph getJob() {
-        return ArchivedExecutionGraph.createFrom(executionGraph);
-    }
-
-    @Override
-    public JobStatus getJobStatus() {
-        return executionGraph.getState();
+        return ArchivedExecutionGraph.createFrom(executionGraph, getJobStatus());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -147,6 +147,15 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         assertThat(suspendedExecutionGraph.getFailureInfo(), notNullValue());
     }
 
+    @Test
+    public void testArchiveWithStatusOverride() throws IOException, ClassNotFoundException {
+        ArchivedExecutionGraph archivedGraph =
+                ArchivedExecutionGraph.createFrom(runtimeGraph, JobStatus.RESTARTING);
+
+        assertThat(archivedGraph.getState(), is(JobStatus.RESTARTING));
+        assertThat(archivedGraph.getStatusTimestamp(JobStatus.FAILED), is(0L));
+    }
+
     private static void compareExecutionGraph(
             AccessExecutionGraph runtimeGraph, AccessExecutionGraph archivedGraph)
             throws IOException, ClassNotFoundException {


### PR DESCRIPTION
Hides the fact that the ExecutionGraph can reach a globally-terminal state while the DeclarativeScheduler is in a Restarting/Canceling/Failing/Executing state.
This can happen because the transition into a globally-terminal state in the EG and the scheduler transition to WaitingForResources/Finished does not happen atomically (mainthread-wise).

This should not happen during Restarting because it would break the contract that a globally-terminal job never transitions into another state.
As for Restarting/Canceling/Failing/Executing, this is mostly for consistency; we should ensure that the scheduler has a chance to cleanup whatever it wants before we communicate to the outside that the job is done.

In short, `ArchivedExecutionGraph#createFrom` now accepts an optional non-terminal JobStatus that overrides the state of the ArchivedExecutionGraph. Additionally, if set, the timestamps for all globally-terminal state transitions are removed (or rather not copied).
All `StateWithExecutionGraph` classes now also pin the job state within `getJobStatus()`.