### PR TITLE
[hotfix][runtime] Add job ID to RuntimeContext

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.jdbc.xa;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -62,6 +63,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -165,6 +167,11 @@ public abstract class JdbcXaSinkTestBase extends JdbcTestBase {
 
     static final RuntimeContext TEST_RUNTIME_CONTEXT =
             new RuntimeContext() {
+                @Override
+                public Optional<JobID> getJobId() {
+                    return Optional.of(new JobID());
+                }
+
                 @Override
                 public String getTaskName() {
                     return "test";

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -60,8 +60,8 @@ public interface RuntimeContext {
 
     /**
      * The ID of the current job. Empty if the execution happens outside of any job context (e.g.
-     * standalone collection executor). The returned ID should NOT be used for any job management
-     * tasks.
+     * standalone collection executor). Note that Job ID can change in particular upon manual
+     * restart. The returned ID should NOT be used for any job management tasks.
      */
     Optional<JobID> getJobId();
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.functions;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -42,6 +43,7 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -55,6 +57,13 @@ import java.util.Set;
  */
 @Public
 public interface RuntimeContext {
+
+    /**
+     * The ID of the current job. Empty if the execution happens outside of any job context (e.g.
+     * standalone collection executor). The returned ID should NOT be used for any job management
+     * tasks.
+     */
+    Optional<JobID> getJobId();
 
     /**
      * Returns the name of the task in which the UDF runs, as assigned during plan construction.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.functions.util;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
@@ -32,6 +33,7 @@ import org.apache.flink.util.SimpleUserCodeClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -112,6 +114,11 @@ public class RuntimeUDFContext extends AbstractRuntimeUDFContext {
                         "The broadcast variable with name '" + name + "' has not been set.");
             }
         }
+    }
+
+    @Override
+    public Optional<JobID> getJobId() {
+        return Optional.empty();
     }
 
     @Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.cep.operator;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -43,6 +44,7 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -61,6 +63,11 @@ class CepRuntimeContext implements RuntimeContext {
 
     CepRuntimeContext(final RuntimeContext runtimeContext) {
         this.runtimeContext = checkNotNull(runtimeContext);
+    }
+
+    @Override
+    public Optional<JobID> getJobId() {
+        return runtimeContext.getJobId();
     }
 
     @Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.state.api.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -48,6 +49,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -76,6 +78,11 @@ public final class SavepointRuntimeContext implements RuntimeContext {
         this.stateRegistrationAllowed = true;
 
         this.registeredDescriptors = new ArrayList<>();
+    }
+
+    @Override
+    public Optional<JobID> getJobId() {
+        return ctx.getJobId();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.iterative.task;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.aggregators.Aggregator;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 /** The abstract base class for all tasks able to participate in an iteration. */
@@ -192,7 +194,8 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
                 env.getDistributedCacheEntries(),
                 this.accumulatorMap,
                 metrics,
-                env.getExternalResourceInfoProvider());
+                env.getExternalResourceInfoProvider(),
+                env.getJobID());
     }
 
     // --------------------------------------------------------------------------------------------
@@ -399,7 +402,8 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
                 Map<String, Future<Path>> cpTasks,
                 Map<String, Accumulator<?, ?>> accumulatorMap,
                 MetricGroup metrics,
-                ExternalResourceInfoProvider externalResourceInfoProvider) {
+                ExternalResourceInfoProvider externalResourceInfoProvider,
+                JobID jobID) {
             super(
                     taskInfo,
                     userCodeClassLoader,
@@ -407,7 +411,8 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
                     cpTasks,
                     accumulatorMap,
                     metrics,
-                    externalResourceInfoProvider);
+                    externalResourceInfoProvider,
+                    jobID);
         }
 
         @Override
