### PR TITLE
[FLINK-21451][coordination] Remove JobID from TaskExecutionState

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskExecutionStateTransition.java
@@ -64,10 +64,6 @@ public class TaskExecutionStateTransition {
         return taskExecutionState.getExecutionState();
     }
 
-    public JobID getJobID() {
-        return taskExecutionState.getJobID();
-    }
-
     public AccumulatorSnapshot getAccumulators() {
         return taskExecutionState.getAccumulators();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -236,7 +236,6 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
                         for (ExecutionAttemptID executionAttemptId : executionAttemptIds) {
                             schedulerNG.updateTaskExecutionState(
                                     new TaskExecutionState(
-                                            jobGraph.getJobID(),
                                             executionAttemptId,
                                             ExecutionState.FAILED,
                                             new FlinkException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -305,7 +305,7 @@ public abstract class SchedulerBase implements SchedulerNG {
         }
 
         newExecutionGraph.setInternalTaskFailuresListener(
-                new UpdateSchedulerNgOnInternalFailuresListener(this, jobGraph.getJobID()));
+                new UpdateSchedulerNgOnInternalFailuresListener(this));
         newExecutionGraph.registerJobStatusListener(jobStatusListener);
         newExecutionGraph.start(mainThreadExecutor);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/UpdateSchedulerNgOnInternalFailuresListener.java
@@ -19,7 +19,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
@@ -35,13 +34,9 @@ public class UpdateSchedulerNgOnInternalFailuresListener implements InternalFail
 
     private final SchedulerNG schedulerNg;
 
-    private final JobID jobId;
-
-    public UpdateSchedulerNgOnInternalFailuresListener(
-            final SchedulerNG schedulerNg, final JobID jobId) {
+    public UpdateSchedulerNgOnInternalFailuresListener(final SchedulerNG schedulerNg) {
 
         this.schedulerNg = checkNotNull(schedulerNg);
-        this.jobId = checkNotNull(jobId);
     }
 
     @Override
@@ -52,7 +47,7 @@ public class UpdateSchedulerNgOnInternalFailuresListener implements InternalFail
             final boolean releasePartitions) {
 
         final TaskExecutionState state =
-                new TaskExecutionState(jobId, attemptId, ExecutionState.FAILED, t);
+                new TaskExecutionState(attemptId, ExecutionState.FAILED, t);
         schedulerNg.updateTaskExecutionState(
                 new TaskExecutionStateTransition(state, cancelTask, releasePartitions));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -605,7 +605,7 @@ public class AdaptiveScheduler
         executionGraph.transitionToRunning();
 
         executionGraph.setInternalTaskFailuresListener(
-                new UpdateSchedulerNgOnInternalFailuresListener(this, jobInformation.getJobID()));
+                new UpdateSchedulerNgOnInternalFailuresListener(this));
 
         for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
             final LogicalSlot assignedSlot =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1749,7 +1749,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             updateTaskExecutionState(
                     jobMasterGateway,
                     new TaskExecutionState(
-                            task.getJobID(),
                             task.getExecutionId(),
                             task.getExecutionState(),
                             task.getFailureCause(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -745,7 +745,7 @@ public class Task
 
             // notify everyone that we switched to running
             taskManagerActions.updateTaskExecutionState(
-                    new TaskExecutionState(jobId, executionId, ExecutionState.RUNNING));
+                    new TaskExecutionState(executionId, ExecutionState.RUNNING));
 
             // make sure the user code classloader is accessible thread-locally
             executingThread.setContextClassLoader(userCodeClassLoader.asClassLoader());
@@ -1001,7 +1001,7 @@ public class Task
     private void notifyFinalState() {
         checkState(executionState.isTerminal());
         taskManagerActions.updateTaskExecutionState(
-                new TaskExecutionState(jobId, executionId, executionState, failureCause));
+                new TaskExecutionState(executionId, executionState, failureCause));
     }
 
     private void notifyFatalError(String message, Throwable cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskExecutionState.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -39,8 +38,6 @@ public class TaskExecutionState implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final JobID jobID;
-
     private final ExecutionAttemptID executionId;
 
     private final ExecutionState executionState;
@@ -55,53 +52,44 @@ public class TaskExecutionState implements Serializable {
     /**
      * Creates a new task execution state update, with no attached exception and no accumulators.
      *
-     * @param jobID the ID of the job the task belongs to
      * @param executionId the ID of the task execution whose state is to be reported
      * @param executionState the execution state to be reported
      */
-    public TaskExecutionState(
-            JobID jobID, ExecutionAttemptID executionId, ExecutionState executionState) {
-        this(jobID, executionId, executionState, null, null, null);
+    public TaskExecutionState(ExecutionAttemptID executionId, ExecutionState executionState) {
+        this(executionId, executionState, null, null, null);
     }
 
     /**
      * Creates a new task execution state update, with an attached exception but no accumulators.
      *
-     * @param jobID the ID of the job the task belongs to
      * @param executionId the ID of the task execution whose state is to be reported
      * @param executionState the execution state to be reported
      */
     public TaskExecutionState(
-            JobID jobID,
-            ExecutionAttemptID executionId,
-            ExecutionState executionState,
-            Throwable error) {
-        this(jobID, executionId, executionState, error, null, null);
+            ExecutionAttemptID executionId, ExecutionState executionState, Throwable error) {
+        this(executionId, executionState, error, null, null);
     }
 
     /**
      * Creates a new task execution state update, with an attached exception. This constructor may
      * never throw an exception.
      *
-     * @param jobID the ID of the job the task belongs to
      * @param executionId the ID of the task execution whose state is to be reported
      * @param executionState the execution state to be reported
      * @param error an optional error
      * @param accumulators The flink and user-defined accumulators which may be null.
      */
     public TaskExecutionState(
-            JobID jobID,
             ExecutionAttemptID executionId,
             ExecutionState executionState,
             Throwable error,
             AccumulatorSnapshot accumulators,
             IOMetrics ioMetrics) {
 
-        if (jobID == null || executionId == null || executionState == null) {
+        if (executionId == null || executionState == null) {
             throw new NullPointerException();
         }
 
-        this.jobID = jobID;
         this.executionId = executionId;
         this.executionState = executionState;
         if (error != null) {
@@ -148,15 +136,6 @@ public class TaskExecutionState implements Serializable {
         return this.executionState;
     }
 
-    /**
-     * The ID of the job the task belongs to
-     *
-     * @return the ID of the job the task belongs to
-     */
-    public JobID getJobID() {
-        return this.jobID;
-    }
-
     /** Gets flink and user-defined accumulators in serialized form. */
     public AccumulatorSnapshot getAccumulators() {
         return accumulators;
@@ -172,8 +151,7 @@ public class TaskExecutionState implements Serializable {
     public boolean equals(Object obj) {
         if (obj instanceof TaskExecutionState) {
             TaskExecutionState other = (TaskExecutionState) obj;
-            return other.jobID.equals(this.jobID)
-                    && other.executionId.equals(this.executionId)
+            return other.executionId.equals(this.executionId)
                     && other.executionState == this.executionState
                     && (other.throwable == null) == (this.throwable == null);
         } else {
@@ -183,16 +161,13 @@ public class TaskExecutionState implements Serializable {
 
     @Override
     public int hashCode() {
-        return jobID.hashCode() + executionId.hashCode() + executionState.ordinal();
+        return executionId.hashCode() + executionState.ordinal();
     }
 
     @Override
     public String toString() {
         return String.format(
-                "TaskExecutionState jobId=%s, executionId=%s, state=%s, error=%s",
-                jobID,
-                executionId,
-                executionState,
-                throwable == null ? "(null)" : throwable.toString());
+                "TaskExecutionState executionId=%s, state=%s, error=%s",
+                executionId, executionState, throwable == null ? "(null)" : throwable.toString());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -117,9 +117,7 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
             final Execution currentExecutionAttempt = executionVertex.getCurrentExecutionAttempt();
             scheduler.updateTaskExecutionState(
                     new TaskExecutionState(
-                            graph.getJobID(),
-                            currentExecutionAttempt.getAttemptId(),
-                            ExecutionState.FINISHED));
+                            currentExecutionAttempt.getAttemptId(), ExecutionState.FINISHED));
         }
 
         assertThat(graph.getTerminationFuture().get(), is(JobStatus.FINISHED));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -118,7 +118,6 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         scheduler.startScheduling();
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobGraph.getJobID(),
                         runtimeGraph
                                 .getAllExecutionVertices()
                                 .iterator()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -340,7 +340,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
         TaskExecutionState state =
                 new TaskExecutionState(
-                        graph.getJobID(),
                         execution1.getAttemptId(),
                         ExecutionState.CANCELED,
                         null,
@@ -364,7 +363,6 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
         TaskExecutionState state2 =
                 new TaskExecutionState(
-                        graph.getJobID(),
                         execution2.getAttemptId(),
                         ExecutionState.FAILED,
                         null,
@@ -491,9 +489,9 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
                         .getCurrentExecutionAttempt()
                         .getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobId, attemptID, ExecutionState.RUNNING));
+                new TaskExecutionState(attemptID, ExecutionState.RUNNING));
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobId, attemptID, ExecutionState.FINISHED, null));
+                new TaskExecutionState(attemptID, ExecutionState.FINISHED, null));
 
         assertEquals(JobStatus.FAILED, eg.getState());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -89,9 +89,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                             getCurrentExecution(sourceVertex, executionGraph);
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    sourceExecution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    sourceExecution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, empty());
                 });
 
@@ -103,9 +101,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                             getCurrentExecution(operatorVertex, executionGraph);
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    operatorExecution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    operatorExecution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, hasSize(1));
                     assertThat(
                             releasedPartitions.remove(),
@@ -127,9 +123,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     final Execution sinkExecution = getCurrentExecution(sinkVertex, executionGraph);
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    sinkExecution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    sinkExecution.getAttemptId(), ExecutionState.FINISHED));
 
                     assertThat(releasedPartitions, hasSize(1));
                     assertThat(
@@ -187,9 +181,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     // consumer o1 was not finished
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    sourceExecution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    sourceExecution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, empty());
                 });
 
@@ -207,9 +199,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     }
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    operator1Execution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    operator1Execution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, empty());
                 });
 
