### PR TITLE
[FLINK-21413][state] Clean TtlMapState and TtlListState after all elements are expired

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
@@ -103,6 +103,11 @@ class TtlListState<K, N, T>
     @Nullable
     @Override
     public List<TtlValue<T>> getUnexpiredOrNull(@Nonnull List<TtlValue<T>> ttlValues) {
+        // the update operation will clear the whole state if the list becomes empty after init
+        if (ttlValues.isEmpty()) {
+            return ttlValues;
+        }
+
         long currentTimestamp = timeProvider.currentTimestamp();
         List<TtlValue<T>> unexpired = new ArrayList<>(ttlValues.size());
         TypeSerializer<TtlValue<T>> elementSerializer =
@@ -117,7 +122,8 @@ class TtlListState<K, N, T>
         if (!unexpired.isEmpty()) {
             return unexpired;
         } else {
-            return ttlValues.size() == unexpired.size() ? ttlValues : unexpired;
+            // list is not empty and all expired
+            return null;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlMapState.java
@@ -134,6 +134,10 @@ class TtlMapState<K, N, UK, UV>
     @Nullable
     @Override
     public Map<UK, TtlValue<UV>> getUnexpiredOrNull(@Nonnull Map<UK, TtlValue<UV>> ttlValue) {
+        // the remove operation will clear the whole state if the map becomes empty after init
+        if (ttlValue.isEmpty()) {
+            return ttlValue;
+        }
         Map<UK, TtlValue<UV>> unexpired = new HashMap<>();
         TypeSerializer<TtlValue<UV>> valueSerializer =
                 ((MapSerializer<UK, TtlValue<UV>>) original.getValueSerializer())
@@ -144,7 +148,12 @@ class TtlMapState<K, N, UK, UV>
                 unexpired.put(e.getKey(), valueSerializer.copy(e.getValue()));
             }
         }
-        return ttlValue.size() == unexpired.size() ? ttlValue : unexpired;
+        if (!unexpired.isEmpty()) {
+            return unexpired;
+        } else {
+            // map is not empty but all values expired
+            return null;
+        }
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestContextBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestContextBase.java
@@ -37,6 +37,7 @@ public abstract class TtlStateTestContextBase<S extends InternalKvState<?, Strin
     GV getUpdateExpired;
 
     public GV emptyValue = null;
+    public String currentNamespace = "defaultNamespace";
 
     abstract void initTestValues();
 
@@ -59,5 +60,9 @@ public abstract class TtlStateTestContextBase<S extends InternalKvState<?, Strin
     @Override
     public String toString() {
         return this.getClass().getSimpleName();
+    }
+
+    public void setCurrentNamespace(String currentNamespace) {
+        this.currentNamespace = currentNamespace;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Solve the memory leak in #TtlMapState and #TtlListState with #FsStateBackend and incremental cleanup feature. 

## Brief change log

Changes in #TtlMapState and #TtlListState  

* In #getUnexpiredOrNull method, return null if all the elements are expired

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
