### PR TITLE
[FLINK-21445][kubernetes] Application mode does not set the configuration when building PackagedProgram

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -843,7 +843,7 @@ public class CliFrontend {
 
         return PackagedProgram.newBuilder()
                 .setJarFile(jarFile)
-                .setUserClassPaths(classpaths)
+                .setUserClasspaths(classpaths)
                 .setEntryPointClassName(entryPointClass)
                 .setConfiguration(configuration)
                 .setSavepointRestoreSettings(runOptions.getSavepointRestoreSettings())

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/AbstractPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/AbstractPackagedProgramRetriever.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.FunctionUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+/**
+ * An abstract {@link PackagedProgramRetriever} which creates the {@link PackagedProgram} containing
+ * the user's {@code main()} from a class on the class path.
+ */
+@Internal
+public abstract class AbstractPackagedProgramRetriever implements PackagedProgramRetriever {
+
+    private final String[] programArguments;
+
+    private final Configuration configuration;
+
+    /** User class paths in relative form to the working directory. */
+    protected final Collection<URL> userClassPaths;
+
+    AbstractPackagedProgramRetriever(
+            String[] programArguments, Configuration configuration, @Nullable File userLibDirectory)
+            throws IOException {
+        this.programArguments = Preconditions.checkNotNull(programArguments);
+        this.configuration = Preconditions.checkNotNull(configuration);
+        this.userClassPaths = discoverUserClassPaths(userLibDirectory);
+    }
+
+    private static Collection<URL> discoverUserClassPaths(@Nullable File jobDir)
+            throws IOException {
+        if (jobDir == null) {
+            return Collections.emptyList();
+        }
+
+        final Path workingDirectory = FileUtils.getCurrentWorkingDirectory();
+        final Collection<URL> relativeJarURLs =
+                FileUtils.listFilesInDirectory(jobDir.toPath(), FileUtils::isJarFile).stream()
+                        .map(path -> FileUtils.relativizePath(workingDirectory, path))
+                        .map(FunctionUtils.uncheckedFunction(FileUtils::toURL))
+                        .collect(Collectors.toList());
+        return Collections.unmodifiableCollection(relativeJarURLs);
+    }
+
+    @Override
+    public PackagedProgram getPackagedProgram() throws FlinkException {
+        try {
+            PackagedProgram.Builder packagedProgramBuilder =
+                    PackagedProgram.newBuilder()
+                            .setArguments(programArguments)
+                            .setConfiguration(configuration)
+                            .setUserClassPaths(new ArrayList<>(userClassPaths));
+            return buildPackagedProgram(packagedProgramBuilder);
+        } catch (ProgramInvocationException e) {
+            throw new FlinkException("Could not load the provided entry point class.", e);
+        }
+    }
+
+    protected abstract PackagedProgram buildPackagedProgram(
+            PackagedProgram.Builder packagedProgramBuilder)
+            throws ProgramInvocationException, FlinkException;
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/AbstractPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/AbstractPackagedProgramRetriever.java
@@ -51,17 +51,17 @@ public abstract class AbstractPackagedProgramRetriever implements PackagedProgra
     private final Configuration configuration;
 
     /** User class paths in relative form to the working directory. */
-    protected final Collection<URL> userClassPaths;
+    protected final Collection<URL> userClasspaths;
 
     AbstractPackagedProgramRetriever(
             String[] programArguments, Configuration configuration, @Nullable File userLibDirectory)
             throws IOException {
         this.programArguments = Preconditions.checkNotNull(programArguments);
         this.configuration = Preconditions.checkNotNull(configuration);
-        this.userClassPaths = discoverUserClassPaths(userLibDirectory);
+        this.userClasspaths = discoverUserClasspaths(userLibDirectory);
     }
 
-    private static Collection<URL> discoverUserClassPaths(@Nullable File jobDir)
+    private static Collection<URL> discoverUserClasspaths(@Nullable File jobDir)
             throws IOException {
         if (jobDir == null) {
             return Collections.emptyList();
@@ -83,7 +83,7 @@ public abstract class AbstractPackagedProgramRetriever implements PackagedProgra
                     PackagedProgram.newBuilder()
                             .setArguments(programArguments)
                             .setConfiguration(configuration)
-                            .setUserClassPaths(new ArrayList<>(userClassPaths));
+                            .setUserClasspaths(new ArrayList<>(userClasspaths));
             return buildPackagedProgram(packagedProgramBuilder);
         } catch (ProgramInvocationException e) {
             throw new FlinkException("Could not load the provided entry point class.", e);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ClassPathPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ClassPathPackagedProgramRetriever.java
@@ -22,27 +22,21 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramRetriever;
-import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.function.FunctionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 import java.util.jar.JarEntry;
@@ -50,109 +44,50 @@ import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
-
 /**
- * A {@link org.apache.flink.client.program.PackagedProgramRetriever PackagedProgramRetriever} which
- * creates the {@link org.apache.flink.client.program.PackagedProgram PackagedProgram} containing
- * the user's {@code main()} from a class on the class path.
+ * A classpath {@link PackagedProgramRetriever} which creates the {@link PackagedProgram} through
+ * scanning the classpath for the job class.
  */
 @Internal
-public class ClassPathPackagedProgramRetriever implements PackagedProgramRetriever {
+public class ClassPathPackagedProgramRetriever extends AbstractPackagedProgramRetriever {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(ClassPathPackagedProgramRetriever.class);
 
-    /** User classpaths in relative form to the working directory. */
-    @Nonnull private final Collection<URL> userClassPaths;
-
-    @Nonnull private final String[] programArguments;
-
-    @Nullable private final String jobClassName;
-
-    @Nonnull private final Supplier<Iterable<File>> jarsOnClassPath;
+    private final Supplier<Iterable<File>> jarsOnClassPath;
 
     @Nullable private final File userLibDirectory;
 
-    @Nullable private final File jarFile;
+    @Nullable private final String jobClassName;
 
-    private ClassPathPackagedProgramRetriever(
-            @Nonnull String[] programArguments,
-            @Nullable String jobClassName,
-            @Nonnull Supplier<Iterable<File>> jarsOnClassPath,
+    ClassPathPackagedProgramRetriever(
+            String[] programArguments,
+            Configuration configuration,
             @Nullable File userLibDirectory,
-            @Nullable File jarFile)
+            @Nullable String jobClassName,
+            @Nullable Supplier<Iterable<File>> jarsOnClassPath)
             throws IOException {
+        super(programArguments, configuration, userLibDirectory);
         this.userLibDirectory = userLibDirectory;
-        this.programArguments = requireNonNull(programArguments, "programArguments");
         this.jobClassName = jobClassName;
-        this.jarsOnClassPath = requireNonNull(jarsOnClassPath);
-        this.userClassPaths = discoverUserClassPaths(userLibDirectory);
-        this.jarFile = jarFile;
-    }
-
-    private Collection<URL> discoverUserClassPaths(@Nullable File jobDir) throws IOException {
-        if (jobDir == null) {
-            return Collections.emptyList();
-        }
-
-        final Path workingDirectory = FileUtils.getCurrentWorkingDirectory();
-        final Collection<URL> relativeJarURLs =
-                FileUtils.listFilesInDirectory(jobDir.toPath(), FileUtils::isJarFile).stream()
-                        .map(path -> FileUtils.relativizePath(workingDirectory, path))
-                        .map(FunctionUtils.uncheckedFunction(FileUtils::toURL))
-                        .collect(Collectors.toList());
-        return Collections.unmodifiableCollection(relativeJarURLs);
+        this.jarsOnClassPath = jarsOnClassPath == null ? JarsOnClassPath.INSTANCE : jarsOnClassPath;
     }
 
     @Override
-    public PackagedProgram getPackagedProgram() throws FlinkException {
-        try {
-            // It is Python job if program arguments contain "-py"/--python" or "-pym/--pyModule",
-            // set the fixed
-            // jobClassName and jarFile path.
-            if (PackagedProgramUtils.isPython(jobClassName)
-                    || PackagedProgramUtils.isPython(programArguments)) {
-                String pythonJobClassName = PackagedProgramUtils.getPythonDriverClassName();
-                File pythonJarFile = new File(PackagedProgramUtils.getPythonJar().getPath());
-                return PackagedProgram.newBuilder()
-                        .setUserClassPaths(new ArrayList<>(userClassPaths))
-                        .setArguments(programArguments)
-                        .setJarFile(pythonJarFile)
-                        .setEntryPointClassName(pythonJobClassName)
-                        .build();
-            }
-
-            if (jarFile != null) {
-                return PackagedProgram.newBuilder()
-                        .setUserClassPaths(new ArrayList<>(userClassPaths))
-                        .setArguments(programArguments)
-                        .setJarFile(jarFile)
-                        .setEntryPointClassName(jobClassName)
-                        .build();
-            }
-
-            final String entryClass = getJobClassNameOrScanClassPath();
-            return PackagedProgram.newBuilder()
-                    .setUserClassPaths(new ArrayList<>(userClassPaths))
-                    .setEntryPointClassName(entryClass)
-                    .setArguments(programArguments)
-                    .build();
-        } catch (ProgramInvocationException e) {
-            throw new FlinkException("Could not load the provided entrypoint class.", e);
-        }
+    public PackagedProgram buildPackagedProgram(PackagedProgram.Builder packagedProgramBuilder)
+            throws ProgramInvocationException, FlinkException {
+        final String entryClass = getJobClassNameOrScanClassPath();
+        return packagedProgramBuilder.setEntryPointClassName(entryClass).build();
     }
 
     private String getJobClassNameOrScanClassPath() throws FlinkException {
         if (jobClassName != null) {
-            if (userLibDirectory != null) {
-                // check that we find the entrypoint class in the user lib directory.
-                if (!userClassPathContainsJobClass(jobClassName)) {
-                    throw new FlinkException(
-                            String.format(
-                                    "Could not find the provided job class (%s) in the user lib directory (%s).",
-                                    jobClassName, userLibDirectory));
-                }
+            // check that we find the entry point class in the user lib directory.
+            if (userLibDirectory != null && !userClassPathContainsJobClass(jobClassName)) {
+                throw new FlinkException(
+                        String.format(
+                                "Could not find the provided job class (%s) in the user lib directory (%s).",
+                                jobClassName, userLibDirectory));
             }
             return jobClassName;
         }
@@ -237,52 +172,5 @@ public class ClassPathPackagedProgramRetriever implements PackagedProgramRetriev
         private static boolean notNullAndNotEmpty(String string) {
             return string != null && !string.equals("");
         }
-    }
-
-    /** A builder for the {@link ClassPathPackagedProgramRetriever}. */
-    public static class Builder {
-
-        private final String[] programArguments;
-
-        @Nullable private String jobClassName;
-
-        @Nullable private File userLibDirectory;
-
-        private Supplier<Iterable<File>> jarsOnClassPath = JarsOnClassPath.INSTANCE;
-
-        private File jarFile;
-
-        private Builder(String[] programArguments) {
-            this.programArguments = requireNonNull(programArguments);
-        }
-
-        public Builder setJobClassName(@Nullable String jobClassName) {
-            this.jobClassName = jobClassName;
-            return this;
-        }
-
-        public Builder setUserLibDirectory(File userLibDirectory) {
-            this.userLibDirectory = userLibDirectory;
-            return this;
-        }
-
-        public Builder setJarsOnClassPath(Supplier<Iterable<File>> jarsOnClassPath) {
-            this.jarsOnClassPath = jarsOnClassPath;
-            return this;
-        }
-
-        public Builder setJarFile(File file) {
-            this.jarFile = file;
-            return this;
-        }
-
-        public ClassPathPackagedProgramRetriever build() throws IOException {
-            return new ClassPathPackagedProgramRetriever(
-                    programArguments, jobClassName, jarsOnClassPath, userLibDirectory, jarFile);
-        }
-    }
-
-    public static Builder newBuilder(String[] programArguments) {
-        return new Builder(programArguments);
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetriever.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * A jar file {@link PackagedProgramRetriever} which creates the {@link PackagedProgram} with the
+ * specified jar file.
+ */
+@Internal
+public class JarFilePackagedProgramRetriever extends AbstractPackagedProgramRetriever {
+
+    private final File jarFile;
+
+    @Nullable private final String jobClassName;
+
+    JarFilePackagedProgramRetriever(
+            String[] programArguments,
+            Configuration configuration,
+            @Nullable File userLibDirectory,
+            @Nullable String jobClassName,
+            File jarFile)
+            throws IOException {
+        super(programArguments, configuration, userLibDirectory);
+        this.jobClassName = jobClassName;
+        this.jarFile = Preconditions.checkNotNull(jarFile);
+    }
+
+    @Override
+    public PackagedProgram buildPackagedProgram(PackagedProgram.Builder packagedProgramBuilder)
+            throws ProgramInvocationException {
+        return packagedProgramBuilder
+                .setJarFile(jarFile)
+                .setEntryPointClassName(jobClassName)
+                .build();
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapter.java
@@ -54,7 +54,7 @@ public final class PackagedProgramRetrieverAdapter {
 
         @Nullable private String jobClassName;
 
-        @Nullable private Supplier<Iterable<File>> jarsOnClassPath;
+        @Nullable private Supplier<Iterable<File>> jarsOnClasspath;
 
         private Builder(String[] programArguments, Configuration configuration, File jarFile) {
             this(programArguments, configuration);
@@ -76,8 +76,8 @@ public final class PackagedProgramRetrieverAdapter {
             return this;
         }
 
-        public Builder setJarsOnClassPath(@Nullable Supplier<Iterable<File>> jarsOnClassPath) {
-            this.jarsOnClassPath = jarsOnClassPath;
+        public Builder setJarsOnClasspath(@Nullable Supplier<Iterable<File>> jarsOnClasspath) {
+            this.jarsOnClasspath = jarsOnClasspath;
             return this;
         }
 
@@ -91,12 +91,12 @@ public final class PackagedProgramRetrieverAdapter {
                 return new JarFilePackagedProgramRetriever(
                         programArguments, configuration, userLibDirectory, jobClassName, jarFile);
             }
-            return new ClassPathPackagedProgramRetriever(
+            return new ClasspathPackagedProgramRetriever(
                     programArguments,
                     configuration,
                     userLibDirectory,
                     jobClassName,
-                    jarsOnClassPath);
+                    jarsOnClasspath);
         }
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/** Adapter to provide a {@link Builder} to build a {@link PackagedProgramRetriever}. */
+public final class PackagedProgramRetrieverAdapter {
+
+    public static Builder newBuilder(String[] programArguments, Configuration configuration) {
+        return new Builder(programArguments, configuration);
+    }
+
+    public static Builder newBuilder(
+            String[] programArguments, Configuration configuration, File jarFile) {
+        return new Builder(programArguments, configuration, jarFile);
+    }
+
+    /** A builder for the {@link PackagedProgramRetriever}. */
+    public static class Builder {
+
+        private final String[] programArguments;
+
+        private final Configuration configuration;
+
+        private File jarFile;
+
+        @Nullable private File userLibDirectory;
+
+        @Nullable private String jobClassName;
+
+        @Nullable private Supplier<Iterable<File>> jarsOnClassPath;
+
+        private Builder(String[] programArguments, Configuration configuration, File jarFile) {
+            this(programArguments, configuration);
+            this.jarFile = Preconditions.checkNotNull(jarFile);
+        }
+
+        private Builder(String[] programArguments, Configuration configuration) {
+            this.programArguments = Preconditions.checkNotNull(programArguments);
+            this.configuration = Preconditions.checkNotNull(configuration);
+        }
+
+        public Builder setUserLibDirectory(@Nullable File userLibDirectory) {
+            this.userLibDirectory = userLibDirectory;
+            return this;
+        }
+
+        public Builder setJobClassName(@Nullable String jobClassName) {
+            this.jobClassName = jobClassName;
+            return this;
+        }
+
+        public Builder setJarsOnClassPath(@Nullable Supplier<Iterable<File>> jarsOnClassPath) {
+            this.jarsOnClassPath = jarsOnClassPath;
+            return this;
+        }
+
+        public PackagedProgramRetriever build() throws IOException {
+            if (PackagedProgramUtils.isPython(jobClassName)
+                    || PackagedProgramUtils.isPython(programArguments)) {
+                return new PythonBasedPackagedProgramRetriever(
+                        programArguments, configuration, userLibDirectory);
+            }
+            if (jarFile != null) {
+                return new JarFilePackagedProgramRetriever(
+                        programArguments, configuration, userLibDirectory, jobClassName, jarFile);
+            }
+            return new ClassPathPackagedProgramRetriever(
+                    programArguments,
+                    configuration,
+                    userLibDirectory,
+                    jobClassName,
+                    jarsOnClassPath);
+        }
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetriever.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * A python based {@link PackagedProgramRetriever} which creates the {@link PackagedProgram} when
+ * program arguments contain "-py/--python" or "-pym/--pyModule".
+ */
+@Internal
+public class PythonBasedPackagedProgramRetriever extends AbstractPackagedProgramRetriever {
+
+    PythonBasedPackagedProgramRetriever(
+            String[] programArguments, Configuration configuration, @Nullable File userLibDirectory)
+            throws IOException {
+        super(programArguments, configuration, userLibDirectory);
+    }
+
+    @Override
+    public PackagedProgram buildPackagedProgram(PackagedProgram.Builder packagedProgramBuilder)
+            throws ProgramInvocationException {
+        // It is Python job if program arguments contain "-py/--python" or "-pym/--pyModule",
+        // set the fixed jobClassName and jarFile path.
+        return packagedProgramBuilder
+                .setJarFile(new File(PackagedProgramUtils.getPythonJar().getPath()))
+                .setEntryPointClassName(PackagedProgramUtils.getPythonDriverClassName())
+                .build();
+    }
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -646,7 +646,7 @@ public class PackagedProgram implements AutoCloseable {
 
         private String[] args = new String[0];
 
-        private List<URL> userClassPaths = Collections.emptyList();
+        private List<URL> userClasspaths = Collections.emptyList();
 
         private Configuration configuration = new Configuration();
 
@@ -657,8 +657,8 @@ public class PackagedProgram implements AutoCloseable {
             return this;
         }
 
-        public Builder setUserClassPaths(List<URL> userClassPaths) {
-            this.userClassPaths = userClassPaths;
+        public Builder setUserClasspaths(List<URL> userClasspaths) {
+            this.userClasspaths = userClasspaths;
             return this;
         }
 
@@ -690,7 +690,7 @@ public class PackagedProgram implements AutoCloseable {
             }
             return new PackagedProgram(
                     jarFile,
-                    userClassPaths,
+                    userClasspaths,
                     entryPointClassName,
                     configuration,
                     savepointRestoreSettings,

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -54,10 +54,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 public enum PackagedProgramUtils {
     ;
 
-    private static final String PYTHON_GATEWAY_CLASS_NAME =
+    public static final String PYTHON_GATEWAY_CLASS_NAME =
             "org.apache.flink.client.python.PythonGatewayServer";
 
-    private static final String PYTHON_DRIVER_CLASS_NAME =
+    public static final String PYTHON_DRIVER_CLASS_NAME =
             "org.apache.flink.client.python.PythonDriver";
 
     /**

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -476,7 +476,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
 
         final PackagedProgram program =
                 PackagedProgram.newBuilder()
-                        .setUserClassPaths(
+                        .setUserClasspaths(
                                 Collections.singletonList(
                                         new File(CliFrontendTestUtils.getTestJarPath())
                                                 .toURI()
@@ -722,7 +722,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
     private PackagedProgram getProgram(int noOfJobs) throws FlinkException {
         try {
             return PackagedProgram.newBuilder()
-                    .setUserClassPaths(
+                    .setUserClasspaths(
                             Collections.singletonList(
                                     new File(CliFrontendTestUtils.getTestJarPath())
                                             .toURI()

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ClasspathPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ClasspathPackagedProgramRetrieverTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.client.deployment.application;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetriever.JarsOnClassPath;
+import org.apache.flink.client.deployment.application.ClasspathPackagedProgramRetriever.JarsOnClasspath;
 import org.apache.flink.client.program.PackagedProgramRetriever;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.testjar.TestJob;
@@ -40,8 +40,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetriever.JarsOnClassPath.JAVA_CLASS_PATH;
-import static org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetriever.JarsOnClassPath.PATH_SEPARATOR;
+import static org.apache.flink.client.deployment.application.ClasspathPackagedProgramRetriever.JarsOnClasspath.JAVA_CLASSPATH;
+import static org.apache.flink.client.deployment.application.ClasspathPackagedProgramRetriever.JarsOnClasspath.PATH_SEPARATOR;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,11 +52,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-/** Tests for the {@link ClassPathPackagedProgramRetriever}. */
-public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrieverTestBase {
+/** Tests for the {@link ClasspathPackagedProgramRetriever}. */
+public class ClasspathPackagedProgramRetrieverTest extends PackagedProgramRetrieverTestBase {
 
     @Test
-    public void testJobGraphRetrievalFromClassPath()
+    public void testJobGraphRetrievalFromClasspath()
             throws IOException, FlinkException, ProgramInvocationException {
         final int parallelism = 42;
         final JobID jobId = new JobID();
@@ -81,7 +81,7 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
     }
 
     @Test
-    public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClassPath()
+    public void testJobGraphRetrievalJobClassNameHasPrecedenceOverClasspath()
             throws IOException, FlinkException, ProgramInvocationException {
         final File testJar = new File("non-existing");
 
@@ -90,7 +90,7 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
                         // Both a class name is specified and a JAR "is" on the class path
                         // The class name should have precedence.
                         .setJobClassName(TestJob.class.getCanonicalName())
-                        .setJarsOnClassPath(() -> Collections.singleton(testJar))
+                        .setJarsOnClasspath(() -> Collections.singleton(testJar))
                         .build();
 
         final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
@@ -104,7 +104,7 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
                         .setUserLibDirectory(userDirHasNotEntryClass)
-                        .setJarsOnClassPath(() -> Collections.singleton(testJar))
+                        .setJarsOnClasspath(() -> Collections.singleton(testJar))
                         .build();
         try {
             retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
@@ -124,7 +124,7 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
                 PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
                         .setUserLibDirectory(userDirHasNotEntryClass)
                         .setJobClassName(TestJobInfo.JOB_CLASS)
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
         try {
             retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
@@ -138,15 +138,15 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
     }
 
     @Test
-    public void testJarFromClassPathSupplier() throws IOException {
+    public void testJarFromClasspathSupplier() throws IOException {
         final File file1 = temporaryFolder.newFile();
         final File file2 = temporaryFolder.newFile();
         final File directory = temporaryFolder.newFolder();
 
         // Mock java.class.path property. The empty strings are important as the shell scripts
         // that prepare the Flink class path often have such entries.
-        final String classPath =
-                javaClassPath(
+        final String classpath =
+                javaClasspath(
                         "",
                         "",
                         "",
@@ -158,14 +158,14 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
                         "",
                         "");
 
-        Iterable<File> jarFiles = setClassPathAndGetJarsOnClassPath(classPath);
+        Iterable<File> jarFiles = setClasspathAndGetJarsOnClasspath(classpath);
 
         assertThat(jarFiles, contains(file1, file2));
     }
 
     @Test
-    public void testJarFromClassPathSupplierSanityCheck() {
-        Iterable<File> jarFiles = JarsOnClassPath.INSTANCE.get();
+    public void testJarFromClasspathSupplierSanityCheck() {
+        Iterable<File> jarFiles = JarsOnClasspath.INSTANCE.get();
 
         // Junit executes this test, so it should be returned as part of JARs on the class path
         assertThat(jarFiles, hasItem(hasProperty("name", containsString("junit"))));
@@ -182,26 +182,26 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
                         .setUserLibDirectory(userDirHasEntryClass)
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
-        testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
                         .setUserLibDirectory(userDirHasEntryClass)
                         .setJobClassName(TestJobInfo.JOB_CLASS)
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
-        testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test
@@ -219,19 +219,19 @@ public class ClassPathPackagedProgramRetrieverTest extends PackagedProgramRetrie
                         instanceof FlinkUserCodeClassLoaders.ParentFirstClassLoader);
     }
 
-    private static String javaClassPath(String... entries) {
+    private static String javaClasspath(String... entries) {
         String pathSeparator = System.getProperty(PATH_SEPARATOR);
         return String.join(pathSeparator, entries);
     }
 
-    private static Iterable<File> setClassPathAndGetJarsOnClassPath(String classPath) {
-        final String originalClassPath = System.getProperty(JAVA_CLASS_PATH);
+    private static Iterable<File> setClasspathAndGetJarsOnClasspath(String classpath) {
+        final String originalClasspath = System.getProperty(JAVA_CLASSPATH);
         try {
-            System.setProperty(JAVA_CLASS_PATH, classPath);
-            return JarsOnClassPath.INSTANCE.get();
+            System.setProperty(JAVA_CLASSPATH, classpath);
+            return JarsOnClasspath.INSTANCE.get();
         } finally {
             // Reset property
-            System.setProperty(JAVA_CLASS_PATH, originalClassPath);
+            System.setProperty(JAVA_CLASSPATH, originalClasspath);
         }
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetrieverTest.java
@@ -85,28 +85,28 @@ public class JarFilePackagedProgramRetrieverTest extends PackagedProgramRetrieve
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(
                                 PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
                         .setUserLibDirectory(userDirHasEntryClass)
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
-        testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(
                                 PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
                         .setUserLibDirectory(userDirHasEntryClass)
                         .setJobClassName(TestJob.class.getCanonicalName())
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
-        testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/JarFilePackagedProgramRetrieverTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.client.testjar.TestJob;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link JarFilePackagedProgramRetriever}. */
+public class JarFilePackagedProgramRetrieverTest extends PackagedProgramRetrieverTestBase {
+
+    @Test
+    public void testRetrieveFromJarFileWithoutUserLib()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
+                        .build();
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(jobGraph.getUserJars(), containsInAnyOrder(new Path(testJar.toURI())));
+        assertThat(jobGraph.getClasspaths().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testRetrieveFromJarFileWithUserLib()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .build();
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(
+                jobGraph.getUserJars(),
+                containsInAnyOrder(new org.apache.flink.core.fs.Path(testJar.toURI())));
+        assertThat(
+                jobGraph.getClasspaths().stream().map(URL::toString).collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_URLS.stream().map(URL::toString).toArray()));
+    }
+
+    @Test
+    public void testSavepointRestoreSettings()
+            throws FlinkException, IOException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
+                        .build();
+        testSavepointRestoreSettings(retrieverUnderTest);
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .setJarsOnClassPath(Collections::emptyList)
+                        .build();
+        testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(retrieverUnderTest);
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .setJobClassName(TestJob.class.getCanonicalName())
+                        .setJarsOnClassPath(Collections::emptyList)
+                        .build();
+        testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(retrieverUnderTest);
+    }
+
+    @Test
+    public void testGetPackagedProgramWithConfiguration() throws IOException, FlinkException {
+        final Configuration configuration = new Configuration();
+        configuration.setString(CoreOptions.CLASSLOADER_RESOLVE_ORDER, "parent-first");
+        configuration.setBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER, false);
+
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, configuration, testJar)
+                        .build();
+        assertTrue(
+                retrieverUnderTest.getPackagedProgram().getUserCodeClassLoader()
+                        instanceof FlinkUserCodeClassLoaders.ParentFirstClassLoader);
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapterTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.testjar.TestJob;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+
+import static org.apache.flink.client.program.PackagedProgramUtils.PYTHON_DRIVER_CLASS_NAME;
+import static org.apache.flink.client.program.PackagedProgramUtils.PYTHON_GATEWAY_CLASS_NAME;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link PackagedProgramRetrieverAdapter}. */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PackagedProgramUtils.class)
+public class PackagedProgramRetrieverAdapterTest extends TestLogger {
+
+    private static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
+    private static final Configuration CONFIGURATION = new Configuration();
+
+    @Test
+    public void testBuildClassPathPackagedProgramRetriever() throws IOException, FlinkException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
+                        .setJobClassName(TestJob.class.getCanonicalName())
+                        .build();
+        assertTrue(retrieverUnderTest instanceof ClassPathPackagedProgramRetriever);
+
+        final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
+        assertArrayEquals(PROGRAM_ARGUMENTS, packagedProgram.getArguments());
+        assertEquals(TestJob.class.getCanonicalName(), packagedProgram.getMainClassName());
+    }
+
+    @Test
+    public void testBuildJarFilePackagedProgramRetriever() throws IOException, FlinkException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(
+                                PROGRAM_ARGUMENTS, CONFIGURATION, TestJob.getTestJobJar())
+                        .build();
+        assertTrue(retrieverUnderTest instanceof JarFilePackagedProgramRetriever);
+
+        final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
+        assertArrayEquals(PROGRAM_ARGUMENTS, packagedProgram.getArguments());
+        assertEquals(
+                TestJob.getTestJobJar().getAbsoluteFile().toURI().toURL(),
+                packagedProgram.getJobJarAndDependencies().get(0));
+    }
+
+    @Test
+    public void testBuildPythonBasedPackagedProgramRetriever() throws IOException, FlinkException {
+        PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
+                        .setJobClassName(PYTHON_GATEWAY_CLASS_NAME)
+                        .build();
+        assertTrue(retrieverUnderTest instanceof PythonBasedPackagedProgramRetriever);
+
+        retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
+                        .setJobClassName(PYTHON_DRIVER_CLASS_NAME)
+                        .build();
+        assertTrue(retrieverUnderTest instanceof PythonBasedPackagedProgramRetriever);
+
+        final String[] pythonArguments = {"-py", "test.py"};
+        retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(pythonArguments, CONFIGURATION).build();
+        assertTrue(retrieverUnderTest instanceof PythonBasedPackagedProgramRetriever);
+
+        PowerMockito.mockStatic(PackagedProgramUtils.class);
+        PowerMockito.when(PackagedProgramUtils.getPythonJar())
+                .thenReturn(TestJob.getTestJobJar().getAbsoluteFile().toURI().toURL());
+
+        final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
+        assertArrayEquals(pythonArguments, packagedProgram.getArguments());
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapterTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverAdapterTest.java
@@ -49,12 +49,12 @@ public class PackagedProgramRetrieverAdapterTest extends TestLogger {
     private static final Configuration CONFIGURATION = new Configuration();
 
     @Test
-    public void testBuildClassPathPackagedProgramRetriever() throws IOException, FlinkException {
+    public void testBuildClasspathPackagedProgramRetriever() throws IOException, FlinkException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PROGRAM_ARGUMENTS, CONFIGURATION)
                         .setJobClassName(TestJob.class.getCanonicalName())
                         .build();
-        assertTrue(retrieverUnderTest instanceof ClassPathPackagedProgramRetriever);
+        assertTrue(retrieverUnderTest instanceof ClasspathPackagedProgramRetriever);
 
         final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
         assertArrayEquals(PROGRAM_ARGUMENTS, packagedProgram.getArguments());

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverTestBase.java
@@ -179,7 +179,7 @@ public abstract class PackagedProgramRetrieverTestBase extends TestLogger {
         assertEquals(jobGraph.getJobID(), jobId);
     }
 
-    protected void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(
+    protected void testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass(
             PackagedProgramRetriever retrieverUnderTest)
             throws IOException, FlinkException, ProgramInvocationException {
         final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
@@ -189,7 +189,7 @@ public abstract class PackagedProgramRetrieverTestBase extends TestLogger {
                 containsInAnyOrder(EXPECTED_URLS.stream().map(URL::toString).toArray()));
     }
 
-    protected void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(
+    protected void testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass(
             PackagedProgramRetriever retrieverUnderTest)
             throws IOException, FlinkException, ProgramInvocationException {
         final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PackagedProgramRetrieverTestBase.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.client.deployment.executors.PipelineExecutorUtils;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.client.testjar.TestJob;
+import org.apache.flink.client.testjar.TestJobInfo;
+import org.apache.flink.configuration.ConfigUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.PipelineOptionsInternal;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.FunctionUtils;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/** Abstract test base for the {@link PackagedProgramRetriever}. */
+public abstract class PackagedProgramRetrieverTestBase extends TestLogger {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @ClassRule public static final TemporaryFolder JOB_DIRS = new TemporaryFolder();
+
+    static final String[] PROGRAM_ARGUMENTS = {"--arg", "suffix"};
+
+    static final String[] PYTHON_ARGUMENTS = {"-py", "test.py"};
+
+    static final Configuration CONFIGURATION = new Configuration();
+
+    /*
+     * The directory structure used to test
+     *
+     * userDirHasEntryClass/
+     *                    |_jarWithEntryClass
+     *                    |_jarWithoutEntryClass
+     *                    |_textFile
+     *
+     * userDirHasNotEntryClass/
+     *                       |_jarWithoutEntryClass
+     *                       |_textFile
+     */
+
+    static final Collection<URL> EXPECTED_URLS = new ArrayList<>();
+
+    static File userDirHasEntryClass;
+
+    static File userDirHasNotEntryClass;
+
+    static File testJar;
+
+    @BeforeClass
+    public static void init() throws IOException {
+        final String textFileName = "test.txt";
+        final String userDirHasEntryClassName = "_test_user_dir_has_entry_class";
+        final String userDirHasNotEntryClassName = "_test_user_dir_has_not_entry_class";
+
+        userDirHasEntryClass = JOB_DIRS.newFolder(userDirHasEntryClassName);
+        userDirHasNotEntryClass = JOB_DIRS.newFolder(userDirHasNotEntryClassName);
+        testJar = TestJob.getTestJobJar();
+
+        final Path userJarPath =
+                userDirHasEntryClass.toPath().resolve(TestJobInfo.JOB_JAR_PATH.toFile().getName());
+        final Path userLibJarPath =
+                userDirHasEntryClass
+                        .toPath()
+                        .resolve(TestJobInfo.JOB_LIB_JAR_PATH.toFile().getName());
+
+        // create files
+        Files.copy(TestJobInfo.JOB_JAR_PATH, userJarPath);
+        Files.copy(TestJobInfo.JOB_LIB_JAR_PATH, userLibJarPath);
+
+        Files.createFile(userDirHasEntryClass.toPath().resolve(textFileName));
+        Files.copy(
+                TestJobInfo.JOB_LIB_JAR_PATH,
+                userDirHasNotEntryClass
+                        .toPath()
+                        .resolve(TestJobInfo.JOB_LIB_JAR_PATH.toFile().getName()));
+
+        Files.createFile(userDirHasNotEntryClass.toPath().resolve(textFileName));
+
+        final Path workingDirectory = FileUtils.getCurrentWorkingDirectory();
+        Stream.of(userJarPath, userLibJarPath)
+                .map(path -> FileUtils.relativizePath(workingDirectory, path))
+                .map(FunctionUtils.uncheckedFunction(FileUtils::toURL))
+                .forEach(EXPECTED_URLS::add);
+    }
+
+    @AfterClass
+    public static void clean() {
+        if (!EXPECTED_URLS.isEmpty()) {
+            EXPECTED_URLS.clear();
+        }
+    }
+
+    protected JobGraph retrieveJobGraph(
+            PackagedProgramRetriever retrieverUnderTest, Configuration configuration)
+            throws FlinkException, ProgramInvocationException, MalformedURLException {
+        final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
+
+        final int defaultParallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+        ConfigUtils.encodeCollectionToConfig(
+                configuration,
+                PipelineOptions.JARS,
+                packagedProgram.getJobJarAndDependencies(),
+                URL::toString);
+        ConfigUtils.encodeCollectionToConfig(
+                configuration,
+                PipelineOptions.CLASSPATHS,
+                packagedProgram.getClasspaths(),
+                URL::toString);
+
+        final Pipeline pipeline =
+                PackagedProgramUtils.getPipelineFromProgram(
+                        packagedProgram, configuration, defaultParallelism, false);
+        return PipelineExecutorUtils.getJobGraph(pipeline, configuration);
+    }
+
+    protected void testSavepointRestoreSettings(PackagedProgramRetriever retrieverUnderTest)
+            throws FlinkException, IOException, ProgramInvocationException {
+        final Configuration configuration = new Configuration();
+        final SavepointRestoreSettings savepointRestoreSettings =
+                SavepointRestoreSettings.forPath("foobar", true);
+        final JobID jobId = new JobID();
+
+        configuration.setString(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
+        SavepointRestoreSettings.toConfiguration(savepointRestoreSettings, configuration);
+
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, configuration);
+
+        assertThat(jobGraph.getSavepointRestoreSettings(), is(equalTo(savepointRestoreSettings)));
+        assertEquals(jobGraph.getJobID(), jobId);
+    }
+
+    protected void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(
+            PackagedProgramRetriever retrieverUnderTest)
+            throws IOException, FlinkException, ProgramInvocationException {
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(
+                jobGraph.getClasspaths().stream().map(URL::toString).collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_URLS.stream().map(URL::toString).toArray()));
+    }
+
+    protected void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(
+            PackagedProgramRetriever retrieverUnderTest)
+            throws IOException, FlinkException, ProgramInvocationException {
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(
+                jobGraph.getClasspaths().stream().map(URL::toString).collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_URLS.stream().map(URL::toString).toArray()));
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetrieverTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.operators.GenericDataSinkBase;
+import org.apache.flink.api.common.operators.GenericDataSourceBase;
+import org.apache.flink.api.common.operators.OperatorInformation;
+import org.apache.flink.api.common.operators.UnaryOperatorInformation;
+import org.apache.flink.api.common.operators.util.TestNonRichInputFormat;
+import org.apache.flink.api.common.operators.util.TestNonRichOutputFormat;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.client.testjar.TestJob;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.types.Nothing;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/** Tests for the {@link PythonBasedPackagedProgramRetriever}. */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PackagedProgramUtils.class)
+public class PythonBasedPackagedProgramRetrieverTest extends PackagedProgramRetrieverTestBase {
+
+    @BeforeClass
+    public static void init() throws FileNotFoundException {
+        testJar = TestJob.getTestJobJar();
+    }
+
+    @Test
+    public void testRetrieveFromPythonBasedWithoutUserLib()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
+                        .build();
+
+        mockGetPythonJar();
+        mockGetPipelineFromProgram();
+
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(jobGraph.getUserJars(), containsInAnyOrder(new Path(testJar.toURI())));
+        assertThat(jobGraph.getClasspaths().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testRetrieveFromPythonBasedWithUserLib()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .build();
+
+        mockGetPythonJar();
+        mockGetPipelineFromProgram();
+
+        final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, CONFIGURATION);
+
+        assertThat(jobGraph.getUserJars(), containsInAnyOrder(new Path(testJar.toURI())));
+        assertThat(
+                jobGraph.getClasspaths().stream().map(URL::toString).collect(Collectors.toList()),
+                containsInAnyOrder(EXPECTED_URLS.stream().map(URL::toString).toArray()));
+    }
+
+    @Test
+    public void testSavepointRestoreSettings()
+            throws FlinkException, IOException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
+                        .build();
+
+        mockGetPythonJar();
+        mockGetPipelineFromProgram();
+
+        testSavepointRestoreSettings(retrieverUnderTest);
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .setJarsOnClassPath(Collections::emptyList)
+                        .build();
+
+        mockGetPythonJar();
+        mockGetPipelineFromProgram();
+
+        testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(retrieverUnderTest);
+    }
+
+    @Test
+    public void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass()
+            throws IOException, FlinkException, ProgramInvocationException {
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
+                        .setUserLibDirectory(userDirHasEntryClass)
+                        .setJobClassName(TestJob.class.getCanonicalName())
+                        .setJarsOnClassPath(Collections::emptyList)
+                        .build();
+
+        mockGetPythonJar();
+        mockGetPipelineFromProgram();
+
+        testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(retrieverUnderTest);
+    }
+
+    @Test
+    public void testGetPackagedProgramWithConfiguration() throws IOException, FlinkException {
+        final Configuration configuration = new Configuration();
+        configuration.setString(CoreOptions.CLASSLOADER_RESOLVE_ORDER, "parent-first");
+        configuration.setBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER, false);
+
+        final PackagedProgramRetriever retrieverUnderTest =
+                PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, configuration, testJar)
+                        .build();
+
+        mockGetPythonJar();
+
+        assertTrue(
+                retrieverUnderTest.getPackagedProgram().getUserCodeClassLoader()
+                        instanceof FlinkUserCodeClassLoaders.ParentFirstClassLoader);
+    }
+
+    private void mockGetPythonJar() throws MalformedURLException {
+        mockStatic(PackagedProgramUtils.class);
+        when(PackagedProgramUtils.getPythonJar())
+                .thenReturn(testJar.getAbsoluteFile().toURI().toURL());
+    }
+
+    private void mockGetPipelineFromProgram() throws ProgramInvocationException {
+        final GenericDataSourceBase<String, TestNonRichInputFormat> source =
+                new GenericDataSourceBase<String, TestNonRichInputFormat>(
+                        new TestNonRichInputFormat(),
+                        new OperatorInformation<>(BasicTypeInfo.STRING_TYPE_INFO),
+                        "testSource");
+        final GenericDataSinkBase<String> sink =
+                new GenericDataSinkBase<>(
+                        new TestNonRichOutputFormat(),
+                        new UnaryOperatorInformation<>(
+                                BasicTypeInfo.STRING_TYPE_INFO,
+                                BasicTypeInfo.getInfoFor(Nothing.class)),
+                        "testSink");
+        sink.setInput(source);
+        final Plan plan = new Plan(sink, "testGetPipelineFromProgram");
+        plan.setExecutionConfig(new ExecutionConfig());
+        when(PackagedProgramUtils.getPipelineFromProgram(
+                        any(PackagedProgram.class),
+                        any(Configuration.class),
+                        anyInt(),
+                        anyBoolean()))
+                .thenReturn(plan);
+    }
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/PythonBasedPackagedProgramRetrieverTest.java
@@ -122,34 +122,34 @@ public class PythonBasedPackagedProgramRetrieverTest extends PackagedProgramRetr
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
                         .setUserLibDirectory(userDirHasEntryClass)
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
 
         mockGetPythonJar();
         mockGetPipelineFromProgram();
 
-        testRetrieveCorrectUserClassPathsWithoutSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithoutSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test
-    public void testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass()
+    public void testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass()
             throws IOException, FlinkException, ProgramInvocationException {
         final PackagedProgramRetriever retrieverUnderTest =
                 PackagedProgramRetrieverAdapter.newBuilder(PYTHON_ARGUMENTS, CONFIGURATION, testJar)
                         .setUserLibDirectory(userDirHasEntryClass)
                         .setJobClassName(TestJob.class.getCanonicalName())
-                        .setJarsOnClassPath(Collections::emptyList)
+                        .setJarsOnClasspath(Collections::emptyList)
                         .build();
 
         mockGetPythonJar();
         mockGetPipelineFromProgram();
 
-        testRetrieveCorrectUserClassPathsWithSpecifiedEntryClass(retrieverUnderTest);
+        testRetrieveCorrectUserClasspathsWithSpecifiedEntryClass(retrieverUnderTest);
     }
 
     @Test

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramTest.java
@@ -62,7 +62,7 @@ public class PackagedProgramTest {
     @Test
     public void testNotThrowExceptionWhenJarFileIsNull() throws Exception {
         PackagedProgram.newBuilder()
-                .setUserClassPaths(
+                .setUserClasspaths(
                         Collections.singletonList(
                                 new File(CliFrontendTestUtils.getTestJarPath()).toURI().toURL()))
                 .setEntryPointClassName(TEST_JAR_MAIN_CLASS);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramUtilsPipelineTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramUtilsPipelineTest.java
@@ -107,7 +107,7 @@ public class PackagedProgramUtilsPipelineTest {
 
         PackagedProgram packagedProgram =
                 PackagedProgram.newBuilder()
-                        .setUserClassPaths(userUrls)
+                        .setUserClasspaths(userUrls)
                         .setEntryPointClassName(testParameter.entryClass().getName())
                         .build();
 

--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/TestJob.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/TestJob.java
@@ -19,7 +19,7 @@
 package org.apache.flink.client.testjar;
 
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetrieverTest;
+import org.apache.flink.client.deployment.application.ClasspathPackagedProgramRetrieverTest;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import java.io.File;
 import java.io.FileNotFoundException;
 
-/** Test job which is used for {@link ClassPathPackagedProgramRetrieverTest}. */
+/** Test job which is used for {@link ClasspathPackagedProgramRetrieverTest}. */
 public class TestJob {
 
     public static void main(String[] args) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -448,7 +448,7 @@ public class ClassLoaderITCase extends TestLogger {
         final PackagedProgram childFirstProgram =
                 PackagedProgram.newBuilder()
                         .setJarFile(new File(CLASSLOADING_POLICY_JAR_PATH))
-                        .setUserClassPaths(
+                        .setUserClasspaths(
                                 Collections.singletonList(childResourceDir.toURI().toURL()))
                         .setConfiguration(childFirstConf)
                         .setArguments(testResourceName, childResourceDirName)
@@ -487,7 +487,7 @@ public class ClassLoaderITCase extends TestLogger {
         final PackagedProgram parentFirstProgram =
                 PackagedProgram.newBuilder()
                         .setJarFile(new File(CLASSLOADING_POLICY_JAR_PATH))
-                        .setUserClassPaths(
+                        .setUserClasspaths(
                                 Collections.singletonList(childResourceDir.toURI().toURL()))
                         .setConfiguration(parentFirstConf)
                         .setArguments(testResourceName, "test-classes")

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnApplicationClusterEntryPoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnApplicationClusterEntryPoint.java
@@ -21,7 +21,7 @@ package org.apache.flink.yarn.entrypoint;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.client.deployment.application.ApplicationClusterEntryPoint;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
-import org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetriever;
+import org.apache.flink.client.deployment.application.PackagedProgramRetrieverAdapter;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramRetriever;
 import org.apache.flink.configuration.Configuration;
@@ -113,7 +113,6 @@ public final class YarnApplicationClusterEntryPoint extends ApplicationClusterEn
 
     private static PackagedProgram getPackagedProgram(final Configuration configuration)
             throws IOException, FlinkException {
-
         final ApplicationConfiguration applicationConfiguration =
                 ApplicationConfiguration.fromConfiguration(configuration);
 
@@ -130,15 +129,13 @@ public final class YarnApplicationClusterEntryPoint extends ApplicationClusterEn
             final String[] programArguments,
             @Nullable final String jobClassName)
             throws IOException {
-
         final File userLibDir = YarnEntrypointUtils.getUsrLibDir(configuration).orElse(null);
         final File userApplicationJar = getUserApplicationJar(userLibDir, configuration);
-        final ClassPathPackagedProgramRetriever.Builder retrieverBuilder =
-                ClassPathPackagedProgramRetriever.newBuilder(programArguments)
-                        .setUserLibDirectory(userLibDir)
-                        .setJarFile(userApplicationJar)
-                        .setJobClassName(jobClassName);
-        return retrieverBuilder.build();
+        return PackagedProgramRetrieverAdapter.newBuilder(
+                        programArguments, configuration, userApplicationJar)
+                .setJobClassName(jobClassName)
+                .setUserLibDirectory(userLibDir)
+                .build();
     }
 
     private static File getUserApplicationJar(


### PR DESCRIPTION
## What is the purpose of the change

*Application mode uses `ClassPathPackagedProgramRetriever` to create the `PackagedProgram` which doesn't set the configuration. This causes some client configurations not take effect. `ClassPathPackagedProgramRetriever` should refactor to have separate classes for the Python-based PackagedProgram and the PackagedProgram with and without a jar.*

## Brief change log

  - *`ClassPathPackagedProgramRetriever` refactors to have separate implementations which are `PythonBasedPackagedProgramRetriever`, `JarFilePackagedProgramRetriever` and `ScanClassPathPackagedProgramRetriever`, which set the configuration to `PackagedProgram`.*
  - *`ApplicationClusterEntryPoint` gets the `PackagedProgramRetriever` with setting the configuration.*

## Verifying this change

  - *`ClassPathPackagedProgramRetrieverTest` adds the test case `testGetPackagedProgramWithConfiguration` to verify whether get the `PackagedProgram` with the specified configuration.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)