### PR TITLE
[FLINK-21442] [connectors/jdbc] Make XaSinkStateSerializer SNAPSHOT state restorable during recovery

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
@@ -134,6 +134,7 @@ public final class XaSinkStateSerializer extends TypeSerializer<JdbcXaSinkFuncti
         return SNAPSHOT;
     }
 
+    /** Simple {@link TypeSerializerSnapshot} for {@link XaSinkStateSerializer}. */
     public static class XaSinkStateSimpleXaTypeSerializerSnapshot extends SimpleTypeSerializerSnapshot<JdbcXaSinkFunctionState> {
         private static final int VERSION = 1;
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
@@ -32,30 +32,14 @@ import java.util.List;
 
 /** XaSinkStateSerializer. */
 @Internal
-final class XaSinkStateSerializer extends TypeSerializer<JdbcXaSinkFunctionState> {
+public final class XaSinkStateSerializer extends TypeSerializer<JdbcXaSinkFunctionState> {
 
     private static final TypeSerializerSnapshot<JdbcXaSinkFunctionState> SNAPSHOT =
-            new SimpleTypeSerializerSnapshot<JdbcXaSinkFunctionState>(XaSinkStateSerializer::new) {
-                private static final int VERSION = 1;
-
-                @Override
-                public void writeSnapshot(DataOutputView out) throws IOException {
-                    super.writeSnapshot(out);
-                    out.writeInt(VERSION);
-                }
-
-                @Override
-                public void readSnapshot(int readVersion, DataInputView in, ClassLoader classLoader)
-                        throws IOException {
-                    super.readSnapshot(readVersion, in, classLoader);
-                    in.readInt();
-                }
-            };
-
+            new XaSinkStateSimpleXaTypeSerializerSnapshot();
     private final TypeSerializer<Xid> xidSerializer;
     private final TypeSerializer<CheckpointAndXid> checkpointAndXidSerializer;
 
-    XaSinkStateSerializer() {
+    public XaSinkStateSerializer() {
         this(new XidSerializer(), new CheckpointAndXidSerializer());
     }
 
@@ -148,5 +132,26 @@ final class XaSinkStateSerializer extends TypeSerializer<JdbcXaSinkFunctionState
     @Override
     public TypeSerializerSnapshot<JdbcXaSinkFunctionState> snapshotConfiguration() {
         return SNAPSHOT;
+    }
+
+    public static class XaSinkStateSimpleXaTypeSerializerSnapshot extends SimpleTypeSerializerSnapshot<JdbcXaSinkFunctionState> {
+        private static final int VERSION = 1;
+
+        public XaSinkStateSimpleXaTypeSerializerSnapshot() {
+            super(XaSinkStateSerializer::new);
+        }
+
+        @Override
+        public void writeSnapshot(DataOutputView out) throws IOException {
+            super.writeSnapshot(out);
+            out.writeInt(VERSION);
+        }
+
+        @Override
+        public void readSnapshot(int readVersion, DataInputView in, ClassLoader classLoader)
+                throws IOException {
+            super.readSnapshot(readVersion, in, classLoader);
+            in.readInt();
+        }
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaSinkStateSerializer.java
@@ -135,7 +135,8 @@ public final class XaSinkStateSerializer extends TypeSerializer<JdbcXaSinkFuncti
     }
 
     /** Simple {@link TypeSerializerSnapshot} for {@link XaSinkStateSerializer}. */
-    public static class XaSinkStateSimpleXaTypeSerializerSnapshot extends SimpleTypeSerializerSnapshot<JdbcXaSinkFunctionState> {
+    public static class XaSinkStateSimpleXaTypeSerializerSnapshot
+            extends SimpleTypeSerializerSnapshot<JdbcXaSinkFunctionState> {
         private static final int VERSION = 1;
 
         public XaSinkStateSimpleXaTypeSerializerSnapshot() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make XaSinkStateSerializer able to be restored from checkpoint.

## Brief change log

  - Make SNAPSHOT implementation to be static inner class, not anonymous inner class, which are not public.
  - The implementation is similar to existing ones used in this package, like CheckpointAndXidSerializer.

## Verifying this change

  - Manually verified the change - job that was failing (due to other error) started to be recoverable after the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
