### PR TITLE
[FLINK-21135][coord] Adjust parallelism of job for reactive mode

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -140,11 +140,16 @@ public class ClusterOptions {
     }
 
     public static JobManagerOptions.SchedulerType getSchedulerType(Configuration configuration) {
-        if (isAdaptiveSchedulerEnabled(configuration)) {
+        if (isAdaptiveSchedulerEnabled(configuration) || isReactiveModeEnabled(configuration)) {
             return JobManagerOptions.SchedulerType.Adaptive;
         } else {
             return configuration.get(JobManagerOptions.SCHEDULER);
         }
+    }
+
+    private static boolean isReactiveModeEnabled(Configuration configuration) {
+        return configuration.get(JobManagerOptions.SCHEDULER_MODE)
+                == SchedulerExecutionMode.REACTIVE;
     }
 
     public static boolean isAdaptiveSchedulerEnabled(Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -47,6 +47,8 @@ public class JobVertex implements java.io.Serializable {
 
     private static final String DEFAULT_NAME = "(unnamed vertex)";
 
+    public static final int MAX_PARALLELISM_DEFAULT = -1;
+
     // --------------------------------------------------------------------------------------------
     // Members that define the structure / topology of the graph
     // --------------------------------------------------------------------------------------------
@@ -77,7 +79,7 @@ public class JobVertex implements java.io.Serializable {
     private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 
     /** Maximum number of subtasks to split this task into a runtime. */
-    private int maxParallelism = -1;
+    private int maxParallelism = MAX_PARALLELISM_DEFAULT;
 
     /** The minimum resource of the vertex. */
     private ResourceSpec minResources = ResourceSpec.DEFAULT;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
@@ -79,6 +79,11 @@ public final class DefaultSlotPoolServiceSchedulerFactory
     }
 
     @Override
+    public JobManagerOptions.SchedulerType getSchedulerType() {
+        return schedulerNGFactory.getSchedulerType();
+    }
+
+    @Override
     public SchedulerNG createScheduler(
             Logger log,
             JobGraph jobGraph,
@@ -143,7 +148,6 @@ public final class DefaultSlotPoolServiceSchedulerFactory
         if (ClusterOptions.isDeclarativeResourceManagementEnabled(configuration)) {
             JobManagerOptions.SchedulerType schedulerType =
                     ClusterOptions.getSchedulerType(configuration);
-
             if (schedulerType == JobManagerOptions.SchedulerType.Adaptive
                     && jobType == JobType.BATCH) {
                 LOG.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotPoolServiceSchedulerFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -47,6 +48,13 @@ public interface SlotPoolServiceSchedulerFactory {
      * @return created SlotPoolService
      */
     SlotPoolService createSlotPoolService(JobID jid);
+
+    /**
+     * Returns the scheduler type this factory is creating.
+     *
+     * @return the scheduler type this factory is creating.
+     */
+    JobManagerOptions.SchedulerType getSchedulerType();
 
     /**
      * Creates a {@link SchedulerNG}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -125,5 +126,10 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 initializationTimestamp,
                 mainThreadExecutor,
                 jobStatusListener);
+    }
+
+    @Override
+    public JobManagerOptions.SchedulerType getSchedulerType() {
+        return JobManagerOptions.SchedulerType.Ng;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNGFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -62,4 +63,6 @@ public interface SchedulerNGFactory {
             FatalErrorHandler fatalErrorHandler,
             JobStatusListener jobStatusListener)
             throws Exception;
+
+    JobManagerOptions.SchedulerType getSchedulerType();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
@@ -251,12 +250,6 @@ public class AdaptiveScheduler
                 new SlotSharingSlotAllocator(
                         declarativeSlotPool::reserveFreeSlot,
                         declarativeSlotPool::freeReservedSlot);
-
-        for (JobVertex vertex : jobGraph.getVertices()) {
-            if (vertex.getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
-                vertex.setParallelism(1);
-            }
-        }
 
         declarativeSlotPool.registerNewSlotsListener(this::newResourcesAvailable);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -106,5 +107,10 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                 mainThreadExecutor,
                 fatalErrorHandler,
                 jobStatusListener);
+    }
+
+    @Override
+    public JobManagerOptions.SchedulerType getSchedulerType() {
+        return JobManagerOptions.SchedulerType.Adaptive;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/ReactiveModeUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/ReactiveModeUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utilities for reactive mode. */
+public final class ReactiveModeUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ReactiveModeUtils.class);
+
+    /**
+     * Sets the parallelism of all vertices in the passed JobGraph to the highest possible max
+     * parallelism, unless the user defined a maxParallelism.
+     *
+     * @param jobGraph The JobGraph to modify.
+     */
+    public static void configureJobGraphForReactiveMode(JobGraph jobGraph) {
+        LOG.info("Modifying job parallelism for running in reactive mode.");
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            if (vertex.getMaxParallelism() == JobVertex.MAX_PARALLELISM_DEFAULT) {
+                vertex.setParallelism(Transformation.UPPER_BOUND_MAX_PARALLELISM);
+                vertex.setMaxParallelism(Transformation.UPPER_BOUND_MAX_PARALLELISM);
+            } else {
+                vertex.setParallelism(vertex.getMaxParallelism());
+            }
+        }
+    }
+
+    private ReactiveModeUtils() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
@@ -47,5 +47,25 @@ public class DefaultSlotPoolServiceSchedulerFactoryTest extends TestLogger {
         assertThat(
                 defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory(),
                 is(instanceOf(DefaultSchedulerFactory.class)));
+        assertThat(
+                defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
+                is(JobManagerOptions.SchedulerType.Ng));
+    }
+
+    @Test
+    public void testAdaptiveSchedulerForReactiveMode() {
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
+
+        final DefaultSlotPoolServiceSchedulerFactory defaultSlotPoolServiceSchedulerFactory =
+                DefaultSlotPoolServiceSchedulerFactory.fromConfiguration(
+                        configuration, JobType.STREAMING);
+
+        assertThat(
+                defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory(),
+                is(instanceOf(AdaptiveSchedulerFactory.class)));
+        assertThat(
+            defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
+            is(JobManagerOptions.SchedulerType.Adaptive));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
@@ -21,8 +21,10 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerFactory;
+import org.apache.flink.runtime.scheduler.adaptive.AdaptiveSchedulerFactory;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -65,7 +67,7 @@ public class DefaultSlotPoolServiceSchedulerFactoryTest extends TestLogger {
                 defaultSlotPoolServiceSchedulerFactory.getSchedulerNGFactory(),
                 is(instanceOf(AdaptiveSchedulerFactory.class)));
         assertThat(
-            defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
-            is(JobManagerOptions.SchedulerType.Adaptive));
+                defaultSlotPoolServiceSchedulerFactory.getSchedulerType(),
+                is(JobManagerOptions.SchedulerType.Adaptive));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterSchedulerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -118,6 +119,11 @@ public class JobMasterSchedulerTest extends TestLogger {
                                 throw new FlinkRuntimeException("Could not start scheduling.");
                             })
                     .build();
+        }
+
+        @Override
+        public JobManagerOptions.SchedulerType getSchedulerType() {
+            return JobManagerOptions.SchedulerType.Ng;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingSchedulerNGFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -71,5 +72,10 @@ public class TestingSchedulerNGFactory implements SchedulerNGFactory {
             JobStatusListener jobStatusListener)
             throws Exception {
         return schedulerNG;
+    }
+
+    @Override
+    public JobManagerOptions.SchedulerType getSchedulerType() {
+        return JobManagerOptions.SchedulerType.Ng;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -711,6 +711,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         // create a new operator
         final JobVertex jobVertex = new JobVertex("New operator");
         jobVertex.setInvokableClass(NoOpInvokable.class);
+        jobVertex.setParallelism(1);
 
         // this test will fail in the end due to the previously created Savepoint having a state for
         // a given OperatorID that does not match any operator of the newly created JobGraph
@@ -759,6 +760,8 @@ public class AdaptiveSchedulerTest extends TestLogger {
         // create a new operator
         final JobVertex jobVertex = new JobVertex("New operator");
         jobVertex.setInvokableClass(NoOpInvokable.class);
+        jobVertex.setParallelism(1);
+
         final JobGraph jobGraphWithNewOperator =
                 TestUtils.createJobGraphFromJobVerticesWithCheckpointing(
                         savepointRestoreSettings, jobVertex);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -205,6 +205,15 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 
                 JobStatus jobStatus = jobStatusFuture.get(5, TimeUnit.SECONDS);
 
+                if (jobStatus == JobStatus.FAILED) {
+                    LOG.warn(
+                            "Job reached status failed",
+                            client.requestJobResult(jobID)
+                                    .get()
+                                    .getSerializedThrowable()
+                                    .get()
+                                    .deserializeError(ClassLoader.getSystemClassLoader()));
+                }
                 assertNotEquals(JobStatus.FAILED, jobStatus);
             } catch (Exception e) {
                 fail("Could not connect to job: " + e);

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.test.scheduling;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
@@ -60,11 +59,7 @@ public class ReactiveModeITCase extends TestLogger {
 
     private static Configuration getReactiveModeConfiguration() {
         final Configuration conf = new Configuration();
-
-        conf.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
         conf.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
-        conf.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
-
         return conf;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.scheduling;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResource;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+/** Tests for Reactive Mode (FLIP-159). */
+public class ReactiveModeITCase extends TestLogger {
+    private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
+    private static final int INITIAL_NUMBER_TASK_MANAGERS = 1;
+
+    @Rule
+    public final MiniClusterResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getReactiveModeConfiguration())
+                            .setNumberTaskManagers(INITIAL_NUMBER_TASK_MANAGERS)
+                            .setNumberSlotsPerTaskManager(NUMBER_SLOTS_PER_TASK_MANAGER)
+                            .build());
+
+    private static Configuration getReactiveModeConfiguration() {
+        final Configuration conf = new Configuration();
+
+        conf.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
+        conf.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
+        conf.set(ClusterOptions.ENABLE_DECLARATIVE_RESOURCE_MANAGEMENT, true);
+
+        return conf;
+    }
+
+    /**
+     * Users can set maxParallelism and reactive mode must not run with a parallelism higher than
+     * maxParallelism.
+     */
+    @Test
+    public void testScaleLimitByMaxParallelism() throws Exception {
+        // test preparation: ensure we have 2 TaskManagers running
+        startAdditionalTaskManager();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // we set maxParallelism = 1 and assert it never exceeds it
+        final DataStream<String> input =
+                env.addSource(new ParallelismTrackingSource()).setMaxParallelism(1);
+        input.addSink(new ParallelismTrackingSink<>()).getTransformation().setMaxParallelism(1);
+
+        ParallelismTrackingSource.expectInstances(1);
+        ParallelismTrackingSink.expectInstances(1);
+
+        env.executeAsync();
+
+        ParallelismTrackingSource.waitForInstances();
+        ParallelismTrackingSink.waitForInstances();
+    }
+
+    /** Test that a job scales up when a TaskManager gets added to the cluster. */
+    @Test
+    public void testScaleUpOnAdditionalTaskManager() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStream<String> input = env.addSource(new ParallelismTrackingSource());
+        input.addSink(new ParallelismTrackingSink<>());
+
+        ParallelismTrackingSource.expectInstances(
+                NUMBER_SLOTS_PER_TASK_MANAGER * INITIAL_NUMBER_TASK_MANAGERS);
+        ParallelismTrackingSink.expectInstances(
+                NUMBER_SLOTS_PER_TASK_MANAGER * INITIAL_NUMBER_TASK_MANAGERS);
+
+        env.executeAsync();
+
+        ParallelismTrackingSource.waitForInstances();
+        ParallelismTrackingSink.waitForInstances();
+
+        // expect scale up to 2 TaskManagers:
+        ParallelismTrackingSource.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER * 2);
+        ParallelismTrackingSink.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER * 2);
+
+        miniClusterResource.getMiniCluster().startTaskManager();
+
+        ParallelismTrackingSource.waitForInstances();
+        ParallelismTrackingSink.waitForInstances();
+    }
+
+    @Test
+    public void testScaleDownOnTaskManagerLoss() throws Exception {
+        // test preparation: ensure we have 2 TaskManagers running
+        startAdditionalTaskManager();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 0L));
+        final DataStream<String> input = env.addSource(new ParallelismTrackingSource());
+        input.addSink(new ParallelismTrackingSink<>());
+
+        ParallelismTrackingSource.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER * 2);
+        ParallelismTrackingSink.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER * 2);
+
+        env.executeAsync();
+
+        ParallelismTrackingSource.waitForInstances();
+        ParallelismTrackingSink.waitForInstances();
+
+        // scale down to 1 TaskManagers:
+        ParallelismTrackingSource.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER);
+        ParallelismTrackingSink.expectInstances(NUMBER_SLOTS_PER_TASK_MANAGER);
+
+        miniClusterResource.getMiniCluster().terminateTaskManager(0).get();
+
+        ParallelismTrackingSource.waitForInstances();
+        ParallelismTrackingSink.waitForInstances();
+    }
+
+    private int getNumberOfConnectedTaskManagers() throws ExecutionException, InterruptedException {
+        return miniClusterResource
+                .getMiniCluster()
+                .requestClusterOverview()
+                .get()
+                .getNumTaskManagersConnected();
+    }
+
+    private void startAdditionalTaskManager() throws Exception {
+        miniClusterResource.getMiniCluster().startTaskManager();
+        CommonTestUtils.waitUntilCondition(
+                () -> getNumberOfConnectedTaskManagers() == 2,
+                Deadline.fromNow(Duration.ofMillis(10_000L)));
+    }
+
+    private static class ParallelismTrackingSource implements ParallelSourceFunction<String> {
+        private volatile boolean running = true;
+
+        private static final InstanceTracker instances = new InstanceTracker();
+
+        public static void expectInstances(int count) {
+            instances.expectInstances(count);
+        }
+
+        public static void waitForInstances() throws InterruptedException {
+            instances.waitForInstances();
+        }
+
+        @Override
+        public void run(SourceContext<String> ctx) throws Exception {
+            instances.reportNewInstance();
+            while (running) {
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect("test");
+                }
+                Thread.sleep(100);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+    }
+
+    private static class ParallelismTrackingSink<T> extends RichSinkFunction<T> {
+
+        private static final InstanceTracker instances = new InstanceTracker();
+
+        public static void expectInstances(int count) {
+            instances.expectInstances(count);
+        }
+
+        public static void waitForInstances() throws InterruptedException {
+            instances.waitForInstances();
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            instances.reportNewInstance();
+        }
+    }
+
+    private static class InstanceTracker {
+        private final Object lock = new Object();
+
+        @GuardedBy("lock")
+        private CountDownLatch latch = new CountDownLatch(0);
+
+        public void reportNewInstance() {
+            synchronized (lock) {
+                if (latch.getCount() == 0) {
+                    throw new RuntimeException("Test error. More instances than expected.");
+                }
+                latch.countDown();
+            }
+        }
+
+        public void waitForInstances() throws InterruptedException {
+            //noinspection FieldAccessNotGuarded
+            latch.await();
+        }
+
+        public void expectInstances(int count) {
+            synchronized (lock) {
+                Preconditions.checkState(
+                        latch.getCount() == 0, "Assuming previous latch has triggered");
+                latch = new CountDownLatch(count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

For reactive mode, a job has to have the parallelism to "infinity", capped by maxParallelism.

## Verifying this change

IT case added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

