### PR TITLE
[FLINK-21586][table-planner-blink] Implement ResolvedExpression.asSerializableString for SQL

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ResolvedExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ResolvedExpression.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.expressions;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.types.DataType;
 
 import java.util.List;
@@ -46,7 +47,11 @@ public interface ResolvedExpression extends Expression {
      * @return detailed string for persisting in a catalog
      */
     default String asSerializableString() {
-        throw new UnsupportedOperationException("Expressions are not string serializable for now.");
+        throw new TableException(
+                String.format(
+                        "Expression '%s' is not string serializable. Currently, only expressions that "
+                                + "originated from a SQL expression have a well-defined string representation.",
+                        asSummaryString()));
     }
 
     /** Returns the data type of the computation result. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -24,18 +24,24 @@ import org.apache.calcite.rex.RexNode;
 public interface SqlExprToRexConverter {
 
     /**
+     * Converts the given SQL expression string to an expanded string with fully qualified function
+     * calls and escaped identifiers.
+     *
+     * <p>E.g. {@code my_udf(f0) + 1} to {@code `my_catalog`.`my_database`.`my_udf`(`f0`) + 1}
+     */
+    String expand(String expr);
+
+    /**
      * Converts a SQL expression to a {@link RexNode} expression.
      *
-     * @param expr a SQL expression which must be quoted and expanded, e.g.
-     *     "`my_catalog`.`my_database`.`my_udf`(`f0`) + 1".
+     * @param expr a SQL expression e.g. e.g. {@code `my_catalog`.`my_database`.`my_udf`(`f0`) + 1}
      */
     RexNode convertToRexNode(String expr);
 
     /**
      * Converts an array of SQL expressions to an array of {@link RexNode} expressions.
      *
-     * @param exprs SQL expressions which must be quoted and expanded, e.g.
-     *     "`my_catalog`.`my_database`.`my_udf`(`f0`) + 1".
+     * @param exprs a SQL expression e.g. {@code `my_catalog`.`my_database`.`my_udf`(`f0`) + 1}
      */
     RexNode[] convertToRexNodes(String[] exprs);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -34,7 +34,7 @@ public interface SqlExprToRexConverter {
     /**
      * Converts a SQL expression to a {@link RexNode} expression.
      *
-     * @param expr a SQL expression e.g. e.g. {@code `my_catalog`.`my_database`.`my_udf`(`f0`) + 1}
+     * @param expr a SQL expression e.g. {@code `my_catalog`.`my_database`.`my_udf`(`f0`) + 1}
      */
     RexNode convertToRexNode(String expr);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterImpl.java
@@ -26,6 +26,8 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.tools.FrameworkConfig;
 
 import java.util.Collections;
@@ -37,12 +39,15 @@ public class SqlExprToRexConverterImpl implements SqlExprToRexConverter {
 
     private final FlinkPlannerImpl planner;
 
+    private final SqlDialect sqlDialect;
+
     private final RelDataType tableRowType;
 
     public SqlExprToRexConverterImpl(
             FrameworkConfig config,
             FlinkTypeFactory typeFactory,
             RelOptCluster cluster,
+            SqlDialect sqlDialect,
             RelDataType tableRowType) {
         this.planner =
                 new FlinkPlannerImpl(
@@ -50,7 +55,16 @@ public class SqlExprToRexConverterImpl implements SqlExprToRexConverter {
                         (isLenient) -> createEmptyCatalogReader(typeFactory),
                         typeFactory,
                         cluster);
+        this.sqlDialect = sqlDialect;
         this.tableRowType = tableRowType;
+    }
+
+    @Override
+    public String expand(String expr) {
+        final CalciteParser parser = planner.parser();
+        final SqlNode node = parser.parseExpression(expr);
+        final SqlNode validated = planner.validateExpression(node, tableRowType);
+        return validated.toSqlString(sqlDialect).getSql();
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
@@ -88,10 +88,16 @@ public class ParserImpl implements Parser {
 
     @Override
     public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
-        SqlExprToRexConverter sqlExprToRexConverter =
+        final SqlExprToRexConverter sqlExprToRexConverter =
                 sqlExprToRexConverterCreator.apply(inputSchema);
-        RexNode rexNode = sqlExprToRexConverter.convertToRexNode(sqlExpression);
-        LogicalType logicalType = FlinkTypeFactory.toLogicalType(rexNode.getType());
-        return new RexNodeExpression(rexNode, TypeConversions.fromLogicalToDataType(logicalType));
+        final RexNode rexNode = sqlExprToRexConverter.convertToRexNode(sqlExpression);
+        final LogicalType logicalType = FlinkTypeFactory.toLogicalType(rexNode.getType());
+        // expand expression for serializable expression strings similar to views
+        final String sqlExpressionExpanded = sqlExprToRexConverter.expand(sqlExpression);
+        return new RexNodeExpression(
+                rexNode,
+                TypeConversions.fromLogicalToDataType(logicalType),
+                sqlExpression,
+                sqlExpressionExpanded);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -60,6 +60,8 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.dialect.HiveSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.validate.SqlConformance;
@@ -128,6 +130,7 @@ public class PlannerContext {
                 checkNotNull(frameworkConfig),
                 checkNotNull(typeFactory),
                 checkNotNull(cluster),
+                checkNotNull(getCalciteSqlDialect()),
                 rowType);
     }
 
@@ -254,6 +257,18 @@ public class PlannerContext {
                 return FlinkSqlConformance.HIVE;
             case DEFAULT:
                 return FlinkSqlConformance.DEFAULT;
+            default:
+                throw new TableException("Unsupported SQL dialect: " + sqlDialect);
+        }
+    }
+
+    private org.apache.calcite.sql.SqlDialect getCalciteSqlDialect() {
+        SqlDialect sqlDialect = tableConfig.getSqlDialect();
+        switch (sqlDialect) {
+            case HIVE:
+                return HiveSqlDialect.DEFAULT;
+            case DEFAULT:
+                return AnsiSqlDialect.DEFAULT;
             default:
                 throw new TableException("Unsupported SQL dialect: " + sqlDialect);
         }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/DeclarativeExpressionResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/DeclarativeExpressionResolver.java
@@ -99,7 +99,8 @@ public abstract class DeclarativeExpressionResolver
     public static ResolvedExpression toRexInputRef(RelBuilder builder, int i, LogicalType t) {
         RelDataType tp =
                 ((FlinkTypeFactory) builder.getTypeFactory()).createFieldTypeFromLogicalType(t);
-        return new RexNodeExpression(new RexInputRef(i, tp), fromLogicalTypeToDataType(t));
+        return new RexNodeExpression(
+                new RexInputRef(i, tp), fromLogicalTypeToDataType(t), null, null);
     }
 
     public static ResolvedExpression toRexDistinctKey(
@@ -110,6 +111,8 @@ public abstract class DeclarativeExpressionResolver
                         ((FlinkTypeFactory) builder.getTypeFactory())
                                 .createFieldTypeFromLogicalType(t),
                         t),
-                fromLogicalTypeToDataType(t));
+                fromLogicalTypeToDataType(t),
+                null,
+                null);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeExpression.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeExpression.java
@@ -80,7 +80,7 @@ public final class RexNodeExpression implements ResolvedExpression {
         throw new TableException(
                 String.format(
                         "Expression '%s' is not string serializable. Currently, only expressions that "
-                                + "originated from a SQL expressions have a well-defined string representation.",
+                                + "originated from a SQL expression have a well-defined string representation.",
                         asSummaryString()));
     }
 
@@ -102,5 +102,10 @@ public final class RexNodeExpression implements ResolvedExpression {
     @Override
     public List<ResolvedExpression> getResolvedChildren() {
         return new ArrayList<>();
+    }
+
+    @Override
+    public String toString() {
+        return asSummaryString();
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeExpression.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/RexNodeExpression.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.expressions;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionVisitor;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -25,19 +27,37 @@ import org.apache.flink.table.types.DataType;
 
 import org.apache.calcite.rex.RexNode;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/** Dummy wrapper for expressions that were converted to RexNode in a different way. */
-public class RexNodeExpression implements ResolvedExpression {
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
-    private RexNode rexNode;
-    private DataType outputDataType;
+/**
+ * Wrapper for a {@link ResolvedExpression} that originated from a {@link RexNode}.
+ *
+ * <p>If the {@link RexNode} was generated from a SQL expression, the expression can be made string
+ * serializable and print the original SQL string as a summary.
+ */
+@Internal
+public final class RexNodeExpression implements ResolvedExpression {
 
-    public RexNodeExpression(RexNode rexNode, DataType outputDataType) {
-        this.rexNode = rexNode;
-        this.outputDataType = outputDataType;
+    private final RexNode rexNode;
+    private final DataType outputDataType;
+    private final @Nullable String summaryString;
+    private final @Nullable String serializableString;
+
+    public RexNodeExpression(
+            RexNode rexNode,
+            DataType outputDataType,
+            @Nullable String summaryString,
+            @Nullable String serializableString) {
+        this.rexNode = checkNotNull(rexNode, "RexNode must not be null.");
+        this.outputDataType = checkNotNull(outputDataType, "Output data type must not be null.");
+        this.summaryString = summaryString;
+        this.serializableString = serializableString;
     }
 
     public RexNode getRexNode() {
@@ -46,7 +66,22 @@ public class RexNodeExpression implements ResolvedExpression {
 
     @Override
     public String asSummaryString() {
+        if (summaryString != null) {
+            return summaryString;
+        }
         return rexNode.toString();
+    }
+
+    @Override
+    public String asSerializableString() {
+        if (serializableString != null) {
+            return serializableString;
+        }
+        throw new TableException(
+                String.format(
+                        "Expression '%s' is not string serializable. Currently, only expressions that "
+                                + "originated from a SQL expressions have a well-defined string representation.",
+                        asSummaryString()));
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/QueryOperationConverter.java
@@ -645,7 +645,9 @@ public class QueryOperationConverter extends QueryOperationDefaultVisitor<RelNod
                                         RexNode convertedNode = expr.accept(this);
                                         return new RexNodeExpression(
                                                 convertedNode,
-                                                ((ResolvedExpression) expr).getOutputDataType());
+                                                ((ResolvedExpression) expr).getOutputDataType(),
+                                                null,
+                                                null);
                                     })
                             .collect(Collectors.toList());
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DeclarativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DeclarativeAggCodeGen.scala
@@ -235,7 +235,7 @@ class DeclarativeAggCodeGen(
         val constantIndex = inputIndex - inputTypes.length
         val constant = constants(constantIndex)
         new RexNodeExpression(constant,
-          fromLogicalTypeToDataType(FlinkTypeFactory.toLogicalType(constant.getType)))
+          fromLogicalTypeToDataType(FlinkTypeFactory.toLogicalType(constant.getType)), null, null)
       } else { // it is a input field
         if (isDistinctMerge) { // this is called from distinct merge
           if (function.operandCount == 1) {


### PR DESCRIPTION
## What is the purpose of the change

Implements `ResolvedExpression.asSerializableString` for SQL expressions. The expression is expanded to use fully qualified identifiers similar to views.

## Brief change log

- Adapt `SqlExprToRexConverter` and `RexNodeExpression`.

## Verifying this change

Tests will follow as part of FLINK-21396.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
