### PR TITLE
[FLINK-21398][tests] Fix JobMasterTest.testRestoringFromSavepoint and .testRestoringModifiedJobFromSavepoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultAllocatedSlotPool.java
@@ -23,6 +23,9 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.jobmaster.SlotInfo;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -36,6 +39,8 @@ import java.util.Set;
 
 /** Default {@link AllocatedSlotPool} implementation. */
 public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultAllocatedSlotPool.class);
 
     private final Map<AllocationID, AllocatedSlot> registeredSlots;
 
@@ -136,6 +141,7 @@ public class DefaultAllocatedSlotPool implements AllocatedSlotPool {
 
     @Override
     public AllocatedSlot reserveFreeSlot(AllocationID allocationId) {
+        LOG.debug("Reserve free slot with allocation id {}.", allocationId);
         Preconditions.checkState(
                 freeSlotsSince.remove(allocationId) != null,
                 "The slot with id %s was not free.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -841,6 +841,8 @@ public class AdaptiveScheduler
                             ? archivedExecutionGraph.getFailureInfo().getException()
                             : null);
         }
+
+        terminationFuture.complete(null);
     }
 
     private void stopCheckpointServicesSafely(JobStatus terminalState) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -106,6 +106,11 @@ class WaitingForResources implements State, ResourceConsumer {
 
             context.goToExecuting(executionGraph);
         } catch (Exception exception) {
+            log.info(
+                    "Failed to go from {} to {} because the ExecutionGraph creation failed.",
+                    WaitingForResources.class.getSimpleName(),
+                    Executing.class.getSimpleName(),
+                    exception);
             context.goToFinished(context.getArchivedExecutionGraph(JobStatus.FAILED, exception));
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestUtils.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
+import org.apache.flink.runtime.checkpoint.Checkpoints;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Random;
+
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
+
+/** Class for common test utilities. */
+public class TestUtils {
+
+    public static File createSavepointWithOperatorState(
+            File savepointFile, long savepointId, OperatorID... operatorIds) throws IOException {
+        final Collection<OperatorState> operatorStates = createOperatorState(operatorIds);
+        final CheckpointMetadata savepoint =
+                new CheckpointMetadata(savepointId, operatorStates, Collections.emptyList());
+
+        try (FileOutputStream fileOutputStream = new FileOutputStream(savepointFile)) {
+            Checkpoints.storeCheckpointMetadata(savepoint, fileOutputStream);
+        }
+
+        return savepointFile;
+    }
+
+    private static Collection<OperatorState> createOperatorState(OperatorID... operatorIds) {
+        Random random = new Random();
+        Collection<OperatorState> operatorStates = new ArrayList<>(operatorIds.length);
+
+        for (OperatorID operatorId : operatorIds) {
+            final OperatorState operatorState = new OperatorState(operatorId, 1, 42);
+            final OperatorSubtaskState subtaskState =
+                    OperatorSubtaskState.builder()
+                            .setManagedOperatorState(
+                                    new OperatorStreamStateHandle(
+                                            Collections.emptyMap(),
+                                            new ByteStreamStateHandle("foobar", new byte[0])))
+                            .setInputChannelState(
+                                    singleton(createNewInputChannelStateHandle(10, random)))
+                            .setResultSubpartitionState(
+                                    singleton(createNewResultSubpartitionStateHandle(10, random)))
+                            .build();
+            operatorState.putState(0, subtaskState);
+            operatorStates.add(operatorState);
+        }
+
+        return operatorStates;
+    }
+
+    @Nonnull
+    public static JobGraph createJobGraphFromJobVerticesWithCheckpointing(
+            SavepointRestoreSettings savepointRestoreSettings, JobVertex... jobVertices) {
+        final JobGraph jobGraph = new JobGraph(jobVertices);
+
+        // enable checkpointing which is required to resume from a savepoint
+        final CheckpointCoordinatorConfiguration checkpoinCoordinatorConfiguration =
+                CheckpointCoordinatorConfiguration.builder()
+                        .setCheckpointInterval(1000L)
+                        .setCheckpointTimeout(1000L)
+                        .setMinPauseBetweenCheckpoints(1000L)
+                        .setMaxConcurrentCheckpoints(1)
+                        .setCheckpointRetentionPolicy(
+                                CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION)
+                        .setExactlyOnce(true)
+                        .setUnalignedCheckpointsEnabled(false)
+                        .setPreferCheckpointForRecovery(false)
+                        .setTolerableCheckpointFailureNumber(0)
+                        .build();
+        final JobCheckpointingSettings checkpointingSettings =
+                new JobCheckpointingSettings(checkpoinCoordinatorConfiguration, null);
+        jobGraph.setSnapshotSettings(checkpointingSettings);
+        jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
+        jobGraph.setJobType(JobType.STREAMING);
+
+        return jobGraph;
+    }
+
+    private TestUtils() {
+        throw new UnsupportedOperationException("This class should not be instantiated.");
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTestUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+
+/** Utilities for testing slot pool implementations. */
+public final class SlotPoolTestUtils {
+
+    private SlotPoolTestUtils() {
+        throw new UnsupportedOperationException("This class should never be instantiated.");
+    }
+
+    static TaskManagerGateway createTaskManagerGateway(
+            @Nullable TaskExecutorGateway taskExecutorGateway) {
+        return new RpcTaskManagerGateway(
+                taskExecutorGateway == null
+                        ? new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway()
+                        : taskExecutorGateway,
+                JobMasterId.generate());
+    }
+
+    @Nonnull
+    public static Collection<SlotOffer> offerSlots(
+            DeclarativeSlotPool slotPool, Collection<? extends SlotOffer> slotOffers) {
+        return slotPool.offerSlots(
+                slotOffers, new LocalTaskManagerLocation(), createTaskManagerGateway(null), 0);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -17,13 +17,19 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.TestingCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.TestingCheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.TestingCompletedCheckpointStore;
@@ -43,10 +49,12 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmaster.TestUtils;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultAllocatedSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
@@ -55,16 +63,23 @@ import org.apache.flink.runtime.operators.coordination.TestOperatorEvent;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -73,10 +88,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.futureFailedWith;
+import static org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory.useSameServicesForAllJobs;
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
-import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.offerSlots;
+import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -85,6 +102,8 @@ public class AdaptiveSchedulerTest extends TestLogger {
 
     private static final int PARALLELISM = 4;
     private static final JobVertex JOB_VERTEX;
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
     static {
         JOB_VERTEX = new JobVertex("v1");
@@ -152,12 +171,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final JobGraph jobGraph = createJobGraph();
 
         final DefaultDeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobGraph.getJobID(),
-                        new DefaultAllocatedSlotPool(),
-                        ignored -> {},
-                        Time.minutes(10),
-                        Time.minutes(10));
+                createDeclarativeSlotPool(jobGraph.getJobID());
 
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
@@ -180,12 +194,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final JobGraph jobGraph = createJobGraph();
 
         final DefaultDeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobGraph.getJobID(),
-                        new DefaultAllocatedSlotPool(),
-                        ignored -> {},
-                        Time.minutes(10),
-                        Time.minutes(10));
+                createDeclarativeSlotPool(jobGraph.getJobID());
 
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
@@ -211,12 +220,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final JobGraph jobGraph = createJobGraph();
 
         final DefaultDeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobGraph.getJobID(),
-                        new DefaultAllocatedSlotPool(),
-                        ignored -> {},
-                        Time.minutes(10),
-                        Time.minutes(10));
+                createDeclarativeSlotPool(jobGraph.getJobID());
 
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
@@ -309,12 +313,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final JobGraph jobGraph = createJobGraph();
 
         final DefaultDeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobGraph.getJobID(),
-                        new DefaultAllocatedSlotPool(),
-                        ignored -> {},
-                        Time.minutes(10),
-                        Time.minutes(10));
+                createDeclarativeSlotPool(jobGraph.getJobID());
 
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
@@ -334,12 +333,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         final JobGraph jobGraph = createJobGraph();
 
         final DefaultDeclarativeSlotPool declarativeSlotPool =
-                new DefaultDeclarativeSlotPool(
-                        jobGraph.getJobID(),
-                        new DefaultAllocatedSlotPool(),
-                        ignored -> {},
-                        Time.minutes(10),
-                        Time.minutes(10));
+                createDeclarativeSlotPool(jobGraph.getJobID());
 
         final AdaptiveScheduler scheduler =
                 new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
@@ -569,9 +563,117 @@ public class AdaptiveSchedulerTest extends TestLogger {
         scheduler.requestPartitionState(new IntermediateDataSetID(), new ResultPartitionID());
     }
 
+    @Test
+    public void testRestoringModifiedJobFromSavepointFails() throws Exception {
+        // create savepoint data
+        final long savepointId = 42L;
+        final OperatorID operatorID = new OperatorID();
+        final File savepointFile =
+                TestUtils.createSavepointWithOperatorState(
+                        TEMPORARY_FOLDER.newFile(), savepointId, operatorID);
+
+        // set savepoint settings which don't allow non restored state
+        final SavepointRestoreSettings savepointRestoreSettings =
+                SavepointRestoreSettings.forPath(savepointFile.getAbsolutePath(), false);
+
+        // create a new operator
+        final JobVertex jobVertex = new JobVertex("New operator");
+        jobVertex.setInvokableClass(NoOpInvokable.class);
+
+        // this test will fail in the end due to the previously created Savepoint having a state for
+        // a given OperatorID that does not match any operator of the newly created JobGraph
+        final JobGraph jobGraphWithNewOperator =
+                TestUtils.createJobGraphFromJobVerticesWithCheckpointing(
+                        savepointRestoreSettings, jobVertex);
+
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraphWithNewOperator.getJobID());
+
+        final AdaptiveScheduler adaptiveScheduler =
+                new AdaptiveSchedulerBuilder(jobGraphWithNewOperator, mainThreadExecutor)
+                        .setDeclarativeSlotPool(declarativeSlotPool)
+                        .build();
+
+        adaptiveScheduler.startScheduling();
+
+        offerSlots(
+                declarativeSlotPool,
+                createSlotOffersForResourceRequirements(
+                        ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1)));
+
+        final ArchivedExecutionGraph archivedExecutionGraph =
+                adaptiveScheduler.requestJob().getArchivedExecutionGraph();
+
+        assertThat(archivedExecutionGraph.getState(), is(JobStatus.FAILED));
+        assertThat(
+                archivedExecutionGraph.getFailureInfo().getException(),
+                FlinkMatchers.containsMessage("Failed to rollback to checkpoint/savepoint"));
+    }
+
+    @Test
+    public void testRestoringModifiedJobFromSavepointWithAllowNonRestoredStateSucceeds()
+            throws Exception {
+        // create savepoint data
+        final long savepointId = 42L;
+        final OperatorID operatorID = new OperatorID();
+        final File savepointFile =
+                TestUtils.createSavepointWithOperatorState(
+                        TEMPORARY_FOLDER.newFile(), savepointId, operatorID);
+
+        // allow for non restored state
+        final SavepointRestoreSettings savepointRestoreSettings =
+                SavepointRestoreSettings.forPath(savepointFile.getAbsolutePath(), true);
+
+        // create a new operator
+        final JobVertex jobVertex = new JobVertex("New operator");
+        jobVertex.setInvokableClass(NoOpInvokable.class);
+        final JobGraph jobGraphWithNewOperator =
+                TestUtils.createJobGraphFromJobVerticesWithCheckpointing(
+                        savepointRestoreSettings, jobVertex);
+
+        final StandaloneCompletedCheckpointStore completedCheckpointStore =
+                new StandaloneCompletedCheckpointStore(1);
+        final CheckpointRecoveryFactory testingCheckpointRecoveryFactory =
+                useSameServicesForAllJobs(
+                        completedCheckpointStore, new StandaloneCheckpointIDCounter());
+
+        final DefaultDeclarativeSlotPool declarativeSlotPool =
+                createDeclarativeSlotPool(jobGraphWithNewOperator.getJobID());
+
+        AdaptiveScheduler adaptiveScheduler =
+                new AdaptiveSchedulerBuilder(jobGraphWithNewOperator, mainThreadExecutor)
+                        .setCheckpointRecoveryFactory(testingCheckpointRecoveryFactory)
+                        .setDeclarativeSlotPool(declarativeSlotPool)
+                        .build();
+
+        adaptiveScheduler.startScheduling();
+
+        offerSlots(
+                declarativeSlotPool,
+                createSlotOffersForResourceRequirements(
+                        ResourceCounter.withResource(ResourceProfile.UNKNOWN, 1)));
+
+        // starting and offering the required slots should trigger the ExecutionGraph creation
+        final CompletedCheckpoint savepoint = completedCheckpointStore.getLatestCheckpoint(false);
+
+        MatcherAssert.assertThat(savepoint, notNullValue());
+
+        MatcherAssert.assertThat(savepoint.getCheckpointID(), Matchers.is(savepointId));
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Utils
     // ---------------------------------------------------------------------------------------------
+
+    @Nonnull
+    private static DefaultDeclarativeSlotPool createDeclarativeSlotPool(JobID jobId) {
+        return new DefaultDeclarativeSlotPool(
+                jobId,
+                new DefaultAllocatedSlotPool(),
+                ignored -> {},
+                Time.minutes(10),
+                Time.minutes(10));
+    }
 
     private static JobGraph createJobGraph() {
         final JobGraph jobGraph = new JobGraph(JOB_VERTEX);


### PR DESCRIPTION
Fix JobMasterTest.testRestoringFromSavepoint to also work with the AdaptiveScheduler by registering first slots
before checking the savepoint restore.

Fix JobMasterTest.testRestoringModifiedJobFromSavepoint by splitting it into testRestoringModifiedJobFromSavepointFails
and testRestoringModifiedJobFromSavepointWithAllowNonRestoredStateSucceeds and then moving these tests to AdaptiveSchedulerTest
and DefaultSchedulerTest to be more targeted.