### PR TITLE
[FLINK-16444][state] Count the get/put/seek/next/writeBatch latency of RocksDB as metrics

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -15,6 +15,24 @@
             <td>The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.latency-track-enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to track latency of RocksDB actions, e.g put/get/delete/seek/next.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.latency-track-sample-interval</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
+            <td>The sample interval of latency track once 'state.backend.rocksdb.latency-track-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.latency-track-sliding-window</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
+            <td>The sliding window of histogram to record the latency once 'state.backend.rocksdb.latency-track-enabled' is enabled. The default value is 10 seconds, which means we stores only the measurements made in the last 10 seconds.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
@@ -9,6 +9,24 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>state.backend.rocksdb.latency-track-enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to track latency of RocksDB actions, e.g put/get/delete/seek/next.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.latency-track-sample-interval</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
+            <td>The sample interval of latency track once 'state.backend.rocksdb.latency-track-enabled' is enabled. The default value is 100, which means we would track the latency every 100 access requests.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.latency-track-sliding-window</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Long</td>
+            <td>The sliding window of histogram to record the latency once 'state.backend.rocksdb.latency-track-enabled' is enabled. The default value is 10 seconds, which means we stores only the measurements made in the last 10 seconds.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.memory.fixed-per-slot</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.7
+- io.dropwizard.metrics:metrics-core:3.2.6
 - org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -33,10 +33,6 @@ under the License.
 	<name>Flink : Metrics : </name>
 	<packaging>pom</packaging>
 
-	<properties>
-		<dropwizard.version>3.2.6</dropwizard.version>
-	</properties>
-
 	<modules>
 		<module>flink-metrics-core</module>
 		<module>flink-metrics-dropwizard</module>

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -60,6 +60,12 @@ under the License.
 			<version>5.17.2-artisans-2.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>io.dropwizard.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>${dropwizard.version}</version>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
@@ -41,7 +40,7 @@ abstract class AbstractRocksDBAppendingState<K, N, IN, SV, OUT>
      * @param backend The backend for which this state is bind to.
      */
     protected AbstractRocksDBAppendingState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<SV> valueSerializer,
             SV defaultValue,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -30,7 +30,6 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
 
@@ -61,7 +60,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
     protected RocksDBKeyedStateBackend<K> backend;
 
     /** The column family of this particular instance of state. */
-    protected ColumnFamilyHandle columnFamily;
+    protected ColumnFamilyHandleWrapper columnFamily;
 
     protected final V defaultValue;
 
