### PR TITLE
[FLINK-21362][coordination] Move State.onEnter() logic into constructor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
@@ -40,10 +40,7 @@ class Canceling extends StateWithExecutionGraph {
             Logger logger) {
         super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
         this.context = context;
-    }
 
-    @Override
-    public void onEnter() {
         getExecutionGraph().cancel();
     }
 
@@ -70,5 +67,40 @@ class Canceling extends StateWithExecutionGraph {
     @Override
     void onGloballyTerminalState(JobStatus globallyTerminalState) {
         context.goToFinished(ArchivedExecutionGraph.createFrom(getExecutionGraph()));
+    }
+
+    static class Factory implements StateFactory<Canceling> {
+
+        private final Context context;
+        private final Logger log;
+        private final ExecutionGraph executionGraph;
+        private final ExecutionGraphHandler executionGraphHandler;
+        private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+
+        public Factory(
+                Context context,
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Logger log) {
+            this.context = context;
+            this.log = log;
+            this.executionGraph = executionGraph;
+            this.executionGraphHandler = executionGraphHandler;
+            this.operatorCoordinatorHandler = operatorCoordinatorHandler;
+        }
+
+        public Class<Canceling> getStateClass() {
+            return Canceling.class;
+        }
+
+        public Canceling getState() {
+            return new Canceling(
+                    context,
+                    executionGraph,
+                    executionGraphHandler,
+                    operatorCoordinatorHandler,
+                    log);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Created.java
@@ -97,4 +97,23 @@ class Created implements State {
         /** Transitions into the {@link WaitingForResources} state. */
         void goToWaitingForResources();
     }
+
+    static class Factory implements StateFactory<Created> {
+
+        private final Context context;
+        private final Logger log;
+
+        public Factory(Context context, Logger log) {
+            this.context = context;
+            this.log = log;
+        }
+
+        public Class<Created> getStateClass() {
+            return Created.class;
+        }
+
+        public Created getState() {
+            return new Created(this.context, this.log);
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -53,10 +53,7 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
         super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
         this.context = context;
         this.userCodeClassLoader = userCodeClassLoader;
-    }
 
-    @Override
-    public void onEnter() {
         deploy();
     }
 
@@ -260,6 +257,45 @@ class Executing extends StateWithExecutionGraph implements ResourceConsumer {
          */
         static FailureResult canNotRestart(Throwable failureCause) {
             return new FailureResult(null, failureCause);
+        }
+    }
+
+    static class Factory implements StateFactory<Executing> {
+
+        private final Context context;
+        private final Logger log;
+        private final ExecutionGraph executionGraph;
+        private final ExecutionGraphHandler executionGraphHandler;
+        private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+        private final ClassLoader userCodeClassLoader;
+
+        public Factory(
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Logger log,
+                Context context,
+                ClassLoader userCodeClassLoader) {
+            this.context = context;
+            this.log = log;
+            this.executionGraph = executionGraph;
+            this.executionGraphHandler = executionGraphHandler;
+            this.operatorCoordinatorHandler = operatorCoordinatorHandler;
+            this.userCodeClassLoader = userCodeClassLoader;
+        }
+
+        public Class<Executing> getStateClass() {
+            return Executing.class;
+        }
+
+        public Executing getState() {
+            return new Executing(
+                    executionGraph,
+                    executionGraphHandler,
+                    operatorCoordinatorHandler,
+                    log,
+                    context,
+                    userCodeClassLoader);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
@@ -32,8 +32,6 @@ import org.slf4j.Logger;
 class Failing extends StateWithExecutionGraph {
     private final Context context;
 
-    private final Throwable failureCause;
-
     Failing(
             Context context,
             ExecutionGraph executionGraph,
@@ -43,11 +41,7 @@ class Failing extends StateWithExecutionGraph {
             Throwable failureCause) {
         super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
         this.context = context;
-        this.failureCause = failureCause;
-    }
 
-    @Override
-    public void onEnter() {
         getExecutionGraph().failJob(failureCause);
     }
 
@@ -93,5 +87,44 @@ class Failing extends StateWithExecutionGraph {
                 ExecutionGraph executionGraph,
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler);
+    }
+
+    static class Factory implements StateFactory<Failing> {
+
+        private final Context context;
+        private final Logger log;
+        private final ExecutionGraph executionGraph;
+        private final ExecutionGraphHandler executionGraphHandler;
+        private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+        private final Throwable failureCause;
+
+        public Factory(
+                Context context,
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Logger log,
+                Throwable failureCause) {
+            this.context = context;
+            this.log = log;
+            this.executionGraph = executionGraph;
+            this.executionGraphHandler = executionGraphHandler;
+            this.operatorCoordinatorHandler = operatorCoordinatorHandler;
+            this.failureCause = failureCause;
+        }
+
+        public Class<Failing> getStateClass() {
+            return Failing.class;
+        }
+
+        public Failing getState() {
+            return new Failing(
+                    context,
+                    executionGraph,
+                    executionGraphHandler,
+                    operatorCoordinatorHandler,
+                    log,
+                    failureCause);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
@@ -26,20 +26,14 @@ import org.slf4j.Logger;
 /** State which describes a finished job execution. */
 class Finished implements State {
 
-    private final Context context;
-
     private final ArchivedExecutionGraph archivedExecutionGraph;
 
     private final Logger logger;
 
     Finished(Context context, ArchivedExecutionGraph archivedExecutionGraph, Logger logger) {
-        this.context = context;
         this.archivedExecutionGraph = archivedExecutionGraph;
         this.logger = logger;
-    }
 
-    @Override
-    public void onEnter() {
         context.onFinished(archivedExecutionGraph);
     }
 
@@ -77,5 +71,26 @@ class Finished implements State {
          *     job execution
          */
         void onFinished(ArchivedExecutionGraph archivedExecutionGraph);
+    }
+
+    static class Factory implements StateFactory<Finished> {
+
+        private final Context context;
+        private final Logger log;
+        private final ArchivedExecutionGraph archivedExecutionGraph;
+
+        public Factory(Context context, ArchivedExecutionGraph archivedExecutionGraph, Logger log) {
+            this.context = context;
+            this.log = log;
+            this.archivedExecutionGraph = archivedExecutionGraph;
+        }
+
+        public Class<Finished> getStateClass() {
+            return Finished.class;
+        }
+
+        public Finished getState() {
+            return new Finished(context, archivedExecutionGraph, log);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -45,10 +45,7 @@ class Restarting extends StateWithExecutionGraph {
         super(context, executionGraph, executionGraphHandler, operatorCoordinatorHandler, logger);
         this.context = context;
         this.backoffTime = backoffTime;
-    }
 
-    @Override
-    public void onEnter() {
         getExecutionGraph().cancel();
     }
 
@@ -110,5 +107,44 @@ class Restarting extends StateWithExecutionGraph {
          * @param delay delay after which the action should be executed
          */
         void runIfState(State expectedState, Runnable action, Duration delay);
+    }
+
+    static class Factory implements StateFactory<Restarting> {
+
+        private final Context context;
+        private final Logger log;
+        private final ExecutionGraph executionGraph;
+        private final ExecutionGraphHandler executionGraphHandler;
+        private final OperatorCoordinatorHandler operatorCoordinatorHandler;
+        private final Duration backoffTime;
+
+        public Factory(
+                Context context,
+                ExecutionGraph executionGraph,
+                ExecutionGraphHandler executionGraphHandler,
+                OperatorCoordinatorHandler operatorCoordinatorHandler,
+                Logger log,
+                Duration backoffTime) {
+            this.context = context;
+            this.log = log;
+            this.executionGraph = executionGraph;
+            this.executionGraphHandler = executionGraphHandler;
+            this.operatorCoordinatorHandler = operatorCoordinatorHandler;
+            this.backoffTime = backoffTime;
+        }
+
+        public Class<Restarting> getStateClass() {
+            return Restarting.class;
+        }
+
+        public Restarting getState() {
+            return new Restarting(
+                    context,
+                    executionGraph,
+                    executionGraphHandler,
+                    operatorCoordinatorHandler,
+                    log,
+                    backoffTime);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -33,9 +33,6 @@ import java.util.Optional;
  */
 interface State {
 
-    /** This method is called whenever one transitions into this state. */
-    default void onEnter() {}
-
     /**
      * This method is called whenever one transitions out of this state.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateFactory.java
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.scheduler.declarative;
+package org.apache.flink.runtime.scheduler.adaptive;
 
 /**
- * Factory for creating declarative scheduler state instances.
+ * Factory for creating adaptive scheduler state instances.
  *
  * @param <T> Type of the state.
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateFactory.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.scheduler.declarative;
 
 /**
- * Factory for creating state instances.
+ * Factory for creating declarative scheduler state instances.
  *
  * @param <T> Type of the state.
  */
-public interface StateFactory<T> {
+public interface StateFactory<T extends State> {
     Class<T> getStateClass();
 
     T getState();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/declarative/StateFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.declarative;
+
+/**
+ * Factory for creating state instances.
+ *
+ * @param <T> Type of the state.
+ */
+public interface StateFactory<T> {
+    Class<T> getStateClass();
+
+    T getState();
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
@@ -107,7 +107,7 @@ public class AdaptiveSchedulerSimpleITCase extends TestLogger {
     }
 
     @Test
-    public void testGlobalFailoverIfTaskFails() throws IOException {
+    public void testGlobalFailoverIfTaskFails() throws Throwable {
         assumeTrue(ClusterOptions.isDeclarativeResourceManagementEnabled(configuration));
 
         final MiniCluster miniCluster = MINI_CLUSTER_RESOURCE.getMiniCluster();
@@ -117,7 +117,12 @@ public class AdaptiveSchedulerSimpleITCase extends TestLogger {
 
         final JobResult jobResult = miniCluster.requestJobResult(jobGraph.getJobID()).join();
 
-        assertTrue(jobResult.isSuccess());
+        if (!jobResult.isSuccess()) {
+            throw jobResult
+                    .getSerializedThrowable()
+                    .get()
+                    .deserializeError(ClassLoader.getSystemClassLoader());
+        }
     }
 
     private JobGraph createOnceFailingJobGraph() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -77,7 +77,6 @@ import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlot
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.offerSlots;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -423,49 +422,24 @@ public class AdaptiveSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testTransitionToStateCallsOnEnter() throws Exception {
-        final AdaptiveScheduler scheduler =
-                new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor).build();
-
-        final LifecycleMethodCapturingState firstState = new LifecycleMethodCapturingState();
-
-        scheduler.transitionToState(firstState);
-        assertThat(firstState.onEnterCalled, is(true));
-        assertThat(firstState.onLeaveCalled, is(false));
-        firstState.reset();
-    }
-
-    @Test
     public void testTransitionToStateCallsOnLeave() throws Exception {
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor).build();
 
-        final LifecycleMethodCapturingState firstState = new LifecycleMethodCapturingState();
-        final DummyState secondState = new DummyState();
+        final LifecycleMethodCapturingState.Factory firstStateFactory =
+                new LifecycleMethodCapturingState.Factory();
+        final DummyState.Factory secondStateFactory = new DummyState.Factory();
 
-        scheduler.transitionToState(firstState);
+        scheduler.transitionToState(firstStateFactory);
+
+        final LifecycleMethodCapturingState firstState =
+                (LifecycleMethodCapturingState) scheduler.getState();
+
         firstState.reset();
 
-        scheduler.transitionToState(secondState);
-        assertThat(firstState.onEnterCalled, is(false));
+        scheduler.transitionToState(secondStateFactory);
         assertThat(firstState.onLeaveCalled, is(true));
-        assertThat(firstState.onLeaveNewStateArgument, sameInstance(secondState.getClass()));
-    }
-
-    @Test
-    public void testTransitionToStateIgnoresDuplicateTransitions() throws Exception {
-        final AdaptiveScheduler scheduler =
-                new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor).build();
-
-        final LifecycleMethodCapturingState state = new LifecycleMethodCapturingState();
-        scheduler.transitionToState(state);
-        state.reset();
-
-        // attempt to transition into the state we are already in
-        scheduler.transitionToState(state);
-
-        assertThat(state.onEnterCalled, is(false));
-        assertThat(state.onLeaveCalled, is(false));
+        assertThat(firstState.onLeaveNewStateArgument.equals(DummyState.class), is(true));
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -511,6 +485,24 @@ public class AdaptiveSchedulerTest extends TestLogger {
                         .howToHandleFailure(new SuppressRestartsException(new Exception("test")))
                         .canRestart(),
                 is(false));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRepeatedTransitionIntoCurrentStateFails() throws Exception {
+        final DeclarativeScheduler scheduler =
+                new DeclarativeSchedulerBuilder(createJobGraph(), mainThreadExecutor).build();
+
+        final State state = scheduler.getState();
+
+        // safeguard for this test
+        assertThat(state, instanceOf(Created.class));
+
+        transitionToState(scheduler, new Created.Factory(scheduler, log));
+    }
+
+    private static <S extends State> void transitionToState(
+            DeclarativeScheduler scheduler, StateFactory<S> targetState) {
+        scheduler.transitionToState(targetState);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -600,25 +592,31 @@ public class AdaptiveSchedulerTest extends TestLogger {
     }
 
     private static class LifecycleMethodCapturingState extends DummyState {
-        boolean onEnterCalled = false;
         boolean onLeaveCalled = false;
         @Nullable Class<? extends State> onLeaveNewStateArgument = null;
 
         void reset() {
-            onEnterCalled = false;
             onLeaveCalled = false;
             onLeaveNewStateArgument = null;
-        }
-
-        @Override
-        public void onEnter() {
-            onEnterCalled = true;
         }
 
         @Override
         public void onLeave(Class<? extends State> newState) {
             onLeaveCalled = true;
             onLeaveNewStateArgument = newState;
+        }
+
+        private static class Factory implements StateFactory<LifecycleMethodCapturingState> {
+
+            @Override
+            public Class<LifecycleMethodCapturingState> getStateClass() {
+                return LifecycleMethodCapturingState.class;
+            }
+
+            @Override
+            public LifecycleMethodCapturingState getState() {
+                return new LifecycleMethodCapturingState();
+            }
         }
     }
 
@@ -646,6 +644,19 @@ public class AdaptiveSchedulerTest extends TestLogger {
         @Override
         public Logger getLogger() {
             return null;
+        }
+
+        private static class Factory implements StateFactory<DummyState> {
+
+            @Override
+            public Class<DummyState> getStateClass() {
+                return DummyState.class;
+            }
+
+            @Override
+            public DummyState getState() {
+                return new DummyState();
+            }
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -497,12 +497,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         // safeguard for this test
         assertThat(state, instanceOf(Created.class));
 
-        transitionToState(scheduler, new Created.Factory(scheduler, log));
-    }
-
-    private static <S extends State> void transitionToState(
-            DeclarativeScheduler scheduler, StateFactory<S> targetState) {
-        scheduler.transitionToState(targetState);
+        scheduler.transitionToState(new Created.Factory(scheduler, log));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -121,7 +121,6 @@ public class CancelingTest extends TestLogger {
             // ideally we'd delay the async call to #onGloballyTerminalState instead, but the
             // context does not support that
             ctx.setExpectFinished(eg -> {});
-            canceling.onEnter();
 
             meg.completeCancellation();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -39,9 +39,8 @@ public class CancelingTest extends TestLogger {
     public void testExecutionGraphCancelationOnEnter() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             MockExecutionGraph mockExecutionGraph = new MockExecutionGraph();
-            Canceling canceling = createCancelingState(ctx, mockExecutionGraph);
+            createCancelingState(ctx, mockExecutionGraph);
 
-            canceling.onEnter(); // transition of EG from RUNNING to CANCELLING
             assertThat(mockExecutionGraph.getState(), is(JobStatus.CANCELLING));
         }
     }
@@ -50,8 +49,8 @@ public class CancelingTest extends TestLogger {
     public void testTransitionToFinishedWhenCancellationCompletes() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             MockExecutionGraph mockExecutionGraph = new MockExecutionGraph();
+            // transition of EG from RUNNING to CANCELLING
             Canceling canceling = createCancelingState(ctx, mockExecutionGraph);
-            canceling.onEnter(); // transition of EG from RUNNING to CANCELLING
             assertThat(mockExecutionGraph.getState(), is(JobStatus.CANCELLING));
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
@@ -65,7 +64,7 @@ public class CancelingTest extends TestLogger {
     public void testTransitionToSuspend() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             Canceling canceling = createCancelingState(ctx, new MockExecutionGraph());
-            canceling.onEnter();
+
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
@@ -77,7 +76,6 @@ public class CancelingTest extends TestLogger {
     public void testCancelIsIgnored() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             Canceling canceling = createCancelingState(ctx, new MockExecutionGraph());
-            canceling.onEnter();
             canceling.cancel();
             ctx.assertNoStateTransition();
         }
@@ -87,7 +85,6 @@ public class CancelingTest extends TestLogger {
     public void testGlobalFailuresAreIgnored() throws Exception {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             Canceling canceling = createCancelingState(ctx, new MockExecutionGraph());
-            canceling.onEnter();
             canceling.handleGlobalFailure(new RuntimeException("test"));
             ctx.assertNoStateTransition();
         }
@@ -98,7 +95,6 @@ public class CancelingTest extends TestLogger {
         try (MockStateWithExecutionGraphContext ctx = new MockStateWithExecutionGraphContext()) {
             MockExecutionGraph meg = new MockExecutionGraph();
             Canceling canceling = createCancelingState(ctx, meg);
-            canceling.onEnter();
             // register execution at EG
             ExecutingTest.MockExecutionJobVertex ejv =
                     new ExecutingTest.MockExecutionJobVertex(canceling.getExecutionGraph());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -275,7 +275,6 @@ public class ExecutingTest extends TestLogger {
             // ideally we'd delay the async call to #onGloballyTerminalState instead, but the
             // context does not support that
             ctx.setExpectFinished(eg -> {});
-            executing.onEnter();
 
             finishingMockExecutionGraph.finish();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -79,7 +79,6 @@ public class ExecutingTest extends TestLogger {
             Executing exec =
                     new ExecutingStateBuilder().setExecutionGraph(executionGraph).build(ctx);
 
-            exec.onEnter();
             assertThat(mockExecutionJobVertex.isExecutionDeployed(), is(true));
             assertThat(executionGraph.getState(), is(JobStatus.RUNNING));
         }
@@ -106,7 +105,6 @@ public class ExecutingTest extends TestLogger {
         final String failureMsg = "test exception";
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
-            exec.onEnter();
             ctx.setExpectFailing(
                     (failingArguments -> {
                         assertThat(failingArguments.getExecutionGraph(), notNullValue());
@@ -122,7 +120,6 @@ public class ExecutingTest extends TestLogger {
         final Duration duration = Duration.ZERO;
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
-            exec.onEnter();
             ctx.setExpectRestarting(
                     (restartingArguments ->
                             assertThat(restartingArguments.getBackoffTime(), is(duration))));
@@ -135,7 +132,6 @@ public class ExecutingTest extends TestLogger {
     public void testCancelTransitionsToCancellingState() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
-            exec.onEnter();
             ctx.setExpectCancelling(assertNonNull());
             exec.cancel();
         }
@@ -145,7 +141,6 @@ public class ExecutingTest extends TestLogger {
     public void testTransitionToFinishedOnFailedExecutionGraph() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
-            exec.onEnter();
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
@@ -164,7 +159,6 @@ public class ExecutingTest extends TestLogger {
                     archivedExecutionGraph -> {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
                     });
-            exec.onEnter();
             exec.suspend(new RuntimeException("suspend"));
         }
     }
@@ -174,7 +168,6 @@ public class ExecutingTest extends TestLogger {
             throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
-            exec.onEnter();
 
             ctx.setExpectRestarting(
                     restartingArguments -> {
@@ -191,7 +184,6 @@ public class ExecutingTest extends TestLogger {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
             ctx.setCanScaleUp(() -> false);
-            exec.onEnter();
             exec.notifyNewResourcesAvailable();
             ctx.assertNoStateTransition();
         }
@@ -201,7 +193,8 @@ public class ExecutingTest extends TestLogger {
     public void testFailureReportedViaUpdateTaskExecutionStateCausesFailingOnNoRestart()
             throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
-            ExecutionGraph returnsFailedStateExecutionGraph = new MockExecutionGraph(true);
+            ExecutionGraph returnsFailedStateExecutionGraph =
+                    new MockExecutionGraph(true, Collections::emptyList);
             Executing exec =
                     new ExecutingStateBuilder()
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
@@ -218,7 +211,8 @@ public class ExecutingTest extends TestLogger {
     @Test
     public void testFailureReportedViaUpdateTaskExecutionStateCausesRestart() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
-            ExecutionGraph returnsFailedStateExecutionGraph = new MockExecutionGraph(true);
+            ExecutionGraph returnsFailedStateExecutionGraph =
+                    new MockExecutionGraph(true, Collections::emptyList);
             Executing exec =
                     new ExecutingStateBuilder()
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
@@ -234,7 +228,8 @@ public class ExecutingTest extends TestLogger {
     @Test
     public void testFalseReportsViaUpdateTaskExecutionStateAreIgnored() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
-            ExecutionGraph returnsFailedStateExecutionGraph = new MockExecutionGraph(false);
+            MockExecutionGraph returnsFailedStateExecutionGraph =
+                    new MockExecutionGraph(false, Collections::emptyList);
             Executing exec =
                     new ExecutingStateBuilder()
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
@@ -261,7 +256,6 @@ public class ExecutingTest extends TestLogger {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
             Executing exec = new ExecutingStateBuilder().build(ctx);
             final JobID jobId = exec.getExecutionGraph().getJobID();
-            exec.onEnter();
             assertThat(exec.getJob(), instanceOf(ArchivedExecutionGraph.class));
             assertThat(exec.getJob().getJobID(), is(jobId));
             assertThat(exec.getJobStatus(), is(JobStatus.RUNNING));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -127,7 +127,6 @@ public class FailingTest extends TestLogger {
             // ideally we'd delay the async call to #onGloballyTerminalState instead, but the
             // context does not support that
             ctx.setExpectFinished(eg -> {});
-            failing.onEnter();
 
             meg.completeCancellation();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -44,8 +44,9 @@ public class FailingTest extends TestLogger {
     public void testFailingStateOnEnter() throws Exception {
         try (MockFailingContext ctx = new MockFailingContext()) {
             MockExecutionGraph meg = new MockExecutionGraph();
-            Failing failing = createFailingState(ctx, meg);
-            failing.onEnter();
+
+            createFailingState(ctx, meg);
+
             assertThat(meg.isFailing(), is(true));
             ctx.assertNoStateTransition();
         }
@@ -56,7 +57,6 @@ public class FailingTest extends TestLogger {
         try (MockFailingContext ctx = new MockFailingContext()) {
             MockExecutionGraph meg = new MockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
-            failing.onEnter(); // transition from RUNNING to FAILING
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED)));
@@ -70,7 +70,6 @@ public class FailingTest extends TestLogger {
             MockExecutionGraph meg = new MockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
             ctx.setExpectCanceling(assertNonNull());
-            failing.onEnter();
             failing.cancel();
         }
     }
@@ -83,8 +82,6 @@ public class FailingTest extends TestLogger {
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
-
-            failing.onEnter();
             failing.suspend(new RuntimeException("suspend"));
         }
     }
@@ -94,7 +91,6 @@ public class FailingTest extends TestLogger {
         try (MockFailingContext ctx = new MockFailingContext()) {
             MockExecutionGraph meg = new MockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
-            failing.onEnter();
             failing.handleGlobalFailure(new RuntimeException());
             ctx.assertNoStateTransition();
         }
@@ -105,7 +101,6 @@ public class FailingTest extends TestLogger {
         try (MockFailingContext ctx = new MockFailingContext()) {
             MockExecutionGraph meg = new MockExecutionGraph();
             Failing failing = createFailingState(ctx, meg);
-            failing.onEnter();
             // register execution at EG
             ExecutingTest.MockExecutionJobVertex ejv =
                     new ExecutingTest.MockExecutionJobVertex(failing.getExecutionGraph());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FinishedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FinishedTest.java
@@ -36,8 +36,7 @@ public class FinishedTest extends TestLogger {
     @Test
     public void testOnFinishedCallOnEnter() throws Exception {
         MockFinishedContext ctx = new MockFinishedContext();
-        Finished finished = createFinishedState(ctx);
-        finished.onEnter();
+        createFinishedState(ctx);
 
         assertThat(ctx.getArchivedExecutionGraph().getState(), is(testJobStatus));
     }
@@ -46,21 +45,21 @@ public class FinishedTest extends TestLogger {
     public void testCancelIgnored() throws Exception {
         MockFinishedContext ctx = new MockFinishedContext();
         createFinishedState(ctx).cancel();
-        ctx.assertNoStateTransition();
+        assertThat(ctx.getArchivedExecutionGraph().getState(), is(testJobStatus));
     }
 
     @Test
     public void testSuspendIgnored() throws Exception {
         MockFinishedContext ctx = new MockFinishedContext();
         createFinishedState(ctx).suspend(new RuntimeException());
-        ctx.assertNoStateTransition();
+        assertThat(ctx.getArchivedExecutionGraph().getState(), is(testJobStatus));
     }
 
     @Test
     public void testGlobalFailureIgnored() {
         MockFinishedContext ctx = new MockFinishedContext();
         createFinishedState(ctx).handleGlobalFailure(new RuntimeException());
-        ctx.assertNoStateTransition();
+        assertThat(ctx.getArchivedExecutionGraph().getState(), is(testJobStatus));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -58,9 +58,8 @@ public class RestartingTest extends TestLogger {
     public void testExecutionGraphCancellationOnEnter() throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             CancellableExecutionGraph cancellableExecutionGraph = new CancellableExecutionGraph();
-            Restarting restarting = createRestartingState(ctx, cancellableExecutionGraph);
+            createRestartingState(ctx, cancellableExecutionGraph);
 
-            restarting.onEnter();
             assertThat(cancellableExecutionGraph.isCancelled(), is(true));
         }
     }
@@ -86,7 +85,8 @@ public class RestartingTest extends TestLogger {
     @Test
     public void testSuspend() throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            Restarting restarting = createRestartingState(ctx);
+            CancellableExecutionGraph cancellableExecutionGraph = new CancellableExecutionGraph();
+            Restarting restarting = createRestartingState(ctx, cancellableExecutionGraph);
             ctx.setExpectFinished(
                     archivedExecutionGraph ->
                             assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED)));
@@ -98,7 +98,8 @@ public class RestartingTest extends TestLogger {
     @Test
     public void testGlobalFailuresAreIgnored() throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            Restarting restarting = createRestartingState(ctx);
+            CancellableExecutionGraph cancellableExecutionGraph = new CancellableExecutionGraph();
+            Restarting restarting = createRestartingState(ctx, cancellableExecutionGraph);
             restarting.handleGlobalFailure(new RuntimeException());
             ctx.assertNoStateTransition();
         }
@@ -227,6 +228,7 @@ public class RestartingTest extends TestLogger {
                     NoOpExecutionDeploymentListener.get(),
                     (execution, newState) -> {},
                     0L);
+            setJsonPlan("");
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -112,7 +112,6 @@ public class RestartingTest extends TestLogger {
 
             // ideally we'd just delay the state transitions, but the context does not support that
             ctx.setExpectWaitingForResources();
-            restarting.onEnter();
 
             // this is just a sanity check for the test
             assertThat(restarting.getExecutionGraph().getState(), is(JobStatus.CANCELED));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -62,8 +62,9 @@ public class WaitingForResourcesTest extends TestLogger {
             new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
             // run delayed actions
             for (ScheduledRunnable scheduledRunnable : ctx.getScheduledRunnables()) {
-                if (!ctx.hasStateTransition()) {
-                    scheduledRunnable.runAction();
+                scheduledRunnable.runAction();
+                if (ctx.hasStateTransition()) {
+                    break;
                 }
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResourcesTest.java
@@ -57,10 +57,15 @@ public class WaitingForResourcesTest extends TestLogger {
         try (MockContext ctx = new MockContext()) {
             ctx.setHasEnoughResources(() -> true);
 
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
             ctx.setExpectExecuting(assertNonNull());
-            wfr.onEnter();
+
+            new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
+            // run delayed actions
+            for (ScheduledRunnable scheduledRunnable : ctx.getScheduledRunnables()) {
+                if (!ctx.hasStateTransition()) {
+                    scheduledRunnable.runAction();
+                }
+            }
         }
     }
 
@@ -73,13 +78,19 @@ public class WaitingForResourcesTest extends TestLogger {
                         throw new RuntimeException("Test exception");
                     });
 
-            WaitingForResources wfr =
-                    new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
             ctx.setExpectFinished(
                     (archivedExecutionGraph -> {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
                     }));
-            wfr.onEnter();
+
+            new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
+
+            // run delayed actions
+            for (ScheduledRunnable scheduledRunnable : ctx.getScheduledRunnables()) {
+                if (!ctx.hasStateTransition()) {
+                    scheduledRunnable.runAction();
+                }
+            }
         }
     }
 
@@ -91,7 +102,6 @@ public class WaitingForResourcesTest extends TestLogger {
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
 
             // we expect no state transition.
-            wfr.onEnter();
             wfr.notifyNewResourcesAvailable();
         }
     }
@@ -102,7 +112,6 @@ public class WaitingForResourcesTest extends TestLogger {
             ctx.setHasEnoughResources(() -> false); // initially, not enough resources
             WaitingForResources wfr =
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
-            wfr.onEnter();
             ctx.setHasEnoughResources(() -> true); // make resources available
             ctx.setExpectExecuting(assertNonNull());
             wfr.notifyNewResourcesAvailable(); // .. and notify
@@ -116,7 +125,6 @@ public class WaitingForResourcesTest extends TestLogger {
             WaitingForResources wfr =
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
 
-            wfr.onEnter();
             ctx.setExpectExecuting(assertNonNull());
 
             // immediately execute all scheduled runnables
@@ -137,7 +145,6 @@ public class WaitingForResourcesTest extends TestLogger {
             WaitingForResources wfr =
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
 
-            wfr.onEnter();
             ctx.setExpectFinished(
                     archivedExecutionGraph -> {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
@@ -160,7 +167,6 @@ public class WaitingForResourcesTest extends TestLogger {
             WaitingForResources wfr =
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
 
-            wfr.onEnter();
             ctx.setExpectFinished(
                     (archivedExecutionGraph -> {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.CANCELED));
@@ -176,7 +182,6 @@ public class WaitingForResourcesTest extends TestLogger {
             WaitingForResources wfr =
                     new WaitingForResources(ctx, log, RESOURCE_COUNTER, Duration.ZERO);
 
-            wfr.onEnter();
             ctx.setExpectFinished(
                     (archivedExecutionGraph -> {
                         assertThat(archivedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
@@ -191,14 +196,15 @@ public class WaitingForResourcesTest extends TestLogger {
 
         private final StateValidator<ExecutionGraph> executingStateValidator =
                 new StateValidator<>("executing");
-        private final StateValidator<ArchivedExecutionGraph> finishingStateValidator =
-                new StateValidator<>("finishing");
+        private final StateValidator<ArchivedExecutionGraph> finishedStateValidator =
+                new StateValidator<>("finished");
 
         private Supplier<Boolean> hasEnoughResourcesSupplier = () -> false;
         private SupplierWithException<ExecutionGraph, FlinkException>
                 createExecutionGraphWithAvailableResources =
                         () -> TestingExecutionGraphBuilder.newBuilder().build();
         private final List<ScheduledRunnable> scheduledRunnables = new ArrayList<>();
+        private boolean hasStateTransition = false;
 
         public List<ScheduledRunnable> getScheduledRunnables() {
             return scheduledRunnables;
@@ -214,7 +220,7 @@ public class WaitingForResourcesTest extends TestLogger {
         }
 
         void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
-            finishingStateValidator.expectInput(asserter);
+            finishedStateValidator.expectInput(asserter);
         }
 
         void setExpectExecuting(Consumer<ExecutionGraph> asserter) {
@@ -224,7 +230,7 @@ public class WaitingForResourcesTest extends TestLogger {
         @Override
         public void close() throws Exception {
             executingStateValidator.close();
-            finishingStateValidator.close();
+            finishedStateValidator.close();
         }
 
         @Override
@@ -253,12 +259,18 @@ public class WaitingForResourcesTest extends TestLogger {
 
         @Override
         public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
-            finishingStateValidator.validateInput(archivedExecutionGraph);
+            finishedStateValidator.validateInput(archivedExecutionGraph);
+            hasStateTransition = true;
         }
 
         @Override
         public void goToExecuting(ExecutionGraph executionGraph) {
             executingStateValidator.validateInput(executionGraph);
+            hasStateTransition = true;
+        }
+
+        public boolean hasStateTransition() {
+            return hasStateTransition;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Increase robustness by moving the onEnter into the constructor of the states.


