### PR TITLE
[FLINK-21492] Don't let ActiveResourceManager swallow stack trace of exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -291,7 +291,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                                 final int count =
                                         pendingWorkerCounter.decreaseAndGet(workerResourceSpec);
                                 log.warn(
-                                        "Failed requesting worker with resource spec {}, current pending count: {}, exception: {}",
+                                        "Failed requesting worker with resource spec {}, current pending count: {}",
                                         workerResourceSpec,
                                         count,
                                         exception);


### PR DESCRIPTION
By not logging the exception explicitly, we preserve the stack trace of it in the log output.