### PR TITLE
[FLINK-21384][docs] Automatically copy maven dependencies to clipboard on click

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,14 +95,14 @@ to its documentation markdown. The following are available for use:
 
 #### Flink Artifact
 
-    {{< artfiact flink-core >}}
+    {{< artfiact flink-streaming-java withScalaVersion >}}
 
 This will be replaced by the maven artifact for flink-streaming-java that users should copy into their pom.xml file. It will render out to:
 
 ```xml
 <dependency>
     <groupdId>org.apache.flink</groupId>
-    <artifactId>flink-core</artifactId>
+    <artifactId>flink-streaming-java_2.11</artifactId>
     <version><!-- current flink version --></version>
 </dependency>
 ```

--- a/docs/layouts/shortcodes/artifact.html
+++ b/docs/layouts/shortcodes/artifact.html
@@ -48,10 +48,13 @@ under the License.
   {{ $artifactId = printf "%s%s" $artifactId $.Site.Params.ScalaVersion }}
 {{ end }}
 
-<div id="{{ $hash }}" onclick="selectText('{{ $hash }}')" class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+<div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
     <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
     <span class="nt">&ltartifactId&gt</span>{{- $artifactId -}}<span class="nt">&lt/artifactId&gt</span>
     <span class="nt">&ltversion&gt</span>{{- site.Params.Version -}}<span class="nt">&lt/version&gt</span>{{ if ne $testScope "" }}    
     <span class="nt">&ltscope&gt</span>test<span class="nt">&lt/scope&gt</span>{{ end }}{{ if ne $testClassifier "" }}    
     <span class="nt">&ltclassifer&gt</span>tests<span class="nt">&lt/classifier&gt</span>{{ end }}
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
+<div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+  Copied to clipboard!
+</div> 

--- a/docs/layouts/shortcodes/sql_download_table.html
+++ b/docs/layouts/shortcodes/sql_download_table.html
@@ -89,10 +89,13 @@ and SQL Client with SQL JAR bundles.</p>
   rendered documentation. 
 */}}
 {{ define "maven-artifact" }}{{/* (dict "ArtifactId" .ArtifactId */}}
-<div id="{{ .ArtifactId }}" onclick="selectText('{{ .ArtifactId }}')" class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+<div id="{{ .ArtifactId }}" onclick="selectTextAndCopy('{{ .ArtifactId }}')" class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
   <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
   <span class="nt">&ltartifactId&gt</span>{{- partial "docs/interpolate" .ArtifactId -}}<span class="nt">&lt/artifactId&gt</span>
   <span class="nt">&ltversion&gt</span>{{- site.Params.Version -}}<span class="nt">&lt/version&gt</span>
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
+<div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ .ArtifactId }}">
+Copied to clipboard!
+</div>
 {{ end }}
 


### PR DESCRIPTION
Flink has a number of optional dependencies users may need to copy into their pom files to use, such as connectors and formats. The docs should automatically copy the maven dependency to the users' clipboard when clicked.

For example the kafka connector before click:

![image](https://user-images.githubusercontent.com/1891970/108218101-ed940300-70f9-11eb-8659-b5805bbc207c.png)

After click:

![image](https://user-images.githubusercontent.com/1891970/108218157-fc7ab580-70f9-11eb-8278-8b5281dda465.png)

The module is highlighted, an alert shown, and the pom dependency is on the users' clipboard.

If a page has multiple dependencies listed, such as elastic, only one is copied at a time and when a new dep is copied the old alert goes away.

If the requisite javascript functionality is not supported by a users browser this should be a no-op. 

Clicking on something after it's been copied once is also a no-op so users can highlight and copy subsections of the dependency. 