### PR TITLE
[FLINK-21030][runtime] Backport of FLINK-21030 to release-1.12

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointScheduling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointScheduling.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+/**
+ * {@code CheckpointScheduling} provides methods for starting and stopping the periodic scheduling
+ * of checkpoints.
+ */
+public interface CheckpointScheduling {
+
+    /** Starts the periodic scheduling if possible. */
+    void startCheckpointScheduler();
+
+    /** Stops the periodic scheduling if possible. */
+    void stopCheckpointScheduler();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.stopwithsavepoint;
+
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.execution.ExecutionState;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@code StopWithSavepointTerminationHandler} handles the termination steps necessary for the
+ * stop-with-savepoint operation to finish. The order of the terminations matter:
+ *
+ * <ol>
+ *   <li>Creating a savepoint needs to be completed
+ *   <li>Waiting for the executions of the underlying job to finish
+ * </ol>
+ */
+public interface StopWithSavepointTerminationHandler {
+
+    /**
+     * Returns the a {@code CompletableFuture} referring to the result of the stop-with-savepoint
+     * operation.
+     *
+     * @return the {@code CompletableFuture} containing the path to the created savepoint in case of
+     *     success.
+     */
+    CompletableFuture<String> getSavepointPath();
+
+    /**
+     * Handles the result of a {@code CompletableFuture} holding a {@link CompletedCheckpoint}. Only
+     * one of the two parameters are allowed to be set.
+     *
+     * @param completedSavepoint the {@code CompletedCheckpoint} referring to the created savepoint
+     * @param throwable an error that was caught during savepoint creation
+     * @throws IllegalArgumentException if {@code throwable} and {@code completedSavepoint} are set
+     * @throws NullPointerException if none of the parameters is set
+     */
+    void handleSavepointCreation(
+            @Nullable CompletedCheckpoint completedSavepoint, @Nullable Throwable throwable);
+
+    /**
+     * Handles the termination of the job based on the passed terminated {@link ExecutionState
+     * ExecutionStates}. stop-with-savepoint expects the {@code terminatedExecutionStates} to only
+     * contain {@link ExecutionState#FINISHED} to succeed.
+     *
+     * @param terminatedExecutionStates The terminated {@code ExecutionStates} of the underlying
+     *     job.
+     * @throws NullPointerException if {@code null} is passed.
+     */
+    void handleExecutionsTermination(Collection<ExecutionState> terminatedExecutionStates);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandlerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandlerImpl.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.stopwithsavepoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.CheckpointScheduling;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@code StopWithSavepointTerminationHandlerImpl} implements {@link
+ * StopWithSavepointTerminationHandler}.
+ *
+ * <p>The operation only succeeds if both steps, the savepoint creation and the successful
+ * termination of the job, succeed. If the former step fails, the operation fails exceptionally
+ * without any further actions. If the latter one fails, a global fail-over is triggered before
+ * failing the operation.
+ *
+ * <p>The implementation expects the savepoint creation being completed before the executions
+ * terminate.
+ *
+ * @see StopWithSavepointTerminationManager
+ */
+public class StopWithSavepointTerminationHandlerImpl
+        implements StopWithSavepointTerminationHandler {
+
+    private final Logger log;
+
+    private final SchedulerNG scheduler;
+    private final CheckpointScheduling checkpointScheduling;
+    private final JobID jobId;
+
+    private final CompletableFuture<String> result = new CompletableFuture<>();
+
+    private State state = new WaitingForSavepoint();
+
+    public <S extends SchedulerNG & CheckpointScheduling> StopWithSavepointTerminationHandlerImpl(
+            JobID jobId, S schedulerWithCheckpointing, Logger log) {
+        this(jobId, schedulerWithCheckpointing, schedulerWithCheckpointing, log);
+    }
+
+    @VisibleForTesting
+    StopWithSavepointTerminationHandlerImpl(
+            JobID jobId,
+            SchedulerNG scheduler,
+            CheckpointScheduling checkpointScheduling,
+            Logger log) {
+        this.jobId = checkNotNull(jobId);
+        this.scheduler = checkNotNull(scheduler);
+        this.checkpointScheduling = checkNotNull(checkpointScheduling);
+        this.log = checkNotNull(log);
+    }
+
+    @Override
+    public CompletableFuture<String> getSavepointPath() {
+        return result;
+    }
+
+    @Override
+    public void handleSavepointCreation(
+            CompletedCheckpoint completedSavepoint, Throwable throwable) {
+        if (throwable != null) {
+            checkArgument(
+                    completedSavepoint == null,
+                    "No savepoint should be provided if a throwable is passed.");
+            handleSavepointCreationFailure(throwable);
+        } else {
+            handleSavepointCreationSuccess(checkNotNull(completedSavepoint));
+        }
+    }
+
+    @Override
+    public void handleExecutionsTermination(Collection<ExecutionState> terminatedExecutionStates) {
+        final Set<ExecutionState> notFinishedExecutionStates =
+                checkNotNull(terminatedExecutionStates).stream()
+                        .filter(state -> state != ExecutionState.FINISHED)
+                        .collect(Collectors.toSet());
+
+        if (notFinishedExecutionStates.isEmpty()) {
+            handleExecutionsFinished();
+        } else {
+            handleAnyExecutionNotFinished(notFinishedExecutionStates);
+        }
+    }
+
+    private void handleSavepointCreationSuccess(CompletedCheckpoint completedCheckpoint) {
+        final State oldState = state;
+        state = state.onSavepointCreation(completedCheckpoint);
+
+        log.debug(
+                "Stop-with-savepoint transitioned from {} to {} on savepoint creation handling for job {}.",
+                oldState.getName(),
+                state.getName(),
+                jobId);
+    }
+
+    private void handleSavepointCreationFailure(Throwable throwable) {
+        final State oldState = state;
+        state = state.onSavepointCreationFailure(throwable);
+
+        log.debug(
+                "Stop-with-savepoint transitioned from {} to {} on savepoint creation failure handling for job {}.",
+                oldState.getName(),
+                state.getName(),
+                jobId);
+    }
+
+    private void handleExecutionsFinished() {
+        final State oldState = state;
+        state = state.onExecutionsFinished();
+
+        log.debug(
+                "Stop-with-savepoint transitioned from {} to {} on execution termination handling with all executions being finished for job {}.",
+                oldState.getName(),
+                state.getName(),
+                jobId);
+    }
+
+    private void handleAnyExecutionNotFinished(Set<ExecutionState> notFinishedExecutionStates) {
+        final State oldState = state;
+        state = state.onAnyExecutionNotFinished(notFinishedExecutionStates);
+
+        log.warn(
+                "Stop-with-savepoint transitioned from {} to {} on execution termination handling for job {} with some executions being in an not-finished state: {}",
+                oldState.getName(),
+                state.getName(),
+                jobId,
+                notFinishedExecutionStates);
+    }
+
+    /**
+     * Handles the termination of the {@code StopWithSavepointTerminationHandler} exceptionally
+     * after triggering a global job fail-over.
+     *
+     * @param unfinishedExecutionStates the unfinished states that caused the failure.
+     * @param savepointPath the path to the successfully created savepoint.
+     */
+    private void terminateExceptionallyWithGlobalFailover(
+            Iterable<ExecutionState> unfinishedExecutionStates, String savepointPath) {
+        String errorMessage =
+                String.format(
+                        "Inconsistent execution state after stopping with savepoint. At least one execution is still in one of the following states: %s. A global fail-over is triggered to recover the job %s.",
+                        StringUtils.join(unfinishedExecutionStates, ", "), jobId);
+        FlinkException inconsistentFinalStateException = new FlinkException(errorMessage);
+
+        log.warn(
+                "A savepoint was created at {} but the corresponding job {} didn't terminate successfully.",
+                savepointPath,
+                jobId,
+                inconsistentFinalStateException);
+
+        scheduler.handleGlobalFailure(inconsistentFinalStateException);
+
+        result.completeExceptionally(inconsistentFinalStateException);
+    }
+
+    /**
+     * Handles the termination of the {@code StopWithSavepointTerminationHandler} exceptionally
+     * without triggering a global job fail-over but restarting the checkpointing. It does restart
+     * the checkpoint scheduling.
+     *
+     * @param throwable the error that caused the exceptional termination.
+     */
+    private void terminateExceptionally(Throwable throwable) {
+        checkpointScheduling.startCheckpointScheduler();
+        result.completeExceptionally(throwable);
+    }
+
+    /**
+     * Handles the successful termination of the {@code StopWithSavepointTerminationHandler}.
+     *
+     * @param completedSavepoint the completed savepoint
+     */
+    private void terminateSuccessfully(CompletedCheckpoint completedSavepoint) {
+        result.complete(completedSavepoint.getExternalPointer());
+    }
+
+    private final class WaitingForSavepoint implements State {
+
+        @Override
+        public State onSavepointCreation(CompletedCheckpoint completedSavepoint) {
+            return new SavepointCreated(completedSavepoint);
+        }
+
+        @Override
+        public State onSavepointCreationFailure(Throwable throwable) {
+            terminateExceptionally(throwable);
+            return new FinalState();
+        }
+    }
+
+    private final class SavepointCreated implements State {
+
+        private final CompletedCheckpoint completedSavepoint;
+
+        private SavepointCreated(CompletedCheckpoint completedSavepoint) {
+            this.completedSavepoint = completedSavepoint;
+        }
+
+        @Override
+        public State onExecutionsFinished() {
+            terminateSuccessfully(completedSavepoint);
+            return new FinalState();
+        }
+
+        @Override
+        public State onAnyExecutionNotFinished(
+                Iterable<ExecutionState> notFinishedExecutionStates) {
+            terminateExceptionallyWithGlobalFailover(
+                    notFinishedExecutionStates, completedSavepoint.getExternalPointer());
+            return new FinalState();
+        }
+    }
+
+    private static final class FinalState implements State {
+
+        @Override
+        public State onExecutionsFinished() {
+            return this;
+        }
+
+        @Override
+        public State onAnyExecutionNotFinished(
+                Iterable<ExecutionState> notFinishedExecutionStates) {
+            return this;
+        }
+    }
+
+    private interface State {
+
+        default State onSavepointCreation(CompletedCheckpoint completedSavepoint) {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName()
+                            + " state does not support onSavepointCreation.");
+        }
+
+        default State onSavepointCreationFailure(Throwable throwable) {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName()
+                            + " state does not support onSavepointCreationFailure.");
+        }
+
+        default State onExecutionsFinished() {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName()
+                            + " state does not support onExecutionsFinished.");
+        }
+
+        default State onAnyExecutionNotFinished(
+                Iterable<ExecutionState> notFinishedExecutionStates) {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName()
+                            + " state does not support onAnyExecutionNotFinished.");
+        }
+
+        default String getName() {
+            return this.getClass().getSimpleName();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationManager.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.stopwithsavepoint;
+
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@code StopWithSavepointTerminationManager} fulfills the contract given by {@link
+ * StopWithSavepointTerminationHandler} to run the stop-with-savepoint steps in a specific order.
+ */
+public class StopWithSavepointTerminationManager {
+
+    private final StopWithSavepointTerminationHandler stopWithSavepointTerminationHandler;
+
+    public StopWithSavepointTerminationManager(
+            StopWithSavepointTerminationHandler stopWithSavepointTerminationHandler) {
+        this.stopWithSavepointTerminationHandler =
+                Preconditions.checkNotNull(stopWithSavepointTerminationHandler);
+    }
+
+    /**
+     * Enforces the correct completion order of the passed {@code CompletableFuture} instances in
+     * accordance to the contract of {@link StopWithSavepointTerminationHandler}.
+     *
+     * @param completedSavepointFuture The {@code CompletableFuture} of the savepoint creation step.
+     * @param terminatedExecutionStatesFuture The {@code CompletableFuture} of the termination step.
+     * @param mainThreadExecutor The executor the {@code StopWithSavepointTerminationHandler}
+     *     operations run on.
+     * @return A {@code CompletableFuture} containing the path to the created savepoint.
+     */
+    public CompletableFuture<String> stopWithSavepoint(
+            CompletableFuture<CompletedCheckpoint> completedSavepointFuture,
+            CompletableFuture<Collection<ExecutionState>> terminatedExecutionStatesFuture,
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        FutureUtils.assertNoException(
+                completedSavepointFuture
+                        // the completedSavepointFuture could also be completed by
+                        // CheckpointCanceller which doesn't run in the mainThreadExecutor
+                        .handleAsync(
+                                (completedSavepoint, throwable) -> {
+                                    stopWithSavepointTerminationHandler.handleSavepointCreation(
+                                            completedSavepoint, throwable);
+                                    return null;
+                                },
+                                mainThreadExecutor)
+                        .thenRun(
+                                () ->
+                                        FutureUtils.assertNoException(
+                                                // the execution termination has to run in a
+                                                // separate Runnable to disconnect it from any
+                                                // previous task failure handling
+                                                terminatedExecutionStatesFuture.thenAcceptAsync(
+                                                        stopWithSavepointTerminationHandler
+                                                                ::handleExecutionsTermination,
+                                                        mainThreadExecutor))));
+
+        return stopWithSavepointTerminationHandler.getSavepointPath();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointScheduling.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TestingCheckpointScheduling.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@code TestingCheckpointScheduling} is a basic testing implementation of {@link
+ * CheckpointScheduling} that provides a flag indicating whether checkpoint scheduling is enabled.
+ */
+public class TestingCheckpointScheduling implements CheckpointScheduling {
+
+    private final AtomicBoolean checkpointSchedulingEnabled;
+
+    public TestingCheckpointScheduling(boolean initialState) {
+        checkpointSchedulingEnabled = new AtomicBoolean(initialState);
+    }
+
+    @Override
+    public void startCheckpointScheduler() {
+        checkpointSchedulingEnabled.set(true);
+    }
+
+    @Override
+    public void stopCheckpointScheduler() {
+        checkpointSchedulingEnabled.set(false);
+    }
+
+    public boolean isEnabled() {
+        return checkpointSchedulingEnabled.get();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -76,6 +77,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.acknowledgePendingCheckpoint;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.enableCheckpointing;
@@ -442,6 +445,59 @@ public class DefaultSchedulerTest extends TestLogger {
                 testExecutionVertexOperations.getDeployedVertices();
         final ExecutionVertexID executionVertexId = new ExecutionVertexID(onlyJobVertex.getID(), 0);
         assertThat(deployedExecutionVertices, contains(executionVertexId, executionVertexId));
+    }
+
+    /**
+     * This test covers the use-case where a global fail-over is followed by a local task failure.
+     * It verifies (besides checking the expected deployments) that the assert in the global
+     * recovery handling of {@link SchedulerBase#restoreState} is not triggered due to version
+     * updates.
+     */
+    @Test
+    public void handleGlobalFailureWithLocalFailure() {
+        final JobGraph jobGraph = singleJobVertexJobGraph(2);
+        final JobVertex onlyJobVertex = getOnlyJobVertex(jobGraph);
+        enableCheckpointing(jobGraph);
+
+        final DefaultScheduler scheduler = createSchedulerAndStartScheduling(jobGraph);
+
+        final List<ExecutionAttemptID> attemptIds =
+                StreamSupport.stream(
+                                scheduler.requestJob().getAllExecutionVertices().spliterator(),
+                                false)
+                        .map(ArchivedExecutionVertex::getCurrentExecutionAttempt)
+                        .map(ArchivedExecution::getAttemptId)
+                        .collect(Collectors.toList());
+        final ExecutionAttemptID localFailureAttemptId = attemptIds.get(0);
+        scheduler.handleGlobalFailure(new Exception("global failure"));
+        // the local failure shouldn't affect the global fail-over
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(
+                        jobGraph.getJobID(),
+                        localFailureAttemptId,
+                        ExecutionState.FAILED,
+                        new Exception("local failure")));
+
+        for (ExecutionAttemptID attemptId : attemptIds) {
+            scheduler.updateTaskExecutionState(
+                    new TaskExecutionState(
+                            jobGraph.getJobID(), attemptId, ExecutionState.CANCELED));
+        }
+
+        taskRestartExecutor.triggerScheduledTasks();
+
+        final ExecutionVertexID executionVertexId0 =
+                new ExecutionVertexID(onlyJobVertex.getID(), 0);
+        final ExecutionVertexID executionVertexId1 =
+                new ExecutionVertexID(onlyJobVertex.getID(), 1);
+        assertThat(
+                "The execution vertices should be deployed in a specific order reflecting the scheduling start and the global fail-over afterwards.",
+                testExecutionVertexOperations.getDeployedVertices(),
+                contains(
+                        executionVertexId0,
+                        executionVertexId1,
+                        executionVertexId0,
+                        executionVertexId1));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandlerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationHandlerImplTest.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.stopwithsavepoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.runtime.checkpoint.CheckpointProperties;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.TestingCheckpointScheduling;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.TestingSchedulerNG;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.testutils.EmptyStreamStateHandle;
+import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * {@code StopWithSavepointTerminationHandlerImplTest} tests {@link
+ * StopWithSavepointTerminationHandlerImpl}.
+ */
+public class StopWithSavepointTerminationHandlerImplTest extends TestLogger {
+
+    private static final JobID JOB_ID = new JobID();
+
+    private final TestingCheckpointScheduling checkpointScheduling =
+            new TestingCheckpointScheduling(false);
+
+    private StopWithSavepointTerminationHandlerImpl createTestInstanceFailingOnGlobalFailOver() {
+        return createTestInstance(
+                throwableCausingGlobalFailOver -> fail("No global failover should be triggered."));
+    }
+
+    private StopWithSavepointTerminationHandlerImpl createTestInstance(
+            Consumer<Throwable> handleGlobalFailureConsumer) {
+        // checkpointing should be always stopped before initiating stop-with-savepoint
+        checkpointScheduling.stopCheckpointScheduler();
+
+        final SchedulerNG scheduler =
+                TestingSchedulerNG.newBuilder()
+                        .setHandleGlobalFailureConsumer(handleGlobalFailureConsumer)
+                        .build();
+        return new StopWithSavepointTerminationHandlerImpl(
+                JOB_ID, scheduler, checkpointScheduling, log);
+    }
+
+    @Test
+    public void testHappyPath() throws ExecutionException, InterruptedException {
+        final StopWithSavepointTerminationHandlerImpl testInstance =
+                createTestInstanceFailingOnGlobalFailOver();
+
+        final EmptyStreamStateHandle streamStateHandle = new EmptyStreamStateHandle();
+        final CompletedCheckpoint completedSavepoint = createCompletedSavepoint(streamStateHandle);
+        testInstance.handleSavepointCreation(completedSavepoint, null);
+        testInstance.handleExecutionsTermination(Collections.singleton(ExecutionState.FINISHED));
+
+        assertThat(
+                testInstance.getSavepointPath().get(), is(completedSavepoint.getExternalPointer()));
+
+        assertFalse(
+                "The savepoint should not have been discarded.", streamStateHandle.isDisposed());
+        assertFalse("Checkpoint scheduling should be disabled.", checkpointScheduling.isEnabled());
+    }
+
+    @Test
+    public void testSavepointCreationFailureWithoutExecutionTermination() {
+        // savepoint creation failure is handled as expected if no execution termination happens
+        assertSavepointCreationFailure(testInstance -> {});
+    }
+
+    @Test
+    public void testSavepointCreationFailureWithFailingExecutions() {
+        // no global fail-over is expected to be triggered by the stop-with-savepoint despite the
+        // execution failure
+        assertSavepointCreationFailure(
+                testInstance ->
+                        testInstance.handleExecutionsTermination(
+                                Collections.singletonList(ExecutionState.FAILED)));
+    }
+
+    @Test
+    public void testSavepointCreationFailureWithFinishingExecutions() {
+        // checkpoint scheduling should be still enabled despite the finished executions
+        assertSavepointCreationFailure(
+                testInstance ->
+                        testInstance.handleExecutionsTermination(
+                                Collections.singletonList(ExecutionState.FINISHED)));
+    }
+
+    public void assertSavepointCreationFailure(
+            Consumer<StopWithSavepointTerminationHandler> handleExecutionsTermination) {
+        final StopWithSavepointTerminationHandlerImpl testInstance =
+                createTestInstanceFailingOnGlobalFailOver();
+
+        final String expectedErrorMessage = "Expected exception during savepoint creation.";
+        testInstance.handleSavepointCreation(null, new Exception(expectedErrorMessage));
+        handleExecutionsTermination.accept(testInstance);
+
+        try {
+            testInstance.getSavepointPath().get();
+            fail("An ExecutionException is expected.");
+        } catch (Throwable e) {
+            final Optional<Throwable> actualException =
+                    ExceptionUtils.findThrowableWithMessage(e, expectedErrorMessage);
+            assertTrue(
+                    "An exception with the expected error message should have been thrown.",
+                    actualException.isPresent());
+        }
+
+        // the checkpoint scheduling should be enabled in case of failure
+        assertTrue("Checkpoint scheduling should be enabled.", checkpointScheduling.isEnabled());
+    }
+
+    @Test
+    public void testFailedTerminationHandling() throws ExecutionException, InterruptedException {
+        final CompletableFuture<Throwable> globalFailOverTriggered = new CompletableFuture<>();
+        final StopWithSavepointTerminationHandlerImpl testInstance =
+                createTestInstance(globalFailOverTriggered::complete);
+
+        final ExecutionState expectedNonFinishedState = ExecutionState.FAILED;
+        final String expectedErrorMessage =
+                String.format(
+                        "Inconsistent execution state after stopping with savepoint. At least one execution is still in one of the following states: %s. A global fail-over is triggered to recover the job %s.",
+                        expectedNonFinishedState, JOB_ID);
+
+        final EmptyStreamStateHandle streamStateHandle = new EmptyStreamStateHandle();
+        final CompletedCheckpoint completedSavepoint = createCompletedSavepoint(streamStateHandle);
+
+        testInstance.handleSavepointCreation(completedSavepoint, null);
+        testInstance.handleExecutionsTermination(
+                Collections.singletonList(expectedNonFinishedState));
+
+        try {
+            testInstance.getSavepointPath().get();
+            fail("An ExecutionException is expected.");
+        } catch (Throwable e) {
+            final Optional<FlinkException> actualFlinkException =
+                    ExceptionUtils.findThrowable(e, FlinkException.class);
+            assertTrue(
+                    "A FlinkException should have been thrown.", actualFlinkException.isPresent());
+            assertThat(
+                    actualFlinkException.get(),
+                    FlinkMatchers.containsMessage(expectedErrorMessage));
+        }
+
+        assertTrue("Global fail-over was not triggered.", globalFailOverTriggered.isDone());
+        assertThat(
+                globalFailOverTriggered.get(), FlinkMatchers.containsMessage(expectedErrorMessage));
+
+        assertFalse("Savepoint should not be discarded.", streamStateHandle.isDisposed());
+
+        assertFalse(
+                "Checkpoint scheduling should not be enabled in case of failure.",
+                checkpointScheduling.isEnabled());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInvalidExecutionTerminationCall() {
+        createTestInstanceFailingOnGlobalFailOver()
+                .handleExecutionsTermination(Collections.singletonList(ExecutionState.FINISHED));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSavepointCreationParameterBothNull() {
+        createTestInstanceFailingOnGlobalFailOver().handleSavepointCreation(null, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSavepointCreationParameterBothSet() {
+        createTestInstanceFailingOnGlobalFailOver()
+                .handleSavepointCreation(
+                        createCompletedSavepoint(new EmptyStreamStateHandle()),
+                        new Exception(
+                                "No exception should be passed if a savepoint is available."));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testExecutionTerminationWithNull() {
+        createTestInstanceFailingOnGlobalFailOver().handleExecutionsTermination(null);
+    }
+
+    private static CompletedCheckpoint createCompletedSavepoint(
+            StreamStateHandle streamStateHandle) {
+        return new CompletedCheckpoint(
+                JOB_ID,
+                0,
+                0L,
+                0L,
+                new HashMap<>(),
+                null,
+                CheckpointProperties.forSavepoint(true),
+                new TestCompletedCheckpointStorageLocation(streamStateHandle, "savepoint-path"));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/stopwithsavepoint/StopWithSavepointTerminationManagerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.stopwithsavepoint;
+
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.util.TestLogger;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@code StopWithSavepointTerminationManagerTest} tests that {@link
+ * StopWithSavepointTerminationManager} applies the correct order expected by {@link
+ * StopWithSavepointTerminationHandler} regardless of the completion of the provided {@code
+ * CompletableFutures}.
+ */
+public class StopWithSavepointTerminationManagerTest extends TestLogger {
+
+    @Test
+    public void testCompletionInCorrectOrder() {
+        assertCorrectOrderOfProcessing(
+                (completedSavepointFuture, terminatedExecutionStatesFuture) -> {
+                    completedSavepointFuture.complete(null);
+                    terminatedExecutionStatesFuture.complete(null);
+                });
+    }
+
+    @Test
+    public void testCompletionInInverseOrder() {
+        assertCorrectOrderOfProcessing(
+                (completedSavepointFuture, terminatedExecutionStatesFuture) -> {
+                    terminatedExecutionStatesFuture.complete(null);
+                    completedSavepointFuture.complete(null);
+                });
+    }
+
+    private void assertCorrectOrderOfProcessing(
+            BiConsumer<CompletableFuture<CompletedCheckpoint>, CompletableFuture<ExecutionState>>
+                    completion) {
+        final CompletableFuture<CompletedCheckpoint> completedSavepointFuture =
+                new CompletableFuture<>();
+        final CompletableFuture<ExecutionState> terminatedExecutionStateFuture =
+                new CompletableFuture<>();
+
+        final TestingStopWithSavepointTerminationHandler stopWithSavepointTerminationHandler =
+                new TestingStopWithSavepointTerminationHandler();
+        new StopWithSavepointTerminationManager(stopWithSavepointTerminationHandler)
+                .stopWithSavepoint(
+                        completedSavepointFuture,
+                        terminatedExecutionStateFuture.thenApply(Collections::singleton),
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        completion.accept(completedSavepointFuture, terminatedExecutionStateFuture);
+
+        assertThat(
+                stopWithSavepointTerminationHandler.getActualMethodCallOrder(),
+                CoreMatchers.is(
+                        Arrays.asList(
+                                MethodCall.SavepointCreationTermination,
+                                MethodCall.ExecutionTermination)));
+    }
+
+    private enum MethodCall {
+        SavepointCreationTermination,
+        ExecutionTermination
+    }
+
+    private static class TestingStopWithSavepointTerminationHandler
+            implements StopWithSavepointTerminationHandler {
+
+        private final List<MethodCall> methodCalls = new ArrayList<>(2);
+
+        @Override
+        public CompletableFuture<String> getSavepointPath() {
+            return FutureUtils.completedExceptionally(
+                    new Exception("The result is not relevant in this test."));
+        }
+
+        @Override
+        public void handleSavepointCreation(
+                CompletedCheckpoint completedSavepoint, Throwable throwable) {
+            methodCalls.add(MethodCall.SavepointCreationTermination);
+        }
+
+        @Override
+        public void handleExecutionsTermination(
+                Collection<ExecutionState> terminatedExecutionStates) {
+            methodCalls.add(MethodCall.ExecutionTermination);
+        }
+
+        public List<MethodCall> getActualMethodCallOrder() {
+            return methodCalls;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -173,6 +173,14 @@ public class SourceStreamTask<
     }
 
     @Override
+    protected void cleanUpInvoke() throws Exception {
+        if (isFailing()) {
+            interruptSourceThread(true);
+        }
+        super.cleanUpInvoke();
+    }
+
+    @Override
     protected void cancelTask() {
         cancelTask(true);
     }
@@ -196,14 +204,18 @@ public class SourceStreamTask<
                 mainOperator.cancel();
             }
         } finally {
-            if (sourceThread.isAlive()) {
-                if (interrupt) {
-                    sourceThread.interrupt();
-                }
-            } else if (!sourceThread.getCompletionFuture().isDone()) {
-                // source thread didn't start
-                sourceThread.getCompletionFuture().complete(null);
+            interruptSourceThread(interrupt);
+        }
+    }
+
+    private void interruptSourceThread(boolean interrupt) {
+        if (sourceThread.isAlive()) {
+            if (interrupt) {
+                sourceThread.interrupt();
             }
+        } else if (!sourceThread.getCompletionFuture().isDone()) {
+            // source thread didn't start
+            sourceThread.getCompletionFuture().complete(null);
         }
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterWithClientResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterWithClientResource.java
@@ -60,6 +60,7 @@ public class MiniClusterWithClientResource extends MiniClusterResource {
 
     @Override
     public void after() {
+        log.info("Finalization triggered: Cluster shutdown is going to be initiated.");
         TestStreamEnvironment.unsetAsContext();
         TestEnvironment.unsetAsContext();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -35,18 +35,31 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.RestClientConfiguration;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeStream;
@@ -65,6 +78,7 @@ import org.apache.flink.test.util.TestUtils;
 import org.apache.flink.testutils.EntropyInjectingTestFileSystem;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Description;
@@ -98,12 +112,15 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.concurrent.CompletableFuture.allOf;
+import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN;
 import static org.apache.flink.test.util.TestUtils.submitJobAndWaitForResult;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -539,6 +556,165 @@ public class SavepointITCase extends TestLogger {
         }
     }
 
+    @Test
+    public void testStopWithSavepointFailingInSnapshotCreation() throws Exception {
+        testStopWithFailingSourceInOnePipeline(
+                new SnapshotFailingInfiniteTestSource(),
+                folder.newFolder(),
+                // two restarts expected:
+                // 1. task failure restart
+                // 2. job failover triggered by the CheckpointFailureManager
+                2,
+                assertInSnapshotCreationFailure());
+    }
+
+    @Test
+    public void testStopWithSavepointFailingAfterSnapshotCreation() throws Exception {
+        testStopWithFailingSourceInOnePipeline(
+                new CancelFailingInfiniteTestSource(),
+                folder.newFolder(),
+                // two restarts expected:
+                // 1. task failure restart
+                // 2. job failover triggered by SchedulerBase.stopWithSavepoint
+                2,
+                assertAfterSnapshotCreationFailure());
+    }
+
+    private static BiConsumer<JobID, ExecutionException> assertAfterSnapshotCreationFailure() {
+        return (jobId, actualException) -> {
+            Optional<FlinkException> actualFlinkException =
+                    ExceptionUtils.findThrowable(actualException, FlinkException.class);
+            assertTrue(actualFlinkException.isPresent());
+            assertThat(
+                    actualFlinkException.get(),
+                    containsMessage(
+                            String.format(
+                                    "Inconsistent execution state after stopping with savepoint. At least one execution is still in one of the following states: FAILED. A global fail-over is triggered to recover the job %s.",
+                                    jobId)));
+        };
+    }
+
+    private static BiConsumer<JobID, ExecutionException> assertInSnapshotCreationFailure() {
+        return (ignored, actualException) -> {
+            Optional<CheckpointException> actualFailureCause =
+                    ExceptionUtils.findThrowable(actualException, CheckpointException.class);
+            assertTrue(actualFailureCause.isPresent());
+            assertThat(
+                    actualFailureCause.get().getCheckpointFailureReason(),
+                    is(CheckpointFailureReason.JOB_FAILOVER_REGION));
+        };
+    }
+
+    private static OneShotLatch failingPipelineLatch;
+    private static OneShotLatch succeedingPipelineLatch;
+
+    /**
+     * FLINK-21030
+     *
+     * <p>Tests the handling of a failure that happened while stopping an embarrassingly parallel
+     * job with a Savepoint. The test expects that the stopping action fails and all executions are
+     * in state {@code RUNNING} afterwards.
+     *
+     * @param failingSource the failing {@link SourceFunction} used in one of the two pipelines.
+     * @param expectedMaximumNumberOfRestarts the maximum number of restarts allowed by the restart
+     *     strategy.
+     * @param exceptionAssertion asserts the client-call exception to verify that the right error
+     *     was handled.
+     * @see SavepointITCase#failingPipelineLatch The latch used to trigger the successful start of
+     *     the later on failing pipeline.
+     * @see SavepointITCase#succeedingPipelineLatch The latch that triggers the successful start of
+     *     the succeeding pipeline.
+     * @throws Exception if an error occurred while running the test.
+     */
+    private static void testStopWithFailingSourceInOnePipeline(
+            InfiniteTestSource failingSource,
+            File savepointDir,
+            int expectedMaximumNumberOfRestarts,
+            BiConsumer<JobID, ExecutionException> exceptionAssertion)
+            throws Exception {
+        MiniClusterWithClientResource cluster =
+                new MiniClusterWithClientResource(
+                        new MiniClusterResourceConfiguration.Builder().build());
+
+        failingPipelineLatch = new OneShotLatch();
+        succeedingPipelineLatch = new OneShotLatch();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.getConfig()
+                .setRestartStrategy(
+                        RestartStrategies.fixedDelayRestart(expectedMaximumNumberOfRestarts, 0));
+        env.addSource(failingSource)
+                .name("Failing Source")
+                .map(
+                        value -> {
+                            failingPipelineLatch.trigger();
+                            return value;
+                        })
+                .addSink(new DiscardingSink<>());
+        env.addSource(new InfiniteTestSource())
+                .name("Succeeding Source")
+                .map(
+                        value -> {
+                            succeedingPipelineLatch.trigger();
+                            return value;
+                        })
+                .addSink(new DiscardingSink<>());
+
+        final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+
+        cluster.before();
+        try {
+            ClusterClient<?> client = cluster.getClusterClient();
+            client.submitJob(jobGraph).get();
+
+            // we need to wait for both pipelines to be in state RUNNING because that's the only
+            // state which allows creating a savepoint
+            failingPipelineLatch.await();
+            succeedingPipelineLatch.await();
+
+            try {
+                client.stopWithSavepoint(jobGraph.getJobID(), false, savepointDir.getAbsolutePath())
+                        .get();
+                fail("The future should fail exceptionally.");
+            } catch (ExecutionException e) {
+                exceptionAssertion.accept(jobGraph.getJobID(), e);
+            }
+
+            // access the REST endpoint of the cluster to determine the state of each
+            // ExecutionVertex
+            final RestClient restClient =
+                    new RestClient(
+                            RestClientConfiguration.fromConfiguration(
+                                    new UnmodifiableConfiguration(new Configuration())),
+                            TestingUtils.defaultExecutor());
+
+            final URI restAddress = cluster.getRestAddres();
+            final JobDetailsHeaders detailsHeaders = JobDetailsHeaders.getInstance();
+            final JobMessageParameters params = detailsHeaders.getUnresolvedMessageParameters();
+            params.jobPathParameter.resolve(jobGraph.getJobID());
+
+            CommonTestUtils.waitUntilCondition(
+                    () -> {
+                        JobDetailsInfo detailsInfo =
+                                restClient
+                                        .sendRequest(
+                                                restAddress.getHost(),
+                                                restAddress.getPort(),
+                                                detailsHeaders,
+                                                params,
+                                                EmptyRequestBody.getInstance())
+                                        .get();
+
+                        return detailsInfo.getJobVerticesPerState().get(ExecutionState.RUNNING)
+                                == 2;
+                    },
+                    Deadline.fromNow(Duration.ofSeconds(10)));
+        } finally {
+            cluster.after();
+        }
+    }
+
     /**
      * FLINK-5985
      *
@@ -747,6 +923,40 @@ public class SavepointITCase extends TestLogger {
 
         public static void suspendAll() {
             createdSources.forEach(InfiniteTestSource::suspend);
+        }
+    }
+
+    /**
+     * An {@link InfiniteTestSource} implementation that fails when cancel is called for the first
+     * time.
+     */
+    private static class CancelFailingInfiniteTestSource extends InfiniteTestSource {
+
+        private static volatile boolean cancelTriggered = false;
+
+        @Override
+        public void cancel() {
+            if (!cancelTriggered) {
+                cancelTriggered = true;
+                throw new RuntimeException("Expected RuntimeException after snapshot creation.");
+            }
+            super.cancel();
+        }
+    }
+
+    /** An {@link InfiniteTestSource} implementation that fails while creating a snapshot. */
+    private static class SnapshotFailingInfiniteTestSource extends InfiniteTestSource
+            implements CheckpointedFunction {
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            throw new Exception(
+                    "Expected Exception happened during snapshot creation within test source");
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            // all good here
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Applies FLINK-21030 related changes of PR #14847 to the `release-1.12` branch.

## Brief change log

I only skipped cherry-picking [6fd59e3](https://github.com/apache/flink/pull/14847/commits/6fd59e36dc41741ee4d40211d6ca87c9d5c05b5a) as it is based on some refactoring in `master` post-1.12

## Verifying this change

Rerun changed tests locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