@@ -221,9 +211,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     // finished
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    operator2Execution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    operator2Execution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, empty());
                 });
 
@@ -243,9 +231,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     // finish o3; this should not result in any release calls since o2 was reset
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
-                                    executionGraph.getJobID(),
-                                    operator3Execution.getAttemptId(),
-                                    ExecutionState.FINISHED));
+                                    operator3Execution.getAttemptId(), ExecutionState.FINISHED));
                     assertThat(releasedPartitions, empty());
                 });
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -189,9 +189,6 @@ public class UpdatePartitionConsumersTest extends TestLogger {
     private void updateState(
             SchedulerBase scheduler, ExecutionVertex vertex, ExecutionState state) {
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(
-                        jobGraph.getJobID(),
-                        vertex.getCurrentExecutionAttempt().getAttemptId(),
-                        state));
+                new TaskExecutionState(vertex.getCurrentExecutionAttempt().getAttemptId(), state));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -164,9 +164,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
                     taskDeploymentDescriptorFuture.get();
             jobMasterGateway.updateTaskExecutionState(
                     new TaskExecutionState(
-                            taskDeploymentDescriptor.getJobId(),
-                            taskDeploymentDescriptor.getExecutionAttemptId(),
-                            finalExecutionState));
+                            taskDeploymentDescriptor.getExecutionAttemptId(), finalExecutionState));
 
             assertThat(
                     taskExecutorCallSelector.apply(testSetup).get(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1134,10 +1134,7 @@ public class JobMasterTest extends TestLogger {
             // fail the first execution to trigger a failover
             jobMasterGateway
                     .updateTaskExecutionState(
-                            new TaskExecutionState(
-                                    inputSplitJobGraph.getJobID(),
-                                    initialAttemptId,
-                                    ExecutionState.FAILED))
+                            new TaskExecutionState(initialAttemptId, ExecutionState.FAILED))
                     .get();
 
             // wait until the job has been recovered
@@ -1394,10 +1391,7 @@ public class JobMasterTest extends TestLogger {
             // finish the producer task
             jobMasterGateway
                     .updateTaskExecutionState(
-                            new TaskExecutionState(
-                                    producerConsumerJobGraph.getJobID(),
-                                    executionAttemptId,
-                                    ExecutionState.FINISHED))
+                            new TaskExecutionState(executionAttemptId, ExecutionState.FINISHED))
                     .get();
 
             // request the state of the result partition of the producer
@@ -1812,10 +1806,7 @@ public class JobMasterTest extends TestLogger {
 
             jobMasterGateway
                     .updateTaskExecutionState(
-                            new TaskExecutionState(
-                                    jobGraph.getJobID(),
-                                    executionAttemptId,
-                                    ExecutionState.RUNNING))
+                            new TaskExecutionState(executionAttemptId, ExecutionState.RUNNING))
                     .get();
 
             jobReachedRunningState.accept(taskManagerUnresolvedLocation, jobMasterGateway);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -168,10 +168,10 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
                         () -> {
                             scheduler.updateTaskExecutionState(
                                     new TaskExecutionState(
-                                            jobId, executionAttemptId, ExecutionState.RUNNING));
+                                            executionAttemptId, ExecutionState.RUNNING));
                             scheduler.updateTaskExecutionState(
                                     new TaskExecutionState(
-                                            jobId, executionAttemptId, ExecutionState.FINISHED));
+                                            executionAttemptId, ExecutionState.FINISHED));
                         },
                         mainThreadExecutor)
                 .join();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -536,7 +536,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.CANCELED));
