### PR TITLE
[FLINK-20332][runtime][k8s] Add recovered workers to pending resources for native k8s deployment

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -210,6 +210,7 @@ public class ConfigurationUtils {
             }
         }
 
+        checkConfigContains(configs, TaskManagerOptions.CPU_CORES.key());
         checkConfigContains(configs, TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key());
         checkConfigContains(configs, TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key());
         checkConfigContains(configs, TaskManagerOptions.TASK_HEAP_MEMORY.key());

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -221,6 +221,7 @@ public class ConfigurationUtils {
         checkConfigContains(configs, TaskManagerOptions.JVM_METASPACE.key());
         checkConfigContains(configs, TaskManagerOptions.JVM_OVERHEAD_MIN.key());
         checkConfigContains(configs, TaskManagerOptions.JVM_OVERHEAD_MAX.key());
+        checkConfigContains(configs, TaskManagerOptions.NUM_TASK_SLOTS.key());
 
         return configs;
     }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -92,4 +92,23 @@ public class ConfigurationUtilsTest extends TestLogger {
 
         assertThat(resultKeyValuePairs, is(equalTo(expectedKeyValuePairs)));
     }
+
+    @Test
+    public void testParseDynamicConfigs() {
+        final String k1 = "key1";
+        final String v1 = "value1";
+        final String k2 = "key2";
+        final String v2 = "value2";
+
+        final String kv1 = "-D " + k1 + "=" + v1;
+        final String kv2 = "-D" + k2 + "=" + v2;
+
+        final String cmd =
+                "something beginning " + kv1 + " something in middle " + kv2 + " something ending";
+        final Map<String, String> configs = ConfigurationUtils.parseDynamicConfigs(cmd);
+
+        assertThat(configs.size(), is(2));
+        assertThat(configs.get(k1), is(v1));
+        assertThat(configs.get(k2), is(v2));
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
@@ -19,7 +19,7 @@
 package org.apache.flink.kubernetes;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.runtime.resourcemanager.active.AbstractWorkerNode;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 
 import java.util.regex.Matcher;
@@ -28,9 +28,7 @@ import java.util.regex.Pattern;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A stored Kubernetes worker, which contains the kubernetes pod. */
-public class KubernetesWorkerNode implements ResourceIDRetrievable {
-    private final ResourceID resourceID;
-
+public class KubernetesWorkerNode extends AbstractWorkerNode {
     /**
      * This pattern should be updated when {@link
      * KubernetesResourceManagerDriver#TASK_MANAGER_POD_FORMAT} changed.
@@ -39,21 +37,16 @@ public class KubernetesWorkerNode implements ResourceIDRetrievable {
             Pattern.compile("\\S+-taskmanager-([\\d]+)-([\\d]+)");
 
     KubernetesWorkerNode(ResourceID resourceID) {
-        this.resourceID = checkNotNull(resourceID);
-    }
-
-    @Override
-    public ResourceID getResourceID() {
-        return resourceID;
+        super(checkNotNull(resourceID), null);
     }
 
     public long getAttempt() throws ResourceManagerException {
-        Matcher matcher = TASK_MANAGER_POD_PATTERN.matcher(resourceID.toString());
+        Matcher matcher = TASK_MANAGER_POD_PATTERN.matcher(getResourceID().toString());
         if (matcher.find()) {
             return Long.parseLong(matcher.group(1));
         } else {
             throw new ResourceManagerException(
-                    "Error to parse KubernetesWorkerNode from " + resourceID + ".");
+                    "Error to parse KubernetesWorkerNode from " + getResourceID() + ".");
         }
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesWorkerNode.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.active.AbstractWorkerNode;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
@@ -36,8 +37,8 @@ public class KubernetesWorkerNode extends AbstractWorkerNode {
     private static final Pattern TASK_MANAGER_POD_PATTERN =
             Pattern.compile("\\S+-taskmanager-([\\d]+)-([\\d]+)");
 
-    KubernetesWorkerNode(ResourceID resourceID) {
-        super(checkNotNull(resourceID), null);
+    KubernetesWorkerNode(ResourceID resourceID, TaskExecutorProcessSpec taskExecutorProcessSpec) {
+        super(checkNotNull(resourceID), checkNotNull(taskExecutorProcessSpec));
     }
 
     public long getAttempt() throws ResourceManagerException {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
+import org.apache.flink.util.Preconditions;
+
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.Pod;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Represent KubernetesPod resource in kubernetes. */
@@ -68,5 +72,19 @@ public class KubernetesPod extends KubernetesResource<Pod> {
         }
         sb.append("]");
         return sb.toString();
+    }
+
+    public String getCommandArgs(String containerName) {
+        final Optional<Container> containerOpt =
+                this.getInternalResource().getSpec().getContainers().stream()
+                        .filter(
+                                container ->
+                                        Preconditions.checkNotNull(containerName)
+                                                .equals(container.getName()))
+                        .findAny();
+        Preconditions.checkState(containerOpt.isPresent());
+        return String.join(" ", containerOpt.get().getCommand())
+                + " "
+                + String.join(" ", containerOpt.get().getArgs());
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesWorkerNodeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesWorkerNodeTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.kubernetes;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
@@ -28,6 +32,9 @@ import org.junit.rules.ExpectedException;
 
 /** Tests for {@link KubernetesWorkerNode}. */
 public class KubernetesWorkerNodeTest extends TestLogger {
+    private static final TaskExecutorProcessSpec TASK_EXECUTOR_PROCESS_SPEC =
+            TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(
+                    new Configuration(), WorkerResourceSpec.ZERO);
 
     @Rule public final ExpectedException exception = ExpectedException.none();
 
@@ -35,12 +42,13 @@ public class KubernetesWorkerNodeTest extends TestLogger {
     public void testGetAttemptFromWorkerNode() throws Exception {
         final String correctPodName = "flink-on-kubernetes-taskmanager-11-5";
         final KubernetesWorkerNode workerNode =
-                new KubernetesWorkerNode(new ResourceID(correctPodName));
+                new KubernetesWorkerNode(
+                        new ResourceID(correctPodName), TASK_EXECUTOR_PROCESS_SPEC);
         Assert.assertEquals(11L, workerNode.getAttempt());
 
         final String wrongPodName = "flink-on-kubernetes-xxxtaskmanager-11-5";
         final KubernetesWorkerNode workerNode1 =
-                new KubernetesWorkerNode(new ResourceID(wrongPodName));
+                new KubernetesWorkerNode(new ResourceID(wrongPodName), TASK_EXECUTOR_PROCESS_SPEC);
         exception.expect(Exception.class);
         exception.expectMessage("Error to parse KubernetesWorkerNode from " + wrongPodName + ".");
         workerNode1.getAttempt();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
@@ -18,8 +18,25 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+
 /** Testing implementation of {@link KubernetesPod}. */
 public class TestingKubernetesPod extends KubernetesPod {
+    private static final String CMD_ARGS =
+            TaskExecutorProcessUtils.generateDynamicConfigsStr(
+                    new TaskExecutorProcessSpec(
+                            new CPUResource(1.0),
+                            MemorySize.parse("1m"),
+                            MemorySize.parse("2m"),
+                            MemorySize.parse("3m"),
+                            MemorySize.parse("4m"),
+                            MemorySize.parse("5m"),
+                            MemorySize.parse("6m"),
+                            MemorySize.parse("7m"),
+                            MemorySize.parse("8m")));
     private final String name;
     private final boolean isTerminated;
 
@@ -46,5 +63,10 @@ public class TestingKubernetesPod extends KubernetesPod {
     @Override
     public String getTerminatedDiagnostics() {
         return "testing-diagnostics";
+    }
+
+    @Override
+    public String getCommandArgs(String containerName) {
+        return CMD_ARGS;
     }
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.java
@@ -19,8 +19,7 @@
 package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.mesos.runtime.clusterframework.store.MesosWorkerStore;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.runtime.resourcemanager.active.AbstractWorkerNode;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
@@ -28,25 +27,24 @@ import java.io.Serializable;
 /**
  * A representation of a registered Mesos task managed by the {@link MesosResourceManagerDriver}.
  */
-public class RegisteredMesosWorkerNode implements Serializable, ResourceIDRetrievable {
+public class RegisteredMesosWorkerNode extends AbstractWorkerNode implements Serializable {
 
-    private static final long serialVersionUID = 2;
+    private static final long serialVersionUID = 3;
 
     private final MesosWorkerStore.Worker worker;
 
     public RegisteredMesosWorkerNode(MesosWorkerStore.Worker worker) {
-        this.worker = Preconditions.checkNotNull(worker);
+        super(
+                MesosResourceManagerDriver.extractResourceID(
+                        Preconditions.checkNotNull(worker).taskID()),
+                null);
+        this.worker = worker;
         Preconditions.checkArgument(worker.slaveID().isDefined());
         Preconditions.checkArgument(worker.hostname().isDefined());
     }
 
     public MesosWorkerStore.Worker getWorker() {
         return worker;
-    }
-
-    @Override
-    public ResourceID getResourceID() {
-        return MesosResourceManagerDriver.extractResourceID(worker.taskID());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
@@ -85,6 +85,8 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
 
     private final CPUResource cpuCores;
 
+    private final int numSlots;
+
     @VisibleForTesting
     public TaskExecutorProcessSpec(
             CPUResource cpuCores,
@@ -106,16 +108,19 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
                         taskOffHeapSize,
                         networkMemSize,
                         managedMemorySize),
-                new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize));
+                new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize),
+                1);
     }
 
     protected TaskExecutorProcessSpec(
             CPUResource cpuCores,
             TaskExecutorFlinkMemory flinkMemory,
-            JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
+            JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead,
+            int numSlots) {
 
         super(flinkMemory, jvmMetaspaceAndOverhead);
         this.cpuCores = cpuCores;
+        this.numSlots = numSlots;
     }
 
     public CPUResource getCpuCores() {
@@ -146,6 +151,10 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
         return getFlinkMemory().getManaged();
     }
 
+    public int getNumSlots() {
+        return numSlots;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -155,14 +164,15 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
             return Objects.equals(this.cpuCores, that.cpuCores)
                     && Objects.equals(
                             this.getJvmMetaspaceAndOverhead(), that.getJvmMetaspaceAndOverhead())
-                    && Objects.equals(this.getFlinkMemory(), that.getFlinkMemory());
+                    && Objects.equals(this.getFlinkMemory(), that.getFlinkMemory())
+                    && Objects.equals(this.numSlots, that.numSlots);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getJvmMetaspaceAndOverhead(), getFlinkMemory(), cpuCores);
+        return Objects.hash(getJvmMetaspaceAndOverhead(), getFlinkMemory(), cpuCores, numSlots);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -163,7 +163,10 @@ public class TaskExecutorProcessUtils {
                         config, flinkMemory.getTotalFlinkMemorySize());
 
         return new TaskExecutorProcessSpec(
-                workerResourceSpec.getCpuCores(), flinkMemory, jvmMetaspaceAndOverhead);
+                workerResourceSpec.getCpuCores(),
+                flinkMemory,
+                jvmMetaspaceAndOverhead,
+                workerResourceSpec.getNumSlots());
     }
 
     private static TaskExecutorProcessSpec createMemoryProcessSpec(
@@ -173,11 +176,15 @@ public class TaskExecutorProcessUtils {
         JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead =
                 processMemory.getJvmMetaspaceAndOverhead();
         return new TaskExecutorProcessSpec(
-                getCpuCores(config), flinkMemory, jvmMetaspaceAndOverhead);
+                getCpuCores(config), flinkMemory, jvmMetaspaceAndOverhead, getNumSlots(config));
     }
 
     private static CPUResource getCpuCores(final Configuration config) {
         return getCpuCoresWithFallback(config, -1.0);
+    }
+
+    private static int getNumSlots(final Configuration config) {
+        return config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
     }
 
     public static double getCpuCoresWithFallbackConfigOption(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.clusterframework;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -170,6 +171,11 @@ public class TaskExecutorProcessUtils {
                 flinkMemory,
                 jvmMetaspaceAndOverhead,
                 workerResourceSpec.getNumSlots());
+    }
+
+    public static TaskExecutorProcessSpec processSpecFromCmd(final String cmd) {
+        return processSpecFromConfig(
+                Configuration.fromMap(ConfigurationUtils.parseTmResourceDynamicConfigs(cmd)));
     }
 
     private static TaskExecutorProcessSpec createMemoryProcessSpec(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -120,6 +120,9 @@ public class TaskExecutorProcessUtils {
                 TaskManagerOptions.JVM_OVERHEAD_MAX.key(),
                 taskExecutorProcessSpec.getJvmMetaspaceAndOverhead().getOverhead().getBytes()
                         + "b");
+        configs.put(
+                TaskManagerOptions.NUM_TASK_SLOTS.key(),
+                String.valueOf(taskExecutorProcessSpec.getNumSlots()));
         return assembleDynamicConfigsStr(configs);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1127,6 +1127,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
     }
 
+    protected void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkers) {
+        slotManager.notifyPendingWorkers(pendingWorkers);
+    }
+
     // ------------------------------------------------------------------------
     //  Error Handling
     // ------------------------------------------------------------------------
@@ -1234,7 +1238,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                     slotManager.suspend();
 
                     stopHeartbeatServices();
+
+                    loseLeadership();
                 });
+    }
+
+    protected void loseLeadership() {
+        // noop by default
     }
 
     private void startHeartbeatServices() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
