### PR TITLE
[FLINK-21477][table-planner-blink] Lookup joins now deal with intermediate table scans containing just the table source correctly

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -136,11 +136,9 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData> {
     /** the reference of temporal table to look up. */
     private final RelOptTable temporalTable;
     /** calc performed on rows of temporal table before join. */
-    private final @Nullable
-    RexProgram calcOnTemporalTable;
+    private final @Nullable RexProgram calcOnTemporalTable;
     /** join condition except equi-conditions extracted as lookup keys. */
-    private final @Nullable
-    RexNode joinCondition;
+    private final @Nullable RexNode joinCondition;
 
     protected CommonExecLookupJoin(
             FlinkJoinType joinType,
@@ -282,16 +280,16 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData> {
 
         LookupJoinCodeGenerator.GeneratedTableFunctionWithDataType<AsyncFunction<RowData, Object>>
                 generatedFuncWithType =
-                LookupJoinCodeGenerator.generateAsyncLookupFunction(
-                        config,
-                        dataTypeFactory,
-                        inputRowType,
-                        tableSourceRowType,
-                        resultRowType,
-                        allLookupKeys,
-                        LookupJoinUtil.getOrderedLookupKeys(allLookupKeys.keySet()),
-                        asyncLookupFunction,
-                        StringUtils.join(temporalTable.getQualifiedName(), "."));
+                        LookupJoinCodeGenerator.generateAsyncLookupFunction(
+                                config,
+                                dataTypeFactory,
+                                inputRowType,
+                                tableSourceRowType,
+                                resultRowType,
+                                allLookupKeys,
+                                LookupJoinUtil.getOrderedLookupKeys(allLookupKeys.keySet()),
+                                asyncLookupFunction,
+                                StringUtils.join(temporalTable.getQualifiedName(), "."));
 
         RowType rightRowType =
                 Optional.ofNullable(calcOnTemporalTable)
@@ -480,9 +478,9 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData> {
                     TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(
                             tableSource.getProducedDataType());
             if (!(tableSourceProducedType instanceof InternalTypeInfo
-                    && tableSourceProducedType
-                    .getTypeClass()
-                    .isAssignableFrom(RowData.class))
+                            && tableSourceProducedType
+                                    .getTypeClass()
+                                    .isAssignableFrom(RowData.class))
                     && !(tableSourceProducedType instanceof RowTypeInfo)) {
                 throw new TableException(
                         String.format(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
@@ -125,8 +125,7 @@ public final class LookupJoinUtil {
 
         if (temporalTable instanceof IntermediateRelTable) {
             return getLookupFunction(
-                    ((IntermediateRelTable) temporalTable).relNode().getTable(),
-                    lookupKeys);
+                    ((IntermediateRelTable) temporalTable).relNode().getTable(), lookupKeys);
         }
 
         throw new TableException(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
 import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.planner.plan.schema.IntermediateRelTable;
 import org.apache.flink.table.planner.plan.schema.LegacyTableSourceTable;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.runtime.connector.source.LookupRuntimeProviderContext;
@@ -121,6 +122,13 @@ public final class LookupJoinUtil {
                 return tableSource.getLookupFunction(lookupFieldNamesInOrder);
             }
         }
+
+        if (temporalTable instanceof IntermediateRelTable) {
+            return getLookupFunction(
+                    ((IntermediateRelTable) temporalTable).relNode().getTable(),
+                    lookupKeys);
+        }
+
         throw new TableException(
                 String.format(
                         "table %s is neither TableSourceTable not LegacyTableSourceTable",

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/common/CommonTemporalTableJoinRule.scala
@@ -19,16 +19,11 @@
 package org.apache.flink.table.planner.plan.rules.common
 
 import org.apache.flink.table.api.TableException
-import org.apache.flink.table.connector.source.LookupTableSource
-import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalRel, FlinkLogicalSnapshot, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalRel, FlinkLogicalSnapshot}
 import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysicalLookupJoin, StreamPhysicalTemporalJoin}
-import org.apache.flink.table.planner.plan.schema.{LegacyTableSourceTable, TableSourceTable, TimeIndicatorRelDataType}
-import org.apache.flink.table.sources.LookupableTableSource
+import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType
+import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil
 
-import org.apache.calcite.plan.hep.HepRelVertex
-import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.core.TableScan
-import org.apache.calcite.rel.logical.{LogicalProject, LogicalTableScan}
 import org.apache.calcite.rex.{RexCorrelVariable, RexFieldAccess}
 
 /**
@@ -64,61 +59,13 @@ trait CommonTemporalTableJoinRule {
       case _ => false
     }
 
-    val tableScan = getTableScan(snapshotInput)
+    val tableScan = TemporalJoinUtil.getTableScan(snapshotInput)
     val snapshotOnLookupSource = tableScan match {
-      case Some(scan) => isTableSourceScan(scan) && isLookupTableSource(scan)
+      case Some(scan) =>
+        TemporalJoinUtil.isTableSourceScan(scan) && TemporalJoinUtil.isLookupTableSource(scan)
       case _ => false
     }
 
     isProcessingTime && snapshotOnLookupSource
-  }
-
-  private def getTableScan(snapshotInput: RelNode): Option[TableScan] = {
-    snapshotInput match {
-      case tableScan: TableScan
-      => Some(tableScan)
-      // computed column on lookup table
-      case project: LogicalProject if trimHep(project.getInput).isInstanceOf[TableScan]
-      => Some(trimHep(project.getInput).asInstanceOf[TableScan])
-      case _ => None
-    }
-  }
-
-  private def isTableSourceScan(relNode: RelNode): Boolean = {
-    relNode match {
-      case r: LogicalTableScan =>
-        val table = r.getTable
-        table match {
-          case _: LegacyTableSourceTable[Any] | _: TableSourceTable => true
-          case _ => false
-        }
-      case _: FlinkLogicalLegacyTableSourceScan | _: FlinkLogicalTableSourceScan => true
-      case _ => false
-    }
-  }
-
-  private def isLookupTableSource(relNode: RelNode): Boolean = relNode match {
-    case scan: FlinkLogicalLegacyTableSourceScan =>
-      scan.tableSource.isInstanceOf[LookupableTableSource[_]]
-    case scan: FlinkLogicalTableSourceScan =>
-      scan.tableSource.isInstanceOf[LookupTableSource]
-    case scan: LogicalTableScan =>
-      scan.getTable match {
-        case table: LegacyTableSourceTable[_] =>
-          table.tableSource.isInstanceOf[LookupableTableSource[_]]
-        case table: TableSourceTable =>
-          table.tableSource.isInstanceOf[LookupTableSource]
-        case _ => false
-      }
-    case _ => false
-  }
-
-  /** Trim out the HepRelVertex wrapper and get current relational expression. */
-  protected def trimHep(node: RelNode): RelNode = {
-    node match {
-      case hepRelVertex: HepRelVertex =>
-        hepRelVertex.getCurrentRel
-      case _ => node
-    }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
@@ -18,14 +18,26 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.connector.source.LookupTableSource
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.{isProctimeIndicatorType, isRowtimeIndicatorType}
+import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
+import org.apache.flink.table.planner.plan.nodes.common.CommonIntermediateTableScan
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
+import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.planner.plan.nodes.physical.common.{CommonPhysicalLegacyTableSourceScan, CommonPhysicalTableSourceScan}
+import org.apache.flink.table.planner.plan.schema.{IntermediateRelTable, LegacyTableSourceTable, TableSourceTable}
+import org.apache.flink.table.sources.LookupableTableSource
 import org.apache.flink.util.Preconditions.checkState
 
-import org.apache.calcite.rel.core.JoinInfo
+import org.apache.calcite.plan.hep.HepRelVertex
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.{Calc, JoinInfo, Snapshot, TableScan}
+import org.apache.calcite.rel.logical.{LogicalProject, LogicalTableScan}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes}
 import org.apache.calcite.sql.{SqlFunction, SqlFunctionCategory, SqlKind}
+import org.apache.calcite.util.Util
 
 import scala.collection.JavaConversions._
 
@@ -327,6 +339,80 @@ object TemporalJoinUtil {
     //(LEFT_TIME_ATTRIBUTE, RIGHT_TIME_ATTRIBUTE, PRIMARY_KEY)
     rexCall.getOperator == TEMPORAL_JOIN_CONDITION &&
       (rexCall.operands.length == 2 || rexCall.operands.length == 3)
+  }
+
+  def trimHep(node: RelNode): RelNode = {
+    node match {
+      case hepRelVertex: HepRelVertex =>
+        hepRelVertex.getCurrentRel
+      case subset: RelSubset =>
+        Util.first(subset.getBest, subset.getOriginal)
+      case _ => node
+    }
+  }
+
+  /**
+   * Check whether a relNode is a [[TableScan]] contains [[TableSourceTable]].
+   */
+  @scala.annotation.tailrec
+  def isTableSourceScan(relNode: RelNode): Boolean = {
+    relNode match {
+      case r: LogicalTableScan =>
+        val table = r.getTable
+        table match {
+          case _: LegacyTableSourceTable[Any] | _: TableSourceTable => true
+          case intermediate: IntermediateRelTable => isTableSourceScan(intermediate.relNode)
+          case _ => false
+        }
+      case _: FlinkLogicalLegacyTableSourceScan | _: CommonPhysicalLegacyTableSourceScan |
+           _: FlinkLogicalTableSourceScan | _: CommonPhysicalTableSourceScan => true
+      case scan: CommonIntermediateTableScan =>
+        isTableSourceScan(scan.intermediateTable.relNode)
+      case _ => false
+    }
+  }
+
+  /**
+   * Check whether a relNode is [[LookupTableSource]].
+   */
+  @scala.annotation.tailrec
+  def isLookupTableSource(relNode: RelNode): Boolean = relNode match {
+    case scan: FlinkLogicalLegacyTableSourceScan =>
+      scan.tableSource.isInstanceOf[LookupableTableSource[_]]
+    case scan: CommonPhysicalLegacyTableSourceScan =>
+      scan.tableSource.isInstanceOf[LookupableTableSource[_]]
+    case scan: FlinkLogicalTableSourceScan =>
+      scan.tableSource.isInstanceOf[LookupTableSource]
+    case scan: CommonPhysicalTableSourceScan =>
+      scan.tableSource.isInstanceOf[LookupTableSource]
+    case scan: CommonIntermediateTableScan =>
+      isLookupTableSource(scan.intermediateTable.relNode)
+    case scan: LogicalTableScan =>
+      scan.getTable match {
+        case table: LegacyTableSourceTable[_] =>
+          table.tableSource.isInstanceOf[LookupableTableSource[_]]
+        case table: TableSourceTable =>
+          table.tableSource.isInstanceOf[LookupTableSource]
+        case intermediate: IntermediateRelTable => isLookupTableSource(intermediate.relNode)
+        case _ => false
+      }
+    case _ => false
+  }
+
+  /**
+   * Get [[TableScan]] under a [[Snapshot]].
+   */
+  @scala.annotation.tailrec
+  def getTableScan(snapshotInput: RelNode): Option[TableScan] = {
+    snapshotInput match {
+      case tableScan: TableScan => Some(tableScan)
+      // computed column on lookup table
+      case project: LogicalProject => getTableScan(trimHep(project.getInput))
+      case calc: Calc => getTableScan(trimHep(calc.getInput))
+      // watermark assigner on lookup table
+      case watermark: WatermarkAssigner => getTableScan(trimHep(watermark.getInput))
+      case _ => None
+    }
   }
 
   def validateTemporalFunctionCondition(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
@@ -408,9 +408,6 @@ object TemporalJoinUtil {
       case tableScan: TableScan => Some(tableScan)
       // computed column on lookup table
       case project: LogicalProject => getTableScan(trimHep(project.getInput))
-      case calc: Calc => getTableScan(trimHep(calc.getInput))
-      // watermark assigner on lookup table
-      case watermark: WatermarkAssigner => getTableScan(trimHep(watermark.getInput))
       case _ => None
     }
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/TemporalJoinUtil.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.connector.source.LookupTableSource
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory.{isProctimeIndicatorType, isRowtimeIndicatorType}
-import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner
 import org.apache.flink.table.planner.plan.nodes.common.CommonIntermediateTableScan
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalLegacyTableSourceScan, FlinkLogicalTableSourceScan}
@@ -32,7 +31,7 @@ import org.apache.flink.util.Preconditions.checkState
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.RelNode
-import org.apache.calcite.rel.core.{Calc, JoinInfo, Snapshot, TableScan}
+import org.apache.calcite.rel.core.{JoinInfo, Snapshot, TableScan}
 import org.apache.calcite.rel.logical.{LogicalProject, LogicalTableScan}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.{OperandTypes, ReturnTypes}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DagOptimizationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DagOptimizationTest.xml
@@ -671,23 +671,76 @@ LegacySink(name=[`default_catalog`.`default_database`.`sink2`], fields=[a, total
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleSink1">
+  <TestCase name="testSingleSinkWithUDTF">
     <Resource name="ast">
       <![CDATA[
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt])
-+- LogicalAggregate(group=[{0}], cnt=[COUNT($1)])
-   +- LogicalProject(c=[$2], a=[$0])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10], s=[$11])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10])
+      :  +- LogicalFilter(condition=[AND(=($1, $4), =($0, $6))])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalJoin(condition=[true], joinType=[inner])
+      :        :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
+      +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-LegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt])
-+- HashAggregate(isMerge=[true], groupBy=[c], select=[c, Final_COUNT(count$0) AS cnt])
-   +- Exchange(distribution=[hash[c]])
-      +- LocalHashAggregate(groupBy=[c], select=[c, Partial_COUNT(a) AS count$0])
-         +- Calc(select=[c, a])
-            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
++- Correlate(invocation=[split($cor0.c)], correlate=[table(split($cor0.c))], select=[a,b,c,d,e,f,i,j,k,l,m,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, INTEGER d, BIGINT e, VARCHAR(2147483647) f, INTEGER i, BIGINT j, INTEGER k, VARCHAR(2147483647) l, BIGINT m, VARCHAR(2147483647) f0)], joinType=[INNER])
+   +- HashJoin(joinType=[InnerJoin], where=[(a = i)], select=[a, b, c, d, e, f, i, j, k, l, m], build=[left])
+      :- Exchange(distribution=[hash[a]])
+      :  +- HashJoin(joinType=[InnerJoin], where=[(b = e)], select=[a, b, c, d, e, f], build=[right])
+      :     :- Exchange(distribution=[hash[b]])
+      :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      :     +- Exchange(distribution=[hash[e]])
+      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+      +- Exchange(distribution=[hash[i]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSameLookupTableWithMultipleLookupJoins">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[id, val])
++- LogicalProject(id=[$0], val=[$3])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+      :- LogicalProject(id=[$0], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, scanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, lookupTable]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[id, val])
++- LogicalProject(id=[$0], val=[$3])
+   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0, 1}])
+      :- LogicalProject(id=[$0], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, scanTable]])
+      +- LogicalFilter(condition=[=(+($cor1.id, 1), $0)])
+         +- LogicalSnapshot(period=[$cor1.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, lookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])(reuse_id=[1])
++- TableSourceScan(table=[[default_catalog, default_database, scanTable]], fields=[id])
+
+Sink(table=[default_catalog.default_database.sink1], fields=[id, val])
++- Calc(select=[id, val])
+   +- LookupJoin(table=[default_catalog.default_database.lookupTable], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[id, id0, val])
+      +- Calc(select=[id])
+         +- Reused(reference_id=[1])
+
+Sink(table=[default_catalog.default_database.sink2], fields=[id, val])
++- Calc(select=[id, val])
+   +- LookupJoin(table=[default_catalog.default_database.lookupTable], joinType=[InnerJoin], async=[false], lookup=[id=$f2], select=[id, $f2, id0, val])
+      +- Calc(select=[id, (id + 1) AS $f2])
+         +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>
@@ -817,38 +870,6 @@ LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleSinkWithUDTF">
-    <Resource name="ast">
-      <![CDATA[
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
-+- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10], s=[$11])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
-      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10])
-      :  +- LogicalFilter(condition=[AND(=($1, $4), =($0, $6))])
-      :     +- LogicalJoin(condition=[true], joinType=[inner])
-      :        :- LogicalJoin(condition=[true], joinType=[inner])
-      :        :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
-      :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
-      +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
-+- Correlate(invocation=[split($cor0.c)], correlate=[table(split($cor0.c))], select=[a,b,c,d,e,f,i,j,k,l,m,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, INTEGER d, BIGINT e, VARCHAR(2147483647) f, INTEGER i, BIGINT j, INTEGER k, VARCHAR(2147483647) l, BIGINT m, VARCHAR(2147483647) f0)], joinType=[INNER])
-   +- HashJoin(joinType=[InnerJoin], where=[(a = i)], select=[a, b, c, d, e, f, i, j, k, l, m], build=[left])
-      :- Exchange(distribution=[hash[a]])
-      :  +- HashJoin(joinType=[InnerJoin], where=[(b = e)], select=[a, b, c, d, e, f], build=[right])
-      :     :- Exchange(distribution=[hash[b]])
-      :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-      :     +- Exchange(distribution=[hash[e]])
-      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
-      +- Exchange(distribution=[hash[i]])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testSingleSinkSplitOnUnion">
     <Resource name="ast">
       <![CDATA[
@@ -873,6 +894,26 @@ LegacySink(name=[`default_catalog`.`default_database`.`sink`], fields=[total_sum
             :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
             +- Calc(select=[d AS a])
                +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSingleSink1">
+    <Resource name="ast">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt])
++- LogicalAggregate(group=[{0}], cnt=[COUNT($1)])
+   +- LogicalProject(c=[$2], a=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[c, cnt])
++- HashAggregate(isMerge=[true], groupBy=[c], select=[c, Final_COUNT(count$0) AS cnt])
+   +- Exchange(distribution=[hash[c]])
+      +- LocalHashAggregate(groupBy=[c], select=[c, Partial_COUNT(a) AS count$0])
+         +- Calc(select=[c, a])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DagOptimizationTest.xml
@@ -670,6 +670,79 @@ LegacySink(name=[`default_catalog`.`default_database`.`retractSink`], fields=[to
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSingleSinkWithUDTF">
+    <Resource name="ast">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10], s=[$11])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10])
+      :  +- LogicalFilter(condition=[AND(=($1, $4), =($0, $6))])
+      :     +- LogicalJoin(condition=[true], joinType=[inner])
+      :        :- LogicalJoin(condition=[true], joinType=[inner])
+      :        :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
+      :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
+      +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s], changelogMode=[NONE])
++- Correlate(invocation=[split($cor0.c)], correlate=[table(split($cor0.c))], select=[a,b,c,d,e,f,i,j,k,l,m,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, INTEGER d, BIGINT e, VARCHAR(2147483647) f, INTEGER i, BIGINT j, INTEGER k, VARCHAR(2147483647) l, BIGINT m, VARCHAR(2147483647) f0)], joinType=[INNER], changelogMode=[I])
+   +- Join(joinType=[InnerJoin], where=[=(a, i)], select=[a, b, c, d, e, f, i, j, k, l, m], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], changelogMode=[I])
+      :- Exchange(distribution=[hash[a]], changelogMode=[I])
+      :  +- Join(joinType=[InnerJoin], where=[=(b, e)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], changelogMode=[I])
+      :     :- Exchange(distribution=[hash[b]], changelogMode=[I])
+      :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I])
+      :     +- Exchange(distribution=[hash[e]], changelogMode=[I])
+      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f], changelogMode=[I])
+      +- Exchange(distribution=[hash[i]], changelogMode=[I])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSameLookupTableWithMultipleLookupJoins">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[id, val])
++- LogicalProject(id=[$0], val=[$3])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+      :- LogicalProject(id=[$0], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, scanTable]])
+      +- LogicalFilter(condition=[=($cor0.id, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, lookupTable]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[id, val])
++- LogicalProject(id=[$0], val=[$3])
+   +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0, 1}])
+      :- LogicalProject(id=[$0], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, scanTable]])
+      +- LogicalFilter(condition=[=(+($cor1.id, 1), $0)])
+         +- LogicalSnapshot(period=[$cor1.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, lookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, PROCTIME() AS proctime])(reuse_id=[1])
++- TableSourceScan(table=[[default_catalog, default_database, scanTable]], fields=[id])
+
+Sink(table=[default_catalog.default_database.sink1], fields=[id, val])
++- Calc(select=[id, val])
+   +- LookupJoin(table=[default_catalog.default_database.lookupTable], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[id, id0, val])
+      +- Calc(select=[id])
+         +- Reused(reference_id=[1])
+
+Sink(table=[default_catalog.default_database.sink2], fields=[id, val])
++- Calc(select=[id, val])
+   +- LookupJoin(table=[default_catalog.default_database.lookupTable], joinType=[InnerJoin], async=[false], lookup=[id=$f2], select=[id, $f2, id0, val])
+      +- Calc(select=[id, (id + 1) AS $f2])
+         +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSharedUnionNode">
     <Resource name="ast">
       <![CDATA[
@@ -907,38 +980,6 @@ LegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, 
                         +- Exchange(distribution=[hash[a2]], changelogMode=[I])
                            +- Calc(select=[a AS a2], where=[AND(>=(a, 0), >=(b, 5))], changelogMode=[I])
                               +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testSingleSinkWithUDTF">
-    <Resource name="ast">
-      <![CDATA[
-LogicalLegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s])
-+- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10], s=[$11])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
-      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5], i=[$6], j=[$7], k=[$8], l=[$9], m=[$10])
-      :  +- LogicalFilter(condition=[AND(=($1, $4), =($0, $6))])
-      :     +- LogicalJoin(condition=[true], joinType=[inner])
-      :        :- LogicalJoin(condition=[true], joinType=[inner])
-      :        :  :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-      :        :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]])
-      :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]])
-      +- LogicalTableFunctionScan(invocation=[split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-LegacySink(name=[`default_catalog`.`default_database`.`appendSink`], fields=[a, b, c, d, e, f, i, j, k, l, m, s], changelogMode=[NONE])
-+- Correlate(invocation=[split($cor0.c)], correlate=[table(split($cor0.c))], select=[a,b,c,d,e,f,i,j,k,l,m,f0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, INTEGER d, BIGINT e, VARCHAR(2147483647) f, INTEGER i, BIGINT j, INTEGER k, VARCHAR(2147483647) l, BIGINT m, VARCHAR(2147483647) f0)], joinType=[INNER], changelogMode=[I])
-   +- Join(joinType=[InnerJoin], where=[=(a, i)], select=[a, b, c, d, e, f, i, j, k, l, m], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], changelogMode=[I])
-      :- Exchange(distribution=[hash[a]], changelogMode=[I])
-      :  +- Join(joinType=[InnerJoin], where=[=(b, e)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], changelogMode=[I])
-      :     :- Exchange(distribution=[hash[b]], changelogMode=[I])
-      :     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I])
-      :     +- Exchange(distribution=[hash[e]], changelogMode=[I])
-      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(d, e, f)]]], fields=[d, e, f], changelogMode=[I])
-      +- Exchange(distribution=[hash[i]], changelogMode=[I])
-         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(i, j, k, l, m)]]], fields=[i, j, k, l, m], changelogMode=[I])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DagOptimizationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/DagOptimizationTest.scala
@@ -500,4 +500,76 @@ class DagOptimizationTest extends TableTestBase {
     util.verifyExecPlan(stmtSet)
   }
 