+                new TaskExecutionState(attemptId, ExecutionState.CANCELED));
 
         taskRestartExecutor.triggerScheduledTasks();
 
@@ -592,7 +592,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.RUNNING));
+                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -620,7 +620,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.RUNNING));
+                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -656,7 +656,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(jobGraph.getJobID(), attemptId, ExecutionState.RUNNING));
+                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -751,17 +751,11 @@ public class DefaultSchedulerTest extends TestLogger {
 
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobId,
-                        attemptId1,
-                        ExecutionState.FAILED,
-                        new RuntimeException("expected")));
+                        attemptId1, ExecutionState.FAILED, new RuntimeException("expected")));
         final JobStatus jobStatusAfterFirstFailure = scheduler.requestJobStatus();
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobId,
-                        attemptId2,
-                        ExecutionState.FAILED,
-                        new RuntimeException("expected")));
+                        attemptId2, ExecutionState.FAILED, new RuntimeException("expected")));
 
         taskRestartExecutor.triggerNonPeriodicScheduledTask();
         final JobStatus jobStatusWithPendingRestarts = scheduler.requestJobStatus();
@@ -791,20 +785,14 @@ public class DefaultSchedulerTest extends TestLogger {
 
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobid,
-                        attemptId1,
-                        ExecutionState.FAILED,
-                        new RuntimeException("expected")));
+                        attemptId1, ExecutionState.FAILED, new RuntimeException("expected")));
         scheduler.cancel();
         final ExecutionState vertex2StateAfterCancel =
                 topology.getVertex(executionVertex2).getState();
         final JobStatus statusAfterCancelWhileRestarting = scheduler.requestJobStatus();
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobid,
-                        attemptId2,
-                        ExecutionState.CANCELED,
-                        new RuntimeException("expected")));
+                        attemptId2, ExecutionState.CANCELED, new RuntimeException("expected")));
 
         assertThat(vertex2StateAfterCancel, is(equalTo(ExecutionState.CANCELING)));
         assertThat(statusAfterCancelWhileRestarting, is(equalTo(JobStatus.CANCELLING)));