@@ -46,18 +46,22 @@ public final class WorkerResourceSpec implements Serializable {
 
     private final MemorySize managedMemSize;
 
+    private final int numSlots;
+
     private WorkerResourceSpec(
             CPUResource cpuCores,
             MemorySize taskHeapSize,
             MemorySize taskOffHeapSize,
             MemorySize networkMemSize,
-            MemorySize managedMemSize) {
+            MemorySize managedMemSize,
+            int numSlots) {
 
         this.cpuCores = Preconditions.checkNotNull(cpuCores);
         this.taskHeapSize = Preconditions.checkNotNull(taskHeapSize);
         this.taskOffHeapSize = Preconditions.checkNotNull(taskOffHeapSize);
         this.networkMemSize = Preconditions.checkNotNull(networkMemSize);
         this.managedMemSize = Preconditions.checkNotNull(managedMemSize);
+        this.numSlots = numSlots;
     }
 
     public static WorkerResourceSpec fromTaskExecutorProcessSpec(
@@ -68,18 +72,20 @@ public final class WorkerResourceSpec implements Serializable {
                 taskExecutorProcessSpec.getTaskHeapSize(),
                 taskExecutorProcessSpec.getTaskOffHeapSize(),
                 taskExecutorProcessSpec.getNetworkMemSize(),
-                taskExecutorProcessSpec.getManagedMemorySize());
+                taskExecutorProcessSpec.getManagedMemorySize(),
+                taskExecutorProcessSpec.getNumSlots());
     }
 
     public static WorkerResourceSpec fromTotalResourceProfile(
-            final ResourceProfile resourceProfile) {
+            final ResourceProfile resourceProfile, final int numSlots) {
         Preconditions.checkNotNull(resourceProfile);
         return new WorkerResourceSpec(
                 (CPUResource) resourceProfile.getCpuCores(),
                 resourceProfile.getTaskHeapMemory(),
                 resourceProfile.getTaskOffHeapMemory(),
                 resourceProfile.getNetworkMemory(),
-                resourceProfile.getManagedMemory());
+                resourceProfile.getManagedMemory(),
+                numSlots);
     }
 
     public CPUResource getCpuCores() {
@@ -102,10 +108,14 @@ public final class WorkerResourceSpec implements Serializable {
         return managedMemSize;
     }
 
+    public int getNumSlots() {
+        return numSlots;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(
-                cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize);
+                cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize, numSlots);
     }
 
     @Override