+  @Test
+  def testSameLookupTableWithMultipleLookupJoins(): Unit = {
+    // test case for FLINK-21477
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      RelNodeBlockPlanBuilder.TABLE_OPTIMIZER_REUSE_OPTIMIZE_BLOCK_WITH_DIGEST_ENABLED, true)
+
+    prepareTableForSameLookupTableTest()
+
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql(
+      """
+        |INSERT INTO sink1
+        |SELECT T.id, D.val FROM scanTable AS T
+        |JOIN lookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.id = D.id
+        |""".stripMargin
+    )
+    stmtSet.addInsertSql(
+      """
+        |INSERT INTO sink2
+        |SELECT T.id, D.val FROM scanTable AS T
+        |JOIN lookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+        |ON T.id + 1 = D.id
+        |""".stripMargin
+    )
+    util.verifyExecPlan(stmtSet)
+  }
+
+  private def prepareTableForSameLookupTableTest(): Unit = {
+    val scanTableDdl =
+      s"""
+         |CREATE TABLE scanTable (
+         |  id INT,
+         |  proctime AS PROCTIME()
+         |) WITH (
+         |  'connector' = 'values',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin
+    util.tableEnv.executeSql(scanTableDdl)
+    val lookupTableDdl =
+      s"""
+         |CREATE TABLE lookupTable (
+         |  id INT,
+         |  val INT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'bounded' = 'true'
+         |)
+         |""".stripMargin
+    util.tableEnv.executeSql(lookupTableDdl)
+    val sink1Ddl =
+      """
+        |CREATE TABLE sink1 (
+        |  id INT,
+        |  val INT
+        |) WITH (
+        |  'connector' = 'blackhole'
+        |)
+        |""".stripMargin
+    util.tableEnv.executeSql(sink1Ddl)
+    val sink2Ddl =
+      """
+        |CREATE TABLE sink2 (
+        |  id INT,
+        |  val INT
+        |) WITH (
+        |  'connector' = 'blackhole'
+        |)
+        |""".stripMargin
+    util.tableEnv.executeSql(sink2Ddl)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Lookup joins related rules and nodes currently does not deal with intermediate table scans. This might cause exceptions when the same lookup table is joined multiple times. This PR fixes this bug.

## Brief change log

 - Lookup joins now deal with intermediate table scans containing just the table source correctly

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
