### PR TITLE
[BP-1.12][FLINK-21351][checkpointing] Don't subsume last checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointSubsumeHelper.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.util.function.ThrowingConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Deque;
+
+/**
+ * Encapsulates the logic to subsume older checkpoints by {@link CompletedCheckpointStore checkpoint
+ * stores}. In general, checkpoints should be subsumed whenever state.checkpoints.num-retained is
+ * exceeded.
+ *
+ * <p>Additional considerations:
+ *
+ * <ul>
+ *   <li>Savepoints must be stored in the same queue to prevent duplicates (@see <a
+ *       href="https://issues.apache.org/jira/browse/FLINK-10354">FLINK-10354</a>).
+ *   <li>To prevent unlimited queue growth, savepoints are also counted in num-retained together
+ *       with checkpoints
+ *   <li>Savepoints actual state should NOT be discarded when they are subsumed.
+ *   <li>At least one (most recent) checkpoint (not savepoint) should be kept. Otherwise, subsequent
+ *       incremental checkpoints may refer to a discarded state (@see <a
+ *       href="https://issues.apache.org/jira/browse/FLINK-21351">FLINK-21351</a>).
+ *   <li>Except when the job is stopped with savepoint when no future checkpoints will be made.
+ * </ul>
+ */
+class CheckpointSubsumeHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(CheckpointSubsumeHelper.class);
+
+    public static void subsume(
+            Deque<CompletedCheckpoint> checkpoints,
+            int numRetain,
+            ThrowingConsumer<CompletedCheckpoint, Exception> subsumeAction)
+            throws Exception {
+        if (checkpoints.isEmpty() || checkpoints.size() <= numRetain) {
+            return;
+        }
+
+        while (checkpoints.size() > numRetain) {
+            CompletedCheckpoint completedCheckpoint = checkpoints.removeFirst();
+            try {
+                subsumeAction.accept(completedCheckpoint);
+            } catch (Exception e) {
+                LOG.warn("Fail to subsume the old checkpoint.", e);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -230,15 +230,15 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
 
         completedCheckpoints.addLast(checkpoint);
 
-        // Everything worked, let's remove a previous checkpoint if necessary.
-        while (completedCheckpoints.size() > maxNumberOfCheckpointsToRetain) {
-            final CompletedCheckpoint completedCheckpoint = completedCheckpoints.removeFirst();
-            tryRemoveCompletedCheckpoint(
-                    completedCheckpoint,
-                    completedCheckpoint.shouldBeDiscardedOnSubsume(),
-                    checkpointsCleaner,
-                    postCleanup);
-        }
+        CheckpointSubsumeHelper.subsume(
+                completedCheckpoints,
+                maxNumberOfCheckpointsToRetain,
+                completedCheckpoint ->
+                        tryRemoveCompletedCheckpoint(
+                                completedCheckpoint,
+                                completedCheckpoint.shouldBeDiscardedOnSubsume(),
+                                checkpointsCleaner,
+                                postCleanup));
 
         LOG.debug("Added {} to {}.", checkpoint, path);
     }
@@ -266,11 +266,15 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
             LOG.info("Shutting down");
 
             for (CompletedCheckpoint checkpoint : completedCheckpoints) {
-                tryRemoveCompletedCheckpoint(
-                        checkpoint,
-                        checkpoint.shouldBeDiscardedOnShutdown(jobStatus),
-                        checkpointsCleaner,
-                        postCleanup);
+                try {
+                    tryRemoveCompletedCheckpoint(
+                            checkpoint,
+                            checkpoint.shouldBeDiscardedOnShutdown(jobStatus),
+                            checkpointsCleaner,
+                            postCleanup);
+                } catch (Exception e) {
+                    LOG.warn("Fail to remove checkpoint during shutdown.", e);
+                }
             }
 
             completedCheckpoints.clear();
@@ -293,14 +297,11 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
             CompletedCheckpoint completedCheckpoint,
             boolean shouldDiscard,
             CheckpointsCleaner checkpointsCleaner,
-            Runnable postCleanup) {
-        try {
-            if (tryRemove(completedCheckpoint.getCheckpointID())) {
-                checkpointsCleaner.cleanCheckpoint(
-                        completedCheckpoint, shouldDiscard, postCleanup, ioExecutor);
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to subsume the old checkpoint", e);
+            Runnable postCleanup)
+            throws Exception {
+        if (tryRemove(completedCheckpoint.getCheckpointID())) {
+            checkpointsCleaner.cleanCheckpoint(
+                    completedCheckpoint, shouldDiscard, postCleanup, ioExecutor);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -62,9 +62,8 @@ public class EmbeddedCompletedCheckpointStore implements CompletedCheckpointStor
             throws Exception {
         checkpoints.addLast(checkpoint);
 
-        if (checkpoints.size() > maxRetainedCheckpoints) {
-            removeOldestCheckpoint();
-        }
+        CheckpointSubsumeHelper.subsume(
+                checkpoints, maxRetainedCheckpoints, CompletedCheckpoint::discardOnSubsume);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -70,14 +70,8 @@ public class StandaloneCompletedCheckpointStore implements CompletedCheckpointSt
 
         checkpoints.addLast(checkpoint);
 
-        if (checkpoints.size() > maxNumberOfCheckpointsToRetain) {
-            try {
-                CompletedCheckpoint checkpointToSubsume = checkpoints.removeFirst();
-                checkpointToSubsume.discardOnSubsume();
-            } catch (Exception e) {
-                LOG.warn("Fail to subsume the old checkpoint.", e);
-            }
-        }
+        CheckpointSubsumeHelper.subsume(
+                checkpoints, maxNumberOfCheckpointsToRetain, CompletedCheckpoint::discardOnSubsume);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.testutils.FlinkMatchers;
@@ -25,6 +26,7 @@ import org.apache.flink.runtime.persistence.TestingRetrievableStateStorageHelper
 import org.apache.flink.runtime.persistence.TestingStateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -35,6 +37,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -44,8 +47,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
+import static org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -70,6 +76,56 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
     @After
     public void after() {
         executorService.shutdownNow();
+    }
+
+    @Test
+    public void testAtLeastOneCheckpointRetained() throws Exception {
+        CompletedCheckpoint cp1 = getCheckpoint(false, 1L);
+        CompletedCheckpoint cp2 = getCheckpoint(false, 2L);
+        CompletedCheckpoint sp1 = getCheckpoint(true, 3L);
+        CompletedCheckpoint sp2 = getCheckpoint(true, 4L);
+        CompletedCheckpoint sp3 = getCheckpoint(true, 5L);
+        testCheckpointRetention(1, asList(cp1, cp2, sp1, sp2, sp3), asList(cp2, sp3));
+    }
+
+    @Test
+    public void testOlderSavepointSubsumed() throws Exception {
+        CompletedCheckpoint cp1 = getCheckpoint(false, 1L);
+        CompletedCheckpoint sp1 = getCheckpoint(true, 2L);
+        CompletedCheckpoint cp2 = getCheckpoint(false, 3L);
+        testCheckpointRetention(1, asList(cp1, sp1, cp2), asList(cp2));
+    }
+
+    @Test
+    public void testSubsumeAfterStoppingWithSavepoint() throws Exception {
+        CompletedCheckpoint cp1 = getCheckpoint(false, 1L);
+        CompletedCheckpoint sp1 = getCheckpoint(true, 2L);
+        CompletedCheckpoint stop = getCheckpoint(CheckpointProperties.forSyncSavepoint(false), 3L);
+        testCheckpointRetention(1, asList(cp1, sp1, stop), asList(stop));
+    }
+
+    @Test
+    public void testNotSubsumedIfNotNeeded() throws Exception {
+        CompletedCheckpoint cp1 = getCheckpoint(false, 1L);
+        CompletedCheckpoint cp2 = getCheckpoint(false, 2L);
+        CompletedCheckpoint cp3 = getCheckpoint(false, 3L);
+        testCheckpointRetention(3, asList(cp1, cp2, cp3), asList(cp1, cp2, cp3));
+    }
+
+    private void testCheckpointRetention(
+            int numRetain,
+            List<CompletedCheckpoint> completed,
+            List<CompletedCheckpoint> expectedRetained)
+            throws Exception {
+        final TestingStateHandleStore<CompletedCheckpoint> stateHandleStore =
+                builder.setGetAllSupplier(() -> createStateHandles(3)).build();
+        final CompletedCheckpointStore completedCheckpointStore =
+                createCompletedCheckpointStore(stateHandleStore, numRetain);
+
+        for (CompletedCheckpoint c : completed) {
+            completedCheckpointStore.addCheckpoint(c, new CheckpointsCleaner(), () -> {});
+        }
+        assertEquals(expectedRetained, completedCheckpointStore.getAllCheckpoints());
     }
 
     /**
@@ -298,8 +354,13 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
 
     private CompletedCheckpointStore createCompletedCheckpointStore(
             TestingStateHandleStore<CompletedCheckpoint> stateHandleStore) {
+        return createCompletedCheckpointStore(stateHandleStore, 1);
+    }
+
+    private CompletedCheckpointStore createCompletedCheckpointStore(
+            TestingStateHandleStore<CompletedCheckpoint> stateHandleStore, int toRetain) {
         return new DefaultCompletedCheckpointStore<>(
-                1,
+                toRetain,
                 stateHandleStore,
                 new CheckpointStoreUtil() {
                     @Override
@@ -313,5 +374,25 @@ public class DefaultCompletedCheckpointStoreTest extends TestLogger {
                     }
                 },
                 executorService);
+    }
+
+    private CompletedCheckpoint getCheckpoint(boolean isSavepoint, long id) {
+        return getCheckpoint(
+                isSavepoint
+                        ? CheckpointProperties.forSavepoint(false)
+                        : CheckpointProperties.forCheckpoint(NEVER_RETAIN_AFTER_TERMINATION),
+                id);
+    }
+
+    private CompletedCheckpoint getCheckpoint(CheckpointProperties props, long id) {
+        return new CompletedCheckpoint(
+                new JobID(),
+                id,
+                0L,
+                0L,
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                props,
+                new TestCompletedCheckpointStorageLocation());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -26,6 +27,7 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
@@ -42,10 +44,13 @@ import org.junit.Test;
 import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
 import static org.apache.flink.runtime.checkpoint.CompletedCheckpointStoreTest.createCheckpoint;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.ExceptionUtils.rethrow;
@@ -300,5 +305,44 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
         public long getStateSize() {
             return 0;
         }
+    }
+
+    /**
+     * Tests that the checkpoint does not exist in the store when we fail to add it into the store
+     * (i.e., there exists an exception thrown by the method).
+     */
+    @Test
+    public void testAddCheckpointWithFailedRemove() throws Exception {
+
+        final int numCheckpointsToRetain = 1;
+        final Configuration configuration = new Configuration();
+        configuration.setString(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
+
+        final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
+        final CompletedCheckpointStore store = createZooKeeperCheckpointStore(client);
+
+        CountDownLatch discardAttempted = new CountDownLatch(1);
+        for (long i = 0; i < numCheckpointsToRetain + 1; ++i) {
+            CompletedCheckpoint checkpointToAdd =
+                    new CompletedCheckpoint(
+                            new JobID(),
+                            i,
+                            i,
+                            i,
+                            Collections.emptyMap(),
+                            Collections.emptyList(),
+                            CheckpointProperties.forCheckpoint(NEVER_RETAIN_AFTER_TERMINATION),
+                            new TestCompletedCheckpointStorageLocation());
+            // shouldn't fail despite the exception
+            store.addCheckpoint(
+                    checkpointToAdd,
+                    new CheckpointsCleaner(),
+                    () -> {
+                        discardAttempted.countDown();
+                        throw new RuntimeException();
+                    });
+        }
+        discardAttempted.await();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Backport of #14953 to 1.12.

 ```
When a savepoint is added to CompletedCheckpointStore
all previous checkpoints will be removed if number to
retain is 1.

This makes future incremental checkpoints invalid since
they can refer to the discarded state.
```

## Verifying this change

Added unit tests for the `DefaultCompletedCheckpointStore` (`testAtLeastOneCheckpointRetained`, `testOlderSavepointSubsumed`, `testSubsumeAfterStoppingWithSavepoint`, `testNotSubsumedIfNotNeeded`).

I test `DefaultCompletedCheckpointStore` and not the `CheckpointSubsumeHelper` to verify their integration.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
