### PR TITLE
[FLINK-21388] [flink-parquet] support DECIMAL parquet logical type when parquet primitive type is INT32

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -128,6 +128,9 @@ public class ParquetSchemaConverter {
                 case INT32:
                     if (originalType != null) {
                         switch (originalType) {
+                            case DECIMAL: // for 1 <= precision (number of digits before the decimal point) <= 9, the INT32 stores the unscaled value
+                                typeInfo = BasicTypeInfo.INT_TYPE_INFO;
+                                break;
                             case TIME_MICROS:
                             case TIME_MILLIS:
                                 typeInfo = SqlTimeTypeInfo.TIME;
@@ -174,7 +177,7 @@ public class ParquetSchemaConverter {
                                 typeInfo = SqlTimeTypeInfo.TIMESTAMP;
                                 break;
                             case INT_64:
-                            case DECIMAL:
+                            case DECIMAL:// for 1 <= precision (number of digits before the decimal point) <= 18, the INT64 stores the unscaled value
                                 typeInfo = BasicTypeInfo.LONG_TYPE_INFO;
                                 break;
                             default:

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -128,7 +128,8 @@ public class ParquetSchemaConverter {
                 case INT32:
                     if (originalType != null) {
                         switch (originalType) {
-                            case DECIMAL: // for 1 <= precision (number of digits before the decimal point) <= 9, the INT32 stores the unscaled value
+                            case DECIMAL: // for 1 <= precision (number of digits before the decimal
+                                // point) <= 9, the INT32 stores the unscaled value
                                 typeInfo = BasicTypeInfo.INT_TYPE_INFO;
                                 break;
                             case TIME_MICROS:
@@ -177,7 +178,8 @@ public class ParquetSchemaConverter {
                                 typeInfo = SqlTimeTypeInfo.TIMESTAMP;
                                 break;
                             case INT_64:
-                            case DECIMAL:// for 1 <= precision (number of digits before the decimal point) <= 18, the INT64 stores the unscaled value
+                            case DECIMAL: // for 1 <= precision (number of digits before the decimal
+                                // point) <= 18, the INT64 stores the unscaled value
                                 typeInfo = BasicTypeInfo.LONG_TYPE_INFO;
                                 break;
                             default:

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/RowConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/RowConverter.java
@@ -303,6 +303,7 @@ public class RowConverter extends GroupConverter implements ParentDataHolder {
                     case INT_8:
                     case INT_16:
                     case INT_32:
+                    case DECIMAL:
                         parentDataHolder.add(pos, value);
                         break;
                     default:

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.formats.parquet.utils;
 
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 
 import org.apache.parquet.schema.MessageType;
@@ -146,6 +148,21 @@ public class ParquetSchemaConverterTest {
         MessageType simpleType = new MessageType("simple", simpleStandardTypes);
         RowTypeInfo rowTypeInfo = (RowTypeInfo) ParquetSchemaConverter.fromParquetType(simpleType);
         assertEquals(TestUtil.SIMPLE_ROW_TYPE, rowTypeInfo);
+    }
+
+    @Test public void testDecimalParquetLogicalType(){
+        MessageType messageType =
+                new MessageType(
+                        "test",
+                        new PrimitiveType(
+                                Type.Repetition.OPTIONAL,
+                                PrimitiveType.PrimitiveTypeName.INT32,
+                                "int32WithDecimal", OriginalType.DECIMAL));
+        RowTypeInfo rowTypeInfo = (RowTypeInfo) ParquetSchemaConverter.fromParquetType(messageType);
+        assertEquals(Types.ROW_NAMED(
+                new String[] {"int32WithDecimal"},
+                BasicTypeInfo.INT_TYPE_INFO), rowTypeInfo);
+
     }
 
     @Test

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverterTest.java
@@ -150,19 +150,20 @@ public class ParquetSchemaConverterTest {
         assertEquals(TestUtil.SIMPLE_ROW_TYPE, rowTypeInfo);
     }
 
-    @Test public void testDecimalParquetLogicalType(){
+    @Test
+    public void testDecimalParquetLogicalType() {
         MessageType messageType =
                 new MessageType(
                         "test",
                         new PrimitiveType(
                                 Type.Repetition.OPTIONAL,
                                 PrimitiveType.PrimitiveTypeName.INT32,
-                                "int32WithDecimal", OriginalType.DECIMAL));
+                                "int32WithDecimal",
+                                OriginalType.DECIMAL));
         RowTypeInfo rowTypeInfo = (RowTypeInfo) ParquetSchemaConverter.fromParquetType(messageType);
-        assertEquals(Types.ROW_NAMED(
-                new String[] {"int32WithDecimal"},
-                BasicTypeInfo.INT_TYPE_INFO), rowTypeInfo);
-
+        assertEquals(
+                Types.ROW_NAMED(new String[] {"int32WithDecimal"}, BasicTypeInfo.INT_TYPE_INFO),
+                rowTypeInfo);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

support DECIMAL parquet logical type when parquet primitive type is INT32

## Brief change log

The support for INT64 was already done (matching _int64/DECIMAL_ to _BasicTypeInfo.INT_TYPE_INFO_)
Simply added support for INT32 (matching _int32/DECIMAL_ to _BasicTypeInfo.INT_TYPE_INFO_)

## Verifying this change

This change added tests and can be verified as follows:
ParquetSchemaConverterTest#testDecimalParquetLogicalType

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

