### PR TITLE
fixing the example bash command

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -157,8 +157,7 @@ You can then access the Flink UI and submit jobs via different ways:
     2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
     3. Moreover, you can use the following command below to submit jobs to the cluster:
     ```bash
-    $ ./bin/flink run -m localhost:8081 
-    $ ./examples/streaming/TopSpeedWindowing.jar
+    $ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
     ```
 
 *  Create a `NodePort` service on the rest service of jobmanager:
@@ -168,8 +167,7 @@ You can then access the Flink UI and submit jobs via different ways:
     4. Similarly to the `port-forward` solution, you can also use the following command below to submit jobs to the cluster:
 
     ```bash
-    $ ./bin/flink run -m <public-node-ip>:<node-port> 
-    $ ./examples/streaming/TopSpeedWindowing.jar
+    $ ./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/TopSpeedWindowing.jar
     ```
 
 ### Debugging and Log Access

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -74,8 +74,7 @@ Next, we set up a port forward to access the Flink UI and submit jobs:
 2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
 3. Moreover, you could use the following command below to submit jobs to the cluster:
 ```bash
-$ ./bin/flink run -m localhost:8081 
-$ ./examples/streaming/TopSpeedWindowing.jar
+$ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
 ```
 
 

--- a/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -74,8 +74,7 @@ Next, we set up a port forward to access the Flink UI and submit jobs:
 2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
 3. Moreover, you could use the following command below to submit jobs to the cluster:
 ```bash
-$ ./bin/flink run -m localhost:8081 
-$ ./examples/streaming/TopSpeedWindowing.jar
+$ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
 ```
 
 
@@ -158,8 +157,7 @@ You can then access the Flink UI and submit jobs via different ways:
     2. Navigate to [http://localhost:8081](http://localhost:8081) in your browser.
     3. Moreover, you can use the following command below to submit jobs to the cluster:
     ```bash
-    $ ./bin/flink run -m localhost:8081 
-    $ ./examples/streaming/TopSpeedWindowing.jar
+    $ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
     ```
 
 *  Create a `NodePort` service on the rest service of jobmanager:
@@ -169,8 +167,7 @@ You can then access the Flink UI and submit jobs via different ways:
     4. Similarly to the `port-forward` solution, you can also use the following command below to submit jobs to the cluster:
 
     ```bash
-    $ ./bin/flink run -m <public-node-ip>:<node-port> 
-    $ ./examples/streaming/TopSpeedWindowing.jar
+    $ ./bin/flink run -m <public-node-ip>:<node-port> ./examples/streaming/TopSpeedWindowing.jar
     ```
 
 ### Debugging and Log Access


### PR DESCRIPTION
This PR is correcting the example bash commands in the documentation so that it is easy to copy-paste them while running the examples.

Previous (not copy-paste friendly)
```
$ ./bin/flink run -m localhost:8081 
$ ./examples/streaming/TopSpeedWindowing.jar
```

New (little more copy-paste friendly)
```
$ ./bin/flink run -m localhost:8081 ./examples/streaming/TopSpeedWindowing.jar
```