### PR TITLE
[FLINK-21525] Move scheduler benchmarks to Flink

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/JobConfiguration.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/JobConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark;
+
+import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobType;
+
+/**
+ * {@link JobConfiguration} contains the configuration of a STREAMING/BATCH job. It concludes {@link
+ * DistributionPattern}, {@link ResultPartitionType}, {@link JobType}, {@link ExecutionMode}.
+ */
+public enum JobConfiguration {
+    STREAMING(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.PIPELINED,
+            JobType.STREAMING,
+            ExecutionMode.PIPELINED,
+            4000),
+
+    BATCH(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.BLOCKING,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            4000),
+
+    STREAMING_TEST(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.PIPELINED,
+            JobType.STREAMING,
+            ExecutionMode.PIPELINED,
+            10),
+
+    BATCH_TEST(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.BLOCKING,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            10);
+
+    private final int parallelism;
+    private final DistributionPattern distributionPattern;
+    private final ResultPartitionType resultPartitionType;
+    private final JobType jobType;
+    private final ExecutionMode executionMode;
+
+    JobConfiguration(
+            DistributionPattern distributionPattern,
+            ResultPartitionType resultPartitionType,
+            JobType jobType,
+            ExecutionMode executionMode,
+            int parallelism) {
+        this.distributionPattern = distributionPattern;
+        this.resultPartitionType = resultPartitionType;
+        this.jobType = jobType;
+        this.executionMode = executionMode;
+        this.parallelism = parallelism;
+    }
+
+    public int getParallelism() {
+        return parallelism;
+    }
+
+    public DistributionPattern getDistributionPattern() {
+        return distributionPattern;
+    }
+
+    public ResultPartitionType getResultPartitionType() {
+        return resultPartitionType;
+    }
+
+    public JobType getJobType() {
+        return jobType;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/** Utilities for scheduler benchmarks. */
+public class SchedulerBenchmarkUtils {
+
+    public static List<JobVertex> createDefaultJobVertices(JobConfiguration jobConfiguration) {
+
+        final List<JobVertex> jobVertices = new ArrayList<>();
+
+        final JobVertex source = new JobVertex("source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(jobConfiguration.getParallelism());
+        jobVertices.add(source);
+
+        final JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(jobConfiguration.getParallelism());
+        jobVertices.add(sink);
+
+        sink.connectNewDataSetAsInput(
+                source,
+                jobConfiguration.getDistributionPattern(),
+                jobConfiguration.getResultPartitionType());
+
+        return jobVertices;
+    }
+
+    public static JobGraph createJobGraph(JobConfiguration jobConfiguration) throws IOException {
+        return createJobGraph(Collections.emptyList(), jobConfiguration);
+    }
+
+    public static JobGraph createJobGraph(
+            List<JobVertex> jobVertices, JobConfiguration jobConfiguration) throws IOException {
+
+        final JobGraph jobGraph =
+                JobGraphTestUtils.streamingJobGraph(jobVertices.toArray(new JobVertex[0]));
+
+        jobGraph.setJobType(jobConfiguration.getJobType());
+
+        final ExecutionConfig executionConfig = new ExecutionConfig();
+        executionConfig.setExecutionMode(jobConfiguration.getExecutionMode());
+        jobGraph.setExecutionConfig(executionConfig);
+
+        return jobGraph;
+    }
+
+    public static ExecutionGraph createAndInitExecutionGraph(
+            List<JobVertex> jobVertices, JobConfiguration jobConfiguration) throws Exception {
+
+        final JobGraph jobGraph = createJobGraph(jobVertices, jobConfiguration);
+
+        final ComponentMainThreadExecutor mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forMainThread();
+
+        final DefaultScheduler scheduler =
+                SchedulerTestingUtils.createScheduler(jobGraph, mainThreadExecutor);
+
+        return scheduler.getExecutionGraph();
+    }
+
+    public static void deployTasks(
+            ExecutionGraph executionGraph,
+            JobVertexID jobVertexID,
+            TestingLogicalSlotBuilder slotBuilder,
+            boolean sendScheduleOrUpdateConsumersMessage)
+            throws JobException, ExecutionException, InterruptedException {
+
+        for (ExecutionVertex vertex : executionGraph.getJobVertex(jobVertexID).getTaskVertices()) {
+            LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+            Execution execution = vertex.getCurrentExecutionAttempt();
+            execution
+                    .registerProducedPartitions(
+                            slot.getTaskManagerLocation(), sendScheduleOrUpdateConsumersMessage)
+                    .get();
+            assignResourceAndDeploy(vertex, slot);
+        }
+    }
+
+    public static void deployAllTasks(
+            ExecutionGraph executionGraph, TestingLogicalSlotBuilder slotBuilder)
+            throws JobException, ExecutionException, InterruptedException {
+
+        for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+            LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+            vertex.getCurrentExecutionAttempt()
+                    .registerProducedPartitions(slot.getTaskManagerLocation(), true)
+                    .get();
+            assignResourceAndDeploy(vertex, slot);
+        }
+    }
+
+    private static void assignResourceAndDeploy(ExecutionVertex vertex, LogicalSlot slot)
+            throws JobException {
+        vertex.tryAssignResource(slot);
+        vertex.deploy();
+    }
+
+    public static void transitionTaskStatus(
+            ExecutionGraph executionGraph, JobVertexID jobVertexID, ExecutionState state) {
+
+        for (ExecutionVertex vertex : executionGraph.getJobVertex(jobVertexID).getTaskVertices()) {
+            executionGraph.updateState(
+                    new TaskExecutionStateTransition(
+                            new TaskExecutionState(
+                                    vertex.getCurrentExecutionAttempt().getAttemptId(), state)));
+        }
+    }
+
+    public static void transitionTaskStatus(
+            DefaultScheduler scheduler,
+            AccessExecutionJobVertex vertex,
+            int subtask,
+            ExecutionState executionState) {
+
+        final ExecutionAttemptID attemptId =
+                vertex.getTaskVertices()[subtask].getCurrentExecutionAttempt().getAttemptId();
+        scheduler.updateTaskExecutionState(new TaskExecutionState(attemptId, executionState));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+/**
+ * The benchmark of deploying downstream tasks in a BATCH job. The related method is {@link
+ * Execution#deploy}.
+ */
+public class DeployingDownstreamTasksInBatchJobBenchmark extends DeployingTasksBenchmarkBase {
+
+    private ExecutionVertex[] vertices;
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        createAndSetupExecutionGraph(jobConfiguration);
+
+        final JobVertex source = jobVertices.get(0);
+
+        for (ExecutionVertex ev : executionGraph.getJobVertex(source.getID()).getTaskVertices()) {
+            Execution execution = ev.getCurrentExecutionAttempt();
+            execution.deploy();
+        }
+
+        final JobVertex sink = jobVertices.get(1);
+
+        vertices = executionGraph.getJobVertex(sink.getID()).getTaskVertices();
+    }
+
+    public void deployDownstreamTasks() throws Exception {
+        for (ExecutionVertex ev : vertices) {
+            Execution execution = ev.getCurrentExecutionAttempt();
+            execution.deploy();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of deploying downstream tasks in a BATCH job. The related method is {@link
+ * Execution#deploy}.
+ */
+public class DeployingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger {
+
+    @Test
+    public void deployDownstreamTasks() throws Exception {
+        DeployingDownstreamTasksInBatchJobBenchmark benchmark =
+                new DeployingDownstreamTasksInBatchJobBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.deployDownstreamTasks();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/** The base class of benchmarks related to deploying tasks. */
+public class DeployingTasksBenchmarkBase {
+
+    List<JobVertex> jobVertices;
+    ExecutionGraph executionGraph;
+    BlockingQueue<TaskDeploymentDescriptor> taskDeploymentDescriptors;
+
+    public void createAndSetupExecutionGraph(JobConfiguration jobConfiguration) throws Exception {
+
+        jobVertices = createDefaultJobVertices(jobConfiguration);
+
+        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+
+        taskDeploymentDescriptors = new ArrayBlockingQueue<>(jobConfiguration.getParallelism() * 2);
+
+        final SimpleAckingTaskManagerGateway taskManagerGateway =
+                new SimpleAckingTaskManagerGateway();
+        taskManagerGateway.setSubmitConsumer(taskDeploymentDescriptors::offer);
+
+        final TestingLogicalSlotBuilder slotBuilder =
+                new TestingLogicalSlotBuilder().setTaskManagerGateway(taskManagerGateway);
+
+        for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
+            for (ExecutionVertex ev : ejv.getTaskVertices()) {
+                final LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+                final Execution execution = ev.getCurrentExecutionAttempt();
+                execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
+                if (!execution.tryAssignResource(slot)) {
+                    throw new RuntimeException("Error when assigning slot to execution.");
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+/**
+ * The benchmark of deploying tasks in a STREAMING job. The related method is {@link
+ * Execution#deploy}.
+ */
+public class DeployingTasksInStreamingJobBenchmark extends DeployingTasksBenchmarkBase {
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        createAndSetupExecutionGraph(jobConfiguration);
+    }
+
+    public void deployAllTasks() throws Exception {
+        for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
+            for (ExecutionVertex ev : ejv.getTaskVertices()) {
+                Execution execution = ev.getCurrentExecutionAttempt();
+                execution.deploy();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.deploying;
+
+import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of deploying tasks in a STREAMING job. The related method is {@link
+ * Execution#deploy}.
+ */
+public class DeployingTasksInStreamingJobBenchmarkTest extends TestLogger {
+
+    @Test
+    public void deployAllTasks() throws Exception {
+        DeployingTasksInStreamingJobBenchmark benchmark =
+                new DeployingTasksInStreamingJobBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.deployAllTasks();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/FailoverBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/FailoverBenchmarkBase.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import java.util.List;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/** The base class of benchmarks related to failover. */
+public class FailoverBenchmarkBase {
+
+    JobVertex source;
+    List<JobVertex> jobVertices;
+
+    ExecutionGraph executionGraph;
+    SchedulingTopology schedulingTopology;
+    RestartPipelinedRegionFailoverStrategy strategy;
+
+    public void createRestartPipelinedRegionFailoverStrategy(JobConfiguration jobConfiguration)
+            throws Exception {
+        jobVertices = createDefaultJobVertices(jobConfiguration);
+        source = jobVertices.get(0);
+        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        schedulingTopology = executionGraph.getSchedulingTopology();
+        strategy = new RestartPipelinedRegionFailoverStrategy(schedulingTopology);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Set;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.deployTasks;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.transitionTaskStatus;
+
+/**
+ * The benchmark of calculating the regions to restart when failover occurs in a BATCH job. The
+ * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInBatchJobBenchmark extends FailoverBenchmarkBase {
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+
+        final JobVertex source = jobVertices.get(0);
+        final JobVertex sink = jobVertices.get(1);
+
+        final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+        deployTasks(executionGraph, source.getID(), slotBuilder, true);
+
+        transitionTaskStatus(executionGraph, source.getID(), ExecutionState.FINISHED);
+
+        deployTasks(executionGraph, sink.getID(), slotBuilder, true);
+    }
+
+    public Set<ExecutionVertexID> calculateRegionToRestart() {
+        return strategy.getTasksNeedingRestart(
+                executionGraph.getJobVertex(source.getID()).getTaskVertices()[0].getID(),
+                new Exception("For test."));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of calculating the regions to restart when failover occurs in a BATCH job. The
+ * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInBatchJobBenchmarkTest extends TestLogger {
+
+    @Test
+    public void calculateRegionToRestart() throws Exception {
+        RegionToRestartInBatchJobBenchmark benchmark = new RegionToRestartInBatchJobBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.calculateRegionToRestart();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import java.util.Set;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.switchAllVerticesToRunning;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.deployAllTasks;
+
+/**
+ * The benchmark of calculating region to restart when failover occurs in a STREAMING job. The
+ * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInStreamingJobBenchmark extends FailoverBenchmarkBase {
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+
+        TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+        deployAllTasks(executionGraph, slotBuilder);
+
+        switchAllVerticesToRunning(executionGraph);
+    }
+
+    public Set<ExecutionVertexID> calculateRegionToRestart() {
+        return strategy.getTasksNeedingRestart(
+                executionGraph.getJobVertex(source.getID()).getTaskVertices()[0].getID(),
+                new Exception("For test."));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.failover;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of calculating region to restart when failover occurs in a STREAMING job. The
+ * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
+ */
+public class RegionToRestartInStreamingJobBenchmarkTest extends TestLogger {
+
+    @Test
+    public void calculateRegionToRestart() throws Exception {
+        RegionToRestartInStreamingJobBenchmark benchmark =
+                new RegionToRestartInStreamingJobBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.calculateRegionToRestart();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.partitionrelease;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.RegionPartitionReleaseStrategy;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+import java.util.List;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.deployTasks;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.transitionTaskStatus;
+
+/**
+ * The benchmark of releasing partitions in a BATCH job. The related method is {@link
+ * RegionPartitionReleaseStrategy#vertexFinished}.
+ */
+public class PartitionReleaseInBatchJobBenchmark {
+
+    private ExecutionGraph executionGraph;
+    private JobVertex sink;
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        final List<JobVertex> jobVertices = createDefaultJobVertices(jobConfiguration);
+
+        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+
+        final JobVertex source = jobVertices.get(0);
+        sink = jobVertices.get(1);
+
+        final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+        deployTasks(executionGraph, source.getID(), slotBuilder, true);
+
+        transitionTaskStatus(executionGraph, source.getID(), ExecutionState.FINISHED);
+
+        deployTasks(executionGraph, sink.getID(), slotBuilder, true);
+    }
+
+    public void partitionRelease() {
+        transitionTaskStatus(executionGraph, sink.getID(), ExecutionState.FINISHED);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.partitionrelease;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.RegionPartitionReleaseStrategy;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of releasing partitions in a BATCH job. The related method is {@link
+ * RegionPartitionReleaseStrategy#vertexFinished}.
+ */
+public class PartitionReleaseInBatchJobBenchmarkTest extends TestLogger {
+
+    @Test
+    public void partitionRelease() throws Exception {
+        PartitionReleaseInBatchJobBenchmark benchmark = new PartitionReleaseInBatchJobBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.partitionRelease();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+
+/**
+ * The benchmark of initializing {@link PipelinedRegionSchedulingStrategy} in a STREAMING/BATCH job.
+ */
+public class InitSchedulingStrategyBenchmark extends SchedulingBenchmarkBase {
+
+    public InitSchedulingStrategyBenchmark() {}
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        initSchedulingTopology(jobConfiguration);
+    }
+
+    public PipelinedRegionSchedulingStrategy initSchedulingStrategy() {
+        return new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of initializing {@link PipelinedRegionSchedulingStrategy} in a STREAMING/BATCH job.
+ */
+public class InitSchedulingStrategyBenchmarkTest extends TestLogger {
+
+    @Test
+    public void initSchedulingStrategyBenchmarkInStreamingJob() throws Exception {
+        InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.initSchedulingStrategy();
+    }
+
+    @Test
+    public void initSchedulingStrategyBenchmarkInBatchJob() throws Exception {
+        InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.initSchedulingStrategy();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulerOperations;
+
+import java.util.List;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+
+/** The base class of benchmarks related to scheduling tasks. */
+public class SchedulingBenchmarkBase {
+
+    TestingSchedulerOperations schedulerOperations;
+    List<JobVertex> jobVertices;
+    ExecutionGraph executionGraph;
+    SchedulingTopology schedulingTopology;
+
+    public void initSchedulingTopology(JobConfiguration jobConfiguration) throws Exception {
+        schedulerOperations = new TestingSchedulerOperations();
+        jobVertices = createDefaultJobVertices(jobConfiguration);
+        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        schedulingTopology = executionGraph.getSchedulingTopology();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
+ * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
+ */
+public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenchmarkBase {
+
+    private ExecutionVertexID executionVertexID;
+    private PipelinedRegionSchedulingStrategy schedulingStrategy;
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        initSchedulingTopology(jobConfiguration);
+
+        schedulingStrategy =
+                new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
+
+        // When we trying to scheduling downstream tasks via
+        // onExecutionStateChange(ExecutionState.FINISHED),
+        // the result partitions of upstream tasks need to be CONSUMABLE.
+        // The CONSUMABLE status is determined by the variable "numberOfRunningProducers" of the
+        // IntermediateResult.
+        // Its value cannot be changed by any public methods.
+        // So here we use reflections to modify this value and then schedule the downstream tasks.
+        for (IntermediateResult result : executionGraph.getAllIntermediateResults().values()) {
+            Field f = result.getClass().getDeclaredField("numberOfRunningProducers");
+            f.setAccessible(true);
+            AtomicInteger numberOfRunningProducers = (AtomicInteger) f.get(result);
+            numberOfRunningProducers.set(0);
+        }
+
+        executionVertexID =
+                executionGraph
+                        .getJobVertex(jobVertices.get(0).getID())
+                        .getTaskVertices()[0]
+                        .getID();
+    }
+
+    public void schedulingDownstreamTasks() {
+        schedulingStrategy.onExecutionStateChange(executionVertexID, ExecutionState.FINISHED);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.scheduling;
+
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
+ * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
+ */
+public class SchedulingDownstreamTasksInBatchJobBenchmarkTest {
+
+    @Test
+    public void schedulingDownstreamTasksInBatchJobBenchmark() throws Exception {
+        SchedulingDownstreamTasksInBatchJobBenchmark benchmark =
+                new SchedulingDownstreamTasksInBatchJobBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.schedulingDownstreamTasks();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.topology;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+import java.util.List;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createJobGraph;
+
+/**
+ * The benchmark of building the topology of {@link ExecutionGraph} in a STREAMING/BATCH job. The
+ * related method is {@link ExecutionGraph#attachJobGraph},
+ */
+public class BuildExecutionGraphBenchmark {
+
+    private List<JobVertex> jobVertices;
+    private ExecutionGraph executionGraph;
+
+    public BuildExecutionGraphBenchmark() {}
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        jobVertices = createDefaultJobVertices(jobConfiguration);
+        final JobGraph jobGraph = createJobGraph(jobConfiguration);
+        executionGraph =
+                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+    }
+
+    public void buildTopology() throws Exception {
+        executionGraph.attachJobGraph(jobVertices);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.topology;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of building the topology of {@link ExecutionGraph} in a STREAMING/BATCH job. The
+ * related method is {@link ExecutionGraph#attachJobGraph},
+ */
+public class BuildExecutionGraphBenchmarkTest extends TestLogger {
+
+    @Test
+    public void buildTopologyInStreamingJob() throws Exception {
+        BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.buildTopology();
+    }
+
+    @Test
+    public void buildTopologyInBatchJob() throws Exception {
+        BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.buildTopology();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*To improve the stability of scheduler benchmarks, we'll move the implementation of scheduler benchmarks to the Flink repository and add several unit tests. When someone modifies the interfaces/methods used by scheduler benchmarks, the unit tests will fail.*

*For more details about this pull request, please check [FLINK-21525](https://issues.apache.org/jira/browse/FLINK-21524).*

*For more details about scheduler benchmarks, please check [FLINK-20612](https://issues.apache.org/jira/browse/FLINK-20612).*

## Brief change log

  - *Move the implementation of scheduler benchmarks  and its related utils from [flink-benchmark](github.com/apache/flink-benchmark) to Flink*
  - *Add unit tests for each scheduler benchmark*

## Verifying this change

*This change added unit tests for each of scheduler benchmark. These unit tests will make sure scheduler benchmarks works well in [flink-benchmark](github.com/apache/flink-benchmark).*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
