### PR TITLE
[FLINK-21412][python] Fix Decimal type which doesn't work in UDAF and expression DSL

### DIFF
--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1961,7 +1961,7 @@ def _to_java_data_type(data_type: DataType):
     elif isinstance(data_type, BinaryType):
         j_data_type = JDataTypes.BINARY(data_type.length)
     elif isinstance(data_type, DecimalType):
-        j_data_type = JDataTypes.Decimal(data_type.precision, data_type.scale)
+        j_data_type = JDataTypes.DECIMAL(data_type.precision, data_type.scale)
     elif isinstance(data_type, DateType):
         j_data_type = JDataTypes.DATE()
     elif isinstance(data_type, TimeType):


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the bug that Decimal type which doesn't work in UDAF and expression DSL*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
