### PR TITLE
[FLINK-21481][build] Move git-commit-id-plugin execution to flink-runtime

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -350,6 +350,33 @@ under the License.
 
 		<plugins>
 			<plugin>
+				<!-- Description: https://github.com/git-commit-id/git-commit-id-maven-plugin
+					Used to show the git ref when starting the jobManager. -->
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>4.0.2</version>
+				<executions>
+					<execution>
+						<id>get-the-git-infos</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>revision</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<skipPoms>false</skipPoms>
+					<failOnNoGitDirectory>false</failOnNoGitDirectory>
+					<failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+					<gitDescribe>
+						<!-- Don't generate the describe property -->
+						<!-- It is useless due to the way Flink does branches and tags -->
+						<skip>true</skip>
+					</gitDescribe>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<executions>

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/PseudoRandomValueSelector.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/PseudoRandomValueSelector.java
@@ -83,7 +83,7 @@ class PseudoRandomValueSelector {
     private static String getGlobalSeed() {
         // manual seed or set by maven
         final String seed = System.getProperty("test.randomization.seed");
-        if (seed != null) {
+        if (seed != null && !seed.isEmpty()) {
             return seed;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@ under the License.
 		<spotless.version>2.4.2</spotless.version>
 
 		<!-- Can be set to any value to reproduce a specific build. -->
-		<test.randomization.seed>${git.commit.id}</test.randomization.seed>
+		<test.randomization.seed/>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
 	</properties>
 
@@ -1354,33 +1354,6 @@ under the License.
 							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 						</manifest>
 					</archive>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<!-- Description: https://github.com/git-commit-id/git-commit-id-maven-plugin
-					Used to show the git ref when starting the jobManager. -->
-				<groupId>pl.project13.maven</groupId>
-				<artifactId>git-commit-id-plugin</artifactId>
-				<version>4.0.2</version>
-				<executions>
-					<execution>
-						<id>get-the-git-infos</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>revision</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<skipPoms>false</skipPoms>
-					<failOnNoGitDirectory>false</failOnNoGitDirectory>
-					<failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
-					<gitDescribe>
-						<!-- Don't generate the describe property -->
-						<!-- It is useless due to the way Flink does branches and tags -->
-						<skip>true</skip>
-					</gitDescribe>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Optimization of the build process where we only execute the git-commit-id-plugin once within flink-runtime.

The properties from the plugin were used in 2 ways:

1) encoded into a properties file in flink-runtime, no change here

2) The commit id was used as the default value for the test randomization seed in the root pom. This was removed, but in practice the behavior should be identical because the default still relies on git or what commit flink-runtime was compiled with (`PseudoRandomValueSelector#getGlobalSeed`).