### PR TITLE
[FLINK-21114][python] Add ReducingState and corresponding StateDescriptor for Python DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/functions.py
+++ b/flink-python/pyflink/datastream/functions.py
@@ -22,8 +22,8 @@ from typing import Union, Any, Dict
 
 from py4j.java_gateway import JavaObject
 
-from pyflink.datastream.state import ValueState, ValueStateDescriptor, \
-    ListStateDescriptor, ListState, MapStateDescriptor, MapState
+from pyflink.datastream.state import ValueState, ValueStateDescriptor, ListStateDescriptor, \
+    ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState
 from pyflink.datastream.time_domain import TimeDomain
 from pyflink.java_gateway import get_gateway
 
@@ -140,6 +140,16 @@ class RuntimeContext(object):
         """
         Gets a handle to the system's key/value map state. This state is similar to the value state
         access, but is optimized for state that is composed of user-defined key-value pairs.
+
+        This state is only accessible if the function is executed on a KeyedStream.
+        """
+        pass
+
+    def get_reducing_state(self, state_descriptor: ReducingStateDescriptor) -> ReducingState:
+        """
+        Gets a handle to the system's key/value reducing state. This state is similar to the state
+        accessed via get_state(ValueStateDescriptor), but is optimized for state that aggregates
+        values.
 
         This state is only accessible if the function is executed on a KeyedStream.
         """

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -27,7 +27,9 @@ __all__ = [
     'ListStateDescriptor',
     'ListState',
     'MapStateDescriptor',
-    'MapState'
+    'MapState',
+    'ReducingStateDescriptor',
+    'ReducingState'
 ]
 
 T = TypeVar('T')
@@ -113,6 +115,21 @@ class MergingState(AppendingState[IN, OUT]):
     Extension of AppendingState that allows merging of state. That is, two instance of MergingState
     can be combined into a single instance that contains all the information of the two merged
     states.
+    """
+    pass
+
+
+class ReducingState(MergingState[T, T]):
+    """
+    :class:`State` interface for reducing state. Elements can be added to the state, they will be
+    combined using a reduce function. The current state can be inspected.
+
+    The state is accessed and modified by user functions, and checkpointed consistently by the
+    system as part of the distributed snapshots.
+
+    The state is only accessible by functions applied on a KeyedStream. The key is automatically
+    supplied by the system, so the function always sees the value mapped to the key of the current
+    element. That way, the system can handle stream and state partitioning consistently together.
     """
     pass
 
@@ -311,3 +328,33 @@ class MapStateDescriptor(StateDescriptor):
         :param value_type_info: the type information of the value.
         """
         super(MapStateDescriptor, self).__init__(name, Types.MAP(key_type_info, value_type_info))
+
+
+class ReducingStateDescriptor(StateDescriptor):
+    """
+    StateDescriptor for ReducingState. This can be used to create partitioned reducing state using
+    RuntimeContext.get_reducing_state(ReducingStateDescriptor).
+    """
+
+    def __init__(self,
+                 name: str,
+                 reduce_function,
+                 type_info: TypeInformation):
+        """
+        Constructor of the ReducingStateDescriptor.
+
+        :param name: The name of the state.
+        :param reduce_function: The ReduceFunction used to aggregate the state.
+        :param type_info:
+        """
+        super(ReducingStateDescriptor, self).__init__(name, type_info)
+        from pyflink.datastream.functions import ReduceFunction, ReduceFunctionWrapper
+        if not isinstance(reduce_function, ReduceFunction):
+            if callable(reduce_function):
+                reduce_function = ReduceFunctionWrapper(reduce_function)  # type: ignore
+            else:
+                raise TypeError("The input must be a ReduceFunction or a callable function!")
+        self._reduce_function = reduce_function
+
+    def get_reduce_function(self):
+        return self._reduce_function

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -24,7 +24,7 @@ from typing import List, Tuple, Any, Dict
 from apache_beam.coders import PickleCoder
 
 from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
-    ListState, MapStateDescriptor, MapState
+    ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState
 from pyflink.datastream import TimeDomain
 from pyflink.datastream.functions import RuntimeContext, TimerService, ProcessFunction, \
     KeyedProcessFunction
