### PR TITLE
[FLINK-21086][runtime][checkpoint] Support checkpoint alignment with finished input channels

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
@@ -106,7 +106,8 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
             mainOperator.processElement(streamRecord);
         } else {
             mainOperator.endInput();
-            controller.allActionsCompleted();
+            controller.suspendDefaultAction();
+            mailboxProcessor.suspend();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
@@ -54,4 +54,11 @@ public interface NetworkClientHandler extends ChannelHandler {
      * @param inputChannel The input channel to resume data consumption.
      */
     void resumeConsumption(RemoteInputChannel inputChannel);
+
+    /**
+     * Acknowledges all user records are processed for this channel.
+     *
+     * @param inputChannel The input channel to resume data consumption.
+     */
+    void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -52,6 +52,9 @@ public interface NetworkSequenceViewReader {
     /** Resumes data consumption after an exactly once checkpoint. */
     void resumeConsumption();
 
+    /** Acknowledges all the user records are processed. */
+    void acknowledgeAllRecordsProcessed();
+
     /**
      * Checks whether this reader is available or not.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
@@ -57,6 +57,13 @@ public interface PartitionRequestClient {
     void resumeConsumption(RemoteInputChannel inputChannel);
 
     /**
+     * Acknowledges all user records are processed for this channel.
+     *
+     * @param inputChannel The input channel to resume data consumption.
+     */
+    void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel);
+
+    /**
      * Sends a task event backwards to an intermediate result partition.
      *
      * @param partitionId The identifier of result partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfUserRecordsEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfUserRecordsEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+
+/** This event marks a subpartition's user records as fully consumed. */
+public class EndOfUserRecordsEvent extends RuntimeEvent {
+
+    /** The singleton instance of this event. */
+    public static final EndOfUserRecordsEvent INSTANCE = new EndOfUserRecordsEvent();
+
+    // ------------------------------------------------------------------------
+
+    // not instantiable
+    private EndOfUserRecordsEvent() {}
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void write(DataOutputView out) throws IOException {}
+
+    @Override
+    public void read(DataInputView in) throws IOException {}
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public int hashCode() {
+        return 1965146684;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && obj.getClass() == EndOfUserRecordsEvent.class;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfUserRecordsEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/EndOfUserRecordsEvent.java
@@ -24,7 +24,15 @@ import org.apache.flink.runtime.event.RuntimeEvent;
 
 import java.io.IOException;
 
-/** This event marks a subpartition's user records as fully consumed. */
+/**
+ * This event indicates there will be no more data records in a subpartition. There still might be
+ * other events, in particular {@link CheckpointBarrier CheckpointBarriers} traveling. The {@link
+ * EndOfUserRecordsEvent} is acknowledged by the downstream task. That way we can safely assume the
+ * downstream task has consumed all the produced records and therefore we can perform a final
+ * checkpoint for the upstream task.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/x/mw-ZCQ">FLIP-147</a>
+ */
 public class EndOfUserRecordsEvent extends RuntimeEvent {
 
     /** The singleton instance of this event. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
+import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -68,6 +69,8 @@ public class EventSerializer {
 
     private static final int VIRTUAL_CHANNEL_SELECTOR_EVENT = 7;
 
+    private static final int END_OF_USER_RECORDS_EVENT = 8;
+
     private static final int CHECKPOINT_TYPE_CHECKPOINT = 0;
 
     private static final int CHECKPOINT_TYPE_SAVEPOINT = 1;
@@ -90,6 +93,8 @@ public class EventSerializer {
             return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_SUPERSTEP_EVENT});
         } else if (eventClass == EndOfChannelStateEvent.class) {
             return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_CHANNEL_STATE_EVENT});
+        } else if (eventClass == EndOfUserRecordsEvent.class) {
+            return ByteBuffer.wrap(new byte[] {0, 0, 0, END_OF_USER_RECORDS_EVENT});
         } else if (eventClass == CancelCheckpointMarker.class) {
             CancelCheckpointMarker marker = (CancelCheckpointMarker) event;
 
@@ -151,6 +156,8 @@ public class EventSerializer {
                 return EndOfSuperstepEvent.INSTANCE;
             } else if (type == END_OF_CHANNEL_STATE_EVENT) {
                 return EndOfChannelStateEvent.INSTANCE;
+            } else if (type == END_OF_USER_RECORDS_EVENT) {
+                return EndOfUserRecordsEvent.INSTANCE;
             } else if (type == CANCEL_CHECKPOINT_MARKER_EVENT) {
                 long id = buffer.getLong();
                 return new CancelCheckpointMarker(id);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A record-oriented runtime result writer API for producing results.
@@ -64,6 +65,18 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
 
     /** Writes the given {@link AbstractEvent} to all channels. */
     void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException;
+
+    /**
+     * Notifies the downstream tasks that this {@code ResultPartitionWriter} have emitted all the
+     * user records.
+     */
+    void notifyEndOfUserRecords() throws IOException;
+
+    /**
+     * Gets the future indicating whether all the records has been processed by the downstream
+     * tasks.
+     */
+    CompletableFuture<Void> getAllRecordsProcessedFuture();
 
     /** Sets the metric group for the {@link ResultPartitionWriter}. */
     void setMetricGroup(TaskIOMetricGroup metrics);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -106,6 +106,11 @@ class CreditBasedSequenceNumberingViewReader
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {
+        subpartitionView.acknowledgeAllRecordsProcessed();
+    }
+
+    @Override
     public void setRegisteredAsAvailable(boolean isRegisteredAvailable) {
         this.isRegisteredAsAvailable = isRegisteredAvailable;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -233,6 +233,9 @@ public abstract class NettyMessage {
                     case ResumeConsumption.ID:
                         decodedMsg = ResumeConsumption.readFrom(msg);
                         break;
+                    case AckAllUserRecordsProcessed.ID:
+                        decodedMsg = AckAllUserRecordsProcessed.readFrom(msg);
+                        break;
                     default:
                         throw new ProtocolException(
                                 "Received unknown message from producer: " + msg);
@@ -750,6 +753,38 @@ public abstract class NettyMessage {
         @Override
         public String toString() {
             return String.format("ResumeConsumption(%s)", receiverId);
+        }
+    }
+
+    static class AckAllUserRecordsProcessed extends NettyMessage {
+
+        private static final byte ID = 8;
+
+        final InputChannelID receiverId;
+
+        AckAllUserRecordsProcessed(InputChannelID receiverId) {
+            this.receiverId = receiverId;
+        }
+
+        @Override
+        void write(ChannelOutboundInvoker out, ChannelPromise promise, ByteBufAllocator allocator)
+                throws IOException {
+            writeToChannel(
+                    out,
+                    promise,
+                    allocator,
+                    receiverId::writeTo,
+                    ID,
+                    InputChannelID.getByteBufLength());
+        }
+
+        static AckAllUserRecordsProcessed readFrom(ByteBuf buffer) {
+            return new AckAllUserRecordsProcessed(InputChannelID.fromByteBuf(buffer));
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AckAllUserRecordsProcessed(%s)", receiverId);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -204,6 +204,11 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel) {
+        clientHandler.acknowledgeAllRecordsProcessed(inputChannel);
+    }
+
+    @Override
     public void close(RemoteInputChannel inputChannel) throws IOException {
 
         clientHandler.removeInputChannel(inputChannel);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -164,6 +164,20 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
         }
     }
 
+    void acknowledgeAllRecordsProcessed(InputChannelID receiverId) {
+        if (fatalError) {
+            return;
+        }
+
+        NetworkSequenceViewReader reader = allReaders.get(receiverId);
+        if (reader != null) {
+            reader.acknowledgeAllRecordsProcessed();
+        } else {
+            throw new IllegalStateException(
+                    "No reader for receiverId = " + receiverId + " exists.");
+        }
+    }
+
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object msg) throws Exception {
         // The user event triggered event loop callback is used for thread-safe

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -20,10 +20,13 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.AckAllUserRecordsProcessed;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.AddCredit;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.CancelPartitionRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.CloseRequest;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ResumeConsumption;
+import org.apache.flink.runtime.io.network.netty.NettyMessage.TaskEventRequest;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
@@ -33,9 +36,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandl
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.flink.runtime.io.network.netty.NettyMessage.PartitionRequest;
-import static org.apache.flink.runtime.io.network.netty.NettyMessage.TaskEventRequest;
 
 /** Channel handler to initiate data transfers and dispatch backwards flowing task events. */
 class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMessage> {
@@ -123,6 +123,10 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 
                 outboundQueue.addCreditOrResumeConsumption(
                         request.receiverId, NetworkSequenceViewReader::resumeConsumption);
+            } else if (msgClazz == AckAllUserRecordsProcessed.class) {
+                AckAllUserRecordsProcessed request = (AckAllUserRecordsProcessed) msg;
+
+                outboundQueue.acknowledgeAllRecordsProcessed(request.receiverId);
             } else {
                 LOG.warn("Received unexpected client request: {}", msg);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -153,6 +153,11 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {
+        throw new UnsupportedOperationException("Method should never be called.");
+    }
+
+    @Override
     public String toString() {
         return String.format(
                 "Blocking Subpartition Reader: ID=%s, index=%d",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -155,6 +155,11 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {
+        throw new UnsupportedOperationException("Method should never be called.");
+    }
+
+    @Override
     public boolean isAvailable(int numCreditsAvailable) {
         if (numCreditsAvailable > 0) {
             return nextBuffer != null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -43,6 +43,9 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
     public void resumeConsumption() {}
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {}
+
+    @Override
     public Throwable getFailureCause() {
         return null;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -357,6 +357,10 @@ public class PipelinedSubpartition extends ResultSubpartition
         }
     }
 
+    public void acknowledgeAllRecordsProcessed() {
+        parent.onSubpartitionAllRecordsProcessed(subpartitionInfo.getSubPartitionIdx());
+    }
+
     @Override
     public boolean isReleased() {
         return isReleased;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -80,6 +80,11 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {
+        parent.acknowledgeAllRecordsProcessed();
+    }
+
+    @Override
     public boolean isAvailable(int numCreditsAvailable) {
         return parent.isAvailable(numCreditsAvailable);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -190,6 +190,25 @@ public abstract class ResultPartition implements ResultPartitionWriter {
 
     // ------------------------------------------------------------------------
 
+    @Override
+    public void notifyEndOfUserRecords() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The subpartition notifies that the corresponding downstream task have processed all the user
+     * records.
+     *
+     * @see org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent
+     * @param subpartition The index of the subpartition sending the notification.
+     */
+    public void onSubpartitionAllRecordsProcessed(int subpartition) {}
+
     /**
      * Finishes the result partition.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -51,6 +51,8 @@ public interface ResultSubpartitionView {
 
     void resumeConsumption();
 
+    void acknowledgeAllRecordsProcessed();
+
     Throwable getFailureCause();
 
     boolean isAvailable(int numCreditsAvailable);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -203,6 +203,11 @@ class SortMergeSubpartitionReader
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() {
+        throw new UnsupportedOperationException("Method should never be called.");
+    }
+
+    @Override
     public Throwable getFailureCause() {
         synchronized (lock) {
             return failureCause;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -131,6 +131,12 @@ public abstract class InputChannel {
     public abstract void resumeConsumption() throws IOException;
 
     /**
+     * When received {@link org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent} from one
+     * channel, it need to acknowledge after this event get processed.
+     */
+    public abstract void acknowledgeAllRecordsProcessed() throws IOException;
+
+    /**
      * Notifies the owning {@link SingleInputGate} that this channel became non-empty.
      *
      * <p>This is guaranteed to be called only when a Buffer was added to a previously empty input

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -133,6 +133,9 @@ public abstract class InputGate
 
     public abstract void resumeConsumption(InputChannelInfo channelInfo) throws IOException;
 
+    public abstract void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo)
+            throws IOException;
+
     /** Returns the channel of this gate. */
     public abstract InputChannel getChannel(int channelIndex);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -280,6 +280,13 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         }
     }
 
+    @Override
+    public void acknowledgeAllRecordsProcessed() throws IOException {
+        checkState(!isReleased, "Channel released.");
+
+        subpartitionView.acknowledgeAllRecordsProcessed();
+    }
+
     // ------------------------------------------------------------------------
     // Task events
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -206,6 +206,16 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() throws IOException {
+        // We should not receive the EndOfUserRecordsEvent since it would
+        // turn into real channel before requesting partition. Besides,
+        // the event would not be persist in the unaligned checkpoint
+        // case, thus this also cannot happen during restoring state.
+        throw new UnsupportedOperationException(
+                "RecoveredInputChannel should not need acknowledge all records processed.");
+    }
+
+    @Override
     final void requestSubpartition(int subpartitionIndex) {
         throw new UnsupportedOperationException(
                 "RecoveredInputChannel should never request partition.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -362,6 +362,14 @@ public class RemoteInputChannel extends InputChannel {
         partitionRequestClient.resumeConsumption(this);
     }
 
+    @Override
+    public void acknowledgeAllRecordsProcessed() throws IOException {
+        checkState(!isReleased.get(), "Channel released.");
+        checkPartitionRequestQueueInitialized();
+
+        partitionRequestClient.acknowledgeAllRecordsProcessed(this);
+    }
+
     // ------------------------------------------------------------------------
     // Network I/O notifications (called by network I/O thread)
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -822,6 +822,12 @@ public class SingleInputGate extends IndexedInputGate {
         channels[channelInfo.getInputChannelIdx()].resumeConsumption();
     }
 
+    @Override
+    public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
+        checkState(!isFinished(), "InputGate already finished.");
+        channels[channelInfo.getInputChannelIdx()].acknowledgeAllRecordsProcessed();
+    }
+
     // ------------------------------------------------------------------------
     // Channel notifications
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -297,6 +297,13 @@ public class UnionInputGate extends InputGate {
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
+        inputGatesByGateIndex
+                .get(channelInfo.getGateIdx())
+                .acknowledgeAllRecordsProcessed(channelInfo);
+    }
+
+    @Override
     public void setup() {}
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -91,6 +91,12 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed() throws IOException {
+        throw new UnsupportedOperationException(
+                "UnknownInputChannel should not need acknowledge all records processed.");
+    }
+
+    @Override
     public void requestSubpartition(int subpartitionIndex) throws IOException {
         // Nothing to do here
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -149,6 +149,16 @@ public class ConsumableNotifyingResultPartitionWriterDecorator {
         }
 
         @Override
+        public void notifyEndOfUserRecords() throws IOException {
+            partitionWriter.notifyEndOfUserRecords();
+        }
+
+        @Override
+        public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+            return partitionWriter.getAllRecordsProcessedFuture();
+        }
+
+        @Override
         public void setMetricGroup(TaskIOMetricGroup metrics) {
             partitionWriter.setMetricGroup(metrics);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -61,6 +61,11 @@ public class InputGateWithMetrics extends IndexedInputGate {
     }
 
     @Override
+    public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
+        inputGate.acknowledgeAllRecordsProcessed(channelInfo);
+    }
+
+    @Override
     public int getNumberOfInputChannels() {
         return inputGate.getNumberOfInputChannels();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TestingPartitionRequestClient.java
@@ -42,6 +42,9 @@ public class TestingPartitionRequestClient implements PartitionRequestClient {
     public void resumeConsumption(RemoteInputChannel inputChannel) {}
 
     @Override
+    public void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel) {}
+
+    @Override
     public void sendTaskEvent(
             ResultPartitionID partitionId, TaskEvent event, RemoteInputChannel inputChannel) {}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
+import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -48,6 +49,7 @@ public class EventSerializerTest {
     private final AbstractEvent[] events = {
         EndOfPartitionEvent.INSTANCE,
         EndOfSuperstepEvent.INSTANCE,
+        EndOfUserRecordsEvent.INSTANCE,
         new CheckpointBarrier(
                 1678L,
                 4623784L,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -229,6 +229,9 @@ public class CancelPartitionRequestTest {
         public void resumeConsumption() {}
 
         @Override
+        public void acknowledgeAllRecordsProcessed() {}
+
+        @Override
         public boolean isAvailable(int numCreditsAvailable) {
             return true;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageServerSideSerializationTest.java
@@ -126,4 +126,13 @@ public class NettyMessageServerSideSerializationTest extends TestLogger {
 
         assertEquals(expected.receiverId, actual.receiverId);
     }
+
+    @Test
+    public void testAckAllUserRecordsProcessed() {
+        NettyMessage.AckAllUserRecordsProcessed expected =
+                new NettyMessage.AckAllUserRecordsProcessed(new InputChannelID());
+        NettyMessage.AckAllUserRecordsProcessed actual = encodeAndDecode(expected, channel);
+
+        assertEquals(expected.receiverId, actual.receiverId);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -61,6 +61,14 @@ public class MockResultPartitionWriter implements ResultPartitionWriter {
     public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {}
 
     @Override
+    public void notifyEndOfUserRecords() throws IOException {}
+
+    @Override
+    public CompletableFuture<Void> getAllRecordsProcessedFuture() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
     public ResultSubpartitionView createSubpartitionView(
             int index, BufferAvailabilityListener availabilityListener) throws IOException {
         throw new UnsupportedOperationException();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -136,6 +136,9 @@ public class InputChannelTest {
         public void resumeConsumption() {}
 
         @Override
+        public void acknowledgeAllRecordsProcessed() throws IOException {}
+
+        @Override
         void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {}
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -188,6 +189,11 @@ public class TestInputChannel extends InputChannel {
     @Override
     public void resumeConsumption() {
         isBlocked = false;
+    }
+
+    @Override
+    public void acknowledgeAllRecordsProcessed() throws IOException {
+        throw new UnsupportedEncodingException();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
@@ -74,7 +74,7 @@ abstract class AbstractAlternatingAlignedBarrierHandlerState implements BarrierH
         return finishCheckpoint();
     }
 
-    private BarrierHandlerState finishCheckpoint() throws IOException {
+    protected BarrierHandlerState finishCheckpoint() throws IOException {
         state.unblockAllChannels();
         return new AlternatingWaitingForFirstBarrier(state.emptyState());
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
@@ -19,10 +19,13 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 
 import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * We are performing aligned checkpoints with time out. We have seen at least a single aligned
@@ -46,6 +49,32 @@ final class AlternatingCollectingBarriers extends AbstractAlternatingAlignedBarr
         }
         controller.triggerGlobalCheckpoint(unalignedBarrier);
         return new AlternatingCollectingBarriersUnaligned(true, state);
+    }
+
+    @Override
+    public BarrierHandlerState endOfPartitionReceived(
+            Controller controller, InputChannelInfo channelInfo)
+            throws IOException, CheckpointException {
+        state.channelFinished(channelInfo);
+
+        CheckpointBarrier pendingCheckpointBarrier = controller.getPendingCheckpointBarrier();
+        checkState(
+                pendingCheckpointBarrier != null,
+                "At least one barrier received in collecting barrier state.");
+        checkState(
+                !pendingCheckpointBarrier.getCheckpointOptions().isUnalignedCheckpoint(),
+                "Pending checkpoint barrier should be aligned in "
+                        + "collecting aligned barrier state");
+
+        if (controller.allBarriersReceived()) {
+            controller.triggerGlobalCheckpoint(pendingCheckpointBarrier);
+            return finishCheckpoint();
+        } else if (controller.isTimedOut(pendingCheckpointBarrier)) {
+            return alignmentTimeout(controller, pendingCheckpointBarrier)
+                    .endOfPartitionReceived(controller, channelInfo);
+        }
+
+        return this;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
 import java.io.IOException;
@@ -36,6 +37,15 @@ final class AlternatingWaitingForFirstBarrier
             throws IOException, CheckpointException {
         state.prioritizeAllAnnouncements();
         return new AlternatingWaitingForFirstBarrierUnaligned(true, state);
+    }
+
+    @Override
+    public BarrierHandlerState endOfPartitionReceived(
+            Controller controller, InputChannelInfo channelInfo) throws IOException {
+        state.channelFinished(channelInfo);
+
+        // Do nothing since we have no pending checkpoint.
+        return this;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
@@ -88,6 +88,16 @@ final class AlternatingWaitingForFirstBarrierUnaligned implements BarrierHandler
         return stopCheckpoint();
     }
 
+    @Override
+    public BarrierHandlerState endOfPartitionReceived(
+            Controller controller, InputChannelInfo channelInfo)
+            throws IOException, CheckpointException {
+        channelState.channelFinished(channelInfo);
+
+        // Do nothing since we have no pending checkpoint.
+        return this;
+    }
+
     private BarrierHandlerState stopCheckpoint() throws IOException {
         channelState.unblockAllChannels();
         if (alternating) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierHandlerState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierHandlerState.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -53,12 +55,18 @@ interface BarrierHandlerState {
 
     BarrierHandlerState abort(long cancelledId) throws IOException;
 
+    BarrierHandlerState endOfPartitionReceived(Controller controller, InputChannelInfo channelInfo)
+            throws IOException, CheckpointException;
+
     /**
      * An entry point for communication between {@link BarrierHandlerState} and {@link
      * SingleCheckpointBarrierHandler}.
      */
     interface Controller {
         boolean allBarriersReceived();
+
+        @Nullable
+        CheckpointBarrier getPendingCheckpointBarrier();
 
         void triggerGlobalCheckpoint(CheckpointBarrier checkpointBarrier) throws IOException;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
@@ -56,6 +56,11 @@ final class ChannelState {
         blockedChannels.add(channelInfo);
     }
 
+    public void channelFinished(InputChannelInfo channelInfo) {
+        blockedChannels.remove(channelInfo);
+        sequenceNumberInAnnouncedChannels.remove(channelInfo);
+    }
+
     public void prioritizeAllAnnouncements() throws IOException {
         for (Map.Entry<InputChannelInfo, Integer> announcedNumberInChannel :
                 sequenceNumberInAnnouncedChannels.entrySet()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -68,9 +68,19 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
     private CompletableFuture<Long> latestBytesProcessedDuringAlignment = new CompletableFuture<>();
 
+    /**
+     * TODO Whether enables checkpoints after tasks finished. This is a temporary flag and will be
+     * removed in the last PR.
+     */
+    protected boolean enableCheckpointAfterTasksFinished;
+
     public CheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint, Clock clock) {
         this.toNotifyOnCheckpoint = checkNotNull(toNotifyOnCheckpoint);
         this.clock = checkNotNull(clock);
+    }
+
+    public void setEnableCheckpointAfterTasksFinished(boolean enableCheckpointAfterTasksFinished) {
+        this.enableCheckpointAfterTasksFinished = enableCheckpointAfterTasksFinished;
     }
 
     @Override
@@ -83,10 +93,10 @@ public abstract class CheckpointBarrierHandler implements Closeable {
             CheckpointBarrier announcedBarrier, int sequenceNumber, InputChannelInfo channelInfo)
             throws IOException;
 
-    public abstract void processCancellationBarrier(CancelCheckpointMarker cancelBarrier)
-            throws IOException;
+    public abstract void processCancellationBarrier(
+            CancelCheckpointMarker cancelBarrier, InputChannelInfo channelInfo) throws IOException;
 
-    public abstract void processEndOfPartition() throws IOException;
+    public abstract void processEndOfPartition(InputChannelInfo channelInfo) throws IOException;
 
     public abstract long getLatestCheckpointId();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
@@ -30,15 +31,25 @@ import org.apache.flink.util.clock.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * The {@link CheckpointBarrierTracker} keeps track of what checkpoint barriers have been received
  * from which input channels. Once it has observed all checkpoint barriers for a checkpoint ID, it
  * notifies its listener of a completed checkpoint.
  *
- * <p>Unlike the {@link CheckpointBarrierAligner}, the BarrierTracker does not block the input
+ * <p>Unlike the {@link SingleCheckpointBarrierHandler}, the BarrierTracker does not block the input
  * channels that have sent barriers, so it cannot be used to gain "exactly-once" processing
  * guarantees. It can, however, be used to gain "at least once" processing guarantees.
  *
@@ -57,11 +68,8 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 
     // ------------------------------------------------------------------------
 
-    /**
-     * The number of channels. Once that many barriers have been received for a checkpoint, the
-     * checkpoint is considered complete.
-     */
-    private final int totalNumberOfInputChannels;
+    /** The number of open channels. */
+    private int numOpenChannels;
 
     /**
      * All checkpoints for which some (but not all) barriers have been received, and that are not
@@ -75,7 +83,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     public CheckpointBarrierTracker(
             int totalNumberOfInputChannels, AbstractInvokable toNotifyOnCheckpoint, Clock clock) {
         super(toNotifyOnCheckpoint, clock);
-        this.totalNumberOfInputChannels = totalNumberOfInputChannels;
+        this.numOpenChannels = totalNumberOfInputChannels;
         this.pendingCheckpoints = new ArrayDeque<>();
     }
 
@@ -83,8 +91,13 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
             throws IOException {
         final long barrierId = receivedBarrier.getId();
 
-        // fast path for single channel trackers
-        if (totalNumberOfInputChannels == 1) {
+        // fast path for single channel trackers. We only go with the fast path
+        // for new checkpoints, otherwise we might met with the case that
+        // 1. Received barrier from channel 0 (2 in total) and start a new checkpoint.
+        // 2. Received EndOfPartition from channel 0.
+        // 3. Received barrier from channel 1.
+        // In this case we should finish the existing pending checkpoint.
+        if (receivedBarrier.getId() > latestPendingCheckpointID && numOpenChannels == 1) {
             markAlignmentStartAndEnd(receivedBarrier.getTimestamp());
             notifyCheckpoint(receivedBarrier);
             return;
@@ -100,7 +113,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         int pos = 0;
 
         for (CheckpointBarrierCount next : pendingCheckpoints) {
-            if (next.checkpointId == barrierId) {
+            if (next.checkpointId() == barrierId) {
                 barrierCount = next;
                 break;
             }
@@ -109,8 +122,8 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 
         if (barrierCount != null) {
             // add one to the count to that barrier and check for completion
-            int numBarriersNew = barrierCount.incrementBarrierCount();
-            if (numBarriersNew == totalNumberOfInputChannels) {
+            int numChannelsNew = barrierCount.markChannelAligned(channelInfo);
+            if (numChannelsNew == barrierCount.getTargetChannelCount()) {
                 // checkpoint can be triggered (or is aborted and all barriers have been seen)
                 // first, remove this checkpoint and all all prior pending
                 // checkpoints (which are now subsumed)
@@ -120,11 +133,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 
                 // notify the listener
                 if (!barrierCount.isAborted()) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Received all barriers for checkpoint {}", barrierId);
-                    }
-                    markAlignmentEnd();
-                    notifyCheckpoint(receivedBarrier);
+                    triggerCheckpointOnAligned(barrierCount);
                 }
             }
         } else {
@@ -135,7 +144,8 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
             if (barrierId > latestPendingCheckpointID) {
                 markAlignmentStart(receivedBarrier.getTimestamp());
                 latestPendingCheckpointID = barrierId;
-                pendingCheckpoints.addLast(new CheckpointBarrierCount(barrierId));
+                pendingCheckpoints.addLast(
+                        new CheckpointBarrierCount(receivedBarrier, channelInfo, numOpenChannels));
 
                 // make sure we do not track too many checkpoints
                 if (pendingCheckpoints.size() > MAX_CHECKPOINTS_TO_TRACK) {
@@ -153,16 +163,21 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     }
 
     @Override
-    public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier)
-            throws IOException {
+    public void processCancellationBarrier(
+            CancelCheckpointMarker cancelBarrier, InputChannelInfo channelInfo) throws IOException {
         final long checkpointId = cancelBarrier.getCheckpointId();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Received cancellation barrier for checkpoint {}", checkpointId);
         }
 
-        // fast path for single channel trackers
-        if (totalNumberOfInputChannels == 1) {
+        // fast path for single channel trackers. We only go with the fast path
+        // for new checkpoints, otherwise we might met with the case that
+        // 1. Received barrier from channel 0 (2 in total) and start a new checkpoint.
+        // 2. Received EndOfPartition from channel 0.
+        // 3. Received cancellation barrier from channel 1.
+        // In this case we should cleanup the existing pending checkpoint.
+        if (cancelBarrier.getCheckpointId() > latestPendingCheckpointID && numOpenChannels == 1) {
             notifyAbortOnCancellationBarrier(checkpointId);
             return;
         }
@@ -191,7 +206,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 
             // we still count the barriers to be able to remove the entry once all barriers have
             // been seen
-            if (cbc.incrementBarrierCount() == totalNumberOfInputChannels) {
+            if (cbc.markChannelAligned(channelInfo) == cbc.getTargetChannelCount()) {
                 // we can remove this entry
                 pendingCheckpoints.removeFirst();
             }
@@ -200,7 +215,9 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 
             latestPendingCheckpointID = checkpointId;
 
-            CheckpointBarrierCount abortedMarker = new CheckpointBarrierCount(checkpointId);
+            CheckpointBarrierCount abortedMarker =
+                    new CheckpointBarrierCount(
+                            cancelBarrier.getCheckpointId(), channelInfo, numOpenChannels);
             abortedMarker.markAborted();
             pendingCheckpoints.addFirst(abortedMarker);
 
@@ -212,16 +229,66 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     }
 
     @Override
-    public void processEndOfPartition() throws IOException {
-        while (!pendingCheckpoints.isEmpty()) {
-            CheckpointBarrierCount barrierCount = pendingCheckpoints.removeFirst();
-            if (barrierCount.markAborted()) {
-                notifyAbort(
-                        barrierCount.checkpointId(),
-                        new CheckpointException(
-                                CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));
+    public void processEndOfPartition(InputChannelInfo channelInfo) throws IOException {
+        numOpenChannels--;
+
+        if (!enableCheckpointAfterTasksFinished) {
+            while (!pendingCheckpoints.isEmpty()) {
+                CheckpointBarrierCount barrierCount = pendingCheckpoints.removeFirst();
+                if (barrierCount.markAborted()) {
+                    notifyAbort(
+                            barrierCount.checkpointId(),
+                            new CheckpointException(
+                                    CheckpointFailureReason
+                                            .CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));
+                }
+            }
+        } else {
+            checkAlignmentOnEndOfPartitionIfEnabled(channelInfo);
+        }
+    }
+
+    private void checkAlignmentOnEndOfPartitionIfEnabled(InputChannelInfo channelInfo)
+            throws IOException {
+        // Finds the latest pending checkpoints that only waits for this channel.
+        CheckpointBarrierCount barrierCount = null;
+        int pos = pendingCheckpoints.size();
+
+        Iterator<CheckpointBarrierCount> reverseCheckpointIterator =
+                pendingCheckpoints.descendingIterator();
+        while (reverseCheckpointIterator.hasNext()) {
+            CheckpointBarrierCount next = reverseCheckpointIterator.next();
+            pos--;
+
+            if (next.markChannelAligned(channelInfo) == next.getTargetChannelCount()) {
+                barrierCount = next;
+                break;
             }
         }
+
+        if (barrierCount != null) {
+            for (int i = 0; i <= pos; i++) {
+                pendingCheckpoints.pollFirst();
+            }
+
+            if (!barrierCount.isAborted()) {
+                triggerCheckpointOnAligned(barrierCount);
+            }
+        }
+    }
+
+    private void triggerCheckpointOnAligned(CheckpointBarrierCount barrierCount)
+            throws IOException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "All the channels are aligned for checkpoint {}", barrierCount.checkpointId());
+        }
+
+        markAlignmentEnd();
+        checkState(
+                barrierCount.getPendingCheckpoint() != null,
+                "Pending checkpoint barrier must" + "exists for non-aborted checkpoints.");
+        notifyCheckpoint(barrierCount.getPendingCheckpoint());
     }
 
     public long getLatestCheckpointId() {
@@ -232,26 +299,66 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         return !pendingCheckpoints.isEmpty();
     }
 
+    @VisibleForTesting
+    int getNumOpenChannels() {
+        return numOpenChannels;
+    }
+
+    @VisibleForTesting
+    List<Long> getPendingCheckpointIds() {
+        return pendingCheckpoints.stream()
+                .map(CheckpointBarrierCount::checkpointId)
+                .collect(Collectors.toList());
+    }
+
     /** Simple class for a checkpoint ID with a barrier counter. */
     private static final class CheckpointBarrierCount {
 
         private final long checkpointId;
 
-        private int barrierCount;
+        private final int targetChannelCount;
+
+        private final Set<InputChannelInfo> alignedChannels = new HashSet<>();
+
+        @Nullable private final CheckpointBarrier pendingCheckpoint;
 
         private boolean aborted;
 
-        CheckpointBarrierCount(long checkpointId) {
+        CheckpointBarrierCount(
+                CheckpointBarrier pendingCheckpoint,
+                InputChannelInfo channelInfo,
+                int targetChannelCount) {
+            checkNotNull(pendingCheckpoint);
+            this.checkpointId = pendingCheckpoint.getId();
+            this.pendingCheckpoint = pendingCheckpoint;
+            alignedChannels.add(channelInfo);
+            this.targetChannelCount = targetChannelCount;
+        }
+
+        CheckpointBarrierCount(
+                long checkpointId, InputChannelInfo channelInfo, int targetChannelCount) {
             this.checkpointId = checkpointId;
-            this.barrierCount = 1;
+            this.pendingCheckpoint = null;
+            alignedChannels.add(channelInfo);
+            this.targetChannelCount = targetChannelCount;
         }
 
         public long checkpointId() {
             return checkpointId;
         }
 
-        public int incrementBarrierCount() {
-            return ++barrierCount;
+        @Nullable
+        public CheckpointBarrier getPendingCheckpoint() {
+            return pendingCheckpoint;
+        }
+
+        public int getTargetChannelCount() {
+            return targetChannelCount;
+        }
+
+        public int markChannelAligned(InputChannelInfo inputChannelInfo) {
+            alignedChannels.add(inputChannelInfo);
+            return alignedChannels.size();
         }
 
         public boolean isAborted() {
@@ -268,7 +375,9 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         public String toString() {
             return isAborted()
                     ? String.format("checkpointID=%d - ABORTED", checkpointId)
-                    : String.format("checkpointID=%d, count=%d", checkpointId, barrierCount);
+                    : String.format(
+                            "checkpointID=%d, count=%d, targetChannelCount=%d",
+                            checkpointId, alignedChannels.size(), targetChannelCount);
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.EndOfUserRecordsEvent;
 import org.apache.flink.runtime.io.network.api.EventAnnouncement;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
@@ -181,6 +182,8 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         } else if (eventClass == CancelCheckpointMarker.class) {
             barrierHandler.processCancellationBarrier(
                     (CancelCheckpointMarker) bufferOrEvent.getEvent());
+        } else if (eventClass == EndOfUserRecordsEvent.class) {
+            inputGate.acknowledgeAllRecordsProcessed(bufferOrEvent.getChannelInfo());
         } else if (eventClass == EndOfPartitionEvent.class) {
             barrierHandler.processEndOfPartition();
         } else if (eventClass == EventAnnouncement.class) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -181,11 +181,12 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
             barrierHandler.processBarrier(checkpointBarrier, bufferOrEvent.getChannelInfo());
         } else if (eventClass == CancelCheckpointMarker.class) {
             barrierHandler.processCancellationBarrier(
-                    (CancelCheckpointMarker) bufferOrEvent.getEvent());
+                    (CancelCheckpointMarker) bufferOrEvent.getEvent(),
+                    bufferOrEvent.getChannelInfo());
         } else if (eventClass == EndOfUserRecordsEvent.class) {
             inputGate.acknowledgeAllRecordsProcessed(bufferOrEvent.getChannelInfo());
         } else if (eventClass == EndOfPartitionEvent.class) {
-            barrierHandler.processEndOfPartition();
+            barrierHandler.processEndOfPartition(bufferOrEvent.getChannelInfo());
         } else if (eventClass == EventAnnouncement.class) {
             EventAnnouncement eventAnnouncement = (EventAnnouncement) bufferOrEvent.getEvent();
             AbstractEvent announcedEvent = eventAnnouncement.getAnnouncedEvent();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CollectingBarriers.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CollectingBarriers.java
@@ -18,6 +18,12 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
 /** We are performing aligned checkpoints. We have seen at least a single aligned * barrier. */
 final class CollectingBarriers extends AbstractAlignedBarrierHandlerState {
 
@@ -27,6 +33,20 @@ final class CollectingBarriers extends AbstractAlignedBarrierHandlerState {
 
     @Override
     protected BarrierHandlerState convertAfterBarrierReceived(ChannelState state) {
+        return this;
+    }
+
+    @Override
+    public BarrierHandlerState endOfPartitionReceived(
+            Controller controller, InputChannelInfo channelInfo) throws IOException {
+        state.channelFinished(channelInfo);
+        if (controller.allBarriersReceived()) {
+            checkState(
+                    controller.getPendingCheckpointBarrier() != null,
+                    "At least one barrier received in collecting barrier state.");
+            return triggerGlobalCheckpoint(controller, controller.getPendingCheckpointBarrier());
+        }
+
         return this;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/WaitingForFirstBarrier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/WaitingForFirstBarrier.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+
+import java.io.IOException;
 
 /** We are performing aligned checkpoints. We have not seen any barriers yet. */
 final class WaitingForFirstBarrier extends AbstractAlignedBarrierHandlerState {
@@ -30,5 +33,14 @@ final class WaitingForFirstBarrier extends AbstractAlignedBarrierHandlerState {
     @Override
     protected BarrierHandlerState convertAfterBarrierReceived(ChannelState state) {
         return new CollectingBarriers(state);
+    }
+
+    @Override
+    public BarrierHandlerState endOfPartitionReceived(
+            Controller controller, InputChannelInfo channelInfo) throws IOException {
+        state.channelFinished(channelInfo);
+
+        // Do nothing since we have no pending checkpoint.
+        return this;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -173,7 +173,7 @@ public class SourceStreamTask<
                             } else if (!wasStoppedExternally && sourceThreadThrowable != null) {
                                 mailboxProcessor.reportThrowable(sourceThreadThrowable);
                             } else {
-                                mailboxProcessor.allActionsCompleted();
+                                mailboxProcessor.suspend();
                             }
                         });
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -81,7 +81,8 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
                 output.collect(nextRecord);
             }
         } else {
-            controller.allActionsCompleted();
+            controller.suspendDefaultAction();
+            mailboxProcessor.suspend();
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -212,6 +212,14 @@ public class MailboxProcessor implements Closeable {
         sendPoisonMail(() -> suspended = true);
     }
 
+    public void ensureDefaultActionSuspend() {
+        if (isDefaultActionUnavailable()) {
+            ensureControlFlowSignalCheck();
+        } else {
+            suspendDefaultAction(null);
+        }
+    }
+
     /**
      * Execute a single (as small as possible) step of the mailbox.
      *

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -62,6 +64,11 @@ public class MockIndexedInputGate extends IndexedInputGate {
 
     @Override
     public void resumeConsumption(InputChannelInfo channelInfo) {}
+
+    @Override
+    public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
+        throw new UnsupportedEncodingException();
+    }
 
     @Override
     public int getNumberOfInputChannels() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -158,6 +160,11 @@ public class MockInputGate extends IndexedInputGate {
 
     public Set<Integer> getBlockedChannels() {
         return blockedChannels;
+    }
+
+    @Override
+    public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo) throws IOException {
+        throw new UnsupportedEncodingException();
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -234,6 +234,9 @@ public class AlignedCheckpointsMassiveRandomTest {
         @Override
         public void checkpointStopped(long cancelledCheckpointId) {}
 
+        public void acknowledgeAllRecordsProcessed(InputChannelInfo channelInfo)
+                throws IOException {}
+
         @Override
         public void setup() {}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsCancellationTest.java
@@ -103,7 +103,8 @@ public class UnalignedCheckpointsCancellationTest {
 
         for (RuntimeEvent e : events) {
             if (e instanceof CancelCheckpointMarker) {
-                unaligner.processCancellationBarrier((CancelCheckpointMarker) e);
+                unaligner.processCancellationBarrier(
+                        (CancelCheckpointMarker) e, new InputChannelInfo(0, channel));
             } else if (e instanceof CheckpointBarrier) {
                 unaligner.processBarrier((CheckpointBarrier) e, new InputChannelInfo(0, channel));
             } else {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
@@ -41,13 +41,14 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
     private CheckpointFailureReason failureReason;
     private long lastCanceledCheckpointId = -1L;
     private long abortedCheckpointCounter = 0;
-    private final List<CheckpointOptions> triggeredCheckpointOptions = new ArrayList<>();
+    final List<Long> abortedCheckpoints = new ArrayList<>();
 
     long nextExpectedCheckpointId;
     long triggeredCheckpointCounter = 0;
     CompletableFuture<Long> lastAlignmentDurationNanos;
     CompletableFuture<Long> lastBytesProcessedDuringAlignment;
     final List<Long> triggeredCheckpoints = new ArrayList<>();
+    private final List<CheckpointOptions> triggeredCheckpointOptions = new ArrayList<>();
 
     ValidatingCheckpointHandler() {
         this(-1);
@@ -135,6 +136,7 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
         lastCanceledCheckpointId = checkpointId;
         failureReason = cause.getCheckpointFailureReason();
         abortedCheckpointCounter++;
+        abortedCheckpoints.add(checkpointId);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -30,6 +30,10 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
@@ -40,17 +44,19 @@ import org.junit.Test;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.addSourceRecords;
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.buildTestHarness;
-import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.triggerCheckpoint;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -237,51 +243,81 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
     @Test
     public void testRpcTriggerCheckpointWithSourceChain() throws Exception {
-        AtomicReference<Future<?>> lastCheckpointTriggerFuture = new AtomicReference<>();
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
 
-        try (StreamTaskMailboxTestHarness<String> testHarness =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                env ->
-                                        new MultipleInputStreamTaskTest
-                                                .HoldingOnAfterInvokeMultipleInputStreamTask(
-                                                env, lastCheckpointTriggerFuture),
-                                BasicTypeInfo.STRING_TYPE_INFO)
-                        .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
-                        .modifyExecutionConfig(ExecutionConfig::enableObjectReuse)
-                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
-                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
-                        .addSourceInput(
-                                new SourceOperatorFactory<>(
-                                        new MultipleInputStreamTaskTest.LifeCycleTrackingMockSource(
-                                                Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
-                        .addSourceInput(
-                                new SourceOperatorFactory<>(
-                                        new MultipleInputStreamTaskTest.LifeCycleTrackingMockSource(
-                                                Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
-                        .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(4))
-                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
-                        .build()) {
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                            .modifyExecutionConfig(ExecutionConfig::enableObjectReuse)
+                            .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                            .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                            .addSourceInput(
+                                    new SourceOperatorFactory<>(
+                                            new MultipleInputStreamTaskTest
+                                                    .LifeCycleTrackingMockSource(
+                                                    Boundedness.BOUNDED, 1),
+                                            WatermarkStrategy.noWatermarks()))
+                            .addSourceInput(
+                                    new SourceOperatorFactory<>(
+                                            new MultipleInputStreamTaskTest
+                                                    .LifeCycleTrackingMockSource(
+                                                    Boundedness.BOUNDED, 1),
+                                            WatermarkStrategy.noWatermarks()))
+                            .addAdditionalOutput(partitionWriters)
+                            .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(4))
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
 
-            testHarness
-                    .getStreamTask()
-                    .getCheckpointCoordinator()
-                    .setEnableCheckpointAfterTasksFinished(true);
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointCoordinator()
+                        .setEnableCheckpointAfterTasksFinished(true);
 
-            // TODO: Would add the test of part of channel finished after we are able to
-            // complement pending checkpoints when received EndOfPartitionEvent.
+                // TODO: Would add the test of part of channel finished after we are able to
+                // complement pending checkpoints when received EndOfPartitionEvent.
 
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
-            Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 4);
-            lastCheckpointTriggerFuture.set(checkpointFuture);
+                // Tests triggering checkpoint after all the inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 4);
 
-            // The checkpoint 4 would be triggered successfully.
-            // TODO: Would also check the checkpoint succeed after we also waiting
-            // for the asynchronous step to finish on finish.
-            testHarness.finishProcessing();
-            assertTrue(checkpointFuture.isDone());
+                // Notifies the result partition that all records are processed after the
+                // last checkpoint is triggered.
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+
+                // The checkpoint 4 would be triggered successfully.
+                // TODO: Would also check the checkpoint succeed after we also waiting
+                // for the asynchronous step to finish on finish.
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+
+                // Each result partition should have emitted 2 barriers and 1 EndOfUserRecordsEvent.
+                for (ResultPartition resultPartition : partitionWriters) {
+                    assertEquals(2, resultPartition.getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -874,6 +874,11 @@ public class MultipleInputStreamTaskTest {
                         .getStreamTask()
                         .getCheckpointCoordinator()
                         .setEnableCheckpointAfterTasksFinished(true);
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointBarrierHandler()
+                        .get()
+                        .setEnableCheckpointAfterTasksFinished(true);
 
                 // Tests triggering checkpoint when all the inputs are alive.
                 Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -32,17 +32,17 @@ import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingTaskMetricGroup;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
-import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractInput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -92,12 +91,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.processMailTillCheckpointSucceeds;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -783,6 +784,7 @@ public class MultipleInputStreamTaskTest {
 
             finishAddingRecords(testHarness, 1);
             testHarness.endInput();
+            testHarness.finishProcessing();
             testHarness.waitForTaskCompletion();
         }
     }
@@ -848,71 +850,78 @@ public class MultipleInputStreamTaskTest {
 
     @Test
     public void testRpcTriggerCheckpointWithoutSourceChain() throws Exception {
-        AtomicReference<Future<?>> lastCheckpointTriggerFuture = new AtomicReference<>();
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
 
-        try (StreamTaskMailboxTestHarness<String> testHarness =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                env ->
-                                        new HoldingOnAfterInvokeMultipleInputStreamTask(
-                                                env, lastCheckpointTriggerFuture),
-                                BasicTypeInfo.STRING_TYPE_INFO)
-                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
-                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
-                        .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
-                        .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
-                        .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(3))
-                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
-                        .build()) {
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                            .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                            .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
+                            .addAdditionalOutput(partitionWriters)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                            .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(3))
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
 
-            testHarness
-                    .getStreamTask()
-                    .getCheckpointCoordinator()
-                    .setEnableCheckpointAfterTasksFinished(true);
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointCoordinator()
+                        .setEnableCheckpointAfterTasksFinished(true);
 
-            // Tests triggering checkpoint when all the inputs are alive.
-            Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
-            processMailTillCheckpointSuccess(testHarness, checkpointFuture);
-            assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+                // Tests triggering checkpoint when all the inputs are alive.
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
 
-            // Tests trigger checkpoint after some inputs have received EndOfPartition
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
-            checkpointFuture = triggerCheckpoint(testHarness, 4);
-            processMailTillCheckpointSuccess(testHarness, checkpointFuture);
-            assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+                // Tests triggering checkpoint after some inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+                checkpointFuture = triggerCheckpoint(testHarness, 4);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
 
-            // Tests trigger checkpoint after all the inputs have received EndOfPartition.
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 2, 0);
-            checkpointFuture = triggerCheckpoint(testHarness, 6);
-            lastCheckpointTriggerFuture.set(checkpointFuture);
+                // Tests triggering checkpoint after all the inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 2, 0);
+                checkpointFuture = triggerCheckpoint(testHarness, 6);
 
-            // The checkpoint 6 would be triggered successfully.
-            // TODO: Would also check the checkpoint succeed after we also waiting
-            // for the asynchronous step to finish on finish.
-            testHarness.finishProcessing();
-            assertTrue(checkpointFuture.isDone());
+                // Notifies the result partition that all records are processed after the
+                // last checkpoint is triggered.
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+
+                // The checkpoint 6 would be triggered successfully.
+                // TODO: Would also check the checkpoint succeed after we also waiting
+                // for the asynchronous step to finish on finish.
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+
+                // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
+                for (ResultPartition resultPartition : partitionWriters) {
+                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
         }
-    }
-
-    static Future<Boolean> triggerCheckpoint(
-            StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
-        testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
-        return testHarness
-                .getStreamTask()
-                .triggerCheckpointAsync(
-                        new CheckpointMetaData(checkpointId, checkpointId * 1000),
-                        CheckpointOptions.alignedNoTimeout(
-                                CheckpointType.CHECKPOINT,
-                                CheckpointStorageLocationReference.getDefault()));
-    }
-
-    static void processMailTillCheckpointSuccess(
-            StreamTaskMailboxTestHarness<String> testHarness, Future<Boolean> checkpointFuture)
-            throws Exception {
-        while (!checkpointFuture.isDone()) {
-            testHarness.processSingleStep();
-        }
-        testHarness.getTaskStateManager().getWaitForReportLatch().await();
     }
 
     /** Test implementation of {@link MultipleInputStreamOperator}. */
@@ -1236,35 +1245,5 @@ public class MultipleInputStreamTaskTest {
 
         @Override
         public void onPeriodicEmit(WatermarkOutput output) {}
-    }
-
-    /**
-     * Special stream task implementation that would waits till all checkpoints get triggered before
-     * actually finish.
-     *
-     * <p>TODO: It would be removed after we introduce the mechanism that make the upstream tasks
-     * wait for the downstream tasks to process all the records before finished.
-     */
-    static class HoldingOnAfterInvokeMultipleInputStreamTask
-            extends MultipleInputStreamTask<String> {
-
-        private final AtomicReference<Future<?>> lastCheckpointTriggerFuture;
-
-        public HoldingOnAfterInvokeMultipleInputStreamTask(
-                Environment env, AtomicReference<Future<?>> lastCheckpointTriggerFuture)
-                throws Exception {
-            super(env);
-            this.lastCheckpointTriggerFuture = checkNotNull(lastCheckpointTriggerFuture);
-        }
-
-        @Override
-        protected void afterInvoke() throws Exception {
-            while (!lastCheckpointTriggerFuture.get().isDone()) {
-                Thread.sleep(200);
-                mainMailboxExecutor.tryYield();
-            }
-
-            super.afterInvoke();
-        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -30,6 +30,12 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -74,9 +80,11 @@ import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT_SUSPEND;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -576,6 +584,69 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
 
             assertTrue(notifyFuture.isDone());
             assertFalse(interruptedTestingSource.wasInterrupted());
+        }
+    }
+
+    @Test
+    public void testTriggeringCheckpointAfterSourceThreadFinished() throws Exception {
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try (NettyShuffleEnvironment env =
+                new NettyShuffleEnvironmentBuilder()
+                        .setNumNetworkBuffers(partitionWriters.length * 2)
+                        .build()) {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(
+                                env, ResultPartitionType.PIPELINED_BOUNDED, 1);
+                partitionWriters[i].setup();
+            }
+
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    SourceStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                            .addAdditionalOutput(partitionWriters)
+                            .setupOperatorChain(
+                                    new StreamSource<>(new MockSource(0, Integer.MAX_VALUE, 1)))
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointCoordinator()
+                        .setEnableCheckpointAfterTasksFinished(true);
+
+                testHarness.processAll();
+                testHarness.getStreamTask().getCompletionFuture().get();
+
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
+                // Notifies the result partition that all records are processed after the
+                // last checkpoint is triggered.
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+
+                // Each result partition should have emitted 1 barrier, 1 max watermark and 1
+                // EndOfUserRecordEvent.
+                for (ResultPartition resultPartition : partitionWriters) {
+                    assertEquals(3, resultPartition.getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -210,9 +210,12 @@ public class StreamMockEnvironment implements Environment {
 
     public <T> void addOutput(
             final Collection<Object> outputList, final TypeSerializer<T> serializer) {
+        addOutput(new RecordOrEventCollectingResultPartitionWriter<T>(outputList, serializer));
+    }
+
+    public void addOutput(ResultPartitionWriter resultPartitionWriter) {
         try {
-            outputs.add(
-                    new RecordOrEventCollectingResultPartitionWriter<T>(outputList, serializer));
+            outputs.add(resultPartitionWriter);
         } catch (Throwable t) {
             t.printStackTrace();
             fail(t.getMessage());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -147,9 +147,7 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 
     public void waitForTaskCompletion() throws Exception {
         endInput();
-        while (streamTask.isMailboxLoopRunning()) {
-            streamTask.runMailboxStep();
-        }
+        processAll();
     }
 
     public void finishProcessing() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -53,6 +54,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -82,6 +84,8 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 
     protected final ArrayList<InputConfig> inputs = new ArrayList<>();
     protected final ArrayList<Integer> inputChannelsPerGate = new ArrayList<>();
+
+    protected final ArrayList<ResultPartitionWriter> additionalOutputs = new ArrayList<>();
 
     private boolean setupCalled = false;
 
@@ -132,8 +136,14 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         return this;
     }
 
-    public StreamTaskMailboxTestHarness<OUT> buildUnrestored() throws Exception {
+    public StreamTaskMailboxTestHarnessBuilder<OUT> addAdditionalOutput(
+            ResultPartitionWriter... writers) {
+        checkState(!setupCalled, "Additional outputs must be added before harness was setup.");
+        additionalOutputs.addAll(Arrays.asList(writers));
+        return this;
+    }
 
+    public StreamTaskMailboxTestHarness<OUT> buildUnrestored() throws Exception {
         TestTaskStateManager taskStateManager = new TestTaskStateManager(localRecoveryConfig);
         if (taskStateSnapshots != null) {
             taskStateManager.setReportedCheckpointId(taskStateSnapshots.keySet().iterator().next());
@@ -161,6 +171,10 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         Queue<Object> outputList = new ArrayDeque<>();
         streamMockEnvironment.addOutput(outputList, outputStreamRecordSerializer);
         streamMockEnvironment.setTaskMetricGroup(taskMetricGroup);
+
+        for (ResultPartitionWriter writer : additionalOutputs) {
+            streamMockEnvironment.addOutput(writer);
+        }
 
         StreamTask<OUT, ?> task = taskFactory.apply(streamMockEnvironment);
 
@@ -327,7 +341,10 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         checkState(!setupCalled, "This harness was already setup.");
         setupCalled = true;
         streamConfig.setStreamOperatorFactory(headOperatorFactory);
-        return new StreamConfigChainer<>(headOperatorId, streamConfig, this);
+
+        // There is always 1 default output other than the additional ones.
+        return new StreamConfigChainer<>(
+                headOperatorId, streamConfig, this, 1 + additionalOutputs.size());
     }
 
     public StreamTaskMailboxTestHarnessBuilder<OUT> setTaskMetricGroup(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -237,7 +237,8 @@ public class StreamTaskTerminationTest extends TestLogger {
             }
             // wait until we have started an asynchronous checkpoint
             if (isCanceled() || SNAPSHOT_HAS_STARTED.get()) {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1787,6 +1787,11 @@ public class StreamTaskTest extends TestLogger {
                         .getStreamTask()
                         .getCheckpointCoordinator()
                         .setEnableCheckpointAfterTasksFinished(true);
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointBarrierHandler()
+                        .get()
+                        .setEnableCheckpointAfterTasksFinished(true);
 
                 // Tests triggering checkpoint when all the inputs are alive.
                 Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -50,6 +50,10 @@ import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.PipelinedResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.metrics.TimerGauge;
@@ -160,7 +164,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
@@ -172,7 +175,6 @@ import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleto
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox.MAX_PRIORITY;
 import static org.apache.flink.streaming.util.StreamTaskUtil.waitTaskIsRunning;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -335,10 +337,7 @@ public class StreamTaskTest extends TestLogger {
                     savepointResult.accept(harness.streamTask, checkpointId);
                 },
                 "savepointResult");
-
-        while (harness.streamTask.isMailboxLoopRunning()) {
-            harness.streamTask.runMailboxStep();
-        }
+        harness.processAll();
 
         Assert.assertEquals(expectEndInput, TestBoundedOneInputStreamOperator.isInputEnded());
     }
@@ -615,7 +614,8 @@ public class StreamTaskTest extends TestLogger {
             } finally {
                 holder.close();
             }
-            controller.allActionsCompleted();
+            controller.suspendDefaultAction();
+            mailboxProcessor.suspend();
         }
 
         @Override
@@ -1287,7 +1287,8 @@ public class StreamTaskTest extends TestLogger {
                                             mailboxProcessor
                                                     .getMailboxExecutor(0)
                                                     .execute(latch::trigger, "trigger");
-                                            controller.allActionsCompleted();
+                                            controller.suspendDefaultAction();
+                                            mailboxProcessor.suspend();
                                         }
                                     });
             latch.await();
@@ -1337,7 +1338,7 @@ public class StreamTaskTest extends TestLogger {
         // Make sure that there is some output edge in the config so that some RecordWriter is
         // created
         StreamConfigChainer cfg =
-                new StreamConfigChainer(new OperatorID(42, 42), streamConfig, this);
+                new StreamConfigChainer(new OperatorID(42, 42), streamConfig, this, 1);
         cfg.chain(
                 new OperatorID(44, 44),
                 new UnusedOperatorFactory(),
@@ -1729,43 +1730,115 @@ public class StreamTaskTest extends TestLogger {
     }
 
     @Test
-    public void testTriggeringCheckpointWithFinishedChannels() throws Exception {
-        AtomicReference<Future<?>> lastCheckpointTriggerFuture = new AtomicReference<>();
+    public void testNotWaitingForAllRecordsProcessedIfCheckpointNotEnabled() throws Exception {
+        ResultPartitionWriter[] partitionWriters = new ResultPartitionWriter[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
 
-        try (StreamTaskMailboxTestHarness<String> testHarness =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                env ->
-                                        new HoldingOnAfterInvokeStreamTask(
-                                                env, lastCheckpointTriggerFuture),
-                                BasicTypeInfo.STRING_TYPE_INFO)
-                        .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
-                        .setupOutputForSingletonOperatorChain(new EmptyOperator())
-                        .build()) {
-            // Tests triggering checkpoint when all the inputs are alive.
-            Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
-            processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-            assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    OneInputStreamTask::new, STRING_TYPE_INFO)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(false))
+                            .addInput(STRING_TYPE_INFO)
+                            .addAdditionalOutput(partitionWriters)
+                            .setupOperatorChain(new EmptyOperator())
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+                testHarness.endInput();
 
-            // Tests trigger checkpoint after some inputs have received EndOfPartition
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
-            checkpointFuture = triggerCheckpoint(testHarness, 4);
-            processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-            assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
-
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 1);
-            testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 2);
-            checkpointFuture = triggerCheckpoint(testHarness, 6);
-            lastCheckpointTriggerFuture.set(checkpointFuture);
-
-            // The checkpoint 6 would be triggered successfully.
-            // TODO: Would also check the checkpoint succeed after we also waiting
-            // for the asynchronous step to finish on finish.
-            testHarness.finishProcessing();
-            assertTrue(checkpointFuture.isDone());
+                // In this case the result partition should not emit EndOfUserRecordsEvent.
+                for (ResultPartitionWriter writer : partitionWriters) {
+                    assertEquals(0, ((PipelinedResultPartition) writer).getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
         }
     }
 
-    private static Future<Boolean> triggerCheckpoint(
+    @Test
+    public void testTriggeringCheckpointWithFinishedChannels() throws Exception {
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
+
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
+                            .addAdditionalOutput(partitionWriters)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                            .setupOperatorChain(new EmptyOperator())
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointCoordinator()
+                        .setEnableCheckpointAfterTasksFinished(true);
+
+                // Tests triggering checkpoint when all the inputs are alive.
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+
+                // Tests triggering checkpoint after some inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+                checkpointFuture = triggerCheckpoint(testHarness, 4);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+
+                // Tests triggering checkpoint after received all the inputs have received
+                // EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 1);
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 2);
+                checkpointFuture = triggerCheckpoint(testHarness, 6);
+
+                // Notifies the result partition that all records are processed after the
+                // last checkpoint is triggered.
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+
+                // The checkpoint 6 would be triggered successfully.
+                // TODO: Would also check the checkpoint succeed after we also waiting
+                // for the asynchronous step to finish on finish.
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+
+                // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
+                for (ResultPartition resultPartition : partitionWriters) {
+                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+        }
+    }
+
+    static Future<Boolean> triggerCheckpoint(
             StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
         testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
         return testHarness
@@ -1777,7 +1850,7 @@ public class StreamTaskTest extends TestLogger {
                                 CheckpointStorageLocationReference.getDefault()));
     }
 
-    private static void processMailTillCheckpointSucceeds(
+    static void processMailTillCheckpointSucceeds(
             StreamTaskMailboxTestHarness<String> testHarness, Future<Boolean> checkpointFuture)
             throws Exception {
         while (!checkpointFuture.isDone()) {
@@ -2200,7 +2273,8 @@ public class StreamTaskTest extends TestLogger {
             if (fail) {
                 throw new RuntimeException();
             }
-            controller.allActionsCompleted();
+            controller.suspendDefaultAction();
+            mailboxProcessor.suspend();
         }
 
         @Override
@@ -2325,7 +2399,8 @@ public class StreamTaskTest extends TestLogger {
         protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
             checkTaskThreadInfo();
             if (hasTimerTriggered) {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             }
         }
 
@@ -2787,32 +2862,6 @@ public class StreamTaskTest extends TestLogger {
                 @Override
                 public void close() {}
             };
-        }
-    }
-
-    /**
-     * Special stream task implementation that would waits till all checkpoints get triggered before
-     * actually finish.
-     */
-    private static class HoldingOnAfterInvokeStreamTask extends OneInputStreamTask<String, String> {
-
-        private final AtomicReference<Future<?>> lastCheckpointTriggerFuture;
-
-        public HoldingOnAfterInvokeStreamTask(
-                Environment env, AtomicReference<Future<?>> lastCheckpointTriggerFuture)
-                throws Exception {
-            super(env);
-            this.lastCheckpointTriggerFuture = checkNotNull(lastCheckpointTriggerFuture);
-        }
-
-        @Override
-        protected void afterInvoke() throws Exception {
-            while (!lastCheckpointTriggerFuture.get().isDone()) {
-                Thread.sleep(200);
-                mainMailboxExecutor.tryYield();
-            }
-
-            super.afterInvoke();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -475,7 +475,7 @@ public class StreamTaskTestHarness<OUT> {
         setupCalled = true;
         StreamConfig streamConfig = getStreamConfig();
         streamConfig.setStreamOperatorFactory(headOperatorFactory);
-        return new StreamConfigChainer(headOperatorId, streamConfig, this);
+        return new StreamConfigChainer(headOperatorId, streamConfig, this, 1);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -145,7 +145,8 @@ public class SynchronousCheckpointITCase {
                 eventQueue.put(Event.TASK_IS_RUNNING);
             }
             if (isCanceled()) {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             } else {
                 controller.suspendDefaultAction();
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -159,7 +159,8 @@ public class SynchronousCheckpointTest {
         @Override
         protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
             if (stopped || isCanceled()) {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -520,7 +520,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
             while (isRunning()) {
                 Thread.sleep(1L);
             }
-            controller.allActionsCompleted();
+            controller.suspendDefaultAction();
+            mailboxProcessor.suspend();
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -396,7 +396,8 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
             if (suspension == null) {
                 suspension = controller.suspendDefaultAction();
             } else {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             }
         }
 
@@ -427,7 +428,8 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
             if (suspension == null) {
                 suspension = controller.suspendDefaultAction();
             } else {
-                controller.allActionsCompleted();
+                controller.suspendDefaultAction();
+                mailboxProcessor.suspend();
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR makes `CheckpointBarrierHandler` support alignment after some input channels have received EndOfPartition. Based on the discussion under https://github.com/apache/flink/pull/14831, to support different types of checkpoint (e.g., alignment checkpoints and unaligned checkpoints), we would hold the upstream tasks until all the records are processed by the downstream tasks and then emit EndOfPartitionEvent. 

The `CheckpointBarrierHandler` would mark the input channel as aligned for all the pending checkpoints and won't consider this input channel for the following checkpoints. It also need to note that the current implementation does not need to modify the channel persistence logic since now the input channel only consider whether to persist a single Buffer, and when to start persisting and when to stop persisting is decided by `CheckpointBarrierHandler`.

## Brief change log

- 9dbebb28251fab1c23577479fc6ccce00bab0fd6 introduces a new `EndOfUserRecordsEvent`, which is sent after all the user records. 
- aa2862a41a41ea27443f0b634c892c7e596c1365 modifies ResultPartition to support waiting for the downstream tasks to process all the pending records. Only PipelinedResultPartition actually implement the functionality and other types of ResultPartition would return immediately.
- 1407af0bbab73bf671e368c47ff376c6a56ee980 StreamTask would wait for the downstream tasks to process all the pending records if checkpoint is enabled.
- 6ecbd9f254918c209663c73b597d9530d9c3fe5c Downstream tasks would acknowledge the `EndOfUserRecordsEvent` to notify the upstream task.
- b21bfee1dc28e619211f1412f15cd814765b78d1 refactors the checkpoint barrier handler for the future modification.
- 1c2b235ec335c2c699ec7fc27b125880a9581b94 modifies checkpoint barrier handler to support alignment with EndOfPartition received.
-  fa4fe220d8c19a8be9d73581082f305934ea807b Allows taking snapshot with closed operators if enabled checkpoints after tasks finished. 


## Verifying this change


This change added tests and can be verified via added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive):  **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no, the functionality would be enabled in the following PR.**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
