### PR TITLE
[FLINK-21399] Fix JobMasterTest#testRequestNextInputSplitWithGlobalFailover for AdaptiveScheduler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** JobMaster-related test utils. */
+public class JobMasterTestUtils {
+
+    public static void registerTaskExecutorAndOfferSlots(
+            TestingRpcService rpcService,
+            JobMasterGateway jobMasterGateway,
+            int numSlots,
+            Time testingTimeout)
+            throws ExecutionException, InterruptedException {
+
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+        final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation =
+                new LocalUnresolvedTaskManagerLocation();
+
+        rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+
+        jobMasterGateway
+                .registerTaskManager(
+                        taskExecutorGateway.getAddress(),
+                        unresolvedTaskManagerLocation,
+                        testingTimeout)
+                .get();
+
+        Collection<SlotOffer> slotOffers =
+                IntStream.range(0, numSlots)
+                        .mapToObj(
+                                index ->
+                                        new SlotOffer(
+                                                new AllocationID(), index, ResourceProfile.ANY))
+                        .collect(Collectors.toList());
+
+        jobMasterGateway
+                .offerSlots(
+                        unresolvedTaskManagerLocation.getResourceID(), slotOffers, testingTimeout)
+                .get();
+    }
+
+    private JobMasterTestUtils() {}
+}


### PR DESCRIPTION
Based on #14992.

The testRequestNextInputSplitWithLocalFailover and testRequestNextInputSplitWithGlobalFailover tests fail because they request input splits right after starting the JobMaster, assuming splits to already be queryable.
The test should ensure that the job can actually be deployed, because only at that point would splits be requested in production, and there is no practical need for splits to exist earlier than that.

Note that the local failover variant will continue to fail due to FLINK-21450.