### PR TITLE
[FLINK-21561] Add python script to serve small cache proxy for E2E artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ resources:
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
   E2E_CACHE_FOLDER: $(Pipeline.Workspace)/e2e_cache
+  E2E_ARTIFACT_CACHE_FOLDER: $(Pipeline.Workspace)/artifact_cache
   MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
   CACHE_KEY: maven | $(Agent.OS) | **/pom.xml, !**/target/**
   CACHE_FALLBACK_KEY: maven | $(Agent.OS)

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -32,6 +32,12 @@ if [ -z "$FLINK_DIR" ] ; then
     exit 1
 fi
 
+# Start artifact cache proxy
+CACHE_PROXY="http://localhost:7644/"
+export CACHE_PROXY
+python3 ${END_TO_END_DIR}/../tools/ci/e2e_artifact_cache.py -p 7654 -d $E2E_ARTIFACT_CACHE_FOLDER &
+CACHE_PID=$!
+
 source "${END_TO_END_DIR}/../tools/ci/maven-utils.sh"
 source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 
@@ -275,5 +281,6 @@ run_mvn ${MVN_COMMON_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} verify -pl ${e2e
 
 EXIT_CODE=$?
 
+kill $CACHE_PID
 
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -35,7 +35,7 @@ MAX_RETRY_SECONDS=120
 function setup_kafka_dist {
   # download Kafka
   mkdir -p $TEST_DATA_DIR
-  KAFKA_URL="https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
+  KAFKA_URL="${CACHE_PROXY}https://archive.apache.org/dist/kafka/$KAFKA_VERSION/kafka_2.12-$KAFKA_VERSION.tgz"
   echo "Downloading Kafka from $KAFKA_URL"
   curl ${KAFKA_URL} --retry 10 --retry-max-time 120 --output ${TEST_DATA_DIR}/kafka.tgz
 
@@ -49,7 +49,7 @@ function setup_kafka_dist {
 function setup_confluent_dist {
   # download confluent
   mkdir -p $TEST_DATA_DIR
-  CONFLUENT_URL="http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-oss-$CONFLUENT_VERSION-2.11.tar.gz"
+  CONFLUENT_URL="${CACHE_PROXY}http://packages.confluent.io/archive/$CONFLUENT_MAJOR_VERSION/confluent-oss-$CONFLUENT_VERSION-2.11.tar.gz"
   echo "Downloading confluent from $CONFLUENT_URL"
   curl ${CONFLUENT_URL} --retry 10 --retry-max-time 120 --output ${TEST_DATA_DIR}/confluent.tgz
 

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -226,6 +226,13 @@ jobs:
     - script: ${{parameters.environment}} ./tools/ci/compile.sh
       displayName: Build Flink
       condition: not(eq(variables['SKIP'], '1'))
+    - task: Cache@2
+      inputs:
+        key: e2e-artifact-cache | tools/ci/.cache/*.cache
+        path: $(E2E_ARTIFACT_CACHE_FOLDER)
+      displayName: Cache E2E artifact files
+      continueOnError: true
+      condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} FLINK_DIR=`pwd`/build-target ./tools/azure-pipelines/e2e_uploading_watchdog.sh flink-end-to-end-tests/run-nightly-tests.sh
       timeoutInMinutes: 250
       displayName: Run e2e tests

--- a/tools/ci/e2e_artifact_cache.py
+++ b/tools/ci/e2e_artifact_cache.py
@@ -1,0 +1,96 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+#
+# This file serves a basic HTTP server to act as an artifact caching proxy for
+# E2E test artifacts.
+#
+
+import http.server
+import socketserver
+import urllib.request
+import shutil
+import os
+import hashlib
+import signal
+import argparse
+
+CACHE_FOLDER = "./.cache/"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Local file cache proxy for e2e artifacts"
+    )
+    parser.add_argument("-p", "--port", default=7654, type=int)
+    parser.add_argument("-d", "--cache-dir", default=".artifact_cache")
+    return parser.parse_args()
+
+
+def gracefull_kill(sig, stack):
+    httpd.server_close()
+    exit()
+
+
+class CacheHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        # Trim leading '/' from path
+        path = self.path[1:]
+        hashed_path = (
+            CACHE_FOLDER
+            + "/"
+            + hashlib.md5(path.encode("utf-8")).hexdigest()
+            + ".cache"
+        )
+
+        if not os.path.exists(hashed_path):
+            print(path + " not present in cache. Retrieving from source...")
+            request = urllib.request.Request(path)
+            try:
+                response = urllib.request.urlopen(request)
+                with open(hashed_path, "wb") as out:
+                    shutil.copyfileobj(response, out, length=16 * 1024)
+
+            except urllib.error.HTTPError as e:
+                self.send_response(e.code)
+                self.end_headers()
+                return None
+        else:
+            print(path + " present in cache.")
+
+        with open(hashed_path, "rb") as cached:
+            self.send_response(200)
+            self.end_headers()
+            shutil.copyfileobj(cached, self.wfile)
+
+
+args = parse_args()
+
+CACHE_FOLDER = args.cache_dir
+
+if not os.path.exists(CACHE_FOLDER):
+    os.mkdir(CACHE_FOLDER)
+
+for s in [signal.SIGINT, signal.SIGTERM]:
+    signal.signal(s, gracefull_kill)
+
+socketserver.TCPServer.allow_reuse_address = True
+httpd = socketserver.TCPServer(("", args.port), CacheHandler)
+
+httpd.serve_forever()


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This change aims to provide a small Python proxy server to speed up subsequent E2E tests by caching large artifacts (such as Kafka) that are redownloaded on every E2E test run.

The proxy is queries via localhost, such as ``localhost:7654/https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz`` which will download, persist and return the tarball if is not present in the cache folder. If it is present, then the local cached tarball is returned.

## Brief change log

  - *Python script is added to the E2E test pipelines to persist/cache large artifacts used between tests.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