@@ -83,7 +82,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
      * @param backend The backend for which this state is bind to.
      */
     protected AbstractRocksDBState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<V> valueSerializer,
             V defaultValue,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ColumnFamilyHandleWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ColumnFamilyHandleWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+/**
+ * Wrapper of {@link ColumnFamilyHandle}, we introduce this class is to avoid JNI call of {@link
+ * ColumnFamilyHandle#getID()}.
+ */
+public class ColumnFamilyHandleWrapper implements AutoCloseable {
+    private final ColumnFamilyHandle columnFamilyHandle;
+    private final int columnFamilyId;
+
+    public ColumnFamilyHandleWrapper(ColumnFamilyHandle columnFamilyHandle) {
+        this.columnFamilyHandle = columnFamilyHandle;
+        this.columnFamilyId = columnFamilyHandle.getID();
+    }
+
+    public int getColumnFamilyId() {
+        return columnFamilyId;
+    }
+
+    public ColumnFamilyHandle getColumnFamilyHandle() {
+        return columnFamilyHandle;
+    }
+
+    @Override
+    public void close() throws Exception {
+        columnFamilyHandle.close();
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -145,6 +145,9 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
     /** The default rocksdb metrics options. */
     private final RocksDBNativeMetricOptions defaultMetricOptions;
 
+    /** The options to track rocksdb latency. */
+    private final RocksDBAccessMetric.Builder accessMetricBuilder;
+
     // -- runtime values, set on TaskManager when initializing / using the backend
 
     /** Base paths for RocksDB directory, as initialized. */
@@ -190,6 +193,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
         this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
         this.numberOfTransferThreads = UNDEFINED_NUMBER_OF_TRANSFER_THREADS;
         this.defaultMetricOptions = new RocksDBNativeMetricOptions();
+        this.accessMetricBuilder = new RocksDBAccessMetric.Builder();
         this.memoryConfiguration = new RocksDBMemoryConfiguration();
         this.writeBatchSize = UNDEFINED_WRITE_BATCH_SIZE;
     }
@@ -253,6 +257,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
 
         // configure metric options
         this.defaultMetricOptions = RocksDBNativeMetricOptions.fromConfig(config);
+        this.accessMetricBuilder = RocksDBAccessMetric.builderFromConfig(config);
 
         // configure RocksDB predefined options
         this.predefinedOptions =
@@ -467,6 +472,7 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
                         .setNumberOfTransferingThreads(getNumberOfTransferThreads())
                         .setNativeMetricOptions(
                                 resourceContainer.getMemoryWatcherOptions(defaultMetricOptions))
+                        .setAccessMetricBuilder(accessMetricBuilder)
                         .setWriteBatchSize(getWriteBatchSize());
         return builder.build();
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAccessMetric.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAccessMetric.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.Preconditions;
+
+import com.codahale.metrics.SlidingTimeWindowReservoir;
+import com.codahale.metrics.Snapshot;
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor.COLUMN_FAMILY_KEY;
+
+/** Metrics to counting access latency. */
+public class RocksDBAccessMetric implements AutoCloseable {
+    private final Map<Integer, MetricGroup> columnFamilyMetricGroups;
+
+    private final Map<Integer, Counters> countersPerColumnFamily;
+
+    private final Map<Integer, Map<String, Histogram>> histogramMetrics;
+
+    private final MetricGroup metricGroup;
+
+    private final int sampleCountInterval;
+
+    private final boolean metricsSampleEnabled;
+
+    private final long histogramWindowSize;
+
+    private final Supplier<com.codahale.metrics.Histogram> histogramSupplier;
+
+    static final String GET_LATENCY = "getLatency";
+    static final String PUT_LATENCY = "putLatency";
+    static final String WRITE_BATCH_LATENCY = "writeBatchLatency";
+    static final String DELETE_LATENCY = "deleteLatency";
+    static final String MERGE_LATENCY = "mergeLatency";
+    static final String SEEK_LATENCY = "seekLatency";
+    static final String NEXT_LATENCY = "nextLatency";
+
+    RocksDBAccessMetric(
+            MetricGroup metricGroup, int sampleCountInterval, long histogramWindowSize) {
+        this.metricGroup = Preconditions.checkNotNull(metricGroup);
+        this.sampleCountInterval = sampleCountInterval;
+        this.metricsSampleEnabled = sampleCountInterval > 1;
+
+        Preconditions.checkArgument(histogramWindowSize > 0);
+        this.histogramWindowSize = histogramWindowSize;
+        this.histogramMetrics = new HashMap<>();
+        this.columnFamilyMetricGroups = new HashMap<>();
+        this.countersPerColumnFamily = new HashMap<>();
+        this.histogramSupplier =
+                () ->
+                        new com.codahale.metrics.Histogram(
+                                new SlidingTimeWindowReservoir(
+                                        histogramWindowSize, TimeUnit.SECONDS));
+    }
+
+    boolean checkAndUpdateGetCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdateGetCounter();
+    }
+
+    boolean checkAndUpdatePutCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdatePutCounter();
+    }
+
+    boolean checkAndUpdateWriteBatchCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily
+                        .get(columnFamilyHandleId)
+                        .checkAndUpdateWriteBatchCounter();
+    }
+
+    boolean checkAndUpdateDeleteCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdateDeleteCounter();
+    }
+
+    boolean checkAndUpdateMergeCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdateMergeCounter();
+    }
+
+    boolean checkAndUpdateSeekCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdateSeekCounter();
+    }
+
+    boolean checkAndUpdateNextCounter(final int columnFamilyHandleId) {
+        return metricsSampleEnabled
+                && countersPerColumnFamily.get(columnFamilyHandleId).checkAndUpdateNextCounter();
+    }
+
+    public void updateHistogram(
+            final int columnFamilyHandleId, final String metricName, final long durationNanoTime) {
+        this.histogramMetrics
+                .get(columnFamilyHandleId)
+                .computeIfAbsent(
+                        metricName,
+                        (k) -> {
+                            HistogramWrapper histogram =
+                                    new HistogramWrapper(histogramSupplier.get());
+                            columnFamilyMetricGroups
+                                    .get(columnFamilyHandleId)
+                                    .histogram(metricName, histogram);
+                            return histogram;
+                        })
+                .update(durationNanoTime);
+    }
+
+    boolean isMetricsSampleEnabled() {
+        return metricsSampleEnabled;
+    }
+
+    int getSampleCountInterval() {
+        return sampleCountInterval;
+    }
+
+    long getHistogramWindowSize() {
+        return histogramWindowSize;
+    }
+
+    @VisibleForTesting
+    Map<Integer, Map<String, Histogram>> getHistogramMetrics() {
+        return histogramMetrics;
+    }
+
+    /**
+     * Register histogram to track latency metrics for the column family.
+     *
+     * @param columnFamilyName group name for the new gauges
+     * @param handle native handle to the column family
+     */
+    void registerColumnFamily(String columnFamilyName, ColumnFamilyHandle handle) {
+        int columnFamilyId = handle.getID();
+        columnFamilyMetricGroups.putIfAbsent(
+                columnFamilyId, metricGroup.addGroup(COLUMN_FAMILY_KEY, columnFamilyName));
+        histogramMetrics.putIfAbsent(columnFamilyId, new HashMap<>());
+        if (metricsSampleEnabled) {
+            countersPerColumnFamily.putIfAbsent(columnFamilyId, new Counters(sampleCountInterval));
+        }
+    }
+
+    @Override
+    public void close() {
+        this.histogramMetrics.clear();
+        this.countersPerColumnFamily.clear();
+        this.columnFamilyMetricGroups.clear();
+    }
+
+    static class HistogramWrapper implements Histogram {
+        private final com.codahale.metrics.Histogram histogram;
+
+        public HistogramWrapper(com.codahale.metrics.Histogram histogram) {
+            this.histogram = histogram;
+        }
+
+        @Override
+        public void update(long value) {
+            histogram.update(value);
+        }
+
+        @Override
+        public long getCount() {
+            return histogram.getCount();
+        }
+
+        @Override
+        public HistogramStatistics getStatistics() {
+            return new SnapshotHistogramStatistics(this.histogram.getSnapshot());
+        }
+    }
+
+    private static class SnapshotHistogramStatistics extends HistogramStatistics {
+
+        private final Snapshot snapshot;
+
+        SnapshotHistogramStatistics(com.codahale.metrics.Snapshot snapshot) {
+            this.snapshot = snapshot;
+        }
+
+        @Override
+        public double getQuantile(double quantile) {
+            return snapshot.getValue(quantile);
+        }
+
+        @Override
+        public long[] getValues() {
+            return snapshot.getValues();
+        }
+
+        @Override
+        public int size() {
+            return snapshot.size();
+        }
+
+        @Override
+        public double getMean() {
+            return snapshot.getMean();
+        }
+
+        @Override
+        public double getStdDev() {
+            return snapshot.getStdDev();
+        }
+
+        @Override
+        public long getMax() {
+            return snapshot.getMax();
+        }
+
+        @Override
+        public long getMin() {
+            return snapshot.getMin();
+        }
+    }
+
+    public static Builder builderFromConfig(ReadableConfig config) {
+        Builder builder = new Builder();
+        return builder.setEnabled(config.get(RocksDBOptions.LATENCY_TRACK_ENABLED))
+                .setSampleInterval(config.get(RocksDBOptions.LATENCY_TRACK_SAMPLE_INTERVAL))
+                .setHistogramSlidingWindow(config.get(RocksDBOptions.LATENCY_TRACK_SLIDING_WINDOW));
+    }
+
+    /** Builder for {@link RocksDBAccessMetric}. */
+    public static class Builder implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private boolean isEnabled = RocksDBOptions.LATENCY_TRACK_ENABLED.defaultValue();
+        private int sampleInterval = RocksDBOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue();
+        private long histogramSlidingWindow =
+                RocksDBOptions.LATENCY_TRACK_SLIDING_WINDOW.defaultValue();
+        private MetricGroup metricGroup;
+
+        public Builder setEnabled(boolean enabled) {
+            this.isEnabled = enabled;
+            return this;
+        }
+
+        public Builder setSampleInterval(int sampleInterval) {
+            this.sampleInterval = sampleInterval;
+            return this;
+        }
+
+        public Builder setHistogramSlidingWindow(long histogramSlidingWindow) {
+            this.histogramSlidingWindow = histogramSlidingWindow;
+            return this;
+        }
+
+        public Builder setMetricGroup(MetricGroup metricGroup) {
+            this.metricGroup = metricGroup;
+            return this;
+        }
+
+        public RocksDBAccessMetric build() {
+            if (isEnabled) {
+                return new RocksDBAccessMetric(
+                        Preconditions.checkNotNull(metricGroup),
+                        sampleInterval,
+                        histogramSlidingWindow);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    private static class Counters {
+        private final int metricSampledInterval;
+        private int getCounter;
+        private int putCounter;
+        private int writeBatchCounter;
+        private int deleteCounter;
+        private int mergeCounter;
+        private int seekCounter;
+        private int nextCounter;
+
+        Counters(int metricSampledInterval) {
+            this.metricSampledInterval = metricSampledInterval;
+            this.getCounter = 0;
+            this.putCounter = 0;
+            this.writeBatchCounter = 0;
+            this.deleteCounter = 0;
+            this.mergeCounter = 0;
+            this.seekCounter = 0;
+            this.nextCounter = 0;
+        }
+
+        private int updateMetricsSampledCounter(int counter) {
+            return (counter + 1 < metricSampledInterval) ? counter + 1 : 0;
+        }
+
+        boolean checkAndUpdateGetCounter() {
+            boolean result = getCounter == 0;
+            this.getCounter = updateMetricsSampledCounter(getCounter);
+            return result;
+        }
+
+        boolean checkAndUpdatePutCounter() {
+            boolean result = putCounter == 0;
+            this.putCounter = updateMetricsSampledCounter(putCounter);
+            return result;
+        }
+
+        boolean checkAndUpdateWriteBatchCounter() {
+            boolean result = writeBatchCounter == 0;
+            this.writeBatchCounter = updateMetricsSampledCounter(writeBatchCounter);
+            return result;
+        }
+
+        boolean checkAndUpdateDeleteCounter() {
+            boolean result = deleteCounter == 0;
+            this.deleteCounter = updateMetricsSampledCounter(deleteCounter);
+            return result;
+        }
+
+        boolean checkAndUpdateMergeCounter() {
+            boolean result = mergeCounter == 0;
+            this.mergeCounter = updateMetricsSampledCounter(mergeCounter);
+            return result;
+        }
+
+        boolean checkAndUpdateSeekCounter() {
+            boolean result = seekCounter == 0;
+            this.seekCounter = updateMetricsSampledCounter(seekCounter);
+            return result;
+        }
+
+        boolean checkAndUpdateNextCounter() {
+            boolean result = nextCounter == 0;
+            this.nextCounter = updateMetricsSampledCounter(nextCounter);
+            return result;
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -29,8 +29,6 @@ import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.rocksdb.ColumnFamilyHandle;
-
 import java.util.Collection;
 
 /**
@@ -60,7 +58,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
      * @param backend The backend for which this state is bind to.
      */
     private RocksDBAggregatingState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<ACC> valueSerializer,
             ACC defaultValue,
@@ -164,7 +162,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
     @SuppressWarnings("unchecked")
     static <K, N, SV, S extends State, IS extends S> IS create(
             StateDescriptor<S, SV> stateDesc,
-            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
+            Tuple2<ColumnFamilyHandleWrapper, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
                     registerResult,
             RocksDBKeyedStateBackend<K> backend) {
         return (IS)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBCachingPriorityQueueSet.java
@@ -29,9 +29,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava18.com.google.common.primitives.UnsignedBytes;
 
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ReadOptions;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import javax.annotation.Nonnegative;
@@ -62,12 +60,14 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
     private static final byte[] DUMMY_BYTES = new byte[] {};
 
     /** The RocksDB instance that serves as store. */
-    @Nonnull private final RocksDB db;
+    @Nonnull private final RocksDBWrapper db;
 
     @Nonnull private final ReadOptions readOptions;
 
+    @Nullable private final RocksDBAccessMetric accessMetric;
+
     /** Handle to the column family of the RocksDB instance in which the elements are stored. */
-    @Nonnull private final ColumnFamilyHandle columnFamilyHandle;
+    @Nonnull private final ColumnFamilyHandleWrapper columnFamilyHandle;
 
     /**
      * Serializer for the contained elements. The lexicographical order of the bytes of serialized
@@ -108,9 +108,10 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
     RocksDBCachingPriorityQueueSet(
             @Nonnegative int keyGroupId,
             @Nonnegative int keyGroupPrefixBytes,
-            @Nonnull RocksDB db,
+            @Nonnull RocksDBWrapper db,
             @Nonnull ReadOptions readOptions,
-            @Nonnull ColumnFamilyHandle columnFamilyHandle,
+            @Nullable RocksDBAccessMetric accessMetric,
+            @Nonnull ColumnFamilyHandleWrapper columnFamilyHandle,
             @Nonnull TypeSerializer<E> byteOrderProducingSerializer,
             @Nonnull DataOutputSerializer outputStream,
             @Nonnull DataInputDeserializer inputStream,
@@ -118,6 +119,7 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
             @Nonnull OrderedByteArraySetCache orderedByteArraySetCache) {
         this.db = db;
         this.readOptions = readOptions;
+        this.accessMetric = accessMetric;
         this.columnFamilyHandle = columnFamilyHandle;
         this.byteOrderProducingSerializer = byteOrderProducingSerializer;
         this.batchWrapper = batchWrapper;
@@ -303,7 +305,7 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
     private RocksBytesIterator orderedBytesIterator() {
         flushWriteBatch();
         return new RocksBytesIterator(
-                new RocksIteratorWrapper(db.newIterator(columnFamilyHandle, readOptions)));
+                RocksDBOperationUtils.getRocksIterator(db, columnFamilyHandle, readOptions));
     }
 
     /** Ensures that recent writes are flushed and reflect in the RocksDB instance. */
@@ -317,7 +319,7 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
 
     private void addToRocksDB(@Nonnull byte[] toAddBytes) {
         try {
-            batchWrapper.put(columnFamilyHandle, toAddBytes, DUMMY_BYTES);
+            batchWrapper.put(columnFamilyHandle.getColumnFamilyHandle(), toAddBytes, DUMMY_BYTES);
         } catch (RocksDBException e) {
             throw new FlinkRuntimeException(e);
         }
@@ -325,7 +327,7 @@ public class RocksDBCachingPriorityQueueSet<E extends HeapPriorityQueueElement>
 
     private void removeFromRocksDB(@Nonnull byte[] toRemoveBytes) {
         try {
-            batchWrapper.remove(columnFamilyHandle, toRemoveBytes);
+            batchWrapper.remove(columnFamilyHandle.getColumnFamilyHandle(), toRemoveBytes);
         } catch (RocksDBException e) {
             throw new FlinkRuntimeException(e);
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -129,10 +129,10 @@ public class RocksDBIncrementalCheckpointUtils {
         for (ColumnFamilyHandle columnFamilyHandle : columnFamilyHandles) {
             try (ReadOptions readOptions = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
                     RocksIteratorWrapper iteratorWrapper =
-                            RocksDBOperationUtils.getRocksIterator(
+                            RocksDBOperationUtils.getRocksIteratorWithoutAccessMetric(
                                     db, columnFamilyHandle, readOptions);
                     RocksDBWriteBatchWrapper writeBatchWrapper =
-                            new RocksDBWriteBatchWrapper(db, writeBatchSize)) {
+                            new RocksDBWriteBatchWrapper(new RocksDBWrapper(db), writeBatchSize)) {
 
                 iteratorWrapper.seek(beginKeyBytes);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -34,7 +34,6 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
 import javax.annotation.Nullable;
@@ -79,7 +78,7 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
      * @param backend The backend for which this state is bind to.
      */
     private RocksDBListState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<List<V>> valueSerializer,
             List<V> defaultValue,
@@ -245,7 +244,7 @@ class RocksDBListState<K, N, V> extends AbstractRocksDBState<K, N, List<V>>
     @SuppressWarnings("unchecked")
     static <E, K, N, SV, S extends State, IS extends S> IS create(
             StateDescriptor<S, SV> stateDesc,
-            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
+            Tuple2<ColumnFamilyHandleWrapper, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
                     registerResult,
             RocksDBKeyedStateBackend<K> backend) {
         return (IS)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.MemorySize;
@@ -149,4 +150,34 @@ public class RocksDBOptions {
                                             + "the partitions that are required to perform the index/filter query. "
                                             + "This option only has an effect when '%s' or '%s' are configured.",
                                     USE_MANAGED_MEMORY.key(), FIX_PER_SLOT_MEMORY_SIZE.key()));
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
+    public static final ConfigOption<Boolean> LATENCY_TRACK_ENABLED =
+            ConfigOptions.key("state.backend.rocksdb.latency-track-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to track latency of RocksDB actions, e.g put/get/delete/seek/next.");
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
+    public static final ConfigOption<Integer> LATENCY_TRACK_SAMPLE_INTERVAL =
+            ConfigOptions.key("state.backend.rocksdb.latency-track-sample-interval")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            String.format(
+                                    "The sample interval of latency track once '%s' is enabled. "
+                                            + "The default value is 100, which means we would track the latency every 100 access requests.",
+                                    LATENCY_TRACK_ENABLED.key()));
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
+    public static final ConfigOption<Long> LATENCY_TRACK_SLIDING_WINDOW =
+            ConfigOptions.key("state.backend.rocksdb.latency-track-sliding-window")
+                    .longType()
+                    .defaultValue(Time.seconds(10).toMilliseconds())
+                    .withDescription(
+                            String.format(
+                                    "The sliding window of histogram to record the latency once '%s' is enabled. "
+                                            + "The default value is 10 seconds, which means we stores only the measurements made in the last 10 seconds.",
+                                    LATENCY_TRACK_ENABLED.key()));
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -29,8 +29,6 @@ import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.rocksdb.ColumnFamilyHandle;
-
 import java.util.Collection;
 
 /**
@@ -57,7 +55,7 @@ class RocksDBReducingState<K, N, V> extends AbstractRocksDBAppendingState<K, N, 
      * @param backend The backend for which this state is bind to.
      */
     private RocksDBReducingState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<V> valueSerializer,
             V defaultValue,
@@ -157,7 +155,7 @@ class RocksDBReducingState<K, N, V> extends AbstractRocksDBAppendingState<K, N, 
     @SuppressWarnings("unchecked")
     static <K, N, SV, S extends State, IS extends S> IS create(
             StateDescriptor<S, SV> stateDesc,
-            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
+            Tuple2<ColumnFamilyHandleWrapper, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
                     registerResult,
             RocksDBKeyedStateBackend<K> backend) {
         return (IS)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
@@ -52,7 +51,7 @@ class RocksDBValueState<K, N, V> extends AbstractRocksDBState<K, N, V>
      * @param backend The backend for which this state is bind to.
      */
     private RocksDBValueState(
-            ColumnFamilyHandle columnFamily,
+            ColumnFamilyHandleWrapper columnFamily,
             TypeSerializer<N> namespaceSerializer,
             TypeSerializer<V> valueSerializer,
             V defaultValue,
@@ -113,7 +112,7 @@ class RocksDBValueState<K, N, V> extends AbstractRocksDBState<K, N, V>
     @SuppressWarnings("unchecked")
     static <K, N, SV, S extends State, IS extends S> IS create(
             StateDescriptor<S, SV> stateDesc,
-            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
+            Tuple2<ColumnFamilyHandleWrapper, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
                     registerResult,
             RocksDBKeyedStateBackend<K> backend) {
         return (IS)

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWrapper.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import javax.annotation.Nullable;
+
+/** Wrapper of {@link RocksDB} and {@link RocksDBAccessMetric}. */
+public class RocksDBWrapper implements AutoCloseable {
+    /**
+     * Our RocksDB database, this is used to store state. The different k/v states that we have will
+     * have their own RocksDB instance and columnFamilyHandle.
+     */
+    private final RocksDB db;
+
+    @Nullable private final RocksDBAccessMetric accessMetric;
+
+    private final boolean trackLatencyEnabled;
+
+    public RocksDBWrapper(RocksDB db) {
+        this(db, null);
+    }
+
+    public RocksDBWrapper(RocksDB db, @Nullable RocksDBAccessMetric.Builder accessMetricBuilder) {
+        this.db = db;
+        this.accessMetric = accessMetricBuilder != null ? accessMetricBuilder.build() : null;
+        this.trackLatencyEnabled = accessMetric != null;
+    }
+
+    public RocksDB getDb() {
+        return db;
+    }
+
+    public RocksDBAccessMetric getAccessMetric() {
+        return accessMetric;
+    }
+
+    public ColumnFamilyHandle createColumnFamily(ColumnFamilyDescriptor columnFamilyDescriptor)
+            throws RocksDBException {
+        return db.createColumnFamily(columnFamilyDescriptor);
+    }
+
+    public void put(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        if (trackLatencyEnabled) {
+            putAndUpdateMetric(columnFamilyHandle, writeOpt, key, value);
+        } else {
+            originalPut(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+        }
+    }
+
+    /**
+     * Since {@code WriteBatch} might contain several column families only during restore. We
+     * currently does not track latency metrics for that part operations if no column family handle
+     * provided.
+     */
+    public void write(
+            @Nullable final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final WriteBatch writeBatch)
+            throws RocksDBException {
+        if (columnFamilyHandle == null) {
+            originalWrite(writeOpt, writeBatch);
+        } else if (trackLatencyEnabled) {
+            writeAndUpdateMetric(columnFamilyHandle, writeOpt, writeBatch);
+        } else {
+            originalWrite(writeOpt, writeBatch);
+        }
+    }
+
+    public byte[] get(final ColumnFamilyHandleWrapper columnFamilyHandle, final byte[] key)
+            throws RocksDBException {
+        if (trackLatencyEnabled) {
+            return getAndUpdateMetric(columnFamilyHandle, key);
+        } else {
+            return originalGet(columnFamilyHandle.getColumnFamilyHandle(), key);
+        }
+    }
+
+    public void delete(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key)
+            throws RocksDBException {
+        if (trackLatencyEnabled) {
+            deleteAndUpdateMetric(columnFamilyHandle, writeOpt, key);
+        } else {
+            originalDelete(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key);
+        }
+    }
+
+    public void merge(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        if (trackLatencyEnabled) {
+            mergeAndUpdateMetric(columnFamilyHandle, writeOpt, key, value);
+        } else {
+            originalMerge(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+        }
+    }
+
+    private byte[] getAndUpdateMetric(
+            final ColumnFamilyHandleWrapper columnFamilyHandle, final byte[] key)
+            throws RocksDBException {
+        if (accessMetric.checkAndUpdateGetCounter(columnFamilyHandle.getColumnFamilyId())) {
+            long start = System.nanoTime();
+            byte[] result = originalGet(columnFamilyHandle.getColumnFamilyHandle(), key);
+            long end = System.nanoTime();
+            accessMetric.updateHistogram(
+                    columnFamilyHandle.getColumnFamilyId(),
+                    RocksDBAccessMetric.GET_LATENCY,
+                    end - start);
+            return result;
+        } else {
+            return originalGet(columnFamilyHandle.getColumnFamilyHandle(), key);
+        }
+    }
+
+    private void deleteAndUpdateMetric(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key)
+            throws RocksDBException {
+        if (accessMetric.checkAndUpdateDeleteCounter(columnFamilyHandle.getColumnFamilyId())) {
+            long start = System.nanoTime();
+            originalDelete(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key);
+            long end = System.nanoTime();
+            accessMetric.updateHistogram(
+                    columnFamilyHandle.getColumnFamilyId(),
+                    RocksDBAccessMetric.DELETE_LATENCY,
+                    end - start);
+        } else {
+            originalDelete(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key);
+        }
+    }
+
+    private void putAndUpdateMetric(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        if (accessMetric.checkAndUpdatePutCounter(columnFamilyHandle.getColumnFamilyId())) {
+            long start = System.nanoTime();
+            originalPut(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+            long end = System.nanoTime();
+            accessMetric.updateHistogram(
+                    columnFamilyHandle.getColumnFamilyId(),
+                    RocksDBAccessMetric.PUT_LATENCY,
+                    end - start);
+        } else {
+            originalPut(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+        }
+    }
+
+    private void writeAndUpdateMetric(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final WriteBatch writeBatch)
+            throws RocksDBException {
+        if (accessMetric.checkAndUpdateWriteBatchCounter(columnFamilyHandle.getColumnFamilyId())) {
+            long start = System.nanoTime();
+            originalWrite(writeOpt, writeBatch);
+            long end = System.nanoTime();
+            accessMetric.updateHistogram(
+                    columnFamilyHandle.getColumnFamilyId(),
+                    RocksDBAccessMetric.WRITE_BATCH_LATENCY,
+                    end - start);
+        } else {
+            originalWrite(writeOpt, writeBatch);
+        }
+    }
+
+    private void mergeAndUpdateMetric(
+            final ColumnFamilyHandleWrapper columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        if (accessMetric.checkAndUpdateMergeCounter(columnFamilyHandle.getColumnFamilyId())) {
+            long start = System.nanoTime();
+            originalMerge(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+            long end = System.nanoTime();
+            accessMetric.updateHistogram(
+                    columnFamilyHandle.getColumnFamilyId(),
+                    RocksDBAccessMetric.MERGE_LATENCY,
+                    end - start);
+        } else {
+            originalMerge(columnFamilyHandle.getColumnFamilyHandle(), writeOpt, key, value);
+        }
+    }
+
+    private byte[] originalGet(final ColumnFamilyHandle columnFamilyHandle, final byte[] key)
+            throws RocksDBException {
+        return db.get(columnFamilyHandle, key);
+    }
+
+    private void originalDelete(
+            final ColumnFamilyHandle columnFamilyHandle,
+            final WriteOptions writeOpt,
+            final byte[] key)
+            throws RocksDBException {
+        db.delete(columnFamilyHandle, writeOpt, key);
+    }
+
+    private void originalPut(
+            final ColumnFamilyHandle columnFamilyHandle,
+            final WriteOptions writeOpts,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        db.put(columnFamilyHandle, writeOpts, key, value);
+    }
+
+    private void originalWrite(final WriteOptions writeOpts, final WriteBatch writeBatch)
+            throws RocksDBException {
+        db.write(writeOpts, writeBatch);
+    }
+
+    private void originalMerge(
+            final ColumnFamilyHandle columnFamilyHandle,
+            final WriteOptions writeOpts,
+            final byte[] key,
+            final byte[] value)
+            throws RocksDBException {
+        db.merge(columnFamilyHandle, writeOpts, key, value);
+    }
+
+    @Override
+    public void close() {
+        if (accessMetric != null) {
+            accessMetric.close();
+        }
+        db.close();
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/RocksTransformingIteratorWrapper.java
@@ -37,7 +37,7 @@ public class RocksTransformingIteratorWrapper extends RocksIteratorWrapper {
     public RocksTransformingIteratorWrapper(
             @Nonnull RocksIterator iterator,
             @Nonnull StateSnapshotTransformer<byte[]> stateSnapshotTransformer) {
-        super(iterator);
+        super(iterator, null, null);
         this.stateSnapshotTransformer = stateSnapshotTransformer;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBNoneRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBNoneRestoreOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state.restore;
 
+import org.apache.flink.contrib.streaming.state.RocksDBAccessMetric;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
@@ -43,6 +44,7 @@ public class RocksDBNoneRestoreOperation<K> implements RocksDBRestoreOperation {
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             RocksDBNativeMetricOptions nativeMetricOptions,
             MetricGroup metricGroup,
+            RocksDBAccessMetric.Builder accessMetricBuilder,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
             Long writeBufferManagerCapacity) {
         this.rocksHandle =
@@ -53,6 +55,7 @@ public class RocksDBNoneRestoreOperation<K> implements RocksDBRestoreOperation {
                         columnFamilyOptionsFactory,
                         nativeMetricOptions,
                         metricGroup,
+                        accessMetricBuilder,
                         ttlCompactFiltersManager,
                         writeBufferManagerCapacity);
     }
@@ -61,7 +64,7 @@ public class RocksDBNoneRestoreOperation<K> implements RocksDBRestoreOperation {
     public RocksDBRestoreResult restore() throws Exception {
         this.rocksHandle.openDB();
         return new RocksDBRestoreResult(
-                this.rocksHandle.getDb(),
+                this.rocksHandle.getDBWrapper(),
                 this.rocksHandle.getDefaultColumnFamilyHandle(),
                 this.rocksHandle.getNativeMetricMonitor(),
                 -1,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreResult.java
@@ -19,10 +19,10 @@
 package org.apache.flink.contrib.streaming.state.restore;
 
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
+import org.apache.flink.contrib.streaming.state.RocksDBWrapper;
 import org.apache.flink.runtime.state.StateHandleID;
 
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksDB;
 
 import java.util.Set;
 import java.util.SortedMap;
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 /** Entity holding result of RocksDB instance restore. */
 public class RocksDBRestoreResult {
-    private final RocksDB db;
+    private final RocksDBWrapper db;
     private final ColumnFamilyHandle defaultColumnFamilyHandle;
     private final RocksDBNativeMetricMonitor nativeMetricMonitor;
 
@@ -40,7 +40,7 @@ public class RocksDBRestoreResult {
     private final SortedMap<Long, Set<StateHandleID>> restoredSstFiles;
 
     public RocksDBRestoreResult(
-            RocksDB db,
+            RocksDBWrapper db,
             ColumnFamilyHandle defaultColumnFamilyHandle,
             RocksDBNativeMetricMonitor nativeMetricMonitor,
             long lastCompletedCheckpointId,
@@ -54,7 +54,7 @@ public class RocksDBRestoreResult {
         this.restoredSstFiles = restoredSstFiles;
     }
 
-    public RocksDB getDb() {
+    public RocksDBWrapper getDBWrapper() {
         return db;
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state.snapshot;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
+import org.apache.flink.contrib.streaming.state.RocksDBWrapper;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
@@ -28,7 +29,6 @@ import org.apache.flink.runtime.state.SnapshotResources;
 import org.apache.flink.runtime.state.SnapshotStrategy;
 import org.apache.flink.util.ResourceGuard;
 
-import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
 
     @Nonnull private final String description;
     /** RocksDB instance from the backend. */
-    @Nonnull protected RocksDB db;
+    @Nonnull protected RocksDBWrapper db;
 
     /** Resource guard for the RocksDB instance. */
     @Nonnull protected final ResourceGuard rocksDBResourceGuard;
@@ -71,7 +71,7 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
 
     public RocksDBSnapshotStrategyBase(
             @Nonnull String description,
-            @Nonnull RocksDB db,
+            @Nonnull RocksDBWrapper db,
             @Nonnull ResourceGuard rocksDBResourceGuard,
             @Nonnull TypeSerializer<K> keySerializer,
             @Nonnull LinkedHashMap<String, RocksDbKvStateInfo> kvStateInformation,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state.snapshot;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
+import org.apache.flink.contrib.streaming.state.RocksDBWrapper;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
@@ -35,7 +36,6 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapp
 import org.apache.flink.util.ResourceGuard;
 import org.apache.flink.util.function.SupplierWithException;
 
-import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public class RocksFullSnapshotStrategy<K>
             registeredPQStates;
 
     public RocksFullSnapshotStrategy(
-            @Nonnull RocksDB db,
+            @Nonnull RocksDBWrapper db,
             @Nonnull ResourceGuard rocksDBResourceGuard,
             @Nonnull TypeSerializer<K> keySerializer,
             @Nonnull LinkedHashMap<String, RocksDbKvStateInfo> kvStateInformation,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -21,6 +21,7 @@ package org.apache.flink.contrib.streaming.state.snapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDbKvStateInfo;
 import org.apache.flink.contrib.streaming.state.RocksDBStateUploader;
+import org.apache.flink.contrib.streaming.state.RocksDBWrapper;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -52,7 +53,6 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ResourceGuard;
 
 import org.rocksdb.Checkpoint;
-import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +110,7 @@ public class RocksIncrementalSnapshotStrategy<K>
     private final String localDirectoryName;
 
     public RocksIncrementalSnapshotStrategy(
-            @Nonnull RocksDB db,
+            @Nonnull RocksDBWrapper db,
             @Nonnull ResourceGuard rocksDBResourceGuard,
             @Nonnull TypeSerializer<K> keySerializer,
             @Nonnull LinkedHashMap<String, RocksDbKvStateInfo> kvStateInformation,
@@ -279,7 +279,7 @@ public class RocksIncrementalSnapshotStrategy<K>
             throws Exception {
         // create hard links of living files in the output path
         try (ResourceGuard.Lease ignored = rocksDBResourceGuard.acquireResource();
-                Checkpoint checkpoint = Checkpoint.create(db)) {
+                Checkpoint checkpoint = Checkpoint.create(db.getDb())) {
             checkpoint.createCheckpoint(outputDirectory.getDirectory().toString());
         } catch (Exception ex) {
             try {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -249,7 +249,7 @@ public class EmbeddedRocksDBStateBackendTest
                                 return rocksIterator;
                             }
                         })
-                .when(keyedStateBackend.db)
+                .when(keyedStateBackend.db.getDb())
                 .newIterator(any(ColumnFamilyHandle.class), any(ReadOptions.class));
 
         doAnswer(
@@ -264,7 +264,7 @@ public class EmbeddedRocksDBStateBackendTest
                                 return snapshot;
                             }
                         })
-                .when(keyedStateBackend.db)
+                .when(keyedStateBackend.db.getDb())
                 .getSnapshot();
 
         doAnswer(
@@ -279,7 +279,7 @@ public class EmbeddedRocksDBStateBackendTest
                                 return snapshot;
                             }
                         })
-                .when(keyedStateBackend.db)
+                .when(keyedStateBackend.db.getDb())
                 .createColumnFamily(any(ColumnFamilyDescriptor.class));
 
         for (int i = 0; i < 100; ++i) {
@@ -337,7 +337,7 @@ public class EmbeddedRocksDBStateBackendTest
                             testStreamFactory,
                             CheckpointOptions.forCheckpointWithDefaultLocation());
 
-            RocksDB spyDB = keyedStateBackend.db;
+            RocksDB spyDB = keyedStateBackend.db.getDb();
 
             if (!enableIncrementalCheckpointing) {
                 verify(spyDB, times(1)).getSnapshot();
@@ -625,7 +625,7 @@ public class EmbeddedRocksDBStateBackendTest
         }
 
         assertNotNull(null, keyedStateBackend.db);
-        RocksDB spyDB = keyedStateBackend.db;
+        RocksDB spyDB = keyedStateBackend.db.getDb();
 
         if (!enableIncrementalCheckpointing) {
             verify(spyDB, times(1)).getSnapshot();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest.java
@@ -65,9 +65,10 @@ public class KeyGroupPartitionedPriorityQueueWithRocksDBStoreTest
             return new RocksDBCachingPriorityQueueSet<>(
                     keyGroupId,
                     keyGroupPrefixBytes,
-                    rocksDBResource.getRocksDB(),
+                    new RocksDBWrapper(rocksDBResource.getRocksDB()),
                     rocksDBResource.getReadOptions(),
-                    rocksDBResource.getDefaultColumnFamily(),
+                    null,
+                    new ColumnFamilyHandleWrapper(rocksDBResource.getDefaultColumnFamily()),
                     TestElementSerializer.INSTANCE,
                     outputStreamWithPos,
                     inputStreamWithPos,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAccessMetricTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAccessMetricTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link RocksDBAccessMetric}. */
+public class RocksDBAccessMetricTest {
+    @Test
+    public void testRocksDBAccessMetricBuild() {
+        RocksDBAccessMetric.Builder builder = new RocksDBAccessMetric.Builder();
+        assertNull(builder.build());
+
+        builder.setEnabled(true);
+        builder.setMetricGroup(new UnregisteredMetricsGroup());
+        builder.setSampleInterval(200);
+        builder.setHistogramSlidingWindow(Time.seconds(5).toMilliseconds());
+
+        RocksDBAccessMetric rocksDBAccessMetric = builder.build();
+        assertEquals(5 * 1000L, rocksDBAccessMetric.getHistogramWindowSize());
+        assertEquals(200, rocksDBAccessMetric.getSampleCountInterval());
+    }
+
+    @Test
+    public void testRocksDBAccessMetricBuilderFromConfig() {
+        Configuration configuration = new Configuration();
+        RocksDBAccessMetric.Builder builder = RocksDBAccessMetric.builderFromConfig(configuration);
+        // default implementation.
+        assertNull(builder.build());
+
+        configuration.setBoolean(RocksDBOptions.LATENCY_TRACK_ENABLED, true);
+        builder = RocksDBAccessMetric.builderFromConfig(configuration);
+        builder.setMetricGroup(new UnregisteredMetricsGroup());
+        RocksDBAccessMetric dbAccessMetric = builder.build();
+        assertTrue(dbAccessMetric.isMetricsSampleEnabled());
+        assertEquals(
+                (int) RocksDBOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue(),
+                dbAccessMetric.getSampleCountInterval());
+        assertEquals(
+                (long) RocksDBOptions.LATENCY_TRACK_SLIDING_WINDOW.defaultValue(),
+                dbAccessMetric.getHistogramWindowSize());
+
+        configuration.setInteger(RocksDBOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 0);
+        builder = RocksDBAccessMetric.builderFromConfig(configuration);
+        builder.setMetricGroup(new UnregisteredMetricsGroup());
+        assertFalse(builder.build().isMetricsSampleEnabled());
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBLatencyMetricsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBLatencyMetricsTest.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+import org.apache.flink.runtime.metrics.scope.ScopeFormats;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.RocksDB;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.DELETE_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.GET_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.MERGE_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.NEXT_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.PUT_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.SEEK_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBAccessMetric.WRITE_BATCH_LATENCY;
+import static org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder.DB_INSTANCE_DIR_STRING;
+
+/** Tests for {@link RocksDBAccessMetric}. */
+public class RocksDBLatencyMetricsTest {
+    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+    private final int sampleInterval = 20;
+
+    private RocksDB db;
+    private ColumnFamilyHandle defaultCFHandle;
+    private RocksDBResourceContainer optionsContainer;
+    private RocksDBKeyedStateBackend<Integer> stateBackend;
+    private ValueState<String> valueState;
+    private Map<String, Histogram> valueStateHistogram;
+    private ListState<String> listState;
+    private Map<String, Histogram> listStateHistogram;
+    private MapState<Integer, String> mapState;
+    private Map<String, Histogram> mapStateHistogram;
+
+    @Before
+    public void setupRocksDB() throws Exception {
+        optionsContainer = new RocksDBResourceContainer();
+        String dbPath = new File(TEMP_FOLDER.newFolder(), DB_INSTANCE_DIR_STRING).getAbsolutePath();
+        ColumnFamilyOptions columnOptions = optionsContainer.getColumnOptions();
+
+        ArrayList<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
+        db =
+                RocksDBOperationUtils.openDB(
+                        dbPath,
+                        Collections.emptyList(),
+                        columnFamilyHandles,
+                        columnOptions,
+                        optionsContainer.getDbOptions());
+        defaultCFHandle = columnFamilyHandles.remove(0);
+        SimpleMetricRegistry registry = new SimpleMetricRegistry();
+        SimpleMetricGroup group = new SimpleMetricGroup(registry);
+
+        long slidingWindowSize = Time.days(1).toMilliseconds();
+        RocksDBAccessMetric.Builder builder =
+                new RocksDBAccessMetric.Builder()
+                        .setEnabled(true)
+                        .setSampleInterval(sampleInterval)
+                        .setHistogramSlidingWindow(slidingWindowSize)
+                        .setMetricGroup(group);
+        stateBackend =
+                RocksDBTestUtils.builderForTestDB(
+                                TEMP_FOLDER.newFolder(),
+                                IntSerializer.INSTANCE,
+                                db,
+                                defaultCFHandle,
+                                optionsContainer.getColumnOptions(),
+                                group)
+                        .setAccessMetricBuilder(builder)
+                        .build();
+        RocksDBAccessMetric accessMetric = stateBackend.db.getAccessMetric();
+        Preconditions.checkNotNull(accessMetric);
+        Map<Integer, Map<String, Histogram>> histogramMetrics = accessMetric.getHistogramMetrics();
+
+        ValueStateDescriptor<String> valueStateDescriptor =
+                new ValueStateDescriptor<>("value-state", StringSerializer.INSTANCE);
+        valueState =
+                stateBackend.createInternalState(
+                        VoidNamespaceSerializer.INSTANCE, valueStateDescriptor);
+        Map.Entry<Integer, Map<String, Histogram>> next =
+                histogramMetrics.entrySet().iterator().next();
+        int valueStateId = next.getKey();
+        valueStateHistogram = next.getValue();
+
+        ListStateDescriptor<String> listStateDescriptor =
+                new ListStateDescriptor<>("list-state", StringSerializer.INSTANCE);
+        listState =
+                stateBackend.createInternalState(
+                        VoidNamespaceSerializer.INSTANCE, listStateDescriptor);
+        int listStateId = 0;
+        for (Map.Entry<Integer, Map<String, Histogram>> entry : histogramMetrics.entrySet()) {
+            if (entry.getKey() != valueStateId) {
+                listStateId = entry.getKey();
+                listStateHistogram = entry.getValue();
+            }
+        }
+
+        MapStateDescriptor<Integer, String> mapStateDescriptor =
+                new MapStateDescriptor<>(
+                        "map-state", IntSerializer.INSTANCE, StringSerializer.INSTANCE);
+        mapState =
+                stateBackend.createInternalState(
+                        VoidNamespaceSerializer.INSTANCE, mapStateDescriptor);
+        for (Map.Entry<Integer, Map<String, Histogram>> entry : histogramMetrics.entrySet()) {
+            if (entry.getKey() != valueStateId && entry.getKey() != listStateId) {
+                mapStateHistogram = entry.getValue();
+            }
+        }
+    }
+
+    @After
+    public void cleanupRocksDB() {
+        IOUtils.closeQuietly(stateBackend);
+        if (stateBackend != null) {
+            stateBackend.dispose();
+        }
+        IOUtils.closeQuietly(defaultCFHandle);
+        IOUtils.closeQuietly(db);
+        IOUtils.closeQuietly(optionsContainer);
+    }
+
+    @Test
+    public void testTrackPutLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+        for (int i = 0; i < sampleInterval; i++) {
+            valueState.update(value);
+            Assert.assertEquals(1, valueStateHistogram.get(PUT_LATENCY).getCount());
+        }
+        valueState.update(value);
+        Assert.assertEquals(2, valueStateHistogram.get(PUT_LATENCY).getCount());
+
+        for (int i = 0; i < sampleInterval; i++) {
+            mapState.put(ThreadLocalRandom.current().nextInt(), value);
+            Assert.assertEquals(1, mapStateHistogram.get(PUT_LATENCY).getCount());
+        }
+        mapState.put(ThreadLocalRandom.current().nextInt(), value);
+        Assert.assertEquals(2, mapStateHistogram.get(PUT_LATENCY).getCount());
+    }
+
+    @Test
+    public void testTrackGetLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+        valueState.update(value);
+        for (int i = 0; i < sampleInterval; i++) {
+            valueState.value();
+            Assert.assertEquals(1, valueStateHistogram.get(GET_LATENCY).getCount());
+        }
+        valueState.value();
+        Assert.assertEquals(2, valueStateHistogram.get(GET_LATENCY).getCount());
+
+        listState.add(value);
+        for (int i = 0; i < sampleInterval; i++) {
+            listState.get();
+            Assert.assertEquals(1, listStateHistogram.get(GET_LATENCY).getCount());
+        }
+        listState.get();
+        Assert.assertEquals(2, listStateHistogram.get(GET_LATENCY).getCount());
+
+        mapState.put(ThreadLocalRandom.current().nextInt(), value);
+        for (int i = 0; i < sampleInterval; i++) {
+            mapState.get(ThreadLocalRandom.current().nextInt());
+            Assert.assertEquals(1, mapStateHistogram.get(GET_LATENCY).getCount());
+        }
+        mapState.get(ThreadLocalRandom.current().nextInt());
+        Assert.assertEquals(2, mapStateHistogram.get(GET_LATENCY).getCount());
+    }
+
+    @Test
+    public void testTrackWriteBatchLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+
+        for (int i = 0; i < sampleInterval; i++) {
+            mapState.putAll(Collections.singletonMap(ThreadLocalRandom.current().nextInt(), value));
+            Assert.assertEquals(1, mapStateHistogram.get(WRITE_BATCH_LATENCY).getCount());
+        }
+        mapState.putAll(Collections.singletonMap(ThreadLocalRandom.current().nextInt(), value));
+        Assert.assertEquals(2, mapStateHistogram.get(WRITE_BATCH_LATENCY).getCount());
+    }
+
+    @Test
+    public void testTrackMergeLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+
+        for (int i = 0; i < sampleInterval / 2; i++) {
+            listState.add(value);
+            listState.addAll(Collections.singletonList(value));
+            Assert.assertEquals(1, listStateHistogram.get(MERGE_LATENCY).getCount());
+        }
+        listState.add(value);
+        listState.addAll(Collections.singletonList(value));
+        Assert.assertEquals(2, listStateHistogram.get(MERGE_LATENCY).getCount());
+    }
+
+    @Test
+    public void testTrackDeleteLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+
+        valueState.update(value);
+        for (int i = 0; i < sampleInterval; i++) {
+            valueState.clear();
+            Assert.assertEquals(1, valueStateHistogram.get(DELETE_LATENCY).getCount());
+        }
+        valueState.clear();
+        Assert.assertEquals(2, valueStateHistogram.get(DELETE_LATENCY).getCount());
+
+        listState.add(value);
+        for (int i = 0; i < sampleInterval; i++) {
+            listState.clear();
+            Assert.assertEquals(1, listStateHistogram.get(DELETE_LATENCY).getCount());
+        }
+        listState.clear();
+        Assert.assertEquals(2, listStateHistogram.get(DELETE_LATENCY).getCount());
+
+        mapState.put(ThreadLocalRandom.current().nextInt(), value);
+        for (int i = 0; i < sampleInterval; i++) {
+            mapState.remove(ThreadLocalRandom.current().nextInt());
+            Assert.assertEquals(1, mapStateHistogram.get(DELETE_LATENCY).getCount());
+        }
+        mapState.remove(ThreadLocalRandom.current().nextInt());
+        Assert.assertEquals(2, mapStateHistogram.get(DELETE_LATENCY).getCount());
+    }
+
+    @Test
+    public void testTrackSeekAndNextLatency() throws Exception {
+        stateBackend.setCurrentKey(-1);
+        String value = StringUtils.getRandomString(ThreadLocalRandom.current(), 1, 10);
+
+        mapState.put(ThreadLocalRandom.current().nextInt(), value);
+        for (int i = 0; i < sampleInterval / 4; i++) {
+            mapState.iterator().hasNext();
+            mapState.entries().iterator().hasNext();
+            mapState.values().iterator().hasNext();
+            mapState.keys().iterator().hasNext();
+            Assert.assertEquals(1, mapStateHistogram.get(SEEK_LATENCY).getCount());
+            Assert.assertEquals(1, mapStateHistogram.get(NEXT_LATENCY).getCount());
+        }
+        mapState.iterator().hasNext();
+        mapState.entries().iterator().hasNext();
+        mapState.values().iterator().hasNext();
+        mapState.keys().iterator().hasNext();
+        Assert.assertEquals(2, mapStateHistogram.get(SEEK_LATENCY).getCount());
+        Assert.assertEquals(2, mapStateHistogram.get(NEXT_LATENCY).getCount());
+    }
+
+    private static class SimpleMetricRegistry implements MetricRegistry {
+
+        @Override
+        public char getDelimiter() {
+            return 0;
+        }
+
+        @Override
+        public int getNumberReporters() {
+            return 0;
+        }
+
+        @Override
+        public void register(Metric metric, String metricName, AbstractMetricGroup group) {}
+
+        @Override
+        public void unregister(Metric metric, String metricName, AbstractMetricGroup group) {}
+
+        @Override
+        public ScopeFormats getScopeFormats() {
+            Configuration config = new Configuration();
+
+            return ScopeFormats.fromConfig(config);
+        }
+    }
+
+    private static class SimpleMetricGroup extends AbstractMetricGroup {
+
+        public SimpleMetricGroup(MetricRegistry registry) {
+            super(registry, new String[0], null);
+        }
+
+        @Override
+        protected String getGroupName(CharacterFilter filter) {
+            return "test";
+        }
+
+        @Override
+        protected QueryScopeInfo createQueryServiceMetricInfo(CharacterFilter filter) {
+            return null;
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResource.java
@@ -65,7 +65,7 @@ public class RocksDBResource extends ExternalResource {
     private ReadOptions readOptions;
 
     /** The RocksDB instance object. */
-    private RocksDB rocksDB;
+    private RocksDBWrapper rocksDB;
 
     /** List of all column families that have been created with the RocksDB instance. */
     private List<ColumnFamilyHandle> columnFamilyHandles;
@@ -124,7 +124,7 @@ public class RocksDBResource extends ExternalResource {
     }
 
     public RocksDB getRocksDB() {
-        return rocksDB;
+        return rocksDB.getDb();
     }
 
     public ReadOptions getReadOptions() {
@@ -168,14 +168,15 @@ public class RocksDBResource extends ExternalResource {
         this.readOptions = RocksDBOperationUtils.createTotalOrderSeekReadOptions();
         this.columnFamilyHandles = new ArrayList<>(1);
         this.rocksDB =
-                RocksDB.open(
-                        dbOptions,
-                        rocksFolder.getAbsolutePath(),
-                        Collections.singletonList(
-                                new ColumnFamilyDescriptor(
-                                        "default".getBytes(), columnFamilyOptions)),
-                        columnFamilyHandles);
-        this.batchWrapper = new RocksDBWriteBatchWrapper(rocksDB, writeOptions);
+                new RocksDBWrapper(
+                        RocksDB.open(
+                                dbOptions,
+                                rocksFolder.getAbsolutePath(),
+                                Collections.singletonList(
+                                        new ColumnFamilyDescriptor(
+                                                "default".getBytes(), columnFamilyOptions)),
+                                columnFamilyHandles));
+        this.batchWrapper = new RocksDBWriteBatchWrapper(rocksDB, null, writeOptions, 500, 0);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysAndNamespacesIteratorTest.java
@@ -97,7 +97,7 @@ public class RocksDBRocksStateKeysAndNamespacesIteratorTest {
             try (RocksIteratorWrapper iterator =
                             RocksDBOperationUtils.getRocksIterator(
                                     keyedStateBackend.db,
-                                    handle,
+                                    new ColumnFamilyHandleWrapper(handle),
                                     keyedStateBackend.getReadOptions());
                     RocksStateKeysAndNamespaceIterator<K, String> iteratorWrapper =
                             new RocksStateKeysAndNamespaceIterator<>(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksStateKeysIteratorTest.java
@@ -96,7 +96,7 @@ public class RocksDBRocksStateKeysIteratorTest {
             try (RocksIteratorWrapper iterator =
                             RocksDBOperationUtils.getRocksIterator(
                                     keyedStateBackend.db,
-                                    handle,
+                                    new ColumnFamilyHandleWrapper(handle),
                                     keyedStateBackend.getReadOptions());
                     RocksStateKeysIterator<K> iteratorWrapper =
                             new RocksStateKeysIterator<>(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -85,6 +86,22 @@ public final class RocksDBTestUtils {
             ColumnFamilyHandle defaultCFHandle,
             ColumnFamilyOptions columnFamilyOptions) {
 
+        return builderForTestDB(
+                instanceBasePath,
+                keySerializer,
+                db,
+                defaultCFHandle,
+                columnFamilyOptions,
+                new UnregisteredMetricsGroup());
+    }
+
+    public static <K> RocksDBKeyedStateBackendBuilder<K> builderForTestDB(
+            File instanceBasePath,
+            TypeSerializer<K> keySerializer,
+            RocksDB db,
+            ColumnFamilyHandle defaultCFHandle,
+            ColumnFamilyOptions columnFamilyOptions,
+            MetricGroup metricGroup) {
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
         return new RocksDBKeyedStateBackendBuilder<>(
@@ -101,7 +118,7 @@ public final class RocksDBTestUtils {
                 TestLocalRecoveryConfig.disabled(),
                 EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP,
                 TtlTimeProvider.DEFAULT,
-                new UnregisteredMetricsGroup(),
+                metricGroup,
                 Collections.emptyList(),
                 UncompressedStreamCompressionDecorator.INSTANCE,
                 db,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
@@ -49,13 +49,18 @@ public class RocksDBWriteBatchWrapperTest {
             data.add(new Tuple2<>(("key:" + i).getBytes(), ("value:" + i).getBytes()));
         }
 
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+        try (RocksDBWrapper db =
+                        new RocksDBWrapper(RocksDB.open(folder.newFolder().getAbsolutePath()));
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
                 RocksDBWriteBatchWrapper writeBatchWrapper =
                         new RocksDBWriteBatchWrapper(
-                                db, options, 200, WRITE_BATCH_SIZE.defaultValue().getBytes())) {
+                                db,
+                                null,
+                                options,
+                                200,
+                                WRITE_BATCH_SIZE.defaultValue().getBytes())) {
 
             // insert data
             for (Tuple2<byte[], byte[]> item : data) {
@@ -65,7 +70,7 @@ public class RocksDBWriteBatchWrapperTest {
 
             // valid result
             for (Tuple2<byte[], byte[]> item : data) {
-                Assert.assertArrayEquals(item.f1, db.get(handle, item.f0));
+                Assert.assertArrayEquals(item.f1, db.getDb().get(handle, item.f0));
             }
         }
     }
@@ -76,12 +81,13 @@ public class RocksDBWriteBatchWrapperTest {
      */
     @Test
     public void testWriteBatchWrapperFlushAfterMemorySizeExceed() throws Exception {
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+        try (RocksDBWrapper db =
+                        new RocksDBWrapper(RocksDB.open(folder.newFolder().getAbsolutePath()));
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
                 RocksDBWriteBatchWrapper writeBatchWrapper =
-                        new RocksDBWriteBatchWrapper(db, options, 200, 50)) {
+                        new RocksDBWriteBatchWrapper(db, null, options, 500, 50)) {
 
             long initBatchSize = writeBatchWrapper.getDataSize();
             byte[] dummy = new byte[6];
@@ -105,12 +111,13 @@ public class RocksDBWriteBatchWrapperTest {
      */
     @Test
     public void testWriteBatchWrapperFlushAfterCountExceed() throws Exception {
-        try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+        try (RocksDBWrapper db =
+                        new RocksDBWrapper(RocksDB.open(folder.newFolder().getAbsolutePath()));
                 WriteOptions options = new WriteOptions().setDisableWAL(true);
                 ColumnFamilyHandle handle =
                         db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
                 RocksDBWriteBatchWrapper writeBatchWrapper =
-                        new RocksDBWriteBatchWrapper(db, options, 100, 50000)) {
+                        new RocksDBWriteBatchWrapper(db, null, options, 100, 50000)) {
             long initBatchSize = writeBatchWrapper.getDataSize();
             byte[] dummy = new byte[2];
             ThreadLocalRandom.current().nextBytes(dummy);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksKeyGroupsRocksSingleStateIteratorTest.java
@@ -126,7 +126,7 @@ public class RocksKeyGroupsRocksSingleStateIteratorTest {
             for (Tuple2<ColumnFamilyHandle, Integer> columnFamilyHandle :
                     columnFamilyHandlesWithKeyCount) {
                 RocksIteratorWrapper rocksIterator =
-                        RocksDBOperationUtils.getRocksIterator(
+                        RocksDBOperationUtils.getRocksIteratorWithoutAccessMetric(
                                 rocksDB, columnFamilyHandle.f0, readOptions);
                 closeableRegistry.registerCloseable(rocksIterator);
                 rocksIteratorsWithKVStateId.add(new Tuple2<>(rocksIterator, id));

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@ under the License.
 		<jackson.version>2.10.1</jackson.version>
 		<prometheus.version>0.8.1</prometheus.version>
 		<avro.version>1.10.0</avro.version>
+		<dropwizard.version>3.2.6</dropwizard.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION
## What is the purpose of the change

Count the get/put/seek/next/writeBatch latency of RocksDB as metrics.

## Brief change log

Track access latency on client side.
1. Introduce 'state.backend.rocksdb.latency-track-enabled' option to switch whether enable this feature.
1. Introduce 'state.backend.rocksdb.latency-track-sample-interval' option to change the sample interval.
1. Introduce 'state.backend.rocksdb.latency-track-sliding-window' option to tune the sliding window size of histogram metrics.

If want to track the latency, just switch state.backend.rocksdb.latency-track-enabled to true.

## Verifying this change

This change added tests and can be verified as follows:

`RocksDBLatencyMetricsTest` and `RocksDBAccessMetricTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): should not be
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
