### PR TITLE
[hotfix][state] Remove hardcoded backend class name check

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -349,7 +349,11 @@ public abstract class AbstractKeyedStateBackend<K>
     }
 
     // TODO remove this once heap-based timers are working with RocksDB incremental snapshots!
-    public boolean requiresLegacySynchronousTimerSnapshots(CheckpointType checkpointOptions) {
+    public boolean requiresLegacySynchronousTimerSnapshots(CheckpointType checkpointType) {
+        return false;
+    }
+
+    public boolean isStateImmutableInStateBackend(CheckpointType checkpointType) {
         return false;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -859,6 +859,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 && checkpointType == CheckpointType.CHECKPOINT;
     }
 
+    @Override
+    public boolean isStateImmutableInStateBackend(CheckpointType checkpointType) {
+        return !requiresLegacySynchronousTimerSnapshots(checkpointType);
+    }
+
     /** Rocks DB specific information about the k/v states. */
     public static class RocksDbKvStateInfo implements AutoCloseable {
         public final ColumnFamilyHandle columnFamilyHandle;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateConfigUtil.java
@@ -48,17 +48,8 @@ public class StateConfigUtil {
 
     public static boolean isStateImmutableInStateBackend(KeyedStateBackend<?> stateBackend) {
         // TODO: remove the hard code check once FLINK-21027 is supported
-        // state key and value is immutable only when using rocksdb state backend and timer
-        boolean isRocksDbState =
-                ROCKSDB_KEYED_STATE_BACKEND.equals(stateBackend.getClass().getCanonicalName());
-        boolean isHeapTimer = false;
-        if (stateBackend instanceof AbstractKeyedStateBackend) {
-            // currently, requiresLegacySynchronousTimerSnapshots()
-            // indicates the underlying uses heap-bsased timer
-            isHeapTimer =
-                    ((AbstractKeyedStateBackend<?>) stateBackend)
-                            .requiresLegacySynchronousTimerSnapshots(CheckpointType.CHECKPOINT);
-        }
-        return isRocksDbState && !isHeapTimer;
+        return (stateBackend instanceof AbstractKeyedStateBackend)
+                && ((AbstractKeyedStateBackend<?>) stateBackend)
+                        .isStateImmutableInStateBackend(CheckpointType.CHECKPOINT);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

A trivial refactoring to remove hardcoded class check.

## Verifying this change

Covered by existing `StateConfigUtilTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
