### PR TITLE
[FLINK-21404][yarn][tests] Increase resource timeout 

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -134,6 +135,7 @@ public class YARNITCase extends YarnTestBase {
 
     private void deployPerJob(Configuration configuration, JobGraph jobGraph, boolean withDist)
             throws Exception {
+        jobGraph.setJobType(JobType.STREAMING);
         try (final YarnClusterDescriptor yarnClusterDescriptor =
                 withDist
                         ? createYarnClusterDescriptor(configuration)

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -125,6 +125,17 @@ public abstract class YarnTestBase extends TestLogger {
 
     /** These strings are white-listed, overriding the prohibited strings. */
     protected static final Pattern[] WHITELISTED_STRINGS = {
+        // happens if yarn does not support external resources
+        Pattern.compile(
+                "ClassNotFoundException: org.apache.hadoop.yarn.api.records.ResourceInformation"),
+        // occurs if a TM disconnects from a JM because it is no longer hosting any slots
+        Pattern.compile("has no more allocated slots for job"),
+        // can happen if another process hasn't fully started yet
+        Pattern.compile("akka.actor.ActorNotFound: Actor not found for"),
+        // can happen if another process hasn't fully started yet
+        Pattern.compile("RpcConnectionException: Could not connect to rpc endpoint under address"),
+        // rest handler whose registration is logged on DEBUG level
+        Pattern.compile("JobExceptionsHandler"),
         Pattern.compile("akka\\.remote\\.RemoteTransportExceptionNoStackTrace"),
         // workaround for annoying InterruptedException logging:
         // https://issues.apache.org/jira/browse/YARN-1022

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.Preconditions;
@@ -757,6 +758,8 @@ public abstract class YarnTestBase extends TestLogger {
 
             final String confDirPath = flinkConfDirPath.getParentFile().getAbsolutePath();
             globalConfiguration = GlobalConfiguration.loadConfiguration(confDirPath);
+            globalConfiguration.set(
+                    JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30));
 
             // copy conf dir to test temporary workspace location
             tempConfPathForSecureRun = tmp.newFolder("conf");


### PR DESCRIPTION
Yarn tends to be rather slot when it comes to starting task executors, so we increase the resource timeout to 30 seconds to increase the test stability.