### PR TITLE
[FLINK-21298][table] Support 'USE MODULES' syntax both in SQL parser, TableEnvironment and SQL CLI

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -395,6 +395,12 @@ public class CliClient implements AutoCloseable {
                         CliStrings.MESSAGE_UNLOAD_MODULE_SUCCEEDED,
                         CliStrings.MESSAGE_UNLOAD_MODULE_FAILED);
                 break;
+            case USE_MODULES:
+                callDdl(
+                        cmdCall.operands[0],
+                        CliStrings.MESSAGE_USE_MODULES_SUCCEEDED,
+                        CliStrings.MESSAGE_USE_MODULES_FAILED);
+                break;
             default:
                 throw new SqlClientException("Unsupported command: " + cmdCall.command);
         }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -112,6 +112,10 @@ public final class CliStrings {
                             formatCommand(
                                     SqlCommand.UNLOAD_MODULE,
                                     "Unload a module. Syntax: 'UNLOAD MODULE <name>;'"))
+                    .append(
+                            formatCommand(
+                                    SqlCommand.USE_MODULES,
+                                    "Enable loaded modules. Syntax: 'USE MODULES <name1> [, <name2>, ...];'"))
                     .style(AttributedStyle.DEFAULT.underline())
                     .append("\nHint")
                     .style(AttributedStyle.DEFAULT)