@@ -457,6 +457,10 @@ class InternalRuntimeContext(RuntimeContext):
     def get_map_state(self, state_descriptor: MapStateDescriptor) -> MapState:
         return self._keyed_state_backend.get_map_state(state_descriptor.name, PickleCoder(),
                                                        PickleCoder())
+
+    def get_reducing_state(self, state_descriptor: ReducingStateDescriptor) -> ReducingState:
+        return self._keyed_state_backend.get_reducing_state(
+            state_descriptor.get_name(), PickleCoder(), state_descriptor.get_reduce_function())
 
 
 class ProcessFunctionOperation(DataStreamStatelessFunctionOperation):

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -24,7 +24,8 @@ from apache_beam.runners.worker.bundle_processor import SynchronousBagRuntimeSta
 from apache_beam.transforms import userstate
 from typing import List, Tuple, Any
 
-from pyflink.datastream.state import ValueState, ListState, MapState
+from pyflink.datastream import ReduceFunction
+from pyflink.datastream.state import ValueState, ListState, MapState, ReducingState
 
 
 class LRUCache(object):
@@ -118,6 +119,32 @@ class SynchronousListRuntimeState(ListState):
     def update(self, values):
         self.clear()
         self.add_all(values)
+
+    def clear(self):
+        self._internal_state.clear()
+
+
+class SynchronousReducingRuntimeState(ReducingState):
+    """
+    The runtime ListState implementation backed by a :class:`SynchronousBagRuntimeState`.
+    """
+
+    def __init__(self, internal_state: SynchronousBagRuntimeState, reduce_function: ReduceFunction):
+        self._internal_state = internal_state
+        self._reduce_function = reduce_function
+
+    def add(self, v):
+        current_value = self.get()
+        if current_value is None:
+            self._internal_state.add(v)
+        else:
+            self._internal_state.clear()
+            self._internal_state.add(self._reduce_function.reduce(current_value, v))
+
+    def get(self):
+        for i in self._internal_state.read():
+            return i
+        return None
 
     def clear(self):
         self._internal_state.clear()
@@ -774,6 +801,15 @@ class RemoteKeyedStateBackend(object):
         self._all_states[name] = map_state
         return map_state
 
+    def get_reducing_state(self, name, coder, reduce_function):
+        if name in self._all_states:
+            self.validate_reducing_state(name, coder)
+            return self._all_states[name]
+        internal_bag_state = self._get_internal_bag_state(name, coder)
+        reducing_state = SynchronousReducingRuntimeState(internal_bag_state, reduce_function)
+        self._all_states[name] = reducing_state
+        return reducing_state
+
     def validate_value_state(self, name, coder):
         if name in self._all_states:
             state = self._all_states[name]
@@ -800,6 +836,15 @@ class RemoteKeyedStateBackend(object):
                                 % name)
             if state._internal_state._map_key_coder != map_key_coder or \
                     state._internal_state._map_value_coder != map_value_coder:
+                raise Exception("State name corrupted: %s" % name)
+
+    def validate_reducing_state(self, name, coder):
+        if name in self._all_states:
+            state = self._all_states[name]
+            if not isinstance(state, SynchronousReducingRuntimeState):
+                raise Exception("The state name '%s' is already in use and not a reducing state."
+                                % name)
+            if state._internal_state._value_coder != coder:
                 raise Exception("State name corrupted: %s" % name)
 
     def _get_internal_bag_state(self, name, element_coder):
@@ -858,7 +903,10 @@ class RemoteKeyedStateBackend(object):
                 # cache old internal state
                 self._internal_state_cache.put(
                     (state_name, encoded_old_key), state_obj._internal_state)
-            if isinstance(state_obj, (SynchronousValueRuntimeState, SynchronousListRuntimeState)):
+            if isinstance(state_obj,
+                          (SynchronousValueRuntimeState,
+                           SynchronousListRuntimeState,
+                           SynchronousReducingRuntimeState)):
                 state_obj._internal_state = self._get_internal_bag_state(
                     state_name, state_obj._internal_state._value_coder)
             elif isinstance(state_obj, SynchronousMapRuntimeState):


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds ReducingState and corresponding StateDescriptor for Python DataStream API.*


## Brief change log

  - *Add ReducingState and corresponding StateDescriptor for Python DataStream API*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
