### PR TITLE
[FLINK-17401] [mesos] Configure mesos labels for taskmanagers

### DIFF
--- a/docs/layouts/shortcodes/generated/mesos_task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/mesos_task_manager_configuration.html
@@ -81,6 +81,12 @@
             <td>Optional value to define the TaskManager’s hostname. The pattern _TASK_ is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. _TASK_.flink-service.mesos) for name lookups.</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.labels</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>Labels to set on mesos tasks. It is a comma separated list of key value pairs, with each key value pair joined by colon. e.g. key1:value1,key2:value2 </td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.network.bandwidth</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -247,6 +247,13 @@ public class LaunchableMesosWorker implements LaunchableTask {
                     allocation.takeScalar("network", taskRequest.getNetworkMbps(), roles));
         }
 
+        // mesos task labels
+        Protos.Labels.Builder labels = taskInfo.getLabelsBuilder();
+        for (Map.Entry<String, String> entry : params.mesosLabels().entrySet()) {
+            labels.addLabels(
+                    Protos.Label.newBuilder().setKey(entry.getKey()).setValue(entry.getValue()));
+        }
+
         final Protos.CommandInfo.Builder cmd = taskInfo.getCommandBuilder();
         final Protos.Environment.Builder env = cmd.getEnvironmentBuilder();
         final StringBuilder jvmArgs = new StringBuilder();

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerDriverTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerDriverTest.java
@@ -436,7 +436,8 @@ public class MesosResourceManagerDriverTest
                     "",
                     Option.empty(),
                     Option.empty(),
-                    Collections.emptyList());
+                    Collections.emptyList(),
+                    Collections.emptyMap());
         }
 
         private AcceptOffers generateAcceptOffers(String taskIdStr) {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -30,7 +30,9 @@ import com.netflix.fenzo.plugins.HostAttrValueConstraint;
 import org.apache.mesos.Protos;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import scala.Option;
 
@@ -299,6 +301,17 @@ public class MesosTaskManagerParametersTest extends TestLogger {
                         .getTaskExecutorProcessSpec()
                         .getTotalProcessMemorySize(),
                 is(TOTAL_PROCESS_MEMORY_SIZE));
+    }
+
+    @Test
+    public void testMesosLabelsConfiguration() {
+        Map<String, String> expectedLabels = new HashMap<>();
+        expectedLabels.put("key1", "value1");
+        expectedLabels.put("key2", "value2");
+        Configuration conf = getConfiguration();
+        conf.setString("mesos.resourcemanager.tasks.labels", "key1:value1,key2:value2");
+        MesosTaskManagerParameters params = MesosTaskManagerParameters.create(conf);
+        assertEquals(expectedLabels, params.mesosLabels());
     }
 
     private static Configuration getConfiguration() {


### PR DESCRIPTION
Provide an option to configure mesos labels for taskmanagers running on mesos.
Mesos task labels can be used for different purposes such as monitoring, acl, etc.

## What is the purpose of the change

To provide an option for configuring mesos labels for taskmanagers running on mesos. Mesos lables are often useful regarding to mesos resource management (monitoring, acl, etc).
This PR is based on https://github.com/apache/flink/pull/11923, addressing the comments there.

## Brief change log

 - Add an new option "mesos.resourcemanager.tasks.labels"

## Verifying this change

This change added tests and can be verified as follows:

 - Add an unit test for parsing the new option

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