@@ -118,7 +128,8 @@ public final class WorkerResourceSpec implements Serializable {
                     && Objects.equals(this.taskHeapSize, that.taskHeapSize)
                     && Objects.equals(this.taskOffHeapSize, that.taskOffHeapSize)
                     && Objects.equals(this.networkMemSize, that.networkMemSize)
-                    && Objects.equals(this.managedMemSize, that.managedMemSize);
+                    && Objects.equals(this.managedMemSize, that.managedMemSize)
+                    && Objects.equals(this.numSlots, that.numSlots);
         }
         return false;
     }
@@ -146,6 +157,7 @@ public final class WorkerResourceSpec implements Serializable {
         private MemorySize taskOffHeapSize = MemorySize.ZERO;
         private MemorySize networkMemSize = MemorySize.ZERO;
         private MemorySize managedMemSize = MemorySize.ZERO;
+        private int numSlots = 1;
 
         public Builder() {}
 
@@ -174,9 +186,19 @@ public final class WorkerResourceSpec implements Serializable {
             return this;
         }
 
+        public Builder setNumSlots(int numSlots) {
+            this.numSlots = numSlots;
+            return this;
+        }
+
         public WorkerResourceSpec build() {
             return new WorkerResourceSpec(
-                    cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize);
+                    cpuCores,
+                    taskHeapSize,
+                    taskOffHeapSize,
+                    networkMemSize,
+                    managedMemSize,
+                    numSlots);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractResourceManagerDriver.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.util.Preconditions;
 
@@ -29,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.Executor;
 
 /** Abstract common base class for implementations of {@link ResourceManagerDriver}. */
-public abstract class AbstractResourceManagerDriver<WorkerType extends ResourceIDRetrievable>
+public abstract class AbstractResourceManagerDriver<WorkerType extends AbstractWorkerNode>
         implements ResourceManagerDriver<WorkerType> {
 
     protected final Logger log = LoggerFactory.getLogger(getClass());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractWorkerNode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractWorkerNode.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.active;
+
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+/** Represents a worker in {@link ActiveResourceManager}. */
+public abstract class AbstractWorkerNode implements ResourceIDRetrievable {
+    private final ResourceID resourceId;
+    private final Optional<TaskExecutorProcessSpec> taskExecutorProcessSpecOpt;
+
+    protected AbstractWorkerNode(
+            ResourceID resourceId, @Nullable TaskExecutorProcessSpec taskExecutorProcessSpec) {
+        this.resourceId = Preconditions.checkNotNull(resourceId);
+        this.taskExecutorProcessSpecOpt = Optional.ofNullable(taskExecutorProcessSpec);
+    }
+
+    @Override
+    public ResourceID getResourceID() {
+        return resourceId;
+    }
+
+    public Optional<TaskExecutorProcessSpec> getTaskExecutorProcessSpec() {
+        return taskExecutorProcessSpecOpt;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -66,7 +65,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * management frameworks. With different {@link ResourceManagerDriver} provided, this resource
  * manager can work with various frameworks.
  */
-public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
+public class ActiveResourceManager<WorkerType extends AbstractWorkerNode>
         extends ResourceManager<WorkerType> implements ResourceEventHandler<WorkerType> {
 
     protected final Configuration flinkConfig;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -27,7 +27,6 @@ import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -49,7 +48,7 @@ import java.util.concurrent.Executor;
  * Factory class for creating {@link ActiveResourceManager} with various implementations of {@link
  * ResourceManagerDriver}.
  */
-public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceIDRetrievable>
+public abstract class ActiveResourceManagerFactory<WorkerType extends AbstractWorkerNode>
         extends ResourceManagerFactory<WorkerType> {
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceEventHandler.java
@@ -19,12 +19,11 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 
 import java.util.Collection;
 
 /** Callback interfaces for handling resource events from external resource managers. */
-public interface ResourceEventHandler<WorkerType extends ResourceIDRetrievable> {
+public interface ResourceEventHandler<WorkerType extends AbstractWorkerNode> {
 
     /**
      * Notifies that workers of previous attempt have been recovered from the external resource

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
@@ -33,7 +32,7 @@ import java.util.concurrent.Executor;
  * A {@link ResourceManagerDriver} is responsible for requesting and releasing resources from/to a
  * particular external resource manager.
  */
-public interface ResourceManagerDriver<WorkerType extends ResourceIDRetrievable> {
+public interface ResourceManagerDriver<WorkerType extends AbstractWorkerNode> {
 
     /**
      * Initialize the deployment specific components.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -383,6 +383,15 @@ public class DeclarativeSlotManager implements SlotManager {
         checkResourceRequirements();
     }
 
+    @Override
+    public void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs) {
+        Preconditions.checkNotNull(pendingWorkerResourceSpecs);
+        Preconditions.checkArgument(pendingWorkerResourceSpecs.size() == 1);
+
+        int numWorkers = pendingWorkerResourceSpecs.values().iterator().next();
+        taskExecutorManager.notifyPendingWorkers(numWorkers);
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Requirement matching
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -88,7 +88,7 @@ public class FineGrainedSlotManager implements SlotManager {
 
     private boolean sendNotEnoughResourceNotifications = true;
 
-    private Set<JobID> unfulfillableJobs = new HashSet<>();
+    private final Set<JobID> unfulfillableJobs = new HashSet<>();
 
     /** ResourceManager's id. */
     @Nullable private ResourceManagerId resourceManagerId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -572,8 +572,11 @@ public class FineGrainedSlotManager implements SlotManager {
     @Override
     public Map<WorkerResourceSpec, Integer> getRequiredResources() {
         return taskManagerTracker.getPendingTaskManagers().stream()
-                .map(PendingTaskManager::getTotalResourceProfile)
-                .map(WorkerResourceSpec::fromTotalResourceProfile)
+                .map(
+                        pendingTaskManager ->
+                                WorkerResourceSpec.fromTotalResourceProfile(
+                                        pendingTaskManager.getTotalResourceProfile(),
+                                        pendingTaskManager.getNumSlots()))
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(e -> 1)));
     }
 
@@ -655,7 +658,8 @@ public class FineGrainedSlotManager implements SlotManager {
     private boolean allocateResource(PendingTaskManager pendingTaskManager) {
         if (!resourceActions.allocateResource(
                 WorkerResourceSpec.fromTotalResourceProfile(
-                        pendingTaskManager.getTotalResourceProfile()))) {
+                        pendingTaskManager.getTotalResourceProfile(),
+                        pendingTaskManager.getNumSlots()))) {
             // resource cannot be allocated
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -435,6 +435,21 @@ public class FineGrainedSlotManager implements SlotManager {
         }
     }
 
+    @Override
+    public void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs) {
+        for (Map.Entry<WorkerResourceSpec, Integer> entry : pendingWorkerResourceSpecs.entrySet()) {
+            final WorkerResourceSpec workerResourceSpec = entry.getKey();
+            final int numWorkers = entry.getValue();
+            for (int i = 0; i < numWorkers; ++i) {
+                taskManagerTracker.addPendingTaskManager(
+                        new PendingTaskManager(
+                                SlotManagerUtils.generateTaskManagerTotalResourceProfile(
+                                        workerResourceSpec),
+                                workerResourceSpec.getNumSlots()));
+            }
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Requirement matching
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -162,4 +162,13 @@ public interface SlotManager extends AutoCloseable {
     void freeSlot(SlotID slotId, AllocationID allocationId);
 
     void setFailUnfulfillableRequest(boolean failUnfulfillableRequest);
+
+    /**
+     * Notifies slot manager about pending resources recovered from previous attempt.
+     *
+     * @param pendingWorkerResourceSpecs a map whose key set is all the unique resource specs of the
+     *     pending workers, and the corresponding value is number of pending workers of that
+     *     resource spec.
+     */
+    void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -269,11 +270,7 @@ class TaskExecutorManager implements AutoCloseable {
             return Optional.empty();
         }
 
-        for (int i = 0; i < numSlotsPerWorker; ++i) {
-            PendingTaskManagerSlot pendingTaskManagerSlot =
-                    new PendingTaskManagerSlot(defaultSlotResourceProfile);
-            pendingSlots.put(pendingTaskManagerSlot.getTaskManagerSlotId(), pendingTaskManagerSlot);
-        }
+        addPendingSlots(numSlotsPerWorker);
 
         return Optional.of(
                 ResourceRequirement.create(defaultSlotResourceProfile, numSlotsPerWorker));
@@ -295,6 +292,21 @@ class TaskExecutorManager implements AutoCloseable {
     @VisibleForTesting
     int getNumberPendingTaskManagerSlots() {
         return pendingSlots.size();
+    }
+
+    public void notifyPendingWorkers(int numWorkers) {
+        addPendingSlots(numWorkers * numSlotsPerWorker);
+    }
+
+    private List<PendingTaskManagerSlot> addPendingSlots(int num) {
+        List<PendingTaskManagerSlot> addedPendingSlots = new ArrayList<>(num);
+        for (int i = 0; i < num; ++i) {
+            PendingTaskManagerSlot pendingTaskManagerSlot =
+                    new PendingTaskManagerSlot(defaultSlotResourceProfile);
+            pendingSlots.put(pendingTaskManagerSlot.getTaskManagerSlotId(), pendingTaskManagerSlot);
+            addedPendingSlots.add(pendingTaskManagerSlot);
+        }
+        return addedPendingSlots;
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -118,6 +118,14 @@ public class TaskExecutorProcessUtilsTest
     }
 
     @Test
+    public void testProcessSpecFromCmd() {
+        final String cmd = TaskExecutorProcessUtils.generateDynamicConfigsStr(TM_RESOURCE_SPEC);
+        final TaskExecutorProcessSpec processSpec =
+                TaskExecutorProcessUtils.processSpecFromCmd(cmd);
+        assertThat(processSpec, is(TM_RESOURCE_SPEC));
+    }
+
+    @Test
     public void testProcessSpecFromWorkerResourceSpec() {
         final WorkerResourceSpec workerResourceSpec =
                 new WorkerResourceSpec.Builder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -123,6 +123,7 @@ public class TaskExecutorProcessUtilsTest
                         .setTaskOffHeapMemoryMB(200)
                         .setNetworkMemoryMB(300)
                         .setManagedMemoryMB(400)
+                        .setNumSlots(5)
                         .build();
         final TaskExecutorProcessSpec taskExecutorProcessSpec =
                 TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(
@@ -139,6 +140,7 @@ public class TaskExecutorProcessUtilsTest
         assertEquals(
                 workerResourceSpec.getManagedMemSize(),
                 taskExecutorProcessSpec.getManagedMemorySize());
+        assertEquals(workerResourceSpec.getNumSlots(), taskExecutorProcessSpec.getNumSlots());
     }
 
     @Test
@@ -594,6 +596,20 @@ public class TaskExecutorProcessUtilsTest
             assertThat(
                     e.getMessage(), containsString(TaskManagerOptions.TOTAL_PROCESS_MEMORY.key()));
         }
+    }
+
+    @Test
+    public void testConfigNumSlots() {
+        final int numSlots = 5;
+
+        Configuration conf = new Configuration();
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, numSlots);
+
+        validateInAllConfigurations(
+                conf,
+                taskExecutorProcessSpec -> {
+                    assertThat(taskExecutorProcessSpec.getNumSlots(), is(numSlots));
+                });
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -112,6 +112,9 @@ public class TaskExecutorProcessUtilsTest
         assertThat(
                 MemorySize.parse(configs.get(TaskManagerOptions.JVM_OVERHEAD_MAX.key())),
                 is(TM_RESOURCE_SPEC.getJvmMetaspaceAndOverhead().getOverhead()));
+        assertThat(
+                Integer.valueOf(configs.get(TaskManagerOptions.NUM_TASK_SLOTS.key())),
+                is(TM_RESOURCE_SPEC.getNumSlots()));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
@@ -42,6 +42,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec2 =
                 new WorkerResourceSpec.Builder()
@@ -50,6 +51,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec3 =
                 new WorkerResourceSpec.Builder()
@@ -58,6 +60,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec4 =
                 new WorkerResourceSpec.Builder()
@@ -66,6 +69,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec5 =
                 new WorkerResourceSpec.Builder()
@@ -74,6 +78,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(110)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec6 =
                 new WorkerResourceSpec.Builder()
@@ -82,6 +87,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(110)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec7 =
                 new WorkerResourceSpec.Builder()
@@ -90,6 +96,16 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(110)
+                        .setNumSlots(1)
+                        .build();
+        final WorkerResourceSpec spec8 =
+                new WorkerResourceSpec.Builder()
+                        .setCpuCores(1.0)
+                        .setTaskHeapMemoryMB(100)
+                        .setTaskOffHeapMemoryMB(100)
+                        .setNetworkMemoryMB(100)
+                        .setManagedMemoryMB(100)
+                        .setNumSlots(2)
                         .build();
 
         assertEquals(spec1, spec1);
@@ -99,6 +115,7 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertNotEquals(spec1, spec5);
         assertNotEquals(spec1, spec6);
         assertNotEquals(spec1, spec7);
+        assertNotEquals(spec1, spec8);
     }
 
     @Test
@@ -110,6 +127,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec2 =
                 new WorkerResourceSpec.Builder()
@@ -118,6 +136,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec3 =
                 new WorkerResourceSpec.Builder()
@@ -126,6 +145,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec4 =
                 new WorkerResourceSpec.Builder()
@@ -134,6 +154,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec5 =
                 new WorkerResourceSpec.Builder()
@@ -142,6 +163,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(110)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec6 =
                 new WorkerResourceSpec.Builder()
@@ -150,6 +172,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(110)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec7 =
                 new WorkerResourceSpec.Builder()
@@ -158,6 +181,16 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(110)
+                        .setNumSlots(1)
+                        .build();
+        final WorkerResourceSpec spec8 =
+                new WorkerResourceSpec.Builder()
+                        .setCpuCores(1.0)
+                        .setTaskHeapMemoryMB(100)
+                        .setTaskOffHeapMemoryMB(100)
+                        .setNetworkMemoryMB(100)
+                        .setManagedMemoryMB(100)
+                        .setNumSlots(2)
                         .build();
 
         assertEquals(spec1.hashCode(), spec1.hashCode());
@@ -167,6 +200,7 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertNotEquals(spec1.hashCode(), spec5.hashCode());
         assertNotEquals(spec1.hashCode(), spec6.hashCode());
         assertNotEquals(spec1.hashCode(), spec7.hashCode());
+        assertNotEquals(spec1.hashCode(), spec8.hashCode());
     }
 
     @Test
@@ -189,10 +223,12 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertEquals(
                 workerResourceSpec.getManagedMemSize(),
                 taskExecutorProcessSpec.getManagedMemorySize());
+        assertEquals(workerResourceSpec.getNumSlots(), taskExecutorProcessSpec.getNumSlots());
     }
 
     @Test
     public void testCreateFromResourceProfile() {
+        final int numSlots = 3;
         final ResourceProfile resourceProfile =
                 ResourceProfile.newBuilder()
                         .setCpuCores(1)
@@ -202,12 +238,13 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskHeapMemoryMB(10)
                         .build();
         final WorkerResourceSpec workerResourceSpec =
-                WorkerResourceSpec.fromTotalResourceProfile(resourceProfile);
+                WorkerResourceSpec.fromTotalResourceProfile(resourceProfile, numSlots);
         assertEquals(workerResourceSpec.getCpuCores(), resourceProfile.getCpuCores());
         assertEquals(workerResourceSpec.getTaskHeapSize(), resourceProfile.getTaskHeapMemory());
         assertEquals(
                 workerResourceSpec.getTaskOffHeapSize(), resourceProfile.getTaskOffHeapMemory());
         assertEquals(workerResourceSpec.getNetworkMemSize(), resourceProfile.getNetworkMemory());
         assertEquals(workerResourceSpec.getManagedMemSize(), resourceProfile.getManagedMemory());
+        assertEquals(workerResourceSpec.getNumSlots(), numSlots);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactoryTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.TestLogger;
@@ -97,8 +96,8 @@ public class ActiveResourceManagerFactoryTest extends TestLogger {
         assertFalse(effectiveConfig.contains(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
     }
 
-    private static ActiveResourceManagerFactory<ResourceID> getFactory() {
-        return new ActiveResourceManagerFactory<ResourceID>() {
+    private static ActiveResourceManagerFactory<TestingWorkerNode> getFactory() {
+        return new ActiveResourceManagerFactory<TestingWorkerNode>() {
             @Override
             protected ResourceManagerRuntimeServicesConfiguration
                     createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
@@ -107,7 +106,7 @@ public class ActiveResourceManagerFactoryTest extends TestLogger {
             }
 
             @Override
-            protected ResourceManagerDriver<ResourceID> createResourceManagerDriver(
+            protected ResourceManagerDriver<TestingWorkerNode> createResourceManagerDriver(
                     Configuration configuration,
                     @Nullable String webInterfaceUrl,
                     String rpcAddress)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
 
@@ -47,8 +47,16 @@ public abstract class ResourceManagerDriverTestBase<WorkerType extends AbstractW
     protected static final long TIMEOUT_SEC = 5L;
 
     protected static final TaskExecutorProcessSpec TASK_EXECUTOR_PROCESS_SPEC =
-            TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(
-                    new Configuration(), WorkerResourceSpec.ZERO);
+            new TaskExecutorProcessSpec(
+                    new CPUResource(1.0),
+                    MemorySize.parse("1m"),
+                    MemorySize.parse("2m"),
+                    MemorySize.parse("3m"),
+                    MemorySize.parse("4m"),
+                    MemorySize.parse("5m"),
+                    MemorySize.parse("6m"),
+                    MemorySize.parse("7m"),
+                    MemorySize.parse("8m"));
 
     private static final String MAIN_THREAD_NAME = "testing-rpc-main-thread";
     private static final ScheduledExecutor MAIN_THREAD_EXECUTOR =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
@@ -42,7 +41,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /** Common test cases for implementations of {@link ResourceManagerDriver}. */
-public abstract class ResourceManagerDriverTestBase<WorkerType extends ResourceIDRetrievable>
+public abstract class ResourceManagerDriverTestBase<WorkerType extends AbstractWorkerNode>
         extends TestLogger {
 
     protected static final long TIMEOUT_SEC = 5L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceEventHandler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
@@ -27,7 +26,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Testing implementation of {@link ResourceEventHandler}. */
-public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievable>
+public class TestingResourceEventHandler<WorkerType extends AbstractWorkerNode>
         implements ResourceEventHandler<WorkerType> {
 
     private final Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer;
@@ -58,12 +57,12 @@ public class TestingResourceEventHandler<WorkerType extends ResourceIDRetrievabl
         onErrorConsumer.accept(exception);
     }
 
-    public static <WorkerType extends ResourceIDRetrievable> Builder<WorkerType> builder() {
+    public static <WorkerType extends AbstractWorkerNode> Builder<WorkerType> builder() {
         return new Builder<>();
     }
 
     /** Builder class for {@link TestingResourceEventHandler}. */
-    public static class Builder<WorkerType extends ResourceIDRetrievable> {
+    public static class Builder<WorkerType extends AbstractWorkerNode> {
         private Consumer<Collection<WorkerType>> onPreviousAttemptWorkersRecoveredConsumer =
                 (ignore) -> {};
         private BiConsumer<ResourceID, String> onWorkerTerminatedConsumer =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.BiConsumerWithException;
@@ -35,21 +34,25 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** Testing implementation of {@link ResourceManagerDriver}. */
-public class TestingResourceManagerDriver implements ResourceManagerDriver<ResourceID> {
+public class TestingResourceManagerDriver implements ResourceManagerDriver<TestingWorkerNode> {
 
     private final TriFunctionWithException<
-                    ResourceEventHandler<ResourceID>, ScheduledExecutor, Executor, Void, Exception>
+                    ResourceEventHandler<TestingWorkerNode>,
+                    ScheduledExecutor,
+                    Executor,
+                    Void,
+                    Exception>
             initializeFunction;
     private final Supplier<CompletableFuture<Void>> terminateSupplier;
     private final BiConsumerWithException<ApplicationStatus, String, Exception>
             deregisterApplicationConsumer;
-    private final Function<TaskExecutorProcessSpec, CompletableFuture<ResourceID>>
+    private final Function<TaskExecutorProcessSpec, CompletableFuture<TestingWorkerNode>>
             requestResourceFunction;
-    private final Consumer<ResourceID> releaseResourceConsumer;
+    private final Consumer<TestingWorkerNode> releaseResourceConsumer;
 
     private TestingResourceManagerDriver(
             final TriFunctionWithException<
-                            ResourceEventHandler<ResourceID>,
+                            ResourceEventHandler<TestingWorkerNode>,
                             ScheduledExecutor,
                             Executor,
                             Void,
@@ -58,9 +61,9 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
             final Supplier<CompletableFuture<Void>> terminateSupplier,
             final BiConsumerWithException<ApplicationStatus, String, Exception>
                     deregisterApplicationConsumer,
-            final Function<TaskExecutorProcessSpec, CompletableFuture<ResourceID>>
+            final Function<TaskExecutorProcessSpec, CompletableFuture<TestingWorkerNode>>
                     requestResourceFunction,
-            final Consumer<ResourceID> releaseResourceConsumer) {
+            final Consumer<TestingWorkerNode> releaseResourceConsumer) {
         this.initializeFunction = Preconditions.checkNotNull(initializeFunction);
         this.terminateSupplier = Preconditions.checkNotNull(terminateSupplier);
         this.deregisterApplicationConsumer =
@@ -71,7 +74,7 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
 
     @Override
     public void initialize(
-            ResourceEventHandler<ResourceID> resourceEventHandler,
+            ResourceEventHandler<TestingWorkerNode> resourceEventHandler,
             ScheduledExecutor mainThreadExecutor,
             Executor ioExecutor)
             throws Exception {
@@ -90,19 +93,19 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
     }
 
     @Override
-    public CompletableFuture<ResourceID> requestResource(
+    public CompletableFuture<TestingWorkerNode> requestResource(
             TaskExecutorProcessSpec taskExecutorProcessSpec) {
         return requestResourceFunction.apply(taskExecutorProcessSpec);
     }
 
     @Override
-    public void releaseResource(ResourceID worker) {
+    public void releaseResource(TestingWorkerNode worker) {
         releaseResourceConsumer.accept(worker);
     }
 
     public static class Builder {
         private TriFunctionWithException<
-                        ResourceEventHandler<ResourceID>,
+                        ResourceEventHandler<TestingWorkerNode>,
                         ScheduledExecutor,
                         Executor,
                         Void,
@@ -115,15 +118,15 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
         private BiConsumerWithException<ApplicationStatus, String, Exception>
                 deregisterApplicationConsumer = (ignore1, ignore2) -> {};
 
-        private Function<TaskExecutorProcessSpec, CompletableFuture<ResourceID>>
+        private Function<TaskExecutorProcessSpec, CompletableFuture<TestingWorkerNode>>
                 requestResourceFunction =
-                        (ignore) -> CompletableFuture.completedFuture(ResourceID.generate());
+                        (ignore) -> CompletableFuture.completedFuture(new TestingWorkerNode());
 
-        private Consumer<ResourceID> releaseResourceConsumer = (ignore) -> {};
+        private Consumer<TestingWorkerNode> releaseResourceConsumer = (ignore) -> {};
 
         public Builder setInitializeFunction(
                 TriFunctionWithException<
-                                ResourceEventHandler<ResourceID>,
+                                ResourceEventHandler<TestingWorkerNode>,
                                 ScheduledExecutor,
                                 Executor,
                                 Void,
@@ -147,13 +150,14 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
         }
 
         public Builder setRequestResourceFunction(
-                Function<TaskExecutorProcessSpec, CompletableFuture<ResourceID>>
+                Function<TaskExecutorProcessSpec, CompletableFuture<TestingWorkerNode>>
                         requestResourceFunction) {
             this.requestResourceFunction = Preconditions.checkNotNull(requestResourceFunction);
             return this;
         }
 
-        public Builder setReleaseResourceConsumer(Consumer<ResourceID> releaseResourceConsumer) {
+        public Builder setReleaseResourceConsumer(
+                Consumer<TestingWorkerNode> releaseResourceConsumer) {
             this.releaseResourceConsumer = Preconditions.checkNotNull(releaseResourceConsumer);
             return this;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingWorkerNode.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingWorkerNode.java
@@ -16,25 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.yarn;
+package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.resourcemanager.active.AbstractWorkerNode;
-import org.apache.flink.util.Preconditions;
 
-import org.apache.hadoop.yarn.api.records.Container;
+/** Testing implementation of {@link AbstractWorkerNode}. */
+public class TestingWorkerNode extends AbstractWorkerNode {
 
-/** A stored YARN worker, which contains the YARN container. */
-public class YarnWorkerNode extends AbstractWorkerNode {
-
-    private final Container container;
-
-    public YarnWorkerNode(Container container, ResourceID resourceID) {
-        super(Preconditions.checkNotNull(resourceID), null);
-        this.container = Preconditions.checkNotNull(container);
-    }
-
-    public Container getContainer() {
-        return container;
+    public TestingWorkerNode() {
+        super(ResourceID.generate(), null);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingWorkerNode.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingWorkerNode.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 
 /** Testing implementation of {@link AbstractWorkerNode}. */
@@ -25,5 +26,9 @@ public class TestingWorkerNode extends AbstractWorkerNode {
 
     public TestingWorkerNode() {
         super(ResourceID.generate(), null);
+    }
+
+    public TestingWorkerNode(TaskExecutorProcessSpec taskExecutorProcessSpec) {
+        super(ResourceID.generate(), taskExecutorProcessSpec);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtilsTest.java
@@ -102,7 +102,7 @@ public class SlotManagerUtilsTest extends TestLogger {
                 TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
                         taskExecutorResourceSpec);
         final WorkerResourceSpec workerResourceSpec =
-                WorkerResourceSpec.fromTotalResourceProfile(totalResourceProfile);
+                WorkerResourceSpec.fromTotalResourceProfile(totalResourceProfile, numSlots);
 
         assertThat(
                 SlotManagerUtils.generateDefaultSlotResourceProfile(totalResourceProfile, numSlots),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -39,12 +39,15 @@ public class TestingSlotManager implements SlotManager {
 
     private final Consumer<Boolean> setFailUnfulfillableRequestConsumer;
     private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
+    private final Consumer<Map<WorkerResourceSpec, Integer>> notifyPendingWorkersConsumer;
 
     TestingSlotManager(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer,
-            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
+            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier,
+            Consumer<Map<WorkerResourceSpec, Integer>> notifyPendingWorkersConsumer) {
         this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
         this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
+        this.notifyPendingWorkersConsumer = notifyPendingWorkersConsumer;
     }
 
     @Override
@@ -147,7 +150,9 @@ public class TestingSlotManager implements SlotManager {
     }
 
     @Override
-    public void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs) {}
+    public void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs) {
+        notifyPendingWorkersConsumer.accept(pendingWorkerResourceSpecs);
+    }
 
     @Override
     public void close() throws Exception {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -147,5 +147,8 @@ public class TestingSlotManager implements SlotManager {
     }
 
     @Override
+    public void notifyPendingWorkers(Map<WorkerResourceSpec, Integer> pendingWorkerResourceSpecs) {}
+
+    @Override
     public void close() throws Exception {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -31,6 +31,7 @@ public class TestingSlotManagerBuilder {
     private Consumer<Boolean> setFailUnfulfillableRequestConsumer = ignored -> {};
     private Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier =
             () -> Collections.emptyMap();
+    private Consumer<Map<WorkerResourceSpec, Integer>> notifyPendingWorkersConsumer = ignored -> {};
 
     public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
@@ -44,8 +45,16 @@ public class TestingSlotManagerBuilder {
         return this;
     }
 
+    public TestingSlotManagerBuilder setNotifyPendingWorkersConsumer(
+            Consumer<Map<WorkerResourceSpec, Integer>> notifyPendingWorkersConsumer) {
+        this.notifyPendingWorkersConsumer = notifyPendingWorkersConsumer;
+        return this;
+    }
+
     public TestingSlotManager createSlotManager() {
         return new TestingSlotManager(
-                setFailUnfulfillableRequestConsumer, getRequiredResourcesSupplier);
+                setFailUnfulfillableRequestConsumer,
+                getRequiredResourcesSupplier,
+                notifyPendingWorkersConsumer);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
