### PR TITLE
[FLINK-21115][python] Add AggregatingState and corresponding StateDescriptor for Python DataStream API

### DIFF
--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -24,7 +24,8 @@ from typing import List, Tuple, Any, Dict
 from apache_beam.coders import PickleCoder
 
 from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
-    ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState
+    ListState, MapStateDescriptor, MapState, ReducingStateDescriptor, ReducingState, \
+    AggregatingStateDescriptor, AggregatingState
 from pyflink.datastream import TimeDomain, TimerService
 from pyflink.datastream.functions import RuntimeContext, ProcessFunction, KeyedProcessFunction
 from pyflink.fn_execution import flink_fn_execution_pb2, operation_utils
@@ -460,6 +461,11 @@ class InternalRuntimeContext(RuntimeContext):
     def get_reducing_state(self, state_descriptor: ReducingStateDescriptor) -> ReducingState:
         return self._keyed_state_backend.get_reducing_state(
             state_descriptor.get_name(), PickleCoder(), state_descriptor.get_reduce_function())
+
+    def get_aggregating_state(
+            self, state_descriptor: AggregatingStateDescriptor) -> AggregatingState:
+        return self._keyed_state_backend.get_aggregating_state(
+            state_descriptor.get_name(), PickleCoder(), state_descriptor.get_agg_function())
 
 
 class ProcessFunctionOperation(DataStreamStatelessFunctionOperation):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds AggregatingState and corresponding StateDescriptor for Python DataStream API*


## Brief change log

  - *Add AggregatingState and corresponding StateDescriptor for Python DataStream API*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