@@ -825,10 +813,7 @@ public class DefaultSchedulerTest extends TestLogger {
         final String exceptionMessage = "expected exception";
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobId,
-                        attemptId,
-                        ExecutionState.FAILED,
-                        new RuntimeException(exceptionMessage)));
+                        attemptId, ExecutionState.FAILED, new RuntimeException(exceptionMessage)));
 
         final ErrorInfo failureInfo = scheduler.requestJob().getFailureInfo();
         assertThat(failureInfo, is(notNullValue()));
@@ -858,7 +843,6 @@ public class DefaultSchedulerTest extends TestLogger {
         final String exceptionMessage = "expected exception";
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        jobId,
                         v1.getCurrentExecutionAttempt().getAttemptId(),
                         ExecutionState.FAILED,
                         new RuntimeException(exceptionMessage)));
@@ -888,11 +872,7 @@ public class DefaultSchedulerTest extends TestLogger {
         // we have to cancel the task and trigger the restart to have the exception history
         // populated
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(
-                        jobGraph.getJobID(),
-                        attemptId,
-                        ExecutionState.CANCELED,
-                        expectedException));
+                new TaskExecutionState(attemptId, ExecutionState.CANCELED, expectedException));
         taskRestartExecutor.triggerScheduledTasks();
         final long end = System.currentTimeMillis();
 
