### PR TITLE
[FLINK-21489][docs] Hugo docs add two anchor links to headers 68f3679 

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+if ! command -v COMMAND &> /dev/null
+then
+	echo "Hugo must be installed to run the docs locally"
+	echo "Please see docs/README.md for more details"
+	exit 1
+fi
+git submodule update --init --recursive
+
+hugo -b "" serve 

--- a/docs/static/js/flink.js
+++ b/docs/static/js/flink.js
@@ -174,5 +174,5 @@ document.addEventListener("DOMContentLoaded", function(event) {
     anchors.options = {
         placement: 'right'
     };
-    anchors.add();
+    anchors.add('h5');
 });

--- a/docs/static/js/flink.js
+++ b/docs/static/js/flink.js
@@ -174,5 +174,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
     anchors.options = {
         placement: 'right'
     };
+    // add anchors to h5 headings, hugo already adds them to h1-h4 but we use h5 in generated documentation
     anchors.add('h5');
 });


### PR DESCRIPTION
## What is the purpose of the change

Fixes the double anchors in the documentation. Hugo already adds anchor tags so we update `anchor.js` to only add them to the auto-generated configuration files. 

