### PR TITLE
[FLINK-21571][build] Fix japicmp referenceVersion

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -140,6 +140,8 @@ under the License.
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<parameter>
+						<!-- This acts as a canary in case the japicmp.referenceVersion was set to an invalid value -->
+						<ignoreNonResolvableArtifacts>false</ignoreNonResolvableArtifacts>
 						<excludes combine.children="append">
 							<exclude>org.apache.flink.api.common.ExecutionConfig#CONFIG_KEY</exclude>
 							<exclude>org.apache.flink.core.fs.FileSystem\$FSKey</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.13.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.12.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.4.2</spotless.version>
 


### PR DESCRIPTION
Reverts the `japicmp.referenceVersion` to 1.12.0.

Additionally, configures the japicmp check to fail in `flink-core` if the reference artifact could not be resolved.
(We don't do this in general to allow new modules to be added.)