### PR TITLE
[FLINK-21509][python] Add 'withProcessingTime()' method call when creating proctime slide window assigner in 'StreamExecPythonGroupWindowAggregate' class

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -216,7 +216,9 @@ public class StreamExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
             ValueLiteralExpression size = slidingWindow.size();
             ValueLiteralExpression slide = slidingWindow.slide();
             if (isProctimeAttribute(timeField) && hasTimeIntervalType(size)) {
-                windowAssiger = SlidingWindowAssigner.of(toDuration(size), toDuration(slide));
+                windowAssiger =
+                        SlidingWindowAssigner.of(toDuration(size), toDuration(slide))
+                                .withProcessingTime();
                 trigger = ProcessingTimeTriggers.afterEndOfWindow();
             } else if (isRowtimeAttribute(timeField) && hasTimeIntervalType(size)) {
                 windowAssiger = SlidingWindowAssigner.of(toDuration(size), toDuration(slide));


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds 'withProcessingTime()' method call when creating proctime slide window assigner in 'StreamExecPythonGroupWindowAggregate' class*


## Brief change log

  - *Add 'withProcessingTime()' method call when creating proctime slide window assigner in 'StreamExecPythonGroupWindowAggregate' class.*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
