### PR TITLE
[FLINK-21328] Optimize the initialization of DefaultExecutionTopology

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.util;
 
+import org.apache.flink.annotation.Internal;
+
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -40,6 +45,48 @@ public class IterableUtils {
         return iterable instanceof Collection
                 ? ((Collection<E>) iterable).stream()
                 : StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    /**
+     * Flatmap the two-dimensional {@link Iterable} into an one-dimensional {@link Iterable} and
+     * convert the keys into items.
+     *
+     * @param itemGroups to flatmap
+     * @param mapper convert the {@link K} into {@link V}
+     * @param <K> type of key in the two-dimensional iterable
+     * @param <V> type of items that are mapped to
+     * @param <G> iterable of {@link K}
+     * @return flattened one-dimensional {@link Iterable} from the given two-dimensional {@link
+     *     Iterable}
+     */
+    @Internal
+    public static <K, V, G extends Iterable<K>> Iterator<V> flatMap(
+            Iterable<G> itemGroups, Function<K, V> mapper) {
+        return new Iterator<V>() {
+            private final Iterator<G> groupIterator = itemGroups.iterator();
+            private Iterator<K> itemIterator;
+
+            @Override
+            public boolean hasNext() {
+                while (itemIterator == null || !itemIterator.hasNext()) {
+                    if (!groupIterator.hasNext()) {
+                        return false;
+                    } else {
+                        itemIterator = groupIterator.next().iterator();
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public V next() {
+                if (hasNext()) {
+                    return mapper.apply(itemIterator.next());
+                } else {
+                    throw new NoSuchElementException();
+                }
+            }
+        };
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManager.java
@@ -47,11 +47,6 @@ public class EdgeManager {
 
         checkNotNull(consumerVertexGroup);
 
-        checkState(
-                !partitionConsumers.containsKey(resultPartitionId),
-                "There can only be a single consumer for the result partition %s.",
-                resultPartitionId);
-
         final List<ConsumerVertexGroup> consumers =
                 getConsumerVertexGroupsForPartitionInternal(resultPartitionId);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalPipelinedRegion.java
@@ -31,7 +31,7 @@ public class DefaultLogicalPipelinedRegion {
 
     private final Set<JobVertexID> vertexIDs;
 
-    public DefaultLogicalPipelinedRegion(final Set<? extends LogicalVertex<?, ?>> logicalVertices) {
+    public DefaultLogicalPipelinedRegion(final Set<? extends LogicalVertex> logicalVertices) {
         checkNotNull(logicalVertices);
 
         this.vertexIDs =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalResult.java
@@ -33,8 +33,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Default implementation of {@link LogicalResult}. It is an adapter of {@link IntermediateDataSet}.
  */
-public class DefaultLogicalResult
-        implements LogicalResult<DefaultLogicalVertex, DefaultLogicalResult> {
+public class DefaultLogicalResult implements LogicalResult {
 
     private final IntermediateDataSet intermediateDataSet;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
@@ -37,8 +37,7 @@ import java.util.function.Function;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of {@link LogicalTopology}. It is an adapter of {@link JobGraph}. */
-public class DefaultLogicalTopology
-        implements LogicalTopology<DefaultLogicalVertex, DefaultLogicalResult> {
+public class DefaultLogicalTopology implements LogicalTopology {
 
     private final List<DefaultLogicalVertex> verticesSorted;
 
@@ -93,11 +92,11 @@ public class DefaultLogicalTopology
     }
 
     public Set<DefaultLogicalPipelinedRegion> getLogicalPipelinedRegions() {
-        final Set<Set<DefaultLogicalVertex>> regionsRaw =
+        final Set<Set<LogicalVertex>> regionsRaw =
                 PipelinedRegionComputeUtil.computePipelinedRegions(verticesSorted);
 
         final Set<DefaultLogicalPipelinedRegion> regions = new HashSet<>();
-        for (Set<DefaultLogicalVertex> regionVertices : regionsRaw) {
+        for (Set<LogicalVertex> regionVertices : regionsRaw) {
             regions.add(new DefaultLogicalPipelinedRegion(regionVertices));
         }
         return regions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalVertex.java
@@ -30,8 +30,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of {@link LogicalVertex}. It is an adapter of {@link JobVertex}. */
-public class DefaultLogicalVertex
-        implements LogicalVertex<DefaultLogicalVertex, DefaultLogicalResult> {
+public class DefaultLogicalVertex implements LogicalVertex {
 
     private final JobVertex jobVertex;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
@@ -25,6 +25,5 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.topology.PipelinedRegion;
 
 /** Pipelined region on logical level, i.e., {@link JobVertex} level. */
-public interface LogicalPipelinedRegion<
-                V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
-        extends PipelinedRegion<JobVertexID, IntermediateDataSetID, V, R> {}
+public interface LogicalPipelinedRegion
+        extends PipelinedRegion<JobVertexID, IntermediateDataSetID, LogicalVertex, LogicalResult> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalResult.java
@@ -23,5 +23,5 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.topology.Result;
 
 /** Represents a data set produced by a {@link LogicalVertex}, i.e. {@link IntermediateDataSet}. */
-public interface LogicalResult<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
-        extends Result<JobVertexID, IntermediateDataSetID, V, R> {}
+public interface LogicalResult
+        extends Result<JobVertexID, IntermediateDataSetID, LogicalVertex, LogicalResult> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
@@ -23,5 +23,10 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.topology.Topology;
 
 /** Represents a logical topology, i.e. {@link JobGraph}. */
-public interface LogicalTopology<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
-        extends Topology<JobVertexID, IntermediateDataSetID, V, R, LogicalPipelinedRegion<V, R>> {}
+public interface LogicalTopology
+        extends Topology<
+                JobVertexID,
+                IntermediateDataSetID,
+                LogicalVertex,
+                LogicalResult,
+                LogicalPipelinedRegion> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalVertex.java
@@ -23,5 +23,5 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.topology.Vertex;
 
 /** Represents a vertex in {@link LogicalTopology}, i.e. {@link JobVertex}. */
-public interface LogicalVertex<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
-        extends Vertex<JobVertexID, IntermediateDataSetID, V, R> {}
+public interface LogicalVertex
+        extends Vertex<JobVertexID, IntermediateDataSetID, LogicalVertex, LogicalResult> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.runtime.executiongraph.DefaultExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
@@ -119,7 +120,8 @@ public class DefaultExecutionTopology implements SchedulingTopology {
         return pipelinedRegion;
     }
 
-    public static DefaultExecutionTopology fromExecutionGraph(ExecutionGraph executionGraph) {
+    public static DefaultExecutionTopology fromExecutionGraph(
+            DefaultExecutionGraph executionGraph) {
         checkNotNull(executionGraph, "execution graph can not be null");
 
         ExecutionGraphIndex executionGraphIndex =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
@@ -18,14 +18,18 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of {@link SchedulingExecutionVertex}. */
@@ -33,20 +37,35 @@ class DefaultExecutionVertex implements SchedulingExecutionVertex {
 
     private final ExecutionVertexID executionVertexId;
 
-    private final List<DefaultResultPartition> consumedResults;
-
     private final List<DefaultResultPartition> producedResults;
 
     private final Supplier<ExecutionState> stateSupplier;
 
+    private final List<ConsumedPartitionGroup> consumedPartitionGroups;
+
+    private final Function<IntermediateResultPartitionID, DefaultResultPartition>
+            resultPartitionRetriever;
+
+    DefaultExecutionVertex(
+            ExecutionVertexID executionVertexId,
+            List<DefaultResultPartition> producedPartitions,
+            Supplier<ExecutionState> stateSupplier,
+            List<ConsumedPartitionGroup> consumedPartitionGroups,
+            Function<IntermediateResultPartitionID, DefaultResultPartition>
+                    resultPartitionRetriever) {
+        this.executionVertexId = checkNotNull(executionVertexId);
+        this.stateSupplier = checkNotNull(stateSupplier);
+        this.producedResults = checkNotNull(producedPartitions);
+        this.consumedPartitionGroups = consumedPartitionGroups;
+        this.resultPartitionRetriever = resultPartitionRetriever;
+    }
+
+    @VisibleForTesting
     DefaultExecutionVertex(
             ExecutionVertexID executionVertexId,
             List<DefaultResultPartition> producedPartitions,
             Supplier<ExecutionState> stateSupplier) {
-        this.executionVertexId = checkNotNull(executionVertexId);
-        this.consumedResults = new ArrayList<>();
-        this.stateSupplier = checkNotNull(stateSupplier);
-        this.producedResults = checkNotNull(producedPartitions);
+        this(executionVertexId, producedPartitions, stateSupplier, null, null);
     }
 
     @Override
@@ -61,15 +80,16 @@ class DefaultExecutionVertex implements SchedulingExecutionVertex {
 
     @Override
     public Iterable<DefaultResultPartition> getConsumedResults() {
-        return consumedResults;
+        return () -> flatMap(consumedPartitionGroups, resultPartitionRetriever);
+    }
+
+    @Override
+    public List<ConsumedPartitionGroup> getConsumedPartitionGroups() {
+        return consumedPartitionGroups;
     }
 
     @Override
     public Iterable<DefaultResultPartition> getProducedResults() {
         return producedResults;
-    }
-
-    void addConsumedResult(DefaultResultPartition result) {
-        consumedResults.add(result);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingExecutionVertex.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.topology.Vertex;
 
+import java.util.List;
+
 /** Scheduling representation of {@link ExecutionVertex}. */
 public interface SchedulingExecutionVertex
         extends Vertex<
@@ -37,4 +39,11 @@ public interface SchedulingExecutionVertex
      * @return state of the execution vertex
      */
     ExecutionState getState();
+
+    /**
+     * Gets the {@link ConsumedPartitionGroup}s.
+     *
+     * @return list of {@link ConsumedPartitionGroup}s
+     */
+    List<ConsumedPartitionGroup> getConsumedPartitionGroups();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
@@ -23,6 +23,8 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.topology.Result;
 
+import java.util.List;
+
 /** Representation of {@link IntermediateResultPartition}. */
 public interface SchedulingResultPartition
         extends Result<
@@ -44,4 +46,11 @@ public interface SchedulingResultPartition
      * @return result partition state
      */
     ResultPartitionState getState();
+
+    /**
+     * Gets the {@link ConsumerVertexGroup}s.
+     *
+     * @return list of {@link ConsumerVertexGroup}s
+     */
+    List<ConsumerVertexGroup> getConsumerVertexGroups();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -312,24 +312,25 @@ public class ExecutionGraphTestUtils {
     }
 
     /** Creates an execution graph containing the given vertices. */
-    public static ExecutionGraph createSimpleTestGraph(JobVertex... vertices) throws Exception {
+    public static DefaultExecutionGraph createSimpleTestGraph(JobVertex... vertices)
+            throws Exception {
         return createExecutionGraph(TestingUtils.defaultExecutor(), vertices);
     }
 
-    public static ExecutionGraph createExecutionGraph(
+    public static DefaultExecutionGraph createExecutionGraph(
             ScheduledExecutorService executor, JobVertex... vertices) throws Exception {
 
         return createExecutionGraph(executor, Time.seconds(10L), vertices);
     }
 
-    public static ExecutionGraph createExecutionGraph(
+    public static DefaultExecutionGraph createExecutionGraph(
             ScheduledExecutorService executor, Time timeout, JobVertex... vertices)
             throws Exception {
 
         checkNotNull(vertices);
         checkNotNull(timeout);
 
-        ExecutionGraph executionGraph =
+        DefaultExecutionGraph executionGraph =
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setJobGraph(JobGraphTestUtils.streamingJobGraph(vertices))
                         .setFutureExecutor(executor)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.runtime.executiongraph.DefaultExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
@@ -57,7 +58,7 @@ import static org.junit.Assert.fail;
 /** Unit tests for {@link DefaultExecutionTopology}. */
 public class DefaultExecutionTopologyTest extends TestLogger {
 
-    private ExecutionGraph executionGraph;
+    private DefaultExecutionGraph executionGraph;
 
     private DefaultExecutionTopology adapter;
 
@@ -155,7 +156,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
         v2.setSlotSharingGroup(slotSharingGroup);
         v1.setStrictlyCoLocatedWith(v2);
 
-        final ExecutionGraph executionGraph = createSimpleTestGraph(v1, v2);
+        final DefaultExecutionGraph executionGraph = createSimpleTestGraph(v1, v2);
         DefaultExecutionTopology.fromExecutionGraph(executionGraph);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertexTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
@@ -32,6 +33,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
@@ -65,12 +68,20 @@ public class DefaultExecutionVertexTest extends TestLogger {
                         Collections.singletonList(schedulingResultPartition),
                         stateSupplier);
         schedulingResultPartition.setProducer(producerVertex);
+
+        List<ConsumedPartitionGroup> consumedPartitionGroups =
+                Collections.singletonList(
+                        ConsumedPartitionGroup.fromSinglePartition(intermediateResultPartitionId));
+        Map<IntermediateResultPartitionID, DefaultResultPartition> resultPartitionById =
+                Collections.singletonMap(intermediateResultPartitionId, schedulingResultPartition);
+
         consumerVertex =
                 new DefaultExecutionVertex(
                         new ExecutionVertexID(new JobVertexID(), 0),
                         Collections.emptyList(),
-                        stateSupplier);
-        consumerVertex.addConsumedResult(schedulingResultPartition);
+                        stateSupplier,
+                        consumedPartitionGroups,
+                        resultPartitionById::get);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
@@ -20,7 +20,7 @@
 package org.apache.flink.runtime.scheduler.adapter;
 
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.DefaultExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
@@ -110,7 +110,7 @@ public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
         e.connectNewDataSetAsInput(c, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
         e.connectNewDataSetAsInput(d, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
 
-        final ExecutionGraph simpleTestGraph =
+        final DefaultExecutionGraph simpleTestGraph =
                 ExecutionGraphTestUtils.createSimpleTestGraph(a, b, c, d, e);
         final DefaultExecutionTopology topology =
                 DefaultExecutionTopology.fromExecutionGraph(simpleTestGraph);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -19,12 +19,16 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A simple scheduling execution vertex for testing purposes. */
@@ -32,21 +36,27 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
     private final ExecutionVertexID executionVertexId;
 
-    private final Collection<TestingSchedulingResultPartition> consumedPartitions;
+    private final List<ConsumedPartitionGroup> consumedPartitionGroups;
 
     private final Collection<TestingSchedulingResultPartition> producedPartitions;
+
+    private final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+            resultPartitionsById;
 
     private ExecutionState executionState;
 
     public TestingSchedulingExecutionVertex(
             JobVertexID jobVertexId,
             int subtaskIndex,
-            Collection<TestingSchedulingResultPartition> consumedPartitions,
+            List<ConsumedPartitionGroup> consumedPartitionGroups,
+            Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                    resultPartitionsById,
             ExecutionState executionState) {
 
         this.executionVertexId = new ExecutionVertexID(jobVertexId, subtaskIndex);
-        this.consumedPartitions = checkNotNull(consumedPartitions);
+        this.consumedPartitionGroups = checkNotNull(consumedPartitionGroups);
         this.producedPartitions = new ArrayList<>();
+        this.resultPartitionsById = checkNotNull(resultPartitionsById);
         this.executionState = executionState;
     }
 
@@ -66,7 +76,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
     @Override
     public Iterable<TestingSchedulingResultPartition> getConsumedResults() {
-        return consumedPartitions;
+        return () -> flatMap(consumedPartitionGroups, resultPartitionsById::get);
     }
 
     @Override
@@ -74,8 +84,23 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
         return producedPartitions;
     }
 
-    void addConsumedPartition(TestingSchedulingResultPartition partition) {
-        consumedPartitions.add(partition);
+    @Override
+    public List<ConsumedPartitionGroup> getConsumedPartitionGroups() {
+        return consumedPartitionGroups;
+    }
+
+    void addConsumedPartition(TestingSchedulingResultPartition consumedPartition) {
+        this.consumedPartitionGroups.add(
+                ConsumedPartitionGroup.fromSinglePartition(consumedPartition.getId()));
+        this.resultPartitionsById.putIfAbsent(consumedPartition.getId(), consumedPartition);
+    }
+
+    void addConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup,
+            Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                    consumedResultPartitionById) {
+        this.consumedPartitionGroups.add(consumedPartitionGroup);
+        this.resultPartitionsById.putAll(consumedResultPartitionById);
     }
 
     void addProducedPartition(TestingSchedulingResultPartition partition) {
@@ -95,7 +120,9 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
     public static class Builder {
         private JobVertexID jobVertexId = new JobVertexID();
         private int subtaskIndex = 0;
-        private List<TestingSchedulingResultPartition> partitions = new ArrayList<>();
+        private final List<ConsumedPartitionGroup> consumedPartitionGroups = new ArrayList<>();
+        private final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                resultPartitionsById = new HashMap<>();
         private ExecutionState executionState = ExecutionState.CREATED;
 
         Builder withExecutionVertexID(JobVertexID jobVertexId, int subtaskIndex) {
@@ -104,8 +131,21 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
             return this;
         }
 
-        public Builder withConsumedPartitions(List<TestingSchedulingResultPartition> partitions) {
-            this.partitions = partitions;
+        public Builder withConsumedPartitionGroups(
+                List<ConsumedPartitionGroup> consumedPartitionGroups,
+                Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                        resultPartitionsById) {
+            this.resultPartitionsById.putAll(resultPartitionsById);
+
+            for (ConsumedPartitionGroup partitionGroup : consumedPartitionGroups) {
+                List<IntermediateResultPartitionID> partitionIds =
+                        new ArrayList<>(partitionGroup.size());
+                for (IntermediateResultPartitionID partitionId : partitionGroup) {
+                    partitionIds.add(partitionId);
+                }
+                this.consumedPartitionGroups.add(
+                        ConsumedPartitionGroup.fromMultiplePartitions(partitionIds));
+            }
             return this;
         }
 
@@ -116,7 +156,11 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
         public TestingSchedulingExecutionVertex build() {
             return new TestingSchedulingExecutionVertex(
-                    jobVertexId, subtaskIndex, partitions, executionState);
+                    jobVertexId,
+                    subtaskIndex,
+                    consumedPartitionGroups,
+                    resultPartitionsById,
+                    executionState);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -323,21 +324,48 @@ public class TestingSchedulingTopology implements SchedulingTopology {
             final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
             final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
 
+            ConsumerVertexGroup consumerVertexGroup =
+                    ConsumerVertexGroup.fromMultipleVertices(
+                            consumers.stream()
+                                    .map(TestingSchedulingExecutionVertex::getId)
+                                    .collect(Collectors.toList()));
+
+            Map<ExecutionVertexID, TestingSchedulingExecutionVertex> consumerVertexById =
+                    consumers.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            TestingSchedulingExecutionVertex::getId,
+                                            Function.identity()));
+
+            TestingSchedulingResultPartition.Builder resultPartitionBuilder =
+                    initTestingSchedulingResultPartitionBuilder()
+                            .withIntermediateDataSetID(intermediateDataSetId)
+                            .withResultPartitionState(resultPartitionState);
             for (TestingSchedulingExecutionVertex producer : producers) {
 
                 final TestingSchedulingResultPartition resultPartition =
-                        initTestingSchedulingResultPartitionBuilder()
-                                .withIntermediateDataSetID(intermediateDataSetId)
-                                .withResultPartitionState(resultPartitionState)
-                                .build();
+                        resultPartitionBuilder.build();
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
 
-                for (TestingSchedulingExecutionVertex consumer : consumers) {
-                    consumer.addConsumedPartition(resultPartition);
-                    resultPartition.addConsumer(consumer);
-                }
+                resultPartition.addConsumerGroup(consumerVertexGroup, consumerVertexById);
                 resultPartitions.add(resultPartition);
+            }
+
+            ConsumedPartitionGroup consumedPartitionGroup =
+                    ConsumedPartitionGroup.fromMultiplePartitions(
+                            resultPartitions.stream()
+                                    .map(TestingSchedulingResultPartition::getId)
+                                    .collect(Collectors.toList()));
+            Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                    consumedPartitionById =
+                            resultPartitions.stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    TestingSchedulingResultPartition::getId,
+                                                    Function.identity()));
+            for (TestingSchedulingExecutionVertex consumer : consumers) {
+                consumer.addConsumedPartitionGroup(consumedPartitionGroup, consumedPartitionById);
             }
 
             return resultPartitions;


### PR DESCRIPTION
## What is the purpose of the change

*This PR introduces the optimization of the initialization of DefaultExecutionTopology.*

*Based on FLINK-21326, the consumedResults in DefaultExecutionVertex and consumers in DefaultResultPartition can be replaced with ConsumedPartitionGroup and ConsumerVertexGroup in EdgeManager.*

*The complexity of initializing DefaultExecutionTopology decreases from O(N^2) to O(N).*

*For more details, please check [FLINK-21328](https://issues.apache.org/jira/browse/FLINK-21328).*


## Brief change log

  - *Remove generic from LogicalTopology and its components*
  - *Use iterators to implement SchedulingExecutionVertex#getConsumerPartitionGroups and SchedulingResultPartition#getConsumerVertexGroups*
  - *Remove DefaultExecutionTopology#connectVerticesToConsumedPartitions, and replace connections between DefaultExecutionVertices and DefaultResultPartitions with connections stored in EdgeManager*
 

## Verifying this change

*Since these optimizations do not change the original logic of the establishing connections in DefaultExecutionTopology, we believe that this change is already covered by existing tests, such as DefaultExecutionTopologyTest, DefaultExecutionVertexTest, DefaultResultPartitionTest, DefaultSchedulingPipelinedRegionTest, and etc.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
