### PR TITLE
[FLINK-21501][docs] Sync Chinese documentation with FLINK-21343

### DIFF
--- a/docs/content.zh/docs/ops/state/savepoints.md
+++ b/docs/content.zh/docs/ops/state/savepoints.md
@@ -36,9 +36,14 @@ Savepoint 是依据 Flink [checkpointing 机制]({{< ref "docs/learn-flink/fault
 </div>
 从概念上讲， Flink 的 Savepoint 与 Checkpoint 的不同之处类似于传统数据库中的备份与恢复日志之间的差异。 Checkpoint 的主要目的是为意外失败的作业提供恢复机制。 Checkpoint 的生命周期由 Flink 管理，即 Flink 创建，管理和删除 Checkpoint - 无需用户交互。 作为一种恢复和定期触发的方法，Checkpoint 实现有两个设计目标：i）轻量级创建和 ii）尽可能快地恢复。 可能会利用某些特定的属性来达到这个，例如， 工作代码在执行尝试之间不会改变。 在用户终止作业后，通常会删除 Checkpoint（除非明确配置为保留的 Checkpoint）。
 
- 与此相反、Savepoint 由用户创建，拥有和删除。 他们的用例是计划的，手动备份和恢复。 例如，升级 Flink 版本，调整用户逻辑，改变并行度，以及进行红蓝部署等。 当然，Savepoint 必须在作业停止后继续存在。 从概念上讲，Savepoint 的生成，恢复成本可能更高一些，Savepoint 更多地关注可移植性和对前面提到的作业更改的支持。
+与此相反、Savepoint 由用户创建，拥有和删除。 他们的用例是计划的，手动备份和恢复。 例如，升级 Flink 版本，调整用户逻辑，改变并行度，以及进行红蓝部署等。 当然，Savepoint 必须在作业停止后继续存在。 从概念上讲，Savepoint 的生成，恢复成本可能更高一些，Savepoint 更多地关注可移植性和对前面提到的作业更改的支持。
 
-除去这些概念上的差异，Checkpoint 和 Savepoint 的当前实现基本上使用相同的代码并生成相同的格式。然而，目前有一个例外，我们可能会在未来引入更多的差异。例外情况是使用 RocksDB 状态后端的增量 Checkpoint。他们使用了一些 RocksDB 内部格式，而不是 Flink 的本机 Savepoint 格式。这使他们成为了与 Savepoint 相比，更轻量级的 Checkpoint 机制的第一个实例。
+Flink 的 Savepoint 二进制格式在所有 State Backend 之间都是统一的。这意味着你可以在一个 State Backend 下获取一个 Savepoint，然后使用另一个 State Backend 将其还原。
+
+{{< hint info >}}
+所有 State Backend 生成一个通用的 Savepoint 二进制格式是从 Flink 1.13 版本才开始的。因此，如果想切换 State Backend，应当首先升级你的 Flink 版本，然后
+在新版本下获取一个 Savepoint，只有这样你才能够使用其他 State Backend 将其还原。
+{{< /hint >}}
 
 ## 分配算子 ID
 

--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -130,18 +130,18 @@ RocksDBStateBackend 是目前唯一支持增量 CheckPoint 的 State Backend (�
 
 The total memory amount of RocksDB instance(s) per slot can also be bounded, please refer to documentation [here]({{< ref "docs/ops/state/large_state_tuning" >}}#bounding-rocksdb-memory-usage) for details.
 
-# Choose The Right State Backend
+# 选择正确的 State Backend
 
-In general, we recommend avoiding `MemoryStateBackend` in production because it stores its snapshots inside the JobManager as opposed to persistent disk.
-When deciding between `FsStateBackend` and `RocksDB`, it is a choice between performance and scalability.
-`FsStateBackend` is very fast as each state access and update operates on objects on the Java heap; however, state size is limited by available memory within the cluster.
-On the other hand, `RocksDB` can scale based on available disk space and is the only state backend to support incremental snapshots.
-However, each state access and update requires (de-)serialization and potentially reading from disk which leads to average performance that is an order of magnitude slower than the memory state backends.
+通常，我们不建议在生产中使用 `MemoryStateBackend`，因为 `MemoryStateBackend` 会将状态快照保存在 JobManager 中，而不是持久化的磁盘中。
+当决定使用 `FsStateBackend` 或 `RocksDB` 时，其实质上，是在性能和扩展性之间做选择。
+`FsStateBackend` 速度很快，因为每次状态访问和更新都直接操作 Java 堆中的对象，但是，`FsStateBackend` 可管理的状态大小受集群可用内存资源的限制。
+另一方面，`RocksDB` 能够基于可用磁盘空间进行扩展，并且 `RocksDB` 是唯一支持增量快照的 State Backend。
+但是，使用 `RocksDB` 时，每个状态访问和更新都需要（反）序列化，并且可能需要从磁盘读取数据，这就导致其平均性能比内存 State Backend 慢一个数量级。
 
 {{< hint info >}}
-In Flink 1.13 we unified the binary format of Flink's savepoints. That means you can take a savepoint and then restore from it using a different state backend.
-All the state backends produce a common format only starting from version 1.13. Therefore, if you want to switch the state backend you should first upgrade your Flink version then
-take a savepoint with the new version, and only after that you can restore it with a different state backend.
+在 Flink 1.13 中，我们统一了 Savepoint 的二进制格式。这意味着你可以获取一个 Savepoint，然后使用其他 State Backend 从该 Savepoint 进行恢复。
+所有 State Backend 生成一个通用的 Savepoint 格式是从 Flink 1.13 版本才开始的。因此，如果想切换 State Backend，应当首先升级你的 Flink 版本，然后
+在新版本下获取一个 Savepoint，只有这样你才能够使用其他 State Backend 将其还原。
 {{< /hint >}}
 
 ## 设置 State Backend


### PR DESCRIPTION
## What is the purpose of the change

Sync Chinese documentation with FLINK-21343


## Brief change log

  - docs/content.zh/docs/ops/state/state_backends.md
  - docs/content.zh/docs/ops/state/savepoints.md

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
