### PR TITLE
[FLINK-21458][coordination] Add numRestarts metric 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.metrics.util;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
@@ -84,7 +85,7 @@ public class TestingMetricRegistry implements MetricRegistry {
                 (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
         private TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer =
                 (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
-        private ScopeFormats scopeFormats = null;
+        private ScopeFormats scopeFormats = ScopeFormats.fromConfig(new Configuration());
 
         private TestingMetricRegistryBuilder() {}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/TestingMetricRegistry.java
@@ -30,15 +30,15 @@ public class TestingMetricRegistry implements MetricRegistry {
 
     private final char delimiter;
     private final int numberReporters;
-    private final TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer;
-    private final TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer;
+    private final TriConsumer<Metric, String, AbstractMetricGroup<?>> registerConsumer;
+    private final TriConsumer<Metric, String, AbstractMetricGroup<?>> unregisterConsumer;
     private final ScopeFormats scopeFormats;
 
     private TestingMetricRegistry(
             char delimiter,
             int numberReporters,
-            TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer,
-            TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer,
+            TriConsumer<Metric, String, AbstractMetricGroup<?>> registerConsumer,
+            TriConsumer<Metric, String, AbstractMetricGroup<?>> unregisterConsumer,
             ScopeFormats scopeFormats) {
         this.delimiter = delimiter;
         this.numberReporters = numberReporters;
@@ -81,9 +81,9 @@ public class TestingMetricRegistry implements MetricRegistry {
 
         private char delimiter = '.';
         private int numberReporters = 0;
-        private TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer =
+        private TriConsumer<Metric, String, AbstractMetricGroup<?>> registerConsumer =
                 (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
-        private TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer =
+        private TriConsumer<Metric, String, AbstractMetricGroup<?>> unregisterConsumer =
                 (ignoreMetric, ignoreMetricName, ignoreGroup) -> {};
         private ScopeFormats scopeFormats = ScopeFormats.fromConfig(new Configuration());
 
@@ -100,13 +100,13 @@ public class TestingMetricRegistry implements MetricRegistry {
         }
 
         public TestingMetricRegistryBuilder setRegisterConsumer(
-                TriConsumer<Metric, String, AbstractMetricGroup> registerConsumer) {
+                TriConsumer<Metric, String, AbstractMetricGroup<?>> registerConsumer) {
             this.registerConsumer = registerConsumer;
             return this;
         }
 
         public TestingMetricRegistryBuilder setUnregisterConsumer(
-                TriConsumer<Metric, String, AbstractMetricGroup> unregisterConsumer) {
+                TriConsumer<Metric, String, AbstractMetricGroup<?>> unregisterConsumer) {
             this.unregisterConsumer = unregisterConsumer;
             return this;
         }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
@@ -166,6 +166,19 @@ public class ManuallyTriggeredScheduledExecutorService implements ScheduledExecu
     // Execution triggering and access to the queued tasks
     // ------------------------------------------------------------------------
 
+    /**
+     * Executes all runnable and scheduled non-periodic tasks until none are left to run. This is
+     * essentially a combination of {@link #triggerAll()} and {@link
+     * #triggerNonPeriodicScheduledTasks()} that allows making a test agnostic of how exactly a
+     * runnable is passed to the executor.
+     */
+    public void triggerAllNonPeriodicTasks() {
+        while (numQueuedRunnables() > 0 || !nonPeriodicScheduledTasks.isEmpty()) {
+            triggerAll();
+            triggerNonPeriodicScheduledTasks();
+        }
+    }
+
     /** Triggers all {@code queuedRunnables}. */
     public void triggerAll() {
         while (numQueuedRunnables() > 0) {


### PR DESCRIPTION
Adds the `numRestarts` metric to the adaptive scheduler. It effectively counts the number of times we have transitioned into the `Restarting` state.