### PR TITLE
[FLINK-21426][docs] adds details to DataStream JdbcSink documentation

### DIFF
--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -39,7 +39,7 @@ Note that the streaming connectors are currently __NOT__ part of the binary dist
 
 The JDBC sink provides at-least-once guarantee.
 Effectively though, exactly-once can be achieved by crafting upsert SQL statements or idempotent SQL updates.
-Configuration goes as follow (see also [JdbcSink javadoc]{{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcSink.html)):
+Configuration goes as follow (see also [JdbcSink javadoc]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcSink.html)):
 
 ```
 JdbcSink.sink(
@@ -66,11 +66,11 @@ It then repeatedly calls a user-provided function to update that prepared statem
 
 ### JDBC execution options
 
-The SQL DML statements are executed in batches, which can optionally be configured with the following instance (see also [JdbcExecutionOptions javadoc]{{ site.javadocs_baseurl }}(/api/java/org/apache/flink/connector/jdbc/JdbcExecutionOptions.html))
+The SQL DML statements are executed in batches, which can optionally be configured with the following instance (see also [JdbcExecutionOptions javadoc]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcExecutionOptions.html))
 
 ```
 JdbcExecutionOptions.builder()
-        .withBatchIntervalMs(200)             // optional: default = 0, meaning no time-based execution is done)
+        .withBatchIntervalMs(200)             // optional: default = 0, meaning no time-based execution is done
         .withBathSize(1000)                   // optional: default = 5000 values
         .withMaxRetries(5)                    // optional: default = 3 
 .build()
@@ -85,7 +85,7 @@ A JDBC batch is executed as soon as one of the following condition is true:
 ### JDBC connection parameters
 
 The connection to the database is configured with a `JdbcConnectionOptions` instance. 
-Please see [JdbcConnectionOptions javadoc]{{ site.javadocs_baseurl }}(/api/java/org/apache/flink/connector/jdbc/JdbcConnectionOptions.html) for details
+Please see [JdbcConnectionOptions javadoc]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcConnectionOptions.html) for details
 
 ### Full example
 

--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -28,40 +28,119 @@ under the License.
 
 This connector provides a sink that writes data to a JDBC database.
 
-To use it, add the following dependency to your project (along with your JDBC-driver):
+To use it, add the following dependency to your project (along with your JDBC driver):
 
 {{< artifact flink-connector-jdbc withScalaVersion >}}
 
 Note that the streaming connectors are currently __NOT__ part of the binary distribution. See how to link with them for cluster execution [here]({{< ref "docs/dev/datastream/project-configuration" >}}).
 
-Created JDBC sink provides at-least-once guarantee.
-Effectively exactly-once can be achieved using upsert statements or idempotent updates.
 
-Example usage:
+## `JdbcSink.sink`
 