@@ -120,6 +124,7 @@ public final class CliStrings {
                     .toAttributedString();
 
     public static final String MESSAGE_WELCOME;
+
     // make findbugs happy
     static {
         MESSAGE_WELCOME =
@@ -232,9 +237,13 @@ public final class CliStrings {
 
     public static final String MESSAGE_UNLOAD_MODULE_SUCCEEDED = "Unload module succeeded!";
 
+    public static final String MESSAGE_USE_MODULES_SUCCEEDED = "Use modules succeeded!";
+
     public static final String MESSAGE_LOAD_MODULE_FAILED = "Load module failed!";
 
     public static final String MESSAGE_UNLOAD_MODULE_FAILED = "Unload module failed!";
+
+    public static final String MESSAGE_USE_MODULES_FAILED = "Use modules failed!";
 
     // --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.UseModulesOperation;
 import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterTableOperation;
@@ -174,6 +175,8 @@ public final class SqlCommandParser {
             cmd = SqlCommand.LOAD_MODULE;
         } else if (operation instanceof UnloadModuleOperation) {
             cmd = SqlCommand.UNLOAD_MODULE;
+        } else if (operation instanceof UseModulesOperation) {
+            cmd = SqlCommand.USE_MODULES;
         } else if (operation instanceof DescribeTableOperation) {
             cmd = SqlCommand.DESCRIBE;
             operands =
@@ -261,6 +264,8 @@ public final class SqlCommandParser {
         LOAD_MODULE,
 
         UNLOAD_MODULE,
+
+        USE_MODULES,
 
         SHOW_PARTITIONS,
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -72,7 +72,7 @@ public interface Executor {
     /** Executes a SQL statement, and return {@link TableResult} as execution result. */
     TableResult executeSql(String sessionId, String statement) throws SqlExecutionException;
 
-    /** Lists all modules known to the executor in their loaded order. */
+    /** Lists used modules known to the executor in their resolution order. */
     List<String> listModules(String sessionId) throws SqlExecutionException;
 
     /** Returns a sql parser instance. */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -50,6 +50,7 @@ import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
@@ -421,6 +422,13 @@ public class LocalExecutor implements Executor {
             throws SqlExecutionException {
         final ExecutionContext<?> context = getExecutionContext(sessionId);
         return executeUpdateInternal(sessionId, context, statement);
+    }
+
+    @VisibleForTesting
+    List<ModuleEntry> listFullModules(String sessionId) throws SqlExecutionException {
+        final ExecutionContext<?> context = getExecutionContext(sessionId);
+        final TableEnvironment tableEnv = context.getTableEnvironment();
+        return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFullModules()));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -304,6 +304,28 @@ public class SqlCommandParserTest {
                                 "UNLOAD MODULE dummy",
                                 SqlCommand.UNLOAD_MODULE,
                                 "UNLOAD MODULE dummy"),
+                        // use one module
+                        TestItem.validSql(
+                                "USE MODULES dummy", SqlCommand.USE_MODULES, "USE MODULES dummy"),
+                        // use multiple modules
+                        TestItem.validSql(
+                                "USE MODULES x, y, z",
+                                SqlCommand.USE_MODULES,
+                                "USE MODULES x, y, z"),
+                        // use modules with module names as reserved keywords
+                        TestItem.validSql(
+                                "USE MODULES `MODULE`, `MODULES`",
+                                SqlCommand.USE_MODULES,
+                                "USE MODULES `MODULE`, `MODULES`"),
+                        // use modules with module names as literals
+                        TestItem.invalidSql(
+                                "USE MODULES 'dummy'",
+                                SqlExecutionException.class,
+                                "Encountered \"\\'dummy\\'\""),
+                        TestItem.invalidSql(
+                                "USE MODULES",
+                                SqlExecutionException.class,
+                                "Encountered \"<EOF>\""),
                         // Test create function.
                         TestItem.invalidSql(
                                 "CREATE FUNCTION ",

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/data/Parser.tdd
@@ -73,6 +73,7 @@
     "org.apache.flink.sql.parser.ddl.SqlTableOption"
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog"
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase"
+    "org.apache.flink.sql.parser.ddl.SqlUseModules"
     "org.apache.flink.sql.parser.ddl.SqlWatermark"
     "org.apache.flink.sql.parser.dml.RichSqlInsert"
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword"
@@ -129,6 +130,7 @@
     "LINES"
     "LOAD"
     "LOCATION"
+    "MODULES"
     "NORELY"
     "NOVALIDATE"
     "OUTPUTFORMAT"
@@ -532,6 +534,7 @@
     "SqlAlterView()"
     "SqlShowPartitions()"
     "SqlUnloadModule()"
+    "SqlUseModules()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
@@ -1541,13 +1541,43 @@ SqlLoadModule SqlLoadModule() :
 */
 SqlUnloadModule SqlUnloadModule() :
 {
-   SqlParserPos startPos;
-   SqlIdentifier moduleName;
+    SqlParserPos startPos;
+    SqlIdentifier moduleName;
 }
 {
     <UNLOAD> <MODULE> { startPos = getPos(); }
     moduleName = SimpleIdentifier()
     {
         return new SqlUnloadModule(startPos.plus(getPos()), moduleName);
+    }
+}
+
+/**
+* Parses an use modules statement.
+* USE MODULES module_name1 [, module_name2, ...];
+*/
+SqlUseModules SqlUseModules() :
+{
+    final Span s;
+    SqlIdentifier moduleName;
+    final List<SqlIdentifier> moduleNames = new ArrayList<SqlIdentifier>();
+}
+{
+    <USE> <MODULES> { s = span(); }
+    moduleName = SimpleIdentifier()
+    {
+        moduleNames.add(moduleName);
+    }
+    [
+        (
+            <COMMA>
+            moduleName = SimpleIdentifier()
+            {
+                moduleNames.add(moduleName);
+            }
+        )+
+    ]
+    {
+        return new SqlUseModules(s.end(this), moduleNames);
     }
 }

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -454,4 +454,16 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
     public void testUnloadModule() {
         sql("unload module hive").ok("UNLOAD MODULE `HIVE`");
     }
+
+    @Test
+    public void testUseModules() {
+        sql("use modules hive").ok("USE MODULES `HIVE`");
+
+        sql("use modules x, y, z").ok("USE MODULES `X`, `Y`, `Z`");
+
+        sql("use modules x^,^").fails("(?s).*Encountered \"<EOF>\" at line 1, column 14.\n.*");
+
+        sql("use modules ^'hive'^")
+                .fails("(?s).*Encountered \"\\\\'hive\\\\'\" at line 1, column 13.\n.*");
+    }
 }

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -52,6 +52,7 @@
     "org.apache.flink.sql.parser.ddl.SqlTableOption"
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog"
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase"
+    "org.apache.flink.sql.parser.ddl.SqlUseModules"
     "org.apache.flink.sql.parser.ddl.SqlWatermark"
     "org.apache.flink.sql.parser.dml.RichSqlInsert"
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword"
@@ -95,6 +96,7 @@
     "IF"
     "LOAD"
     "METADATA"
+    "MODULES"
     "OVERWRITE"
     "OVERWRITING"
     "PARTITIONED"
@@ -472,6 +474,7 @@
     "SqlAlterTable()"
     "SqlShowViews()"
     "SqlUnloadModule()"
+    "SqlUseModules()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1462,13 +1462,43 @@ SqlLoadModule SqlLoadModule() :
 */
 SqlUnloadModule SqlUnloadModule() :
 {
-   SqlParserPos startPos;
-   SqlIdentifier moduleName;
+    SqlParserPos startPos;
+    SqlIdentifier moduleName;
 }
 {
     <UNLOAD> <MODULE> { startPos = getPos(); }
     moduleName = SimpleIdentifier()
     {
         return new SqlUnloadModule(startPos.plus(getPos()), moduleName);
+    }
+}
+
+/**
+* Parses an use modules statement.
+* USE MODULES module_name1 [, module_name2, ...];
+*/
+SqlUseModules SqlUseModules() :
+{
+    final Span s;
+    SqlIdentifier moduleName;
+    final List<SqlIdentifier> moduleNames = new ArrayList<SqlIdentifier>();
+}
+{
+    <USE> <MODULES> { s = span(); }
+    moduleName = SimpleIdentifier()
+    {
+        moduleNames.add(moduleName);
+    }
+    [
+        (
+            <COMMA>
+            moduleName = SimpleIdentifier()
+            {
+                moduleNames.add(moduleName);
+            }
+        )+
+    ]
+    {
+        return new SqlUseModules(s.end(this), moduleNames);
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseModules.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlUseModules.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/** USE MODULES sql call. */
+public class SqlUseModules extends SqlCall {
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("USE MODULES", SqlKind.OTHER);
+
+    private final List<SqlIdentifier> moduleNames;
+
+    public SqlUseModules(SqlParserPos pos, List<SqlIdentifier> moduleNames) {
+        super(pos);
+        this.moduleNames = requireNonNull(moduleNames, "moduleNames cannot be null");
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.copyOf(moduleNames);
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword("USE MODULES");
+        for (int i = 0; i < moduleNames.size(); i++) {
+            moduleNames.get(i).unparse(writer, leftPrec, rightPrec);
+            if (i < moduleNames.size() - 1) {
+                writer.keyword(",");
+            }
+        }
+    }
+
+    public List<String> moduleNames() {
+        return moduleNames.stream().map(SqlIdentifier::getSimple).collect(Collectors.toList());
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1177,6 +1177,18 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
                 .fails("(?s).*Encountered \"\\\\'core\\\\'\" at line 1, column 15.\n.*");
     }
 
+    @Test
+    public void testUseModules() {
+        sql("use modules core").ok("USE MODULES `CORE`");
+
+        sql("use modules x, y, z").ok("USE MODULES `X`, `Y`, `Z`");
+
+        sql("use modules x^,^").fails("(?s).*Encountered \"<EOF>\" at line 1, column 14.\n.*");
+
+        sql("use modules ^'core'^")
+                .fails("(?s).*Encountered \"\\\\'core\\\\'\" at line 1, column 13.\n.*");
+    }
+
     public static BaseMatcher<SqlNode> validated(String validatedSql) {
         return new TypeSafeDiagnosingMatcher<SqlNode>() {
             @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Operation to describe a USE MODULES statement. */
+public class UseModulesOperation implements UseOperation {
+    private final List<String> moduleNames;
+
+    public UseModulesOperation(List<String> moduleNames) {
+        this.moduleNames = moduleNames;
+    }
+
+    public List<String> getModuleNames() {
+        return Collections.unmodifiableList(moduleNames);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("USE MODULES: %s", moduleNames);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -46,6 +46,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropView;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
+import org.apache.flink.sql.parser.ddl.SqlUseModules;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.sql.parser.dql.SqlLoadModule;
@@ -95,6 +96,7 @@ import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.UseModulesOperation;
 import org.apache.flink.table.operations.ddl.AddPartitionsOperation;
 import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
@@ -208,6 +210,8 @@ public class SqlToOperationConverter {
             return Optional.of(converter.convertUnloadModule((SqlUnloadModule) validated));
         } else if (validated instanceof SqlUseCatalog) {
             return Optional.of(converter.convertUseCatalog((SqlUseCatalog) validated));
+        } else if (validated instanceof SqlUseModules) {
+            return Optional.of(converter.convertUseModules((SqlUseModules) validated));
         } else if (validated instanceof SqlCreateDatabase) {
             return Optional.of(converter.convertCreateDatabase((SqlCreateDatabase) validated));
         } else if (validated instanceof SqlDropDatabase) {
@@ -887,6 +891,11 @@ public class SqlToOperationConverter {
     private Operation convertUnloadModule(SqlUnloadModule sqlUnloadModule) {
         String moduleName = sqlUnloadModule.moduleName();
         return new UnloadModuleOperation(moduleName);
+    }
+
+    /** Convert USE MODULES statement. */
+    private Operation convertUseModules(SqlUseModules sqlUseModules) {
+        return new UseModulesOperation(sqlUseModules.moduleNames());
     }
 
     /** Fallback method for sql query. */

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -22,7 +22,6 @@ import org.apache.flink.sql.parser.ExtendedSqlNode
 import org.apache.flink.sql.parser.dql._
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.config.NullCollation
 import org.apache.calcite.plan._
@@ -36,11 +35,11 @@ import org.apache.calcite.sql.validate.SqlValidator
 import org.apache.calcite.sql.{SqlExplain, SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
+import org.apache.flink.sql.parser.ddl.SqlUseModules
 
 import java.lang.{Boolean => JBoolean}
 import java.util
 import java.util.function.{Function => JFunction}
-
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
@@ -137,7 +136,8 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlShowViews]
         || sqlNode.isInstanceOf[SqlShowPartitions]
         || sqlNode.isInstanceOf[SqlRichDescribeTable]
-        || sqlNode.isInstanceOf[SqlUnloadModule]) {
+        || sqlNode.isInstanceOf[SqlUnloadModule]
+        || sqlNode.isInstanceOf[SqlUseModules]) {
         return sqlNode
       }
       sqlNode match {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
+import org.apache.flink.table.operations.UseModulesOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterTableAddConstraintOperation;
 import org.apache.flink.table.operations.ddl.AlterTableDropConstraintOperation;
@@ -318,6 +319,32 @@ public class SqlToOperationConverterTest {
         final UnloadModuleOperation unloadModuleOperation = (UnloadModuleOperation) operation;
 
         assertEquals(expectedModuleName, unloadModuleOperation.getModuleName());
+    }
+
+    @Test
+    public void testUseOneModule() {
+        final String sql = "USE MODULES dummy";
+        final List<String> expectedModuleNames = Collections.singletonList("dummy");
+
+        Operation operation = parse(sql, SqlDialect.DEFAULT);
+        assert operation instanceof UseModulesOperation;
+        final UseModulesOperation useModulesOperation = (UseModulesOperation) operation;
+
+        assertEquals(expectedModuleNames, useModulesOperation.getModuleNames());
+        assertEquals("USE MODULES: [dummy]", useModulesOperation.asSummaryString());
+    }
+
+    @Test
+    public void testUseMultipleModules() {
+        final String sql = "USE MODULES x, y, z";
+        final List<String> expectedModuleNames = Arrays.asList("x", "y", "z");
+
+        Operation operation = parse(sql, SqlDialect.DEFAULT);
+        assert operation instanceof UseModulesOperation;
+        final UseModulesOperation useModulesOperation = (UseModulesOperation) operation;
+
+        assertEquals(expectedModuleNames, useModulesOperation.getModuleNames());
+        assertEquals("USE MODULES: [x, y, z]", useModulesOperation.asSummaryString());
     }
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -18,23 +18,23 @@
 
 package org.apache.flink.table.api
 
+import org.apache.calcite.plan.RelOptUtil
+import org.apache.calcite.sql.SqlExplainLevel
 import org.apache.flink.api.common.typeinfo.Types.STRING
 import org.apache.flink.api.scala._
 import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment, _}
 import org.apache.flink.table.catalog.{GenericInMemoryCatalog, ObjectPath}
+import org.apache.flink.table.module.ModuleEntry
 import org.apache.flink.table.planner.runtime.stream.sql.FunctionITCase.TestUDF
 import org.apache.flink.table.planner.runtime.stream.table.FunctionITCase.SimpleScalarFunction
 import org.apache.flink.table.planner.utils.TableTestUtil.replaceStageId
 import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
 import org.apache.flink.types.Row
-import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.sql.SqlExplainLevel
-import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
-import org.apache.flink.table.module.ModuleEntry
-import org.junit.Assert.{assertEquals, assertFalse, assertThat, assertTrue, fail}
+import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{Rule, Test}
 
@@ -506,10 +506,11 @@ class TableEnvironmentTest {
   }
 
   @Test
-  def testExecuteSqlWithLoadModule: Unit = {
+  def testExecuteSqlWithLoadModule(): Unit = {
     val result = tableEnv.executeSql("LOAD MODULE dummy")
     assertEquals(ResultKind.SUCCESS, result.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
 
     val statement =
       """
@@ -533,7 +534,8 @@ class TableEnvironmentTest {
       """.stripMargin
     val result = tableEnv.executeSql(statement1)
     assertEquals(ResultKind.SUCCESS, result.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
 
     val statement2 =
       """
@@ -575,16 +577,20 @@ class TableEnvironmentTest {
       """.stripMargin
     val result = tableEnv.executeSql(statement2)
     assertEquals(ResultKind.SUCCESS, result.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
   }
 
   @Test
   def testExecuteSqlWithUnloadModuleTwice(): Unit = {
     tableEnv.executeSql("LOAD MODULE dummy")
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
 
     val result = tableEnv.executeSql("UNLOAD MODULE dummy")
     assertEquals(ResultKind.SUCCESS, result.getResultKind)
+    checkListModules("core")
+    checkListFullModules(("core", true))
 
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
@@ -596,43 +602,28 @@ class TableEnvironmentTest {
   @Test
   def testExecuteSqlWithUseModules(): Unit = {
     tableEnv.executeSql("LOAD MODULE dummy")
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
 
     val result1 = tableEnv.executeSql("USE MODULES dummy")
     assertEquals(ResultKind.SUCCESS, result1.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("dummy")))
-    assert(tableEnv.listFullModules().sameElements(
-      Array[ModuleEntry](
-        new ModuleEntry("dummy", Boolean.box(true)),
-        new ModuleEntry("core", Boolean.box(false))
-      )))
+    checkListModules("dummy")
+    checkListFullModules(("dummy", true), ("core", false))
 
     val result2 = tableEnv.executeSql("USE MODULES dummy, core")
     assertEquals(ResultKind.SUCCESS, result2.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("dummy", "core")))
-    assert(tableEnv.listFullModules().sameElements(
-      Array[ModuleEntry](
-        new ModuleEntry("dummy", Boolean.box(true)),
-        new ModuleEntry("core", Boolean.box(true))
-      )))
+    checkListModules("dummy", "core")
+    checkListFullModules(("dummy", true), ("core", true))
 
     val result3 = tableEnv.executeSql("USE MODULES core, dummy")
     assertEquals(ResultKind.SUCCESS, result3.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("core", "dummy")))
-    assert(tableEnv.listFullModules().sameElements(
-      Array[ModuleEntry](
-        new ModuleEntry("core", Boolean.box(true)),
-        new ModuleEntry("dummy", Boolean.box(true))
-      )))
+    checkListModules("core", "dummy")
+    checkListFullModules(("core", true), ("dummy", true))
 
     val result4 = tableEnv.executeSql("USE MODULES core")
     assertEquals(ResultKind.SUCCESS, result4.getResultKind)
-    assert(tableEnv.listModules().sameElements(Array[String]("core")))
-    assert(tableEnv.listFullModules().sameElements(
-      Array[ModuleEntry](
-        new ModuleEntry("core", Boolean.box(true)),
-        new ModuleEntry("dummy", Boolean.box(false))
-      )))
+    checkListModules("core")
+    checkListFullModules(("core", true), ("dummy", false))
   }
 
   @Test
@@ -1369,4 +1360,19 @@ class TableEnvironmentTest {
     assertEquals(expected.hasNext, actual.hasNext)
   }
 
+  private def checkListModules(expected: String *): Unit = {
+    val actual = tableEnv.listModules()
+    for ((module, i) <- expected.zipWithIndex) {
+      assertEquals(module, actual.apply(i))
+    }
+  }
+
+  private def checkListFullModules(expected: (String, java.lang.Boolean) *): Unit = {
+    val actual = tableEnv.listFullModules()
+      for ((elem, i) <- expected.zipWithIndex) {
+        assertEquals(
+          new ModuleEntry(elem._1, elem._2).asInstanceOf[Object],
+          actual.apply(i).asInstanceOf[Object])
+      }
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports using the module(s) by `USE MODULES x [, y, z, ...]` syntax in both SQL parser, TableEnvironment, and SQL CLI.


## Brief change log
  - Extend `Parser.tdd` and `parserImpls.ftl` templates for both `flink-sql-parser` and `flink-sql-parser-hive` to support syntax. Add `SqlUseModules` to represent the SqlNode after parsing.
  - Extend `FlinkPlannerImpl`, `SqlToOperationConverter` and`TableEnvironmentImpl`  to support operation transformation.
  - Add SqlCli support.


## Verifying this change

This change added tests and can be verified as follows:
  - Added tests in `FlinkSqlParserImplTest` and `FlinkHiveSqlParserImplTest` to verify parsing syntax correctly.
  - Added tests in `SqlToOperatorConverterTest` to verify operation transforming behaves correctly. Added tests in `TableEnvironmentTest` to verify module discovery and module enabling/disabling behave correctly.
  - Added tests in `SqlCommandParserTest` and `LocalExecutorITCase` to verify SqlCli behaves correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
    - Docs will be updated after FLINK-21300 finish.
