### PR TITLE
[hotfix] [docs] Fix typo in learn-flink

### DIFF
--- a/docs/content.zh/docs/learn-flink/etl.md
+++ b/docs/content.zh/docs/learn-flink/etl.md
@@ -341,7 +341,7 @@ connected stream 也可以被用来实现流的关联。
 
 ### 示例
 
-在这个例子中，一个控制流是用来指定哪些词需要从 `datastreamOfWords` 里过滤掉的。 一个称为 `ControlFunction` 的 `RichCoFlatMapFunction` 作用于连接的流来实现这个功能。
+在这个例子中，一个控制流是用来指定哪些词需要从 `streamOfWords` 里过滤掉的。 一个称为 `ControlFunction` 的 `RichCoFlatMapFunction` 作用于连接的流来实现这个功能。
 
 ```java
 public static void main(String[] args) throws Exception {
@@ -356,7 +356,7 @@ public static void main(String[] args) throws Exception {
         .keyBy(x -> x);
   
     control
-        .connect(datastreamOfWords)
+        .connect(streamOfWords)
         .flatMap(new ControlFunction())
         .print();
 
@@ -397,7 +397,7 @@ public static class ControlFunction extends RichCoFlatMapFunction<String, String
 
 布尔变量 `blocked` 被用于记录在数据流 `control` 中出现过的键（在这个例子中是单词），并且这些单词从 `streamOfWords` 过滤掉。这是 _keyed_ state，并且它是被两个流共享的，这也是为什么两个流必须有相同的键值空间。
 
-在 Flink 运行时中，`flatMap1` 和 `flatMap2` 在连接流有新元素到来时被调用 —— 在我们的例子中，`control` 流中的元素会进入 `flatMap1`，`streamOfWords` 中的元素会进入 `flatMap2`。这是由两个流连接的顺序决定的，本例中为 `control.connect(datastreamOfWords)`。
+在 Flink 运行时中，`flatMap1` 和 `flatMap2` 在连接流有新元素到来时被调用 —— 在我们的例子中，`control` 流中的元素会进入 `flatMap1`，`streamOfWords` 中的元素会进入 `flatMap2`。这是由两个流连接的顺序决定的，本例中为 `control.connect(streamOfWords)`。
 
 认识到你没法控制 `flatMap1` 和 `flatMap2` 的调用顺序是很重要的。这两个输入流是相互竞争的关系，Flink 运行时将根据从一个流或另一个流中消费的事件做它要做的。对于需要保证时间和/或顺序的场景，你会发现在 Flink 的管理状态中缓存事件一直到它们能够被处理是必须的。（注意：如果你真的感到绝望，可以使用自定义的算子实现 `InputSelectable` 接口，在两输入算子消费它的输入流时增加一些顺序上的限制。）
 

--- a/docs/content/docs/learn-flink/etl.md
+++ b/docs/content/docs/learn-flink/etl.md
@@ -428,7 +428,7 @@ public static void main(String[] args) throws Exception {
         .keyBy(x -> x);
   
     control
-        .connect(datastreamOfWords)
+        .connect(streamOfWords)
         .flatMap(new ControlFunction())
         .print();
 
@@ -473,7 +473,7 @@ The `blocked` Boolean is being used to remember the keys (words, in this case) t
 mentioned on the `control` stream, and those words are being filtered out of the `streamOfWords` stream. This is _keyed_ state, and it is shared between the two streams, which is why the two streams have to share the same keyspace.
 
 `flatMap1` and `flatMap2` are called by the Flink runtime with elements from each of the two
-connected streams -- in our case, elements from the `control` stream are passed into `flatMap1`, and elements from `streamOfWords` are passed into `flatMap2`. This was determined by the order in which the two streams are connected with `control.connect(datastreamOfWords)`. 
+connected streams -- in our case, elements from the `control` stream are passed into `flatMap1`, and elements from `streamOfWords` are passed into `flatMap2`. This was determined by the order in which the two streams are connected with `control.connect(streamOfWords)`. 
 
 It is important to recognize that you have no control over the order in which the `flatMap1` and `flatMap2` callbacks are called. These two input streams are racing against each other, and the Flink runtime will do what it wants to regarding consuming events from one stream or the other. In cases where timing and/or ordering matter, you may find it necessary to buffer events in managed Flink state until your application is ready to process them. (Note: if you are truly desperate, it is possible to exert some limited control over the order in which a two-input operator consumes its inputs by using a custom Operator that implements the `InputSelectable` interface.
 


### PR DESCRIPTION
## What is the purpose of the change
fix some typo errors to make the context consistent:
some are "streamOfWords" but some are "dataStreamOfWords"