-```java
-StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-env
-        .fromElements(...)
-        .addSink(JdbcSink.sink(
-                "insert into books (id, title, author, price, qty) values (?,?,?,?,?)",
-                (ps, t) -> {
-                    ps.setInt(1, t.id);
-                    ps.setString(2, t.title);
-                    ps.setString(3, t.author);
-                    ps.setDouble(4, t.price);
-                    ps.setInt(5, t.qty);
-                },
-                new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
-                        .withUrl(getDbMetadata().getUrl())
-                        .withDriverName(getDbMetadata().getDriverClass())
-                        .build()));
-env.execute();
+The JDBC sink provides at-least-once guarantee.
+Effectively though, exactly-once can be achieved by crafting upsert SQL statements or idempotent SQL updates.
+Configuration goes as follow (see also [JdbcSink javadoc]{{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcSink.html)):
+
+```
+JdbcSink.sink(
+      	sqlDmlStatement,                       // mandatory
+      	jdbcStatementBuilder,                  // mandatory   	
+      	jdbcExecutionOptions,                  // optional
+      	jdbcConnectionOptions                  // mandatory
+)
+```        	
+
+### SQL DML statement and JDBC statement builder
+
+The sink builds one [JDBC prepared statement](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/PreparedStatement.html) from a user-provider SQL string, e.g.:
+
+```
+INSERT INTO some_table field1, field2 values (?, ?)
 ```
 
-Please refer to the [API documentation]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/jdbc/JdbcSink.html) for more details.
+It then repeatedly calls a user-provided function to update that prepared statement with each value of the stream, e.g.:
 
-## Exactly-once
+```
+(preparedStatement, someRecord) -> { ... update here the preparedStatement with values from someRecord ... }
+```
+
+### JDBC execution options
+
+The SQL DML statements are executed in batches, which can optionally be configured with the following instance (see also [JdbcExecutionOptions javadoc]{{ site.javadocs_baseurl }}(/api/java/org/apache/flink/connector/jdbc/JdbcExecutionOptions.html))
+
+```
+JdbcExecutionOptions.builder()
+        .withBatchIntervalMs(200)             // optional: default = 0, meaning no time-based execution is done)
+        .withBathSize(1000)                   // optional: default = 5000 values
+        .withMaxRetries(5)                    // optional: default = 3 
+.build()
+```
+
+A JDBC batch is executed as soon as one of the following condition is true:
+
+* the configured batch interval time is elapsed
+* the maximum batch size is reached 
+* a Flink checkpoint has started
+
+### JDBC connection parameters
+
+The connection to the database is configured with a `JdbcConnectionOptions` instance. 
+Please see [JdbcConnectionOptions javadoc]{{ site.javadocs_baseurl }}(/api/java/org/apache/flink/connector/jdbc/JdbcConnectionOptions.html) for details
+
+### Full example
+
+```java
+public class JdbcSinkExample {
+
+    static class Book {
+        public Book(Long id, String title, String authors, Integer year) {
+            this.id = id;
+            this.title = title;
+            this.authors = authors;
+            this.year = year;
+        }
+        final Long id;
+        final String title;
+        final String authors;
+        final Integer year;
+    }
+
+    public static void main(String[] args) throws Exception {
+        var env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        env.fromElements(
+                new Book(101L, "Stream Processing with Apache Flink", "Fabian Hueske, Vasiliki Kalavri", 2019),
+                new Book(102L, "Streaming Systems", "Tyler Akidau, Slava Chernyak, Reuven Lax", 2018),
+                new Book(103L, "Designing Data-Intensive Applications", "Martin Kleppmann", 2017),
+                new Book(104L, "Kafka: The Definitive Guide", "Gwen Shapira, Neha Narkhede, Todd Palino", 2017)
+        ).addSink(
+                JdbcSink.sink(
+                        "insert into books (id, title, authors, year) values (?, ?, ?, ?)",
+                        (statement, book) -> {
+                            statement.setLong(1, book.id);
+                            statement.setString(2, book.title);
+                            statement.setString(3, book.authors);
+                            statement.setInt(4, book.year);
+                        },
+                        JdbcExecutionOptions.builder()
+                                .withBatchSize(1000)
+                                .withBatchIntervalMs(200)
+                                .withMaxRetries(5)
+                                .build(),
+                        new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                                .withUrl("jdbc:postgresql://dbhost:5432/postgresdb")
+                                .withDriverName("org.postgresql.Driver")
+                                .withUsername("someUser")
+                                .withPassword("somePassword")
+                                .build()
+                ));
+                
+        env.execute();
+    }
+}
+```
+
+## `JdbcSink.exactlyOnceSink`
 
 Since 1.13, Flink JDBC sink supports exactly-once mode. The implementation relies on the JDBC driver support of XA [standard](https://pubs.opengroup.org/onlinepubs/009680699/toc.pdf).
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Make the configuration options as well as the behavior of the DataStream JdbcSink more explicit in the documentation*


## Brief change log

  - *Added description of the batching behavior of the connector*
  - *Mentioned which parameters are optional and what are the default values*
  - *Made the code example longer by showing all configuration possibilities*

I've not updated the Chinese documentation yet, although I'm happy to copy/paste this English version there if/when it's accepted.

## Verifying this change

I validated the visual aspect of the documentation with `hugo -b "" serve` . I don't know how to validate the links to the javadoc though.

I validated that the example code successfully works

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