@@ -971,10 +951,7 @@ public class DefaultSchedulerTest extends TestLogger {
     private static TaskExecutionState createFailedTaskExecutionState(
             JobID jobId, ExecutionAttemptID executionAttemptID) {
         return new TaskExecutionState(
-                jobId,
-                executionAttemptID,
-                ExecutionState.FAILED,
-                new Exception("Expected failure cause"));
+                executionAttemptID, ExecutionState.FAILED, new Exception("Expected failure cause"));
     }
 
     private static Range<Long> initiateFailure(
@@ -984,8 +961,7 @@ public class DefaultSchedulerTest extends TestLogger {
             Throwable exception) {
         long start = System.currentTimeMillis();
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(
-                        jobId, executionAttemptID, ExecutionState.FAILED, exception));
+                new TaskExecutionState(executionAttemptID, ExecutionState.FAILED, exception));
         return Range.closed(start, System.currentTimeMillis());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -205,10 +205,7 @@ public class SchedulerTestingUtils {
         final ExecutionAttemptID attemptID = getAttemptId(scheduler, jvid, subtask);
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        scheduler.getJobId(),
-                        attemptID,
-                        ExecutionState.FAILED,
-                        new Exception("test task failure")));
+                        attemptID, ExecutionState.FAILED, new Exception("test task failure")));
     }
 
     public static void canceledExecution(
@@ -216,35 +213,29 @@ public class SchedulerTestingUtils {
         final ExecutionAttemptID attemptID = getAttemptId(scheduler, jvid, subtask);
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(
-                        scheduler.getJobId(),
-                        attemptID,
-                        ExecutionState.CANCELED,
-                        new Exception("test task failure")));
+                        attemptID, ExecutionState.CANCELED, new Exception("test task failure")));
     }
 
     public static void setExecutionToRunning(
             DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
         final ExecutionAttemptID attemptID = getAttemptId(scheduler, jvid, subtask);
         scheduler.updateTaskExecutionState(
-                new TaskExecutionState(scheduler.getJobId(), attemptID, ExecutionState.RUNNING));
+                new TaskExecutionState(attemptID, ExecutionState.RUNNING));
     }
 
     public static void setAllExecutionsToRunning(final DefaultScheduler scheduler) {
-        final JobID jid = scheduler.getJobId();
         getAllCurrentExecutionAttempts(scheduler)
                 .forEach(
                         (attemptId) ->
                                 scheduler.updateTaskExecutionState(
-                                        new TaskExecutionState(
-                                                jid, attemptId, ExecutionState.RUNNING)));
+                                        new TaskExecutionState(attemptId, ExecutionState.RUNNING)));
     }
 
     public static void setAllExecutionsToCancelled(final DefaultScheduler scheduler) {
-        final JobID jid = scheduler.getJobId();
         for (final ExecutionAttemptID attemptId : getAllCurrentExecutionAttempts(scheduler)) {
             final boolean setToRunning =
                     scheduler.updateTaskExecutionState(
-                            new TaskExecutionState(jid, attemptId, ExecutionState.CANCELED));
+                            new TaskExecutionState(attemptId, ExecutionState.CANCELED));
 
             assertTrue("could not switch task to RUNNING", setToRunning);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -567,9 +567,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
                 scheduler.updateTaskExecutionState(
                         new TaskExecutionStateTransition(
                                 new TaskExecutionState(
-                                        jobGraph.getJobID(),
-                                        new ExecutionAttemptID(),
-                                        ExecutionState.FAILED))),
+                                        new ExecutionAttemptID(), ExecutionState.FAILED))),
                 is(false));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CancelingTest.java
@@ -105,7 +105,6 @@ public class CancelingTest extends TestLogger {
             TaskExecutionStateTransition update =
                     new TaskExecutionStateTransition(
                             new TaskExecutionState(
-                                    canceling.getJob().getJobID(),
                                     ejv.getMockExecutionVertex()
                                             .getCurrentExecutionAttempt()
                                             .getAttemptId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -210,8 +210,7 @@ public class ExecutingTest extends TestLogger {
             ctx.setHowToHandleFailure(Executing.FailureResult::canNotRestart);
             ctx.setExpectFailing(assertNonNull());
 
-            exec.updateTaskExecutionState(
-                    createFailingStateTransition(exec.getExecutionGraph().getJobID()));
+            exec.updateTaskExecutionState(createFailingStateTransition());
         }
     }
 
@@ -226,8 +225,7 @@ public class ExecutingTest extends TestLogger {
             ctx.setHowToHandleFailure((ign) -> Executing.FailureResult.canRestart(Duration.ZERO));
             ctx.setExpectRestarting(assertNonNull());
 
-            exec.updateTaskExecutionState(
-                    createFailingStateTransition(exec.getExecutionGraph().getJobID()));
+            exec.updateTaskExecutionState(createFailingStateTransition());
         }
     }
 
@@ -240,20 +238,16 @@ public class ExecutingTest extends TestLogger {
                             .setExecutionGraph(returnsFailedStateExecutionGraph)
                             .build(ctx);
 
-            exec.updateTaskExecutionState(
-                    createFailingStateTransition(exec.getExecutionGraph().getJobID()));
+            exec.updateTaskExecutionState(createFailingStateTransition());
 
             ctx.assertNoStateTransition();
         }
     }
 