@@ -424,6 +429,11 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
         @SuppressWarnings("unchecked")
         public <T extends Value> T getPreviousIterationAggregate(String name) {
             return (T) getIterationAggregators().getPreviousGlobalAggregate(name);
+        }
+
+        @Override
+        public Optional<JobID> getJobId() {
+            return runtimeUdfContext.getJobId();
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -1144,7 +1144,8 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable
                 env.getDistributedCacheEntries(),
                 this.accumulatorMap,
                 metrics,
-                env.getExternalResourceInfoProvider());
+                env.getExternalResourceInfoProvider(),
+                env.getJobID());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -445,6 +445,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
                 getEnvironment()
                         .getMetricGroup()
                         .getOrAddOperator(getEnvironment().getTaskInfo().getTaskName()),
-                env.getExternalResourceInfoProvider());
+                env.getExternalResourceInfoProvider(),
+                env.getJobID());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -433,6 +433,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
                 env.getDistributedCacheEntries(),
                 env.getAccumulatorRegistry().getUserMap(),
                 getEnvironment().getMetricGroup().getOrAddOperator(sourceName),
-                env.getExternalResourceInfoProvider());
+                env.getExternalResourceInfoProvider(),
+                env.getJobID());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -91,7 +91,8 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
                             env.getDistributedCacheEntries(),
                             accumulatorMap,
                             metrics,
-                            env.getExternalResourceInfoProvider());
+                            env.getExternalResourceInfoProvider(),
+                            env.getJobID());
         }
 
         this.executionConfig = executionConfig;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
@@ -36,6 +37,7 @@ import org.apache.flink.util.UserCodeClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -47,6 +49,8 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
 
     private final ExternalResourceInfoProvider externalResourceInfoProvider;
 
+    private final JobID jobID;
+
     public DistributedRuntimeUDFContext(
             TaskInfo taskInfo,
             UserCodeClassLoader userCodeClassLoader,
@@ -54,10 +58,12 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
             Map<String, Future<Path>> cpTasks,
             Map<String, Accumulator<?, ?>> accumulators,
             MetricGroup metrics,
-            ExternalResourceInfoProvider externalResourceInfoProvider) {
+            ExternalResourceInfoProvider externalResourceInfoProvider,
+            JobID jobID) {
         super(taskInfo, userCodeClassLoader, executionConfig, accumulators, cpTasks, metrics);
         this.externalResourceInfoProvider =
                 Preconditions.checkNotNull(externalResourceInfoProvider);
+        this.jobID = jobID;
     }
 
     @Override
@@ -106,6 +112,11 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
             throw new IllegalArgumentException(
                     "The broadcast variable with name '" + name + "' has not been set.");
         }
+    }
+
+    @Override
+    public Optional<JobID> getJobId() {
+        return Optional.of(jobID);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.functions.async;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.DoubleCounter;
 import org.apache.flink.api.common.accumulators.Histogram;
@@ -49,6 +50,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -102,6 +104,11 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
 
         RichAsyncFunctionRuntimeContext(RuntimeContext context) {
             runtimeContext = Preconditions.checkNotNull(context);
+        }
+
+        @Override
+        public Optional<JobID> getJobId() {
+            return runtimeContext.getJobId();
         }
 
         @Override
@@ -289,6 +296,11 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         public <T extends Value> T getPreviousIterationAggregate(String name) {
             throw new UnsupportedOperationException(
                     "Iteration aggregators are not supported in rich async functions.");
+        }
+
+        @Override
+        public Optional<JobID> getJobId() {
+            return iterationRuntimeContext.getJobId();
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.externalresource.ExternalResourceInfo;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
@@ -51,6 +52,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -156,6 +158,11 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
      */
     public TaskManagerRuntimeInfo getTaskManagerRuntimeInfo() {
         return taskEnvironment.getTaskManagerInfo();
+    }
+
+    @Override
+    public Optional<JobID> getJobId() {
+        return Optional.of(taskEnvironment.getJobID());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.12.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.13.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.4.2</spotless.version>
 


### PR DESCRIPTION
## What is the purpose of the change

There are some [cases](http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/How-to-get-flink-JobId-in-runtime-td36756.html) when job ID needs to be accessed from the user code (function).
Existing workarounds doesn't look clean (reliable).

This PR adds `Optional<JobID>` to the `RuntimeContext` (the latter already contains some information of the same level, such as subtask index).

cc: @aljoscha, @StephanEwen 

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
