### PR TITLE
[BP-1.12][FLINK-21515][tests] Fix testStopWithSavepointShouldNotInterruptTheSource

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -573,6 +573,7 @@ public class SourceStreamTaskTest {
     public void testStopWithSavepointShouldNotInterruptTheSource() throws Exception {
         long checkpointId = 1;
         WasInterruptedTestingSource interruptedTestingSource = new WasInterruptedTestingSource();
+        WasInterruptedTestingSource.reset();
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
                         .setupOutputForSingletonOperatorChain(
@@ -906,9 +907,6 @@ public class SourceStreamTaskTest {
 
         @Override
         public void run(SourceContext<String> ctx) throws Exception {
-            ALLOW_EXIT.reset();
-            WAS_INTERRUPTED.set(false);
-
             try {
                 while (running || !ALLOW_EXIT.isTriggered()) {
                     Thread.sleep(1);
@@ -925,6 +923,11 @@ public class SourceStreamTaskTest {
 
         public static boolean wasInterrupted() {
             return WAS_INTERRUPTED.get();
+        }
+
+        public static void reset() {
+            ALLOW_EXIT.reset();
+            WAS_INTERRUPTED.set(false);
         }
 
         public static void allowExit() {


### PR DESCRIPTION
## What is the purpose of the change

**Backport of #15038 to 1.12.**

```
SourceStreamTaskTest.testStopWithSavepointShouldNotInterruptTheSource
is unstable because the latch  can be reset after triggering (while it`s
supposed to be reset before the test starts).
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