-    private static TaskExecutionStateTransition createFailingStateTransition(JobID jobId) {
+    private static TaskExecutionStateTransition createFailingStateTransition() {
         return new TaskExecutionStateTransition(
                 new TaskExecutionState(
-                        jobId,
-                        new ExecutionAttemptID(),
-                        ExecutionState.FAILED,
-                        new RuntimeException()));
+                        new ExecutionAttemptID(), ExecutionState.FAILED, new RuntimeException()));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/FailingTest.java
@@ -112,7 +112,6 @@ public class FailingTest extends TestLogger {
             TaskExecutionStateTransition update =
                     new TaskExecutionStateTransition(
                             new TaskExecutionState(
-                                    failing.getJob().getJobID(),
                                     ejv.getMockExecutionVertex()
                                             .getCurrentExecutionAttempt()
                                             .getAttemptId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskExecutionStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskExecutionStateTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -29,7 +28,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Correctness tests for hash/equals and serialization for the {@link
@@ -40,13 +40,12 @@ public class TaskExecutionStateTest {
     @Test
     public void testEqualsHashCode() {
         try {
-            final JobID jid = new JobID();
             final ExecutionAttemptID executionId = new ExecutionAttemptID();
             final ExecutionState state = ExecutionState.RUNNING;
             final Throwable error = new RuntimeException("some test error message");
 
-            TaskExecutionState s1 = new TaskExecutionState(jid, executionId, state, error);
-            TaskExecutionState s2 = new TaskExecutionState(jid, executionId, state, error);
+            TaskExecutionState s1 = new TaskExecutionState(executionId, state, error);
+            TaskExecutionState s2 = new TaskExecutionState(executionId, state, error);
 
             assertEquals(s1.hashCode(), s2.hashCode());
             assertEquals(s1, s2);
@@ -59,13 +58,12 @@ public class TaskExecutionStateTest {
     @Test
     public void testSerialization() {
         try {
-            final JobID jid = new JobID();
             final ExecutionAttemptID executionId = new ExecutionAttemptID();
             final ExecutionState state = ExecutionState.DEPLOYING;
             final Throwable error = new IOException("fubar");
 
-            TaskExecutionState original1 = new TaskExecutionState(jid, executionId, state, error);
-            TaskExecutionState original2 = new TaskExecutionState(jid, executionId, state);
+            TaskExecutionState original1 = new TaskExecutionState(executionId, state, error);
+            TaskExecutionState original2 = new TaskExecutionState(executionId, state);
 
             TaskExecutionState javaSerCopy1 = CommonTestUtils.createCopySerializable(original1);
             TaskExecutionState javaSerCopy2 = CommonTestUtils.createCopySerializable(original2);
@@ -110,8 +108,7 @@ public class TaskExecutionStateTest {
                         }
                     };
 
-            new TaskExecutionState(
-                    new JobID(), new ExecutionAttemptID(), ExecutionState.FAILED, hostile);
+            new TaskExecutionState(new ExecutionAttemptID(), ExecutionState.FAILED, hostile);
         } catch (Exception e) {
             e.printStackTrace();
             fail(e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -1009,7 +1009,6 @@ public class TaskTest extends TestLogger {
                 final TaskExecutionState taskState = queue.take();
                 assertNotNull("There is no additional listener message", state);
 
-                assertEquals(task.getJobID(), taskState.getJobID());
                 assertEquals(task.getExecutionId(), taskState.getID());
                 assertEquals(state, taskState.getExecutionState());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -382,8 +382,7 @@ public class StreamTaskTest extends TestLogger {
                             .build();
 
             final TaskExecutionState state =
-                    new TaskExecutionState(
-                            task.getJobID(), task.getExecutionId(), ExecutionState.RUNNING);
+                    new TaskExecutionState(task.getExecutionId(), ExecutionState.RUNNING);
 
             task.startTaskThread();
 


### PR DESCRIPTION
Removes an unused field, which simplifies things a bit during testing.