### PR TITLE
[FLINK-21433][runtime] Always calculate defaultSlotResourceProfile from totalResourceProfile / numSlotsPerWorker.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Internal;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -102,7 +103,7 @@ public abstract class Resource implements Serializable {
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + value.hashCode();
+        result = 31 * result + Objects.hashCode(value.doubleValue());
         return result;
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
@@ -62,6 +62,13 @@ public class ResourceTest extends TestLogger {
     }
 
     @Test
+    public void testHashCodeIgnoringScale() {
+        final Resource v1 = new TestResource(new BigDecimal("0.1"));
+        final Resource v2 = new TestResource(new BigDecimal("0.10"));
+        assertTrue(v1.hashCode() == v2.hashCode());
+    }
+
+    @Test
     public void testMerge() {
         final Resource v1 = new TestResource(0.1);
         final Resource v2 = new TestResource(0.2);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -211,17 +211,16 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                 } else {
                     if (totalResourceProfile.allFieldsNoLessThan(effectiveProfile)) {
                         // Add new pending task manager
-                        final PendingTaskManagerId pendingTaskManagerId =
-                                PendingTaskManagerId.generate();
-                        resultBuilder.addPendingTaskManagerAllocate(
+                        final PendingTaskManager pendingTaskManager =
                                 new PendingTaskManager(
-                                        pendingTaskManagerId,
-                                        totalResourceProfile,
-                                        defaultSlotResourceProfile));
+                                        totalResourceProfile, defaultSlotResourceProfile);
+                        resultBuilder.addPendingTaskManagerAllocate(pendingTaskManager);
                         resultBuilder.addAllocationOnPendingResource(
-                                jobId, pendingTaskManagerId, effectiveProfile);
+                                jobId,
+                                pendingTaskManager.getPendingTaskManagerId(),
+                                effectiveProfile);
                         availableResources.put(
-                                pendingTaskManagerId,
+                                pendingTaskManager.getPendingTaskManagerId(),
                                 totalResourceProfile.subtract(effectiveProfile));
                     } else {
                         resultBuilder.addUnfulfillableJob(jobId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -55,11 +55,13 @@ import static org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUt
 public class DefaultResourceAllocationStrategy implements ResourceAllocationStrategy {
     private final ResourceProfile defaultSlotResourceProfile;
     private final ResourceProfile totalResourceProfile;
+    private final int numSlotsPerWorker;
 
     public DefaultResourceAllocationStrategy(
             ResourceProfile defaultSlotResourceProfile, int numSlotsPerWorker) {
         this.defaultSlotResourceProfile = defaultSlotResourceProfile;
         this.totalResourceProfile = defaultSlotResourceProfile.multiply(numSlotsPerWorker);
+        this.numSlotsPerWorker = numSlotsPerWorker;
     }
 
     @Override
@@ -212,8 +214,7 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
                     if (totalResourceProfile.allFieldsNoLessThan(effectiveProfile)) {
                         // Add new pending task manager
                         final PendingTaskManager pendingTaskManager =
-                                new PendingTaskManager(
-                                        totalResourceProfile, defaultSlotResourceProfile);
+                                new PendingTaskManager(totalResourceProfile, numSlotsPerWorker);
                         resultBuilder.addPendingTaskManagerAllocate(pendingTaskManager);
                         resultBuilder.addAllocationOnPendingResource(
                                 jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
@@ -28,12 +28,10 @@ public class PendingTaskManager {
     private final ResourceProfile defaultSlotResourceProfile;
 
     public PendingTaskManager(
-            PendingTaskManagerId pendingTaskManagerId,
-            ResourceProfile totalResourceProfile,
-            ResourceProfile defaultSlotResourceProfile) {
+            ResourceProfile totalResourceProfile, ResourceProfile defaultSlotResourceProfile) {
         this.defaultSlotResourceProfile = Preconditions.checkNotNull(defaultSlotResourceProfile);
         this.totalResourceProfile = Preconditions.checkNotNull(totalResourceProfile);
-        this.pendingTaskManagerId = Preconditions.checkNotNull(pendingTaskManagerId);
+        this.pendingTaskManagerId = PendingTaskManagerId.generate();
     }
 
     public ResourceProfile getTotalResourceProfile() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingTaskManager.java
@@ -26,11 +26,13 @@ public class PendingTaskManager {
     private final PendingTaskManagerId pendingTaskManagerId;
     private final ResourceProfile totalResourceProfile;
     private final ResourceProfile defaultSlotResourceProfile;
+    private final int numSlots;
 
-    public PendingTaskManager(
-            ResourceProfile totalResourceProfile, ResourceProfile defaultSlotResourceProfile) {
-        this.defaultSlotResourceProfile = Preconditions.checkNotNull(defaultSlotResourceProfile);
+    public PendingTaskManager(ResourceProfile totalResourceProfile, int numSlots) {
+        this.numSlots = numSlots;
         this.totalResourceProfile = Preconditions.checkNotNull(totalResourceProfile);
+        this.defaultSlotResourceProfile =
+                SlotManagerUtils.generateDefaultSlotResourceProfile(totalResourceProfile, numSlots);
         this.pendingTaskManagerId = PendingTaskManagerId.generate();
     }
 
@@ -44,6 +46,10 @@ public class PendingTaskManager {
 
     public PendingTaskManagerId getPendingTaskManagerId() {
         return pendingTaskManagerId;
+    }
+
+    public int getNumSlots() {
+        return numSlots;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtils.java
@@ -22,6 +22,11 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 /** Utilities for {@link SlotManager} implementations. */
 public class SlotManagerUtils {
+
+    /**
+     * This must be consist with {@link
+     * org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils#generateDefaultSlotResourceProfile}.
+     */
     public static ResourceProfile generateDefaultSlotResourceProfile(
             WorkerResourceSpec workerResourceSpec, int numSlotsPerWorker) {
         return ResourceProfile.newBuilder()
@@ -34,6 +39,10 @@ public class SlotManagerUtils {
                 .build();
     }
 
+    /**
+     * This must be consist with {@link
+     * org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils#generateDefaultSlotResourceProfile}.
+     */
     public static ResourceProfile generateDefaultSlotResourceProfile(
             ResourceProfile resourceProfile, int numSlotsPerWorker) {
         return ResourceProfile.newBuilder()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtils.java
@@ -34,6 +34,18 @@ public class SlotManagerUtils {
                 .build();
     }
 
+    public static ResourceProfile generateDefaultSlotResourceProfile(
+            ResourceProfile resourceProfile, int numSlotsPerWorker) {
+        return ResourceProfile.newBuilder()
+                .setCpuCores(resourceProfile.getCpuCores().divide(numSlotsPerWorker))
+                .setTaskHeapMemory(resourceProfile.getTaskHeapMemory().divide(numSlotsPerWorker))
+                .setTaskOffHeapMemory(
+                        resourceProfile.getTaskOffHeapMemory().divide(numSlotsPerWorker))
+                .setManagedMemory(resourceProfile.getManagedMemory().divide(numSlotsPerWorker))
+                .setNetworkMemory(resourceProfile.getNetworkMemory().divide(numSlotsPerWorker))
+                .build();
+    }
+
     public static int calculateDefaultNumSlots(
             ResourceProfile totalResourceProfile, ResourceProfile defaultSlotResourceProfile) {
         // For ResourceProfile.ANY in test case, return the maximum integer

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -104,7 +104,12 @@ public class TaskExecutorResourceUtils {
         }
     }
 
-    static ResourceProfile generateDefaultSlotResourceProfile(
+    /**
+     * This must be consist with {@link
+     * org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUtils#generateDefaultSlotResourceProfile}.
+     */
+    @VisibleForTesting
+    public static ResourceProfile generateDefaultSlotResourceProfile(
             TaskExecutorResourceSpec taskExecutorResourceSpec, int numberOfSlots) {
         return ResourceProfile.newBuilder()
                 .setCpuCores(taskExecutorResourceSpec.getCpuCores().divide(numberOfSlots))
@@ -118,7 +123,8 @@ public class TaskExecutorResourceUtils {
                 .build();
     }
 
-    static ResourceProfile generateTotalAvailableResourceProfile(
+    @VisibleForTesting
+    public static ResourceProfile generateTotalAvailableResourceProfile(
             TaskExecutorResourceSpec taskExecutorResourceSpec) {
         return ResourceProfile.newBuilder()
                 .setCpuCores(taskExecutorResourceSpec.getCpuCores())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -88,14 +88,12 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
         final JobID jobId = new JobID();
         final List<ResourceRequirement> requirements = new ArrayList<>();
         final ResourceProfile largeResource = DEFAULT_SLOT_RESOURCE.multiply(3);
-        final PendingTaskManagerId pendingTaskManagerId = PendingTaskManagerId.generate();
+        final PendingTaskManager pendingTaskManager =
+                new PendingTaskManager(
+                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), DEFAULT_SLOT_RESOURCE);
         requirements.add(ResourceRequirement.create(largeResource, 1));
         requirements.add(ResourceRequirement.create(ResourceProfile.UNKNOWN, 7));
-        pendingTaskManagers.add(
-                new PendingTaskManager(
-                        pendingTaskManagerId,
-                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
-                        DEFAULT_SLOT_RESOURCE));
+        pendingTaskManagers.add(pendingTaskManager);
 
         final ResourceAllocationResult result =
                 STRATEGY.tryFulfillRequirements(
@@ -110,7 +108,7 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
         ResourceCounter allFulfilledRequirements = ResourceCounter.empty();
         for (Map.Entry<ResourceProfile, Integer> resourceWithCount :
                 result.getAllocationsOnPendingResources()
-                        .get(pendingTaskManagerId)
+                        .get(pendingTaskManager.getPendingTaskManagerId())
                         .get(jobId)
                         .getResourcesWithCount()) {
             allFulfilledRequirements =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -89,8 +89,7 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
         final List<ResourceRequirement> requirements = new ArrayList<>();
         final ResourceProfile largeResource = DEFAULT_SLOT_RESOURCE.multiply(3);
         final PendingTaskManager pendingTaskManager =
-                new PendingTaskManager(
-                        DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), DEFAULT_SLOT_RESOURCE);
+                new PendingTaskManager(DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), NUM_OF_SLOTS);
         requirements.add(ResourceRequirement.create(largeResource, 1));
         requirements.add(ResourceRequirement.create(ResourceProfile.UNKNOWN, 7));
         pendingTaskManagers.add(pendingTaskManager);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -244,7 +244,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                     .addPendingTaskManager(
                                             new PendingTaskManager(
                                                     getDefaultTaskManagerResourceProfile(),
-                                                    getDefaultSlotResourceProfile()));
+                                                    getDefaultNumberSlotsPerWorker()));
                             // task manager with allocated slot cannot deduct pending task manager
                             getSlotManager()
                                     .registerTaskManager(
@@ -387,7 +387,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                         .addPendingTaskManagerAllocate(
                                                 new PendingTaskManager(
                                                         getDefaultTaskManagerResourceProfile(),
-                                                        getDefaultSlotResourceProfile()))
+                                                        getDefaultNumberSlotsPerWorker()))
                                         .build()));
                 runTest(
                         () -> {
@@ -405,7 +405,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final JobID jobId = new JobID();
         final PendingTaskManager pendingTaskManager =
                 new PendingTaskManager(
-                        getDefaultTaskManagerResourceProfile(), getDefaultSlotResourceProfile());
+                        getDefaultTaskManagerResourceProfile(), getDefaultNumberSlotsPerWorker());
         final CompletableFuture<
                         Tuple6<
                                 SlotID,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -243,7 +243,6 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             getTaskManagerTracker()
                                     .addPendingTaskManager(
                                             new PendingTaskManager(
-                                                    PendingTaskManagerId.generate(),
                                                     getDefaultTaskManagerResourceProfile(),
                                                     getDefaultSlotResourceProfile()));
                             // task manager with allocated slot cannot deduct pending task manager
@@ -387,7 +386,6 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                 ResourceAllocationResult.builder()
                                         .addPendingTaskManagerAllocate(
                                                 new PendingTaskManager(
-                                                        PendingTaskManagerId.generate(),
                                                         getDefaultTaskManagerResourceProfile(),
                                                         getDefaultSlotResourceProfile()))
                                         .build()));
@@ -405,7 +403,9 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     @Test
     public void testSlotAllocationForPendingTaskManagerWillBeRespected() throws Exception {
         final JobID jobId = new JobID();
-        final PendingTaskManagerId pendingTaskManagerId = PendingTaskManagerId.generate();
+        final PendingTaskManager pendingTaskManager =
+                new PendingTaskManager(
+                        getDefaultTaskManagerResourceProfile(), getDefaultSlotResourceProfile());
         final CompletableFuture<
                         Tuple6<
                                 SlotID,
@@ -430,14 +430,10 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                 resourceAllocationStrategyBuilder.setTryFulfillRequirementsFunction(
                         ((jobIDCollectionMap, instanceIDTuple2Map, pendingTaskManagers) ->
                                 ResourceAllocationResult.builder()
-                                        .addPendingTaskManagerAllocate(
-                                                new PendingTaskManager(
-                                                        pendingTaskManagerId,
-                                                        getDefaultTaskManagerResourceProfile(),
-                                                        getDefaultSlotResourceProfile()))
+                                        .addPendingTaskManagerAllocate(pendingTaskManager)
                                         .addAllocationOnPendingResource(
                                                 jobId,
-                                                pendingTaskManagerId,
+                                                pendingTaskManager.getPendingTaskManagerId(),
                                                 getDefaultSlotResourceProfile())
                                         .build()));
                 runTest(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
@@ -82,7 +82,8 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
 
     @Test
     public void testAddAndRemovePendingTaskManager() {
-        final PendingTaskManagerId pendingTaskManagerId = PendingTaskManagerId.generate();
+        final PendingTaskManager pendingTaskManager =
+                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final JobID jobId = new JobID();
@@ -90,21 +91,22 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
                 ResourceCounter.withResource(ResourceProfile.ANY, 1);
 
         // Add pending task manager
-        taskManagerTracker.addPendingTaskManager(
-                new PendingTaskManager(
-                        pendingTaskManagerId, ResourceProfile.ANY, ResourceProfile.ANY));
+        taskManagerTracker.addPendingTaskManager(pendingTaskManager);
         taskManagerTracker.replaceAllPendingAllocations(
                 Collections.singletonMap(
-                        pendingTaskManagerId, Collections.singletonMap(jobId, resourceCounter)));
+                        pendingTaskManager.getPendingTaskManagerId(),
+                        Collections.singletonMap(jobId, resourceCounter)));
         assertThat(taskManagerTracker.getPendingTaskManagers().size(), is(1));
 
         // Remove pending task manager
         final Map<JobID, ResourceCounter> records =
-                taskManagerTracker.removePendingTaskManager(pendingTaskManagerId);
+                taskManagerTracker.removePendingTaskManager(
+                        pendingTaskManager.getPendingTaskManagerId());
         assertThat(taskManagerTracker.getPendingTaskManagers(), is(empty()));
         assertThat(
                 taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(pendingTaskManagerId)
+                        .getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager.getPendingTaskManagerId())
                         .size(),
                 is(0));
         assertTrue(records.containsKey(jobId));
@@ -243,37 +245,40 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
     public void testRecordPendingAllocations() {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
-        final PendingTaskManagerId pendingTaskManagerId1 = PendingTaskManagerId.generate();
-        final PendingTaskManagerId pendingTaskManagerId2 = PendingTaskManagerId.generate();
+        final PendingTaskManager pendingTaskManager1 =
+                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
+        final PendingTaskManager pendingTaskManager2 =
+                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
         final JobID jobId = new JobID();
         final ResourceCounter resourceCounter =
                 ResourceCounter.withResource(ResourceProfile.ANY, 1);
-        taskManagerTracker.addPendingTaskManager(
-                new PendingTaskManager(
-                        pendingTaskManagerId1, ResourceProfile.ANY, ResourceProfile.ANY));
-        taskManagerTracker.addPendingTaskManager(
-                new PendingTaskManager(
-                        pendingTaskManagerId2, ResourceProfile.ANY, ResourceProfile.ANY));
+        taskManagerTracker.addPendingTaskManager(pendingTaskManager1);
+        taskManagerTracker.addPendingTaskManager(pendingTaskManager2);
 
         taskManagerTracker.replaceAllPendingAllocations(
                 Collections.singletonMap(
-                        pendingTaskManagerId1, Collections.singletonMap(jobId, resourceCounter)));
+                        pendingTaskManager1.getPendingTaskManagerId(),
+                        Collections.singletonMap(jobId, resourceCounter)));
         // Only the last time is recorded
         taskManagerTracker.replaceAllPendingAllocations(
                 Collections.singletonMap(
-                        pendingTaskManagerId2, Collections.singletonMap(jobId, resourceCounter)));
+                        pendingTaskManager2.getPendingTaskManagerId(),
+                        Collections.singletonMap(jobId, resourceCounter)));
         assertThat(
                 taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(pendingTaskManagerId1)
+                        .getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager1.getPendingTaskManagerId())
                         .size(),
                 is(0));
         assertTrue(
                 taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(pendingTaskManagerId2)
+                        .getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager2.getPendingTaskManagerId())
                         .containsKey(jobId));
         assertThat(
                 taskManagerTracker
-                        .getPendingAllocationsOfPendingTaskManager(pendingTaskManagerId2)
+                        .getPendingAllocationsOfPendingTaskManager(
+                                pendingTaskManager2.getPendingTaskManagerId())
                         .get(jobId)
                         .getResourceCount(ResourceProfile.ANY),
                 is(1));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTrackerTest.java
@@ -83,7 +83,7 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
     @Test
     public void testAddAndRemovePendingTaskManager() {
         final PendingTaskManager pendingTaskManager =
-                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
+                new PendingTaskManager(ResourceProfile.ANY, 1);
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final JobID jobId = new JobID();
@@ -246,9 +246,9 @@ public class FineGrainedTaskManagerTrackerTest extends TestLogger {
         final FineGrainedTaskManagerTracker taskManagerTracker =
                 new FineGrainedTaskManagerTracker();
         final PendingTaskManager pendingTaskManager1 =
-                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
+                new PendingTaskManager(ResourceProfile.ANY, 1);
         final PendingTaskManager pendingTaskManager2 =
-                new PendingTaskManager(ResourceProfile.ANY, ResourceProfile.ANY);
+                new PendingTaskManager(ResourceProfile.ANY, 1);
         final JobID jobId = new JobID();
         final ResourceCounter resourceCounter =
                 ResourceCounter.withResource(ResourceProfile.ANY, 1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerCheckInSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerCheckInSlotManagerTest.java
@@ -211,6 +211,11 @@ public class TaskManagerCheckInSlotManagerTest extends TestLogger {
                                 new SlotRequest(
                                         new JobID(), allocationID, resourceProfile, "foobar"));
                         mainThreadExecutor.triggerAll();
+                        // The test case can be unstable w/o this sleep, because
+                        // TaskManagerRegistration.idleSince, which is set to
+                        // System.currentTimeMillis(), may not change after occupying and
+                        // releasing the slot.
+                        Thread.sleep(1);
                         slotManager.freeSlot(slotId, allocationID);
                     });
             verifyTmReleased(false);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
