### PR TITLE
[FLINK-12607][rest] Introduce a REST API that returns the maxParallelism

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1468,6 +1468,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "jid" : {
       "type" : "any"
     },
+    "maxParallelism" : {
+      "type" : "integer"
+    },
     "name" : {
       "type" : "string"
     },
@@ -1510,6 +1513,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "id" : {
             "type" : "any"
+          },
+          "maxParallelism" : {
+            "type" : "integer"
           },
           "metrics" : {
             "type" : "object",
@@ -3428,6 +3434,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "properties" : {
     "id" : {
       "type" : "any"
+    },
+    "maxParallelism" : {
+      "type" : "integer"
     },
     "name" : {
       "type" : "string"

--- a/flink-core/src/main/java/org/apache/flink/api/common/ArchivedExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ArchivedExecutionConfig.java
@@ -32,11 +32,12 @@ import java.util.Map;
 @Internal
 public class ArchivedExecutionConfig implements Serializable {
 
-    private static final long serialVersionUID = 2126156250920316528L;
+    private static final long serialVersionUID = 2907040336948181163L;
 
     private final String executionMode;
     private final String restartStrategyDescription;
     private final int parallelism;
+    private final int maxParallelism;
     private final boolean objectReuseEnabled;
     private final Map<String, String> globalJobParameters;
 
@@ -47,6 +48,7 @@ public class ArchivedExecutionConfig implements Serializable {
         } else {
             restartStrategyDescription = "default";
         }
+        maxParallelism = ec.getMaxParallelism();
         parallelism = ec.getParallelism();
         objectReuseEnabled = ec.isObjectReuseEnabled();
         if (ec.getGlobalJobParameters() != null && ec.getGlobalJobParameters().toMap() != null) {
@@ -59,11 +61,13 @@ public class ArchivedExecutionConfig implements Serializable {
     public ArchivedExecutionConfig(
             String executionMode,
             String restartStrategyDescription,
+            int maxParallelism,
             int parallelism,
             boolean objectReuseEnabled,
             Map<String, String> globalJobParameters) {
         this.executionMode = executionMode;
         this.restartStrategyDescription = restartStrategyDescription;
+        this.maxParallelism = maxParallelism;
         this.parallelism = parallelism;
         this.objectReuseEnabled = objectReuseEnabled;
         this.globalJobParameters = globalJobParameters;
@@ -75,6 +79,10 @@ public class ArchivedExecutionConfig implements Serializable {
 
     public String getRestartStrategyDescription() {
         return restartStrategyDescription;
+    }
+
+    public int getMaxParallelism() {
+        return maxParallelism;
     }
 
     public int getParallelism() {

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -708,6 +708,9 @@
         "duration" : {
           "type" : "integer"
         },
+        "maxParallelism" : {
+          "type" : "integer"
+        },
         "now" : {
           "type" : "integer"
         },
@@ -728,6 +731,9 @@
               },
               "name" : {
                 "type" : "string"
+              },
+              "maxParallelism" : {
+                "type" : "integer"
               },
               "parallelism" : {
                 "type" : "integer"
@@ -1885,6 +1891,9 @@
           "type" : "string"
         },
         "parallelism" : {
+          "type" : "integer"
+        },
+        "maxParallelism" : {
           "type" : "integer"
         },
         "now" : {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -50,6 +50,7 @@ export interface JobDetailInterface {
   'start-time': number;
   'end-time': number;
   duration: number;
+  maxParallelism: number;
   now: number;
   timestamps: TimestampsStatus;
   vertices: VerticesItemInterface[];
@@ -80,6 +81,7 @@ export interface VerticesItemInterface {
   id: string;
   name: string;
   parallelism: number;
+  maxParallelism: number;
   status: string;
   'start-time': number;
   'end-time': number;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -148,6 +148,7 @@ public class JobDetailsHandler
                 startTime,
                 endTime,
                 duration,
+                executionGraph.getArchivedExecutionConfig().getMaxParallelism(),
                 now,
                 timestamps,
                 jobVertexInfos,
@@ -223,6 +224,7 @@ public class JobDetailsHandler
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 ejv.getJobVertexId(),
                 ejv.getName(),
+                ejv.getMaxParallelism(),
                 ejv.getParallelism(),
                 jobVertexState,
                 startTime,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -130,6 +130,7 @@ public class JobVertexDetailsHandler
                 jobVertex.getJobVertexId(),
                 jobVertex.getName(),
                 jobVertex.getParallelism(),
+                jobVertex.getMaxParallelism(),
                 now,
                 subtasks);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -41,6 +41,7 @@ public class JobVertexDetailsInfo implements ResponseBody {
     public static final String FIELD_NAME_VERTEX_ID = "id";
     public static final String FIELD_NAME_VERTEX_NAME = "name";
     public static final String FIELD_NAME_PARALLELISM = "parallelism";
+    public static final String FIELD_NAME_MAX_PARALLELISM = "maxParallelism";
     public static final String FIELD_NAME_NOW = "now";
     public static final String FIELD_NAME_SUBTASKS = "subtasks";
 
@@ -53,6 +54,9 @@ public class JobVertexDetailsInfo implements ResponseBody {
 
     @JsonProperty(FIELD_NAME_PARALLELISM)
     private final int parallelism;
+
+    @JsonProperty(FIELD_NAME_MAX_PARALLELISM)
+    private final int maxParallelism;
 
     @JsonProperty(FIELD_NAME_NOW)
     private final long now;
@@ -67,11 +71,13 @@ public class JobVertexDetailsInfo implements ResponseBody {
                     JobVertexID id,
             @JsonProperty(FIELD_NAME_VERTEX_NAME) String name,
             @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
+            @JsonProperty(FIELD_NAME_MAX_PARALLELISM) int maxParallelism,
             @JsonProperty(FIELD_NAME_NOW) long now,
             @JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskExecutionAttemptDetailsInfo> subtasks) {
         this.id = checkNotNull(id);
         this.name = checkNotNull(name);
         this.parallelism = parallelism;
+        this.maxParallelism = maxParallelism;
         this.now = now;
         this.subtasks = checkNotNull(subtasks);
     }
@@ -95,12 +101,13 @@ public class JobVertexDetailsInfo implements ResponseBody {
         return Objects.equals(id, that.id)
                 && Objects.equals(name, that.name)
                 && parallelism == that.parallelism
+                && maxParallelism == that.maxParallelism
                 && now == that.now
                 && Objects.equals(subtasks, that.subtasks);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, parallelism, now, subtasks);
+        return Objects.hash(id, name, parallelism, maxParallelism, now, subtasks);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -59,6 +59,8 @@ public class JobDetailsInfo implements ResponseBody {
 
     public static final String FIELD_NAME_DURATION = "duration";
 
+    public static final String FIELD_NAME_MAX_PARALLELISM = "maxParallelism";
+
     // TODO: For what do we need this???
     public static final String FIELD_NAME_NOW = "now";
 
@@ -92,6 +94,9 @@ public class JobDetailsInfo implements ResponseBody {
     @JsonProperty(FIELD_NAME_DURATION)
     private final long duration;
 
+    @JsonProperty(FIELD_NAME_MAX_PARALLELISM)
+    private final long maxParallelism;
+
     @JsonProperty(FIELD_NAME_NOW)
     private final long now;
 
@@ -118,6 +123,7 @@ public class JobDetailsInfo implements ResponseBody {
             @JsonProperty(FIELD_NAME_START_TIME) long startTime,
             @JsonProperty(FIELD_NAME_END_TIME) long endTime,
             @JsonProperty(FIELD_NAME_DURATION) long duration,
+            @JsonProperty(FIELD_NAME_MAX_PARALLELISM) long maxParallelism,
             @JsonProperty(FIELD_NAME_NOW) long now,
             @JsonProperty(FIELD_NAME_TIMESTAMPS) Map<JobStatus, Long> timestamps,
             @JsonProperty(FIELD_NAME_JOB_VERTEX_INFOS)
@@ -133,6 +139,7 @@ public class JobDetailsInfo implements ResponseBody {
         this.startTime = startTime;
         this.endTime = endTime;
         this.duration = duration;
+        this.maxParallelism = maxParallelism;
         this.now = now;
         this.timestamps = Preconditions.checkNotNull(timestamps);
         this.jobVertexInfos = Preconditions.checkNotNull(jobVertexInfos);
@@ -153,6 +160,7 @@ public class JobDetailsInfo implements ResponseBody {
                 && startTime == that.startTime
                 && endTime == that.endTime
                 && duration == that.duration
+                && maxParallelism == that.maxParallelism
                 && now == that.now
                 && Objects.equals(jobId, that.jobId)
                 && Objects.equals(name, that.name)
@@ -173,6 +181,7 @@ public class JobDetailsInfo implements ResponseBody {
                 startTime,
                 endTime,
                 duration,
+                maxParallelism,
                 now,
                 timestamps,
                 jobVertexInfos,
@@ -208,6 +217,11 @@ public class JobDetailsInfo implements ResponseBody {
     @JsonIgnore
     public long getEndTime() {
         return endTime;
+    }
+
+    @JsonIgnore
+    public long getMaxParallelism() {
+        return maxParallelism;
     }
 
     @JsonIgnore
@@ -251,6 +265,8 @@ public class JobDetailsInfo implements ResponseBody {
 
         public static final String FIELD_NAME_JOB_VERTEX_NAME = "name";
 
+        public static final String FIELD_NAME_MAX_PARALLELISM = "maxParallelism";
+
         public static final String FIELD_NAME_PARALLELISM = "parallelism";
 
         public static final String FIELD_NAME_JOB_VERTEX_STATE = "status";
@@ -271,6 +287,9 @@ public class JobDetailsInfo implements ResponseBody {
 
         @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME)
         private final String name;
+
+        @JsonProperty(FIELD_NAME_MAX_PARALLELISM)
+        private final int maxParallelism;
 
         @JsonProperty(FIELD_NAME_PARALLELISM)
         private final int parallelism;
@@ -299,6 +318,7 @@ public class JobDetailsInfo implements ResponseBody {
                         @JsonProperty(FIELD_NAME_JOB_VERTEX_ID)
                         JobVertexID jobVertexID,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME) String name,
+                @JsonProperty(FIELD_NAME_MAX_PARALLELISM) int maxParallelism,
                 @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_STATE) ExecutionState executionState,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_START_TIME) long startTime,
@@ -309,6 +329,7 @@ public class JobDetailsInfo implements ResponseBody {
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) IOMetricsInfo jobVertexMetrics) {
             this.jobVertexID = Preconditions.checkNotNull(jobVertexID);
             this.name = Preconditions.checkNotNull(name);
+            this.maxParallelism = maxParallelism;
             this.parallelism = parallelism;
             this.executionState = Preconditions.checkNotNull(executionState);
             this.startTime = startTime;
@@ -326,6 +347,11 @@ public class JobDetailsInfo implements ResponseBody {
         @JsonIgnore
         public String getName() {
             return name;
+        }
+
+        @JsonIgnore
+        public int getMaxParallelism() {
+            return maxParallelism;
         }
 
         @JsonIgnore
@@ -372,7 +398,8 @@ public class JobDetailsInfo implements ResponseBody {
                 return false;
             }
             JobVertexDetailsInfo that = (JobVertexDetailsInfo) o;
-            return parallelism == that.parallelism
+            return maxParallelism == that.maxParallelism
+                    && parallelism == that.parallelism
                     && startTime == that.startTime
                     && endTime == that.endTime
                     && duration == that.duration
@@ -388,6 +415,7 @@ public class JobDetailsInfo implements ResponseBody {
             return Objects.hash(
                     jobVertexID,
                     name,
+                    maxParallelism,
                     parallelism,
                     executionState,
                     startTime,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionConfigBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionConfigBuilder.java
@@ -28,6 +28,7 @@ import java.util.Map;
 public class ArchivedExecutionConfigBuilder {
     private String executionMode;
     private String restartStrategyDescription;
+    private int maxParallelism;
     private int parallelism;
     private boolean objectReuseEnabled;
     private Map<String, String> globalJobParameters;
@@ -48,6 +49,11 @@ public class ArchivedExecutionConfigBuilder {
         return this;
     }
 
+    public ArchivedExecutionConfigBuilder setMaxParallelism(int parallelism) {
+        this.maxParallelism = maxParallelism;
+        return this;
+    }
+
     public ArchivedExecutionConfigBuilder setObjectReuseEnabled(boolean objectReuseEnabled) {
         this.objectReuseEnabled = objectReuseEnabled;
         return this;
@@ -63,6 +69,7 @@ public class ArchivedExecutionConfigBuilder {
         return new ArchivedExecutionConfig(
                 executionMode != null ? executionMode : ExecutionMode.PIPELINED.name(),
                 restartStrategyDescription != null ? restartStrategyDescription : "default",
+                maxParallelism,
                 parallelism,
                 objectReuseEnabled,
                 globalJobParameters != null

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -83,10 +83,12 @@ public class JobVertexDetailsInfoTest
                         jobVertexMetrics,
                         "taskmanagerId3"));
 
+        int parallelism = 1 + (random.nextInt() / 3);
         return new JobVertexDetailsInfo(
                 new JobVertexID(),
                 "jobVertex" + random.nextLong(),
-                random.nextInt(),
+                parallelism,
+                2 * parallelism,
                 System.currentTimeMillis(),
                 vertexTaskDetailList);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -71,6 +71,7 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
                 1L,
                 2L,
                 1L,
+                8888L,
                 1984L,
                 timestamps,
                 jobVertexInfos,
@@ -96,10 +97,12 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
             tasksPerState.put(executionState, random.nextInt());
         }
 
+        int parallelism = 1 + (random.nextInt() / 3);
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 new JobVertexID(),
                 "jobVertex" + random.nextLong(),
-                random.nextInt(),
+                2 * parallelism,
+                parallelism,
                 ExecutionState.values()[random.nextInt(ExecutionState.values().length)],
                 random.nextLong(),
                 random.nextLong(),


### PR DESCRIPTION
## What is the purpose of the change

Add max parallelism for reporting purposes to the REST api.

## Brief change log

Add max-parallelism to:
- JobVertexDetailsHandler puts maxaParallelism into JobVertexDetailsInfo from jobVertex
- JobDetailsHandler pus:
    - maxParallelism into JobDetailsInfo from ExecutionGraph's archived execution config
    - maxParallelism into JobVertexDetailsInfo from AccessExecutionJobVertex

- ArchivedExecutionConfig

- JobDetailsInfo as "job-max-parallelism"
    - JobDetailsInfo.JobVertexDetailsInfo as "max-parallelism"
- JobVertexDetailsInfo as "max-parallelism"

All have max parallelism added to equals and hash (except ArchivedExecutionConfig)

Resets ArchivedExecutionConfig's `serialVersionUID`

also adds to angular type definitions.



*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Verifying this change

This change is already covered by existing tests, such as `JobDetailsInfoTest` and `JobVertexDetailsInfoTest`. As I'm developing on windows linux subsystem, my maven build works but I am unable to run tests locally. Is there an automation that runs them to check this PR? 

I did manually run the REST api against a local cluster from the bin/start-cluster.sh  of TopSpeedWindowing example with `env.getConfig().setMaxParallelism(4)` and `.setMaxParallelism(2);` on an operator

In both `/jobs`and `/jobs/:id` I saw that "job-max-parallelism" was set to 4 and "max-parallelism" was set to "2" for the specific vertex and "4" for others.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no but I feel like it should?
  - The serializers: yes the ArchivedExecutionConfig's java serializability
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? slightly
  - If yes, how is the feature documented? Needs a follow up for the REST api docs.
