### PR TITLE
[FLINK-21428] Fixes AdaptiveSchedulerSlotSharingITCase

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -99,5 +99,11 @@
             <td>String</td>
             <td>The external RPC port where the TaskManager is exposed. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
+        <tr>
+            <td><h5>taskmanager.slot.timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/task_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_configuration.html
@@ -93,5 +93,11 @@
             <td>String</td>
             <td>The external RPC port where the TaskManager is exposed. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
+        <tr>
+            <td><h5>taskmanager.slot.timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active within the given amount of time. Inactive slots can be caused by an out-dated slot request.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -236,6 +236,16 @@ public class TaskManagerOptions {
                                     + " is typically proportional to the number of physical CPU cores that the TaskManager's machine has"
                                     + " (e.g., equal to the number of cores, or half the number of cores).");
 
+    /** Timeout for identifying inactive slots. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<Duration> SLOT_TIMEOUT =
+            ConfigOptions.key("taskmanager.slot.timeout")
+                    .durationType()
+                    .defaultValue(TimeUtils.parseDuration("10 s"))
+                    .withDescription(
+                            "Timeout used for identifying inactive slots. The TaskManager will free the slot if it does not become active "
+                                    + "within the given amount of time. Inactive slots can be caused by an out-dated slot request.");
+
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
     public static final ConfigOption<Boolean> DEBUG_MEMORY_LOG =
             key("taskmanager.debug.memory.log")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/JobScopedResourceTracker.java
@@ -224,8 +224,8 @@ class JobScopedResourceTracker {
         if (LOG.isTraceEnabled()) {
             LOG.trace(
                     "There are {} excess resources for job {} before re-assignment.",
-                    jobId,
-                    excessResources.getTotalResourceCount());
+                    excessResources.getTotalResourceCount(),
+                    jobId);
         }
 
         ResourceCounter assignedResources = ResourceCounter.empty();
@@ -255,8 +255,8 @@ class JobScopedResourceTracker {
         if (LOG.isTraceEnabled()) {
             LOG.trace(
                     "There are {} excess resources for job {} after re-assignment.",
-                    jobId,
-                    excessResources.getTotalResourceCount());
+                    excessResources.getTotalResourceCount(),
+                    jobId);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -96,6 +96,7 @@ class WaitingForResources implements State, ResourceConsumer {
     }
 
     private void resourceTimeout() {
+        log.debug("Resource timeout triggered: Creating ExecutionGraph with available resources.");
         createExecutionGraphWithAvailableResources();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -593,7 +593,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             jobManagerConnection.getJobManagerGateway(),
                             taskInformation.getJobVertexId(),
                             tdd.getExecutionAttemptId(),
-                            taskManagerConfiguration.getTimeout());
+                            taskManagerConfiguration.getRpcTimeout());
 
             final TaskOperatorEventGateway taskOperatorEventGateway =
                     new RpcTaskOperatorEventGateway(
@@ -1051,7 +1051,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     jobId,
                     allocationId,
                     resourceProfile,
-                    taskManagerConfiguration.getTimeout())) {
+                    taskManagerConfiguration.getSlotTimeout())) {
                 log.info("Allocated slot for {}.", allocationId);
             } else {
                 log.info("Could not allocate slot for {}.", allocationId);
@@ -1264,7 +1264,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                         getResourceID(),
                         taskExecutorRegistrationId,
                         taskSlotTable.createSlotReport(getResourceID()),
-                        taskManagerConfiguration.getTimeout());
+                        taskManagerConfiguration.getRpcTimeout());
 
         slotReportResponseFuture.whenCompleteAsync(
                 (acknowledge, throwable) -> {
@@ -1410,7 +1410,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
             CompletableFuture<Collection<SlotOffer>> acceptedSlotsFuture =
                     jobMasterGateway.offerSlots(
-                            getResourceID(), reservedSlots, taskManagerConfiguration.getTimeout());
+                            getResourceID(),
+                            reservedSlots,
+                            taskManagerConfiguration.getRpcTimeout());
 
             acceptedSlotsFuture.whenCompleteAsync(
                     handleAcceptedSlotOffers(jobId, jobMasterGateway, jobMasterId, reservedSlots),
@@ -1580,7 +1582,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         for (AllocationID activeSlotAllocationID : activeSlotAllocationIDs) {
             try {
                 if (!taskSlotTable.markSlotInactive(
-                        activeSlotAllocationID, taskManagerConfiguration.getTimeout())) {
+                        activeSlotAllocationID, taskManagerConfiguration.getSlotTimeout())) {
                     freeSlotInternal(activeSlotAllocationID, freeingCause);
                 }
             } catch (SlotNotFoundException e) {
@@ -1616,7 +1618,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 new RpcResultPartitionConsumableNotifier(
                         jobMasterGateway,
                         getRpcService().getExecutor(),
-                        taskManagerConfiguration.getTimeout());
+                        taskManagerConfiguration.getRpcTimeout());
 
         PartitionProducerStateChecker partitionStateChecker =
                 new RpcPartitionStateChecker(jobMasterGateway);


### PR DESCRIPTION
## What is the purpose of the change

The test had two problems:
1. The parallelism of the job exceeded the available slots which caused a resource timeout for every job run
2. There's a know race condition between the `ResourceManager` cleaning up the requirements in the `DefaultDeclarativeSlotPool` while freeing the finished job's resources and the corresponding `TaskExecutor` freeing its tasks as part of the job cleanup.

## Brief change log

* The job's parallelism was lowered.
* A new parameter `taskmanager.slot.timeout` is introduced that makes the time a slot becomes inactive configurable independently from the rpc timeout which was used before.
* The new parameter is used in `AdaptiveSchedulerSlotSharingITCase` to break the race condition between the two cleanup mechanisms. The slot is freed faster now If the it was accidentally allocated again for the finished job due to the `TaskExecutor` cleaning up faster than the `ResourceManager`.

## Verifying this  change

We looped over the test where it failed consistently before the change. The [AzureCI run](https://dev.azure.com/mapohl/flink/_build/results?buildId=307&view=results) failed due to no error being caught anymore.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
