### PR TITLE
[FLINK-21415][Connectors / JDBC] JDBC does not query data, and the cache will store an ArrayList without data

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcLookupFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcLookupFunction.java
@@ -176,7 +176,9 @@ public class JdbcLookupFunction extends TableFunction<Row> {
                             collect(row);
                         }
                         rows.trimToSize();
-                        cache.put(keyRow, rows);
+                        if(rows.size() > 0) {
+                            cache.put(keyRow, rows);
+                        }
                     }
                 }
                 break;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataLookupFunction.java
@@ -150,7 +150,7 @@ public class JdbcRowDataLookupFunction extends TableFunction<RowData> {
         RowData keyRow = GenericRowData.of(keys);
         if (cache != null) {
             List<RowData> cachedRows = cache.getIfPresent(keyRow);
-            if (cachedRows != null) {
+            if (cachedRows != null && cacheRows.size() > 0) {
                 for (RowData cachedRow : cachedRows) {
                     collect(cachedRow);
                 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcRowDataLookupFunction.java
@@ -150,7 +150,7 @@ public class JdbcRowDataLookupFunction extends TableFunction<RowData> {
         RowData keyRow = GenericRowData.of(keys);
         if (cache != null) {
             List<RowData> cachedRows = cache.getIfPresent(keyRow);
-            if (cachedRows != null && cacheRows.size() > 0) {
+            if (cachedRows != null) {
                 for (RowData cachedRow : cachedRows) {
                     collect(cachedRow);
                 }
@@ -175,7 +175,9 @@ public class JdbcRowDataLookupFunction extends TableFunction<RowData> {
                             collect(row);
                         }
                         rows.trimToSize();
-                        cache.put(keyRow, rows);
+                        if(rows.size() > 0) {
+                            cache.put(keyRow, rows);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
## What is the purpose of the change

*When JDBC can't find the data, the cache will also store an array of size 0*


## Brief change log

  - *Add size judgment*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
