### PR TITLE
[FLINK-21425][table-planner-blink] Fix equals and notEquals predicates implicit conversions

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -266,10 +266,10 @@ object ScalarOperators {
     else {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         if (isReference(left)) {
-          (leftTerm, rightTerm) => s"$leftTerm.equals($rightTerm)"
+          (leftTerm, rightTerm) => s"$leftTerm.equals(String.valueOf($rightTerm))"
         }
         else if (isReference(right)) {
-          (leftTerm, rightTerm) => s"$rightTerm.equals($leftTerm)"
+          (leftTerm, rightTerm) => s"$rightTerm.equals(String.valueOf($leftTerm))"
         }
         else {
           throw new CodeGenException(s"Incomparable types: ${left.resultType} and " +
@@ -314,10 +314,10 @@ object ScalarOperators {
     else {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         if (isReference(left)) {
-          (leftTerm, rightTerm) => s"!($leftTerm.equals($rightTerm))"
+          (leftTerm, rightTerm) => s"!($leftTerm.equals(String.valueOf($rightTerm)))"
         }
         else if (isReference(right)) {
-          (leftTerm, rightTerm) => s"!($rightTerm.equals($leftTerm))"
+          (leftTerm, rightTerm) => s"!($rightTerm.equals(String.valueOf($leftTerm)))"
         }
         else {
           throw new CodeGenException(s"Incomparable types: ${left.resultType} and " +

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -262,14 +262,28 @@ object ScalarOperators {
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("==", nullCheck, left, right)
     }
+    // string type and other type
+    else if (isString(left.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"$leftTerm.equals(String.valueOf($rightTerm))"
+      }
+    }
+    // other type and string type
+    else if (isString(right.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"$rightTerm.equals(String.valueOf($leftTerm))"
+      }
+    }
     // non comparable types
     else {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         if (isReference(left)) {
-          (leftTerm, rightTerm) => s"$leftTerm.equals(String.valueOf($rightTerm))"
+          (leftTerm, rightTerm) => s"$leftTerm.equals($rightTerm)"
         }
         else if (isReference(right)) {
-          (leftTerm, rightTerm) => s"$rightTerm.equals(String.valueOf($leftTerm))"
+          (leftTerm, rightTerm) => s"$rightTerm.equals($leftTerm)"
         }
         else {
           throw new CodeGenException(s"Incomparable types: ${left.resultType} and " +
@@ -310,14 +324,28 @@ object ScalarOperators {
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("!=", nullCheck, left, right)
     }
+    // string type and other type
+    else if (isString(left.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"!($leftTerm.equals(String.valueOf($rightTerm)))"
+      }
+    }
+    // other type and string type
+    else if (isString(right.resultType) &&
+      left.resultType.getTypeClass != right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"!($rightTerm.equals(String.valueOf($leftTerm)))"
+      }
+    }
     // non-comparable types
     else {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         if (isReference(left)) {
-          (leftTerm, rightTerm) => s"!($leftTerm.equals(String.valueOf($rightTerm)))"
+          (leftTerm, rightTerm) => s"!($leftTerm.equals($rightTerm))"
         }
         else if (isReference(right)) {
-          (leftTerm, rightTerm) => s"!($rightTerm.equals(String.valueOf($leftTerm)))"
+          (leftTerm, rightTerm) => s"!($rightTerm.equals($leftTerm))"
         }
         else {
           throw new CodeGenException(s"Incomparable types: ${left.resultType} and " +

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -195,4 +195,40 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
         String expected = "bar\n" + "spam\n";
         compareResultAsText(results, expected);
     }
+
+    @Test
+    public void testImplicitConvertAtEqual() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
+
+        DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+        Table in = tableEnv.fromDataSet(ds, $("a"), $("b"), $("c"));
+        tableEnv.registerTable("T", in);
+
+        String sqlQuery = "SELECT * FROM T WHERE a = '1'";
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+        List<Row> results = resultSet.collect();
+        String expected = "1,1,Hi\n";
+        compareResultAsText(results, expected);
+    }
+
+    @Test
+    public void testImplicitConvertAtNotEqual() throws Exception {
+        ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+        BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
+
+        DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+        Table in = tableEnv.fromDataSet(ds, $("a"), $("b"), $("c"));
+        tableEnv.registerTable("T", in);
+
+        String sqlQuery = "SELECT * FROM T WHERE a <> '1'";
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+        List<Row> results = resultSet.collect();
+        String expected = "2,2,Hello\n" + "3,2,Hello world\n";
+        compareResultAsText(results, expected);
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -176,4 +176,55 @@ public class JavaSqlITCase extends AbstractTestBase {
 
         StreamITCase.compareWithList(expected);
     }
+
+    @Test
+    public void testImplicitConvertAtEqual() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().useOldPlanner().build();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        StreamITCase.clear();
+
+        DataStream<Tuple3<Integer, Long, String>> ds =
+                JavaStreamTestData.getSmall3TupleDataSet(env);
+        Table in = tableEnv.fromDataStream(ds, $("a"), $("b"), $("c"));
+        tableEnv.registerTable("MyTable", in);
+
+        String sqlQuery = "SELECT * FROM MyTable WHERE a = '1'";
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
+        resultSet.addSink(new StreamITCase.StringSink<Row>());
+        env.execute();
+
+        List<String> expected = new ArrayList<>();
+        expected.add("1,1,Hi");
+
+        StreamITCase.compareWithList(expected);
+    }
+
+    @Test
+    public void testImplicitConvertAtNotEqual() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().useOldPlanner().build();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        StreamITCase.clear();
+
+        DataStream<Tuple3<Integer, Long, String>> ds =
+                JavaStreamTestData.getSmall3TupleDataSet(env);
+        Table in = tableEnv.fromDataStream(ds, $("a"), $("b"), $("c"));
+        tableEnv.registerTable("MyTable", in);
+
+        String sqlQuery = "SELECT * FROM MyTable WHERE a <> '1'";
+        Table result = tableEnv.sqlQuery(sqlQuery);
+
+        DataStream<Row> resultSet = tableEnv.toAppendStream(result, Row.class);
+        resultSet.addSink(new StreamITCase.StringSink<Row>());
+        env.execute();
+
+        List<String> expected = new ArrayList<>();
+        expected.add("2,2,Hello");
+        expected.add("3,2,Hello world");
+
+        StreamITCase.compareWithList(expected);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
This pull request fixes the bug that implicit conversions in equals and notEquals filter predicates doesn't work


## Brief change log
Cast other types as string type when compare between string type and other types in `=` and `<>` predicates

## Verifying this change
This change added tests and can be verified as follows:
JavaSqlITCase#testImplicitConvertAtEqual
JavaSqlITCase#testImplicitConvertAtNotEqual

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
