### PR TITLE
[FLINK-20042][kinesis] Adding Kinesis Table API e2e test using the Java framework

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/KinesisPubsubClient.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/KinesisPubsubClient.java
@@ -23,10 +23,10 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.util.AWSUtil;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
@@ -120,7 +120,7 @@ public class KinesisPubsubClient {
 
     private static AmazonKinesis createClientWithCredentials(Properties props)
             throws AmazonClientException {
-        AWSCredentialsProvider credentialsProvider = new EnvironmentVariableCredentialsProvider();
+        AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(props);
         return AmazonKinesisClientBuilder.standard()
                 .withCredentials(credentialsProvider)
                 .withEndpointConfiguration(

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -53,6 +53,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-end-to-end-tests-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
@@ -64,6 +70,13 @@ under the License.
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.16.22</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 
@@ -93,6 +106,31 @@ under the License.
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.apache.flink</groupId>
+							<artifactId>flink-sql-connector-kinesis_${scala.binary.version}</artifactId>
+							<version>${project.version}</version>
+							<destFileName>sql-kinesis.jar</destFileName>
+							<type>jar</type>
+							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+						</artifactItem>
+					</artifactItems>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
+import org.apache.flink.streaming.kinesis.test.containers.KinesaliteContainer;
+import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.categories.TravisGroup1;
+import org.apache.flink.tests.util.flink.FlinkContainer;
+import org.apache.flink.tests.util.flink.SQLJobSubmission;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.SneakyThrows;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
+import org.testcontainers.containers.Network;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants.AWS_ENDPOINT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** End-to-end test for Kinesis Table API using Kinesalite. */
+@Category(value = {TravisGroup1.class})
+public class KinesisTableApiITCase {
+    private static final String ORDERS = "orders";
+    private static final String LARGE_ORDERS = "large_orders";
+
+    private final Path sqlConnectorKinesisJar = TestUtils.getResource(".*kinesis.jar");
+    private final Network network = Network.newNetwork();
+
+    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+
+    @Rule
+    public final KinesaliteContainer kinesalite = new KinesaliteContainer().withNetwork(network);
+
+    @Rule
+    public final FlinkContainer flink =
+            FlinkContainer.builder()
+                    .build()
+                    .withEnv("AWS_ACCESS_KEY_ID", "fakeid")
+                    .withEnv("AWS_SECRET_KEY", "fakekey")
+                    .withEnv("AWS_CBOR_DISABLE", "1")
+                    .withEnv(
+                            "FLINK_ENV_JAVA_OPTS",
+                            "-Dorg.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking")
+                    .withNetwork(network)
+                    .dependsOn(kinesalite);
+
+    @BeforeClass
+    public static void setUp() {
+        // Required for Kinesalite.
+        // Including shaded and non-shaded conf to support test running from Maven and IntelliJ
+        System.setProperty("com.amazonaws.sdk.disableCertChecking", "1");
+        System.setProperty("com.amazonaws.sdk.disableCbor", "1");
+        System.setProperty(
+                "org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCertChecking", "1");
+        System.setProperty("org.apache.flink.kinesis.shaded.com.amazonaws.sdk.disableCbor", "1");
+    }
+
+    @Test(timeout = 120_000)
+    public void testTableApiSourceAndSink() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(AWS_ENDPOINT, kinesalite.getEndpointUrl());
+
+        List<Order> smallOrders = ImmutableList.of(new Order("A", 5), new Order("B", 10));
+
+        // Large orders have a quantity > 10
+        List<Order> largeOrders =
+                ImmutableList.of(new Order("C", 15), new Order("D", 20), new Order("E", 25));
+
+        KinesisPubsubClient client = new KinesisPubsubClient(properties);
+        client.createTopic(ORDERS, 1, properties);
+        client.createTopic(LARGE_ORDERS, 1, properties);
+
+        smallOrders.forEach(order -> client.sendMessage(ORDERS, toJson(order)));
+        largeOrders.forEach(order -> client.sendMessage(ORDERS, toJson(order)));
+
+        executeSqlStatements(readSqlFile("filter-large-orders.sql"));
+
+        List<Order> result = readAllOrdersFromKinesis(client);
+        assertEquals(largeOrders.size(), result.size());
+        assertTrue(result.containsAll(largeOrders));
+    }
+
+    private List<Order> readAllOrdersFromKinesis(final KinesisPubsubClient client)
+            throws Exception {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(5));
+        List<Order> orders;
+        do {
+            Thread.sleep(1000);
+            orders =
+                    client.readAllMessages(LARGE_ORDERS).stream()
+                            .map(order -> fromJson(order, Order.class))
+                            .collect(Collectors.toList());
+        } while (deadline.hasTimeLeft() && orders.size() < 3);
+
+        return orders;
+    }
+
+    private List<String> readSqlFile(final String resourceName) throws Exception {
+        return Files.readAllLines(Paths.get(getClass().getResource(resourceName).toURI()));
+    }
+
+    private void executeSqlStatements(final List<String> sqlLines) throws Exception {
+        flink.submitSQLJob(
+                new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+                        .addJars(sqlConnectorKinesisJar)
+                        .build());
+    }
+
+    @SneakyThrows
+    private <T> String toJson(final T object) {
+        return new ObjectMapper().writeValueAsString(object);
+    }
+
+    @SneakyThrows
+    private <T> T fromJson(final String json, final Class<T> type) {
+        return new ObjectMapper().readValue(json, type);
+    }
+
+    /** Test data model class for sending and receiving records on Kinesis. */
+    @Data
+    @EqualsAndHashCode
+    public static class Order {
+        private final String code;
+        private final int quantity;
+    }
+}

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/containers/KinesaliteContainer.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/java/org/apache/flink/streaming/kinesis/test/containers/KinesaliteContainer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kinesis.test.containers;
+
+import org.testcontainers.containers.GenericContainer;
+
+/** A test Kinesis Data Streams container using Kinesalite. */
+public class KinesaliteContainer extends GenericContainer<KinesaliteContainer> {
+    public static final String INTER_CONTAINER_KINESALITE_ALIAS = "kinesalite";
+
+    private static final String IMAGE = "instructure/kinesalite:latest";
+    private static final int PORT = 4567;
+
+    public KinesaliteContainer() {
+        super(IMAGE);
+    }
+
+    @Override
+    protected void configure() {
+        withExposedPorts(PORT);
+        withNetworkAliases(INTER_CONTAINER_KINESALITE_ALIAS);
+        withCreateContainerCmdModifier(
+                cmd ->
+                        cmd.withEntrypoint(
+                                "/tini",
+                                "--",
+                                "/usr/src/app/node_modules/kinesalite/cli.js",
+                                "--path",
+                                "/var/lib/kinesalite",
+                                "--ssl"));
+    }
+
+    public String getEndpointUrl() {
+        return "https://" + getHost() + ":" + getMappedPort(PORT);
+    }
+}

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/resources/org/apache/flink/streaming/kinesis/test/filter-large-orders.sql
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/resources/org/apache/flink/streaming/kinesis/test/filter-large-orders.sql
@@ -1,3 +1,21 @@
+--/*
+-- * Licensed to the Apache Software Foundation (ASF) under one
+-- * or more contributor license agreements.  See the NOTICE file
+-- * distributed with this work for additional information
+-- * regarding copyright ownership.  The ASF licenses this file
+-- * to you under the Apache License, Version 2.0 (the
+-- * "License"); you may not use this file except in compliance
+-- * with the License.  You may obtain a copy of the License at
+-- *
+-- *     http://www.apache.org/licenses/LICENSE-2.0
+-- *
+-- * Unless required by applicable law or agreed to in writing, software
+-- * distributed under the License is distributed on an "AS IS" BASIS,
+-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- * See the License for the specific language governing permissions and
+-- * limitations under the License.
+-- */
+
 CREATE TABLE orders (
   `code` STRING,
   `quantity` BIGINT

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/resources/org/apache/flink/streaming/kinesis/test/filter-large-orders.sql
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/main/resources/org/apache/flink/streaming/kinesis/test/filter-large-orders.sql
@@ -1,0 +1,28 @@
+CREATE TABLE orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'kinesis',
+  'stream' = 'orders',
+  'aws.endpoint' = 'https://kinesalite:4567',
+  'scan.stream.initpos' = 'TRIM_HORIZON',
+  'scan.shard.discovery.intervalmillis' = '1000',
+  'scan.shard.adaptivereads' = 'true',
+  'format' = 'json'
+);
+
+CREATE TABLE large_orders (
+  `code` STRING,
+  `quantity` BIGINT
+) WITH (
+  'connector' = 'kinesis',
+  'stream' = 'large_orders',
+  'aws.region' = 'us-east-1',
+  'sink.producer.verify-certificate' = 'false',
+  'sink.producer.kinesis-port' = '4567',
+  'sink.producer.kinesis-endpoint' = 'kinesalite',
+  'sink.producer.aggregation-enabled' = 'false',
+  'format' = 'json'
+);
+
+INSERT INTO large_orders SELECT * FROM orders WHERE quantity > 10;


### PR DESCRIPTION
## What is the purpose of the change

Adding an end to end test for Kinesis Table API using Kinesalite.

## Brief change log

- Added a reusable `KinesaliteContainer`
- Added an `IT` test to execute SQL using Kinesis Table API source and sink, and verify the results

## Verifying this change

This change added tests and can be verified as follows:
- Running `mvn clean install` on `flink-streaming-kinesis-test`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (e2e test only)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
