### PR TITLE
[FLINK-21553][table-runtime-blink] Copy record if needed when flush window buffer records to state

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
@@ -733,7 +733,6 @@ object WindowDistinctAggregateITCase {
   def parameters(): util.Collection[Array[java.lang.Object]] = {
     Seq[Array[AnyRef]](
       Array(Boolean.box(true), HEAP_BACKEND),
-      // add SplitDistinct for HEAP back
       Array(Boolean.box(false), HEAP_BACKEND),
       Array(Boolean.box(true), ROCKSDB_BACKEND),
       Array(Boolean.box(false), ROCKSDB_BACKEND))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowDistinctAggregateITCase.scala
@@ -733,8 +733,9 @@ object WindowDistinctAggregateITCase {
   def parameters(): util.Collection[Array[java.lang.Object]] = {
     Seq[Array[AnyRef]](
       Array(Boolean.box(true), HEAP_BACKEND),
+      // add SplitDistinct for HEAP back
+      Array(Boolean.box(false), HEAP_BACKEND),
       Array(Boolean.box(true), ROCKSDB_BACKEND),
-      // we only disable SplitDistinct for ROCKSDB, to reduce test time
       Array(Boolean.box(false), ROCKSDB_BACKEND))
   }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
@@ -109,7 +109,7 @@ public class SlicingWindowAggOperatorBuilder {
         final WindowBuffer.Factory bufferFactory =
                 new RecordsWindowBuffer.Factory(keyTypes, inputType);
         final WindowCombineFunction.Factory combinerFactory =
-                new CombineRecordsFunction.Factory(generatedAggregateFunction);
+                new CombineRecordsFunction.Factory(generatedAggregateFunction, inputType);
         final SlicingWindowProcessor<Long> windowProcessor;
         if (assigner instanceof SliceSharedAssigner) {
             windowProcessor =

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
@@ -29,7 +29,10 @@ import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunc
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.window.state.StateKeyContext;
 import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.Iterator;
 
@@ -54,8 +57,10 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     /** Function used to handle all aggregates. */
     private final NamespaceAggsHandleFunction<Long> aggregator;
 
-    /** Whether to copy input key, because key is reused. */
-    private final boolean requiresCopyKey;
+    /** Whether to copy input record, because record is reused. */
+    private final boolean requiresCopy;
+
+    private final RowDataSerializer recordSerializer;
 
     /** Whether the operator works in event-time mode, used to indicate registering which timer. */
     private final boolean isEventTime;
@@ -65,13 +70,23 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
             StateKeyContext keyContext,
             WindowValueState<Long> accState,
             NamespaceAggsHandleFunction<Long> aggregator,
-            boolean requiresCopyKey,
+            boolean requiresCopy,
+            RowType recordType,
             boolean isEventTime) {
         this.timerService = timerService;
         this.keyContext = keyContext;
         this.accState = accState;
         this.aggregator = aggregator;
-        this.requiresCopyKey = requiresCopyKey;
+        this.requiresCopy = requiresCopy;
+        if (requiresCopy) {
+            LogicalType[] recordFieldTypes =
+                    recordType.getFields().stream()
+                            .map(RowType.RowField::getType)
+                            .toArray(LogicalType[]::new);
+            this.recordSerializer = new RowDataSerializer(recordFieldTypes);
+        } else {
+            this.recordSerializer = null;
+        }
         this.isEventTime = isEventTime;
     }
 
@@ -79,7 +94,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     public void combine(WindowKey windowKey, Iterator<RowData> records) throws Exception {
         // step 0: set current key for states and timers
         final BinaryRowData key;
-        if (requiresCopyKey) {
+        if (requiresCopy) {
             // the incoming key is reused, we should copy it if state backend doesn't copy it
             key = windowKey.getKey().copy();
         } else {
@@ -100,6 +115,10 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
         // step 3: do accumulate
         while (records.hasNext()) {
             RowData record = records.next();
+            if (requiresCopy) {
+                // the incoming record is reused, we should copy it if state backend doesn't copy it
+                record = recordSerializer.copy(record);
+            }
             if (isAccumulateMsg(record)) {
                 aggregator.accumulate(record);
             } else {
@@ -134,9 +153,12 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
         private static final long serialVersionUID = 1L;
 
         private final GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler;
+        private final RowType recordType;
 
-        public Factory(GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler) {
+        public Factory(
+                GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler, RowType recordType) {
             this.genAggsHandler = genAggsHandler;
+            this.recordType = recordType;
         }
 
         @Override
@@ -152,13 +174,14 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
             aggregator.open(
                     new PerWindowStateDataViewStore(
                             stateBackend, LongSerializer.INSTANCE, runtimeContext));
-            boolean requiresCopyKey = !isStateImmutableInStateBackend(stateBackend);
+            boolean requiresCopyRecord = !isStateImmutableInStateBackend(stateBackend);
             return new CombineRecordsFunction(
                     timerService,
                     stateBackend::setCurrentKey,
                     windowState,
                     aggregator,
-                    requiresCopyKey,
+                    requiresCopyRecord,
+                    recordType,
                     isEventTime);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to fix a minor bug in WTF which may cause unstable output. 

## Brief change log

  - Update CombineRecordsFunction to copy record if needed when flush window buffer records to state
  - Update SlicingWindowAggOperatorBuilder to pass InputRowType to CombineRecordsFunction.Factory.


## Verifying this change

- Existed unstable case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
