### PR TITLE
[FLINK-18726][table-planner-blink] Support INSERT INTO specific colum…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
@@ -259,4 +259,8 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
                 Thread.currentThread().getContextClassLoader(),
                 schemaTable.isTemporary());
     }
+
+    public CatalogTable getCatalogTable() {
+        return catalogTable;
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -39,6 +39,7 @@ import org.apache.flink.table.planner.plan.schema.{GenericRelDataType, _}
 import org.apache.flink.table.runtime.types.{LogicalTypeDataTypeConverter, PlannerTypeUtils}
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.table.utils.TableSchemaUtils
 import org.apache.flink.types.Nothing
 import org.apache.flink.util.Preconditions.checkArgument
 
@@ -232,6 +233,16 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem)
   def buildRelNodeRowType(rowType: RowType): RelDataType = {
     val fields = rowType.getFields
     buildStructType(fields.map(_.getName), fields.map(_.getType), StructKind.FULLY_QUALIFIED)
+  }
+
+  /**
+    * Creates a struct type with the physical columns using FlinkTypeFactory
+    *
+    * @param tableSchema schema to convert to Calcite's specific one
+    * @return a struct type with the input fieldNames, input fieldTypes.
+    */
+  def buildPhysicalRelNodeRowType(tableSchema: TableSchema): RelDataType = {
+    buildRelNodeRowType(TableSchemaUtils.getPhysicalSchema(tableSchema))
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -24,8 +24,8 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.utils.LegacyRowResource
 import org.apache.flink.util.ExceptionUtils
-
 import org.junit.Assert.{assertEquals, assertTrue, fail}
+import org.junit.rules.ExpectedException
 import org.junit.{Rule, Test}
 
 import scala.collection.JavaConversions._
@@ -34,6 +34,11 @@ class TableSinkITCase extends BatchTestBase {
 
   @Rule
   def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+
+  var _expectedEx: ExpectedException = ExpectedException.none
+
+  @Rule
+  def expectedEx: ExpectedException = _expectedEx
 
   @Test
   def testDecimalOnOutputFormatTableSink(): Unit = {
@@ -206,5 +211,337 @@ class TableSinkITCase extends BatchTestBase {
     val result = TestValuesTableFactory.getResults("not_null_sink")
     val expected = List("book,1,12", "book,4,11", "fruit,3,44")
     assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testSinkWithPartitionAndComputedColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021', `d`=1)
+         |SELECT x, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "1,2021,1,0.1",
+      "2,2021,1,0.4",
+      "3,2021,1,1.0",
+      "4,2021,1,2.2",
+      "5,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsert(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` DOUBLE
+         |)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (b)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,0.1",
+      "null,0.4",
+      "null,1.0",
+      "null,2.2",
+      "null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithNotNullColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT NOT NULL,
+         |  `b` DOUBLE
+         |)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    expectedEx.expect(classOf[ValidationException])
+    expectedEx.expectMessage("Column 'a' has no default value and does not allow NULLs")
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (b)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+  }
+
+  @Test
+  def testPartialInsertWithPartitionAndComputedColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021', `d`=1) (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testFullInsertWithPartitionAndComputedColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021', `d`=1) (a, e)
+         |SELECT x, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "1,2021,1,0.1",
+      "2,2021,1,0.4",
+      "3,2021,1,1.0",
+      "4,2021,1,2.2",
+      "5,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicPartitionAndComputedColumn1(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,null,null,0.1",
+      "null,null,null,0.4",
+      "null,null,null,1.0",
+      "null,null,null,2.2",
+      "null,null,null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicPartitionAndComputedColumn2(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (c, d, e)
+         |SELECT '2021', 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition1(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (d, e)
+         |SELECT 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition2(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,null,0.1",
+      "null,2021,null,0.4",
+      "null,2021,null,1.0",
+      "null,2021,null,2.2",
+      "null,2021,null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition3(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    expectedEx.expect(classOf[ValidationException])
+    expectedEx.expectMessage("Target column 'e' is assigned more than once")
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (e, e)
+         |SELECT 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -446,6 +446,41 @@ class TableSinkITCase extends BatchTestBase {
   }
 
   @Test
+  def testPartialInsertWithReorder(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'true'
+         |)
+         |""".stripMargin)
+
+    registerCollection("MyTable", simpleData2, simpleType2, "x, y", nullableOfSimpleData2)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (e, d, c)
+         |SELECT sum(y), 1, '2021' FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
   def testPartialInsertWithDynamicAndStaticPartition1(): Unit = {
     tEnv.executeSql(
       s"""

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableSinkITCase.scala
@@ -24,18 +24,20 @@ import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase
-import org.apache.flink.table.planner.runtime.utils.TestData.{data1, nullData4, smallTupleData3, tupleData3, tupleData5}
+import org.apache.flink.table.planner.runtime.utils.TestData.{data1, nullData4, smallTupleData3, tupleData2, tupleData3, tupleData5}
 import org.apache.flink.table.utils.LegacyRowResource
 import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler
 import org.apache.flink.util.ExceptionUtils
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.experimental.categories.Category
 import org.junit.{Rule, Test}
+import org.junit.rules.ExpectedException
 
 import java.io.File
 import java.lang.{Long => JLong}
 import java.math.{BigDecimal => JBigDecimal}
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.JavaConversions._
 import scala.collection.{Seq, mutable}
 import scala.io.Source
@@ -45,6 +47,11 @@ class TableSinkITCase extends StreamingTestBase {
 
   @Rule
   def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+
+  var _expectedEx: ExpectedException = ExpectedException.none
+
+  @Rule
+  def expectedEx: ExpectedException = _expectedEx
 
   @Test
   def testAppendSinkOnAppendTable(): Unit = {
@@ -841,6 +848,312 @@ class TableSinkITCase extends StreamingTestBase {
       .executeSql(s"INSERT INTO $sinkTableWithPkName SELECT * FROM $sourceTableName")
       .await()).isSuccess)
 
+  }
+
+  @Test
+  def testPartialInsert(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` DOUBLE
+         |)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (b)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,0.1",
+      "null,0.4",
+      "null,1.0",
+      "null,2.2",
+      "null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithNotNullColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT NOT NULL,
+         |  `b` DOUBLE
+         |)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    expectedEx.expect(classOf[ValidationException])
+    expectedEx.expectMessage("Column 'a' has no default value and does not allow NULLs")
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (b)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+  }
+
+  @Test
+  def testPartialInsertWithPartitionAndComputedColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021', `d`=1) (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testFullInsertWithPartitionAndComputedColumn(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021', `d`=1) (a, e)
+         |SELECT x, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "1,2021,1,0.1",
+      "2,2021,1,0.4",
+      "3,2021,1,1.0",
+      "4,2021,1,2.2",
+      "5,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicPartitionAndComputedColumn1(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,null,null,0.1",
+      "null,null,null,0.4",
+      "null,null,null,1.0",
+      "null,null,null,2.2",
+      "null,null,null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicPartitionAndComputedColumn2(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink (c, d, e)
+         |SELECT '2021', 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition1(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (d, e)
+         |SELECT 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,1,0.1",
+      "null,2021,1,0.4",
+      "null,2021,1,1.0",
+      "null,2021,1,2.2",
+      "null,2021,1,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition2(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (e)
+         |SELECT sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
+    val expected = List(
+      "null,2021,null,0.1",
+      "null,2021,null,0.4",
+      "null,2021,null,1.0",
+      "null,2021,null,2.2",
+      "null,2021,null,3.9")
+    val result = TestValuesTableFactory.getResults("testSink")
+    assertEquals(expected.sorted, result.sorted)
+  }
+
+  @Test
+  def testPartialInsertWithDynamicAndStaticPartition3(): Unit = {
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE testSink (
+         |  `a` INT,
+         |  `b` AS `a` + 1,
+         |  `c` STRING,
+         |  `d` INT,
+         |  `e` DOUBLE
+         |)
+         |PARTITIONED BY (`c`, `d`)
+         |WITH (
+         |  'connector' = 'values',
+         |  'sink-insert-only' = 'false'
+         |)
+         |""".stripMargin)
+
+    val t = env.fromCollection(tupleData2).toTable(tEnv, 'x, 'y)
+    tEnv.createTemporaryView("MyTable", t)
+
+    expectedEx.expect(classOf[ValidationException])
+    expectedEx.expectMessage("Target column 'e' is assigned more than once")
+
+    tEnv.executeSql(
+      s"""
+         |INSERT INTO testSink PARTITION(`c`='2021') (e, e)
+         |SELECT 1, sum(y) FROM MyTable GROUP BY x
+         |""".stripMargin).await()
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -195,6 +195,25 @@ object TestData {
     row(5, 0.9)
   )
 
+  lazy val tupleData2: Seq[(Int, Double)] = {
+    val data = new mutable.MutableList[(Int, Double)]
+    data.+=((1, 0.1))
+    data.+=((2, 0.2))
+    data.+=((2, 0.2))
+    data.+=((3, 0.3))
+    data.+=((3, 0.3))
+    data.+=((3, 0.4))
+    data.+=((4, 0.5))
+    data.+=((4, 0.5))
+    data.+=((4, 0.6))
+    data.+=((4, 0.6))
+    data.+=((5, 0.7))
+    data.+=((5, 0.7))
+    data.+=((5, 0.8))
+    data.+=((5, 0.8))
+    data.+=((5, 0.9))
+  }
+
   lazy val tupleData3: Seq[(Int, Long, String)] = {
     val data = new mutable.MutableList[(Int, Long, String)]
     data.+=((1, 1L, "Hi"))


### PR DESCRIPTION
…ns in blink planner

## What is the purpose of the change

This PR supports INSERT INTO specific columns in blink planner.

## Brief change log

- aa8dede: Support INSERT INTO specific columns in blink planner

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
