### PR TITLE
[FLINK-21518][tests] Fix testMinCheckpointPause instability

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -276,6 +276,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // will use a different thread to allow checkpoint triggering before exiting from
         // receiveAcknowledgeMessage
         ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        CheckpointCoordinator coordinator = null;
         try {
             int pause = 1000;
             JobVertexID jobVertexId = new JobVertexID();
@@ -291,7 +292,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             ExecutionVertex vertex = graph.getJobVertex(jobVertexId).getTaskVertices()[0];
             ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
 
-            CheckpointCoordinator coordinator =
+            coordinator =
                     new CheckpointCoordinatorBuilder()
                             .setTimer(new ScheduledExecutorServiceAdapter(executorService))
                             .setCheckpointCoordinatorConfiguration(
@@ -319,9 +320,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
                     TASK_MANAGER_LOCATION_INFO);
             Thread.sleep(pause / 2);
             assertEquals(0, coordinator.getNumberOfPendingCheckpoints());
-            Thread.sleep(pause);
-            assertEquals(1, coordinator.getNumberOfPendingCheckpoints());
+            // make sure that the 2nd request is eventually processed
+            while (coordinator.getNumberOfPendingCheckpoints() == 0) {
+                Thread.sleep(1);
+            }
         } finally {
+            if (coordinator != null) {
+                coordinator.shutdown();
+            }
             executorService.shutdownNow();
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

```
The instability is caused by last assertion depending on timing.
Solve by waiting on condition.

Another issue is that failure can cause RejectionExecutionException.
This is caused by shutting down executor (in tests finally block)
without shutting down CheckpointCoordinator.
Solve by shutting down CheckpointCoordinator first.
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
