### PR TITLE
[FLINK-16947][Azure] Attempt to fix maven network issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
+    image: rmetzger/flink-ci:ubuntu-amd64-98ad098
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
+    image: rmetzger/flink-ci:ubuntu-amd64-98ad098
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
This updates the base docker image to use a modified maven version with a fixed http wagon version.

Diff on the Dockerfile:

```diff
diff --git a/Dockerfile b/Dockerfile
index dc8f1b5..68d080d 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,17 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && rm -f /tmp/apache-maven.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

+# put custom http-wagon. More details: https://issues.apache.org/jira/browse/FLINK-16947?focusedCommentId=17285028&page
+RUN cd /usr/share/maven/lib/ \
+  && rm wagon-http-*-shaded.jar \
+  && curl -O https://jitpack.io/com/github/lhotari/maven-wagon/wagon-http/5ff79d284/wagon-http-5ff79d284-shaded.jar
+
+# add commons logging (needed for custom wagon)
+RUN cd /tmp \
+  && wget https://mirror.synyx.de/apache//commons/logging/binaries/commons-logging-1.2-bin.zip \
+  && unzip commons-logging-1.2-bin.zip \
+  && cp commons-logging-1.2/commons-logging-1.2.jar /usr/share/maven/lib/
+
 ENV MAVEN_HOME /usr/share/maven
```

This has been committed in https://github.com/rmetzger/flink-ci/commit/98ad098128398c6b0621a7b17bea05fc0fbf1c07

