### PR TITLE
[FLINK-20658][connectors/jdbc] Establish connection through driver with given name

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcOutputFormatTest.java
@@ -49,6 +49,7 @@ import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /** Tests for the {@link JdbcOutputFormat}. */
 public class JdbcOutputFormatTest extends JdbcDataTestBase {
@@ -91,6 +92,7 @@ public class JdbcOutputFormatTest extends JdbcDataTestBase {
                             .setQuery(String.format(INSERT_TEMPLATE, INPUT_TABLE))
                             .finish();
             jdbcOutputFormat.open(0, 1);
+            fail("expect exception");
         } catch (Exception e) {
             assertTrue(findThrowable(e, IOException.class).isPresent());
             assertTrue(findThrowableWithMessage(e, expectedMsg).isPresent());

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/FakeDBUtils.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/FakeDBUtils.java
@@ -23,11 +23,14 @@ public class FakeDBUtils {
     public static final String URL_PREFIX = "jdbc:fake:";
 
     public static final String TEST_DB_URL = composeDBUrl("test");
+    public static final String TEST_DB_INVALID_URL = "jdbc:no-existing-driver:test";
 
     public static final String DRIVER1_CLASS_NAME =
             "org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver1";
     public static final String DRIVER2_CLASS_NAME =
             "org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver2";
+    public static final String DRIVER3_CLASS_NAME =
+            "org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver3";
 
     public static String composeDBUrl(String db) {
         return URL_PREFIX + db;

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/driver/FakeConnection3.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/driver/FakeConnection3.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.fakedb.driver;
+
+import java.util.Properties;
+
+/** Sql connection created by {@link FakeDriver3#connect(String, Properties)}. */
+public class FakeConnection3 extends FakeConnection {}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/driver/FakeDriver3.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/fakedb/driver/FakeDriver3.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.fakedb.driver;
+
+import org.apache.flink.connector.jdbc.fakedb.FakeDBUtils;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/** Yet another {@link Driver} for FakeDB. */
+public class FakeDriver3 implements Driver {
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        if (!acceptsURL(url)) {
+            return null;
+        }
+        return new FakeConnection3();
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return FakeDBUtils.acceptsUrl(url);
+    }
+
+    @Override
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        return new DriverPropertyInfo[0];
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/resources/META-INF/services/java.sql.Driver
+++ b/flink-connectors/flink-connector-jdbc/src/test/resources/META-INF/services/java.sql.Driver
@@ -15,3 +15,5 @@
 
 org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver1
 org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver2
+# Comment intentionally for unregistered driver
+# org.apache.flink.connector.jdbc.fakedb.driver.FakeDriver3


### PR DESCRIPTION
## What is the purpose of the change
Establish jdbc connection through driver with given name.

## Brief change log
* Establish jdb connection through driver with given name.


## Verifying this change
This change is already covered by existing tests:
* `SimpleJdbcConnectionProviderTest.testEstablishDriverConnection`(ignored previously)

This change added tests and can be verified as follows:
* `SimpleJdbcConnectionProviderTest.testEstablishUnregisteredDriverConnection`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